### PR TITLE
Fixed bug related to whitespace stripping

### DIFF
--- a/course_discovery/static/js/catalogs-change-form.js
+++ b/course_discovery/static/js/catalogs-change-form.js
@@ -39,9 +39,6 @@ $(function () {
             e.preventDefault();
 
             if (query) {
-                // Remove all whitespace
-                query = query.replace(/\s/g, "");
-
                 // URL encode
                 query = encodeURIComponent(query);
 


### PR DESCRIPTION
Stripping all whitespace breaks the queries being previewed. We can live with the extra bytes of whitespace going over the wire.
