### PR TITLE
Fixups

### DIFF
--- a/course_discovery/apps/core/admin.py
+++ b/course_discovery/apps/core/admin.py
@@ -8,24 +8,27 @@ from course_discovery.apps.core.forms import UserThrottleRateForm
 from course_discovery.apps.core.models import User, UserThrottleRate, Currency
 
 
+@admin.register(User)
 class CustomUserAdmin(UserAdmin):
     """ Admin configuration for the custom User model. """
     list_display = ('username', 'email', 'full_name', 'first_name', 'last_name', 'is_staff')
     fieldsets = (
         (None, {'fields': ('username', 'password')}),
         (_('Personal info'), {'fields': ('full_name', 'first_name', 'last_name', 'email')}),
-        (_('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser',
-                                       'groups', 'user_permissions')}),
+        (_('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser', 'groups', 'user_permissions')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
     )
 
 
+@admin.register(UserThrottleRate)
 class UserThrottleRateAdmin(admin.ModelAdmin):
     """ Admin configuration for the UserThrottleRate model. """
     form = UserThrottleRateForm
     raw_id_fields = ('user',)
 
 
-admin.site.register(User, CustomUserAdmin)
-admin.site.register(UserThrottleRate, UserThrottleRateAdmin)
-admin.site.register(Currency)
+@admin.register(Currency)
+class CurrencyAdmin(admin.ModelAdmin):
+    list_display = ('code', 'name',)
+    ordering = ('code', 'name',)
+    search_fields = ('code', 'name',)

--- a/course_discovery/apps/core/models.py
+++ b/course_discovery/apps/core/models.py
@@ -39,19 +39,13 @@ class UserThrottleRate(models.Model):
     )
 
 
-class AbstractCodeModel(models.Model):
-    """ Abstract base class for models based on ISO, or similar, standards. """
+class Currency(models.Model):
+    """ Table of currencies as defined by ISO-4217. """
     code = models.CharField(max_length=6, primary_key=True, unique=True)
     name = models.CharField(max_length=255)
 
     def __str__(self):
         return '{code} - {name}'.format(code=self.code, name=self.name)
 
-    class Meta(object):
-        abstract = True
-
-
-class Currency(AbstractCodeModel):
-    """ Table of currencies as defined by ISO-4217. """
     class Meta(object):
         verbose_name_plural = 'Currencies'

--- a/course_discovery/apps/core/tests/test_models.py
+++ b/course_discovery/apps/core/tests/test_models.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django_dynamic_fixture import G
 from social.apps.django_app.default.models import UserSocialAuth
 
-from course_discovery.apps.core.models import User, AbstractCodeModel
+from course_discovery.apps.core.models import User, Currency
 
 
 # pylint: disable=no-member
@@ -40,16 +40,13 @@ class UserTests(TestCase):
         self.assertEqual(user.get_full_name(), full_name)
 
 
-class AbstractCodeModelTests(TestCase):
-    """ Tests for the AbstractCodeModel class. """
+class CurrencyTests(TestCase):
+    """ Tests for the Currency class. """
 
     def test_str(self):
-        """ Verify casting the child model to a string returns a string containing the ID and name of the model. """
+        """ Verify casting an instance to a string returns a string containing the ID and name of the currency. """
 
-        class TestCodeModel(AbstractCodeModel):
-            pass
-
-        code = 'ABC',
-        name = 'Test Instance'
-        instance = TestCodeModel(code=code, name=name)
+        code = 'USD',
+        name = 'U.S. Dollar'
+        instance = Currency(code=code, name=name)
         self.assertEqual(str(instance), '{code} - {name}'.format(code=code, name=name))

--- a/course_discovery/apps/ietf_language_tags/__init__.py
+++ b/course_discovery/apps/ietf_language_tags/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'course_discovery.apps.ietf_language_tags.apps.IETFLanguageTagsConfig'

--- a/course_discovery/apps/ietf_language_tags/admin.py
+++ b/course_discovery/apps/ietf_language_tags/admin.py
@@ -1,8 +1,12 @@
-""" Admin configuration for ietf language tag models. """
+""" Admin configuration. """
 
 from django.contrib import admin
 
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 
 
-admin.site.register(LanguageTag)
+@admin.register(LanguageTag)
+class LanguageTagAdmin(admin.ModelAdmin):
+    list_display = ('code', 'name',)
+    ordering = ('code', 'name',)
+    search_fields = ('code', 'name',)

