### PR TITLE
Removed Elasticsearch sniff_on_start

### DIFF
--- a/course_discovery/apps/courses/management/commands/install_es_indexes.py
+++ b/course_discovery/apps/courses/management/commands/install_es_indexes.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         alias = settings.ELASTICSEARCH['index']
 
         logger.info('Attempting to establish initial connection to Elasticsearch host [%s]...', host)
-        es = Elasticsearch(host, sniff_on_start=True)
+        es = Elasticsearch(host)
         logger.info('...success!')
 
         ElasticsearchUtils.create_alias_and_index(es, alias)


### PR DESCRIPTION
This functionality is broken on AWS.
