### PR TITLE
Filtering catalog courses

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -129,6 +129,10 @@ class CourseSerializer(TimestampModelSerializer):
         )
 
 
+class CourseSerializerExcludingClosedRuns(CourseSerializer):
+    course_runs = CourseRunSerializer(many=True, source='active_course_runs')
+
+
 class ContainedCoursesSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     courses = serializers.DictField(
         child=serializers.BooleanField(),

--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -6,7 +6,9 @@ import responses
 from django.conf import settings
 from rest_framework.test import APIRequestFactory
 
-from course_discovery.apps.api.serializers import CatalogSerializer, CourseSerializer
+from course_discovery.apps.api.serializers import (
+    CatalogSerializer, CourseSerializer, CourseSerializerExcludingClosedRuns
+)
 
 
 class SerializationMixin(object):
@@ -24,6 +26,9 @@ class SerializationMixin(object):
 
     def serialize_course(self, course, many=False, format=None):
         return self._serialize_object(CourseSerializer, course, many, format)
+
+    def serialize_catalog_course(self, course, many=False, format=None):
+        return self._serialize_object(CourseSerializerExcludingClosedRuns, course, many, format)
 
 
 class OAuth2Mixin(object):

--- a/course_discovery/apps/catalogs/models.py
+++ b/course_discovery/apps/catalogs/models.py
@@ -27,10 +27,11 @@ class Catalog(ModelPermissionsMixin, TimeStampedModel):
         """ Returns the list of courses contained within this catalog.
 
         Returns:
-            Course[]
+            QuerySet
         """
-        results = self._get_query_results().load_all()
-        return [result.object for result in results]
+        results = self._get_query_results()
+        ids = [result.pk for result in results]
+        return Course.objects.filter(pk__in=ids)
 
     @property
     def courses_count(self):

--- a/course_discovery/apps/catalogs/tests/test_models.py
+++ b/course_discovery/apps/catalogs/tests/test_models.py
@@ -24,8 +24,8 @@ class CatalogTests(ElasticsearchTestMixin, TestCase):
         self.assertEqual(str(self.catalog), expected)
 
     def test_courses(self):
-        """ Verify the method returns a list of courses contained in the catalog. """
-        self.assertEqual(self.catalog.courses(), [self.course])
+        """ Verify the method returns a QuerySet of courses contained in the catalog. """
+        self.assertEqual(list(self.catalog.courses()), [self.course])
 
     def test_contains(self):
         """ Verify the method returns a mapping of course IDs to booleans. """

--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -1,0 +1,12 @@
+import datetime
+
+import pytz
+from django.db import models
+
+
+class CourseQuerySet(models.QuerySet):
+    def active(self):
+        """ Filters Courses to those with CourseRuns that are either currently open for enrollment,
+        or will be open for enrollment in the future. """
+
+        return self.filter(course_runs__enrollment_end__gt=datetime.datetime.now(pytz.UTC))

--- a/course_discovery/apps/course_metadata/tests/test_query.py
+++ b/course_discovery/apps/course_metadata/tests/test_query.py
@@ -1,0 +1,21 @@
+import datetime
+
+import pytz
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.models import Course
+from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory
+
+
+class CourseQuerySetTests(TestCase):
+    def test_active(self):
+        """ Verify the method filters the Courses to those with active course runs. """
+        # Create an active course
+        enrollment_end = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=30)
+        active_course = CourseRunFactory(enrollment_end=enrollment_end).course
+
+        # Create an inactive course
+        enrollment_end = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=30)
+        CourseRunFactory(enrollment_end=enrollment_end, course__title='ABC Test Course 2')
+
+        self.assertListEqual(list(Course.objects.active()), [active_course])


### PR DESCRIPTION
The catalog/{id}/courses endpoint only returns courses with with active course runs.

ECOM-4043