--- a/course_discovery/apps/ietf_language_tags/apps.py
+++ b/course_discovery/apps/ietf_language_tags/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class IETFLanguageTagsConfig(AppConfig):
+    name = 'course_discovery.apps.ietf_language_tags'
+    verbose_name = 'IETF Language Tags'

--- a/course_discovery/apps/ietf_language_tags/migrations/0001_initial.py
+++ b/course_discovery/apps/ietf_language_tags/migrations/0001_initial.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='LanguageTag',
             fields=[
-                ('id', models.CharField(serialize=False, max_length=50, primary_key=True)),
+                ('code', models.CharField(primary_key=True, max_length=50, serialize=False)),
                 ('name', models.CharField(max_length=255)),
             ],
         ),

--- a/course_discovery/apps/ietf_language_tags/migrations/0002_language_tag_data_migration.py
+++ b/course_discovery/apps/ietf_language_tags/migrations/0002_language_tag_data_migration.py
@@ -105,7 +105,6 @@ LANGTAGS = (
     ("Slovak", "sk"),
     ("Sorbian", "sb"),
     ("Spanish – Spain (Modern)", "es-es"),
-    ("Spanish – Spain (Traditional)", "&nbsp;"),
     ("Spanish – Argentina", "es-ar"),
     ("Spanish – Bolivia", "es-bo"),
     ("Spanish – Chile", "es-cl"),
@@ -146,17 +145,15 @@ LANGTAGS = (
 def add_language_tags(apps, schema_editor):
     LanguageTag = apps.get_model('ietf_language_tags', 'LanguageTag')
 
-    for name, lcid in LANGTAGS:
-        langtag, __ = LanguageTag.objects.get_or_create(id=lcid)
-        langtag.name = name
-        langtag.save()
+    for name, code in LANGTAGS:
+        LanguageTag.objects.update_or_create(code=code, defaults={ 'name': name })
 
 
 def drop_language_tags(apps, schema_editor):
     LanguageTag = apps.get_model('ietf_language_tags', 'LanguageTag')
 
-    lcids = [lcid for __, lcid in LANGTAGS]
-    LanguageTag.objects.filter(id__in=lcids).delete()
+    codes = [code for __, code in LANGTAGS]
+    LanguageTag.objects.filter(code__in=codes).delete()
 
 
 class Migration(migrations.Migration):

--- a/course_discovery/apps/ietf_language_tags/models.py
+++ b/course_discovery/apps/ietf_language_tags/models.py
@@ -5,8 +5,8 @@ from django.db import models
 
 class LanguageTag(models.Model):
     """ Table of language tags as defined by BCP 47. https://tools.ietf.org/html/bcp47 """
-    id = models.CharField(max_length=50, primary_key=True)
+    code = models.CharField(max_length=50, primary_key=True)
     name = models.CharField(max_length=255)
 
     def __str__(self):
-        return '{id} - {name}'.format(id=self.id, name=self.name)
+        return '{code} - {name}'.format(code=self.code, name=self.name)

--- a/course_discovery/apps/ietf_language_tags/tests/test_models.py
+++ b/course_discovery/apps/ietf_language_tags/tests/test_models.py
@@ -1,4 +1,4 @@
-""" Tests for ietf language tag models. """
+""" Tests for models. """
 
 from django.test import TestCase
 
@@ -9,9 +9,9 @@ class LanguageTagTests(TestCase):
     """ Tests for the LanguageTag class. """
 
     def test_str(self):
-        """ Verify LanguageTag returns a string containing the ID and name of the model. """
+        """ Verify casting a LanguageTag to a string returns a string containing the code and name of the model. """
 
-        lcid = 'te-st',
+        code = 'te-st',
         name = 'Test LanguageTag'
-        langtag = LanguageTag(id=lcid, name=name)
-        self.assertEqual(str(langtag), '{lcid} - {name}'.format(lcid=lcid, name=name))
+        tag = LanguageTag(code=code, name=name)
+        self.assertEqual(str(tag), '{code} - {name}'.format(code=code, name=name))


### PR DESCRIPTION
- Removed `AbstractCodeModel` since there is only one class using it
- Renamed `LanguageTag` `id` field to `code`
- Updated admin list views for `LanguageTag` and `Currency` models
- Removed invalid entry in translation data
- Using `update_or_create` to create/modify data
- Removed references to LCID, a Microsoft concept.
