### PR TITLE
Use the latest docker image for devstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ memcache:
 
 course-discovery:
   # Uncomment this line to use the official course-discovery base image
-  image: edxops/course-discovery:v1
+  image: edxops/course-discovery:latest
 
   # Uncomment the next two lines to build from a local configuration repo
   #build: ../configuration


### PR DESCRIPTION
@clintonb: Turns out that `latest` is the right tag to use for active development.
