### PR TITLE
Update requirements to fix docker-compose version to 1.5.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Calen Pennington <cale@edx.org>
 Clinton Blackburn <cblackburn@edx.org>
+Bill DeRusha <bill@edx.org>

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -9,4 +9,4 @@ transifex-client == 0.11
 git+https://github.com/edx/i18n-tools.git@v0.1.4#egg=i18n_tools==0.1.4
 
 # docker devstack
-docker-compose >= 1.5.1
+docker-compose >=1.5.1,<1.6.0


### PR DESCRIPTION
@cpennington @clintonb Tiny fix to prevent 1.6 `--x-networking` errors until we decide to convert to 1.6 ways to doing things
