### PR TITLE
Removed pinned version of python-social-auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ clean: clean_static
 	coverage erase
 
 requirements:
-	pip install -qr requirements/local.txt --exists-action w
+	pip install -r requirements/local.txt --exists-action w
 
 production-requirements:
-	pip install -qr requirements.txt --exists-action w
+	pip install -r requirements.txt --exists-action w
 
 test: clean
 	coverage run ./manage.py test course_discovery --settings=course_discovery.settings.test

--- a/course_discovery/apps/core/models.py
+++ b/course_discovery/apps/core/models.py
@@ -16,10 +16,12 @@ class User(GuardianUserMixin, AbstractUser):
 
         Assumes user has authenticated at least once with edX Open ID Connect.
         """
-        try:
-            return self.social_auth.first().extra_data[u'access_token']  # pylint: disable=no-member
-        except Exception:  # pylint: disable=broad-except
-            return None
+        social_auth = self.social_auth.first()  # pylint: disable=no-member
+
+        if social_auth:
+            return social_auth.access_token
+
+        return None
 
     class Meta(object):  # pylint:disable=missing-docstring
         get_latest_by = 'date_joined'

--- a/course_discovery/apps/core/tests/test_models.py
+++ b/course_discovery/apps/core/tests/test_models.py
@@ -1,42 +1,46 @@
 """ Tests for core models. """
 
 from django.test import TestCase
-from django_dynamic_fixture import G
 from social.apps.django_app.default.models import UserSocialAuth
 
-from course_discovery.apps.core.models import User, Currency
+from course_discovery.apps.core.models import Currency
+from course_discovery.apps.core.tests.factories import UserFactory
 
 
-# pylint: disable=no-member
 class UserTests(TestCase):
     """ User model tests. """
-    TEST_CONTEXT = {'foo': 'bar', 'baz': None}
+
+    def setUp(self):
+        super(UserTests, self).setUp()
+        self.user = UserFactory()
+
+    def test_access_token_without_social_auth(self):
+        """ Verify the property returns None if the user is not associated with a UserSocialAuth. """
+        self.assertIsNone(self.user.access_token)
 
     def test_access_token(self):
-        user = G(User)
-        self.assertIsNone(user.access_token)
+        """ Verify the property returns the value of the access_token stored with the UserSocialAuth. """
+        social_auth = UserSocialAuth.objects.create(user=self.user, provider='test', uid=self.user.username)
+        self.assertIsNone(self.user.access_token)
 
-        social_auth = G(UserSocialAuth, user=user)
-        self.assertIsNone(user.access_token)
-
-        access_token = u'My voice is my passport. Verify me.'
-        social_auth.extra_data[u'access_token'] = access_token
+        access_token = 'My voice is my passport. Verify me.'
+        social_auth.extra_data.update({'access_token': access_token})
         social_auth.save()
-        self.assertEqual(user.access_token, access_token)
+        self.assertEqual(self.user.access_token, access_token)
 
     def test_get_full_name(self):
         """ Test that the user model concatenates first and last name if the full name is not set. """
         full_name = "George Costanza"
-        user = G(User, full_name=full_name)
+        user = UserFactory(full_name=full_name)
         self.assertEqual(user.get_full_name(), full_name)
 
         first_name = "Jerry"
         last_name = "Seinfeld"
-        user = G(User, full_name=None, first_name=first_name, last_name=last_name)
+        user = UserFactory(full_name=None, first_name=first_name, last_name=last_name)
         expected = "{first_name} {last_name}".format(first_name=first_name, last_name=last_name)
         self.assertEqual(user.get_full_name(), expected)
 
-        user = G(User, full_name=full_name, first_name=first_name, last_name=last_name)
+        user = UserFactory(full_name=full_name, first_name=first_name, last_name=last_name)
         self.assertEqual(user.get_full_name(), full_name)
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ djangorestframework==3.3.3
 djangorestframework-jwt==1.7.2
 django-rest-swagger[reST]==0.3.5
 dry-rest-permissions==0.1.6
-edx-auth-backends==0.2.1
+edx-auth-backends==0.2.3
 edx-ccx-keys==0.2.0
 edx-drf-extensions==0.5.0
 edx-opaque-keys==0.3.0
@@ -19,5 +19,4 @@ elasticsearch>=1.0.0,<2.0.0
 html2text==2016.4.2
 pycountry==1.20
 python-dateutil==2.5.2
-python-social-auth==0.2.14
 pytz==2015.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,6 @@
 
 coverage==4.0.2
 ddt==1.0.1
-django-dynamic-fixture==1.8.5
 django-nose==1.4.2
 edx-lint==0.5.0
 factory-boy==2.6.0


### PR DESCRIPTION
Any version after 0.2.18 should work. Also, removed the quiet flag from the calls to pip install.
