### PR TITLE
Include courses with no end date in active course runs.

### DIFF
--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytz
 from django.db import models
+from django.db.models.query_utils import Q
 
 
 class CourseQuerySet(models.QuerySet):
@@ -9,4 +10,7 @@ class CourseQuerySet(models.QuerySet):
         """ Filters Courses to those with CourseRuns that are either currently open for enrollment,
         or will be open for enrollment in the future. """
 
-        return self.filter(course_runs__enrollment_end__gt=datetime.datetime.now(pytz.UTC))
+        return self.filter(
+            Q(course_runs__enrollment_end__gt=datetime.datetime.now(pytz.UTC)) |
+            Q(course_runs__enrollment_end__isnull=True)
+        )

--- a/course_discovery/apps/course_metadata/tests/test_query.py
+++ b/course_discovery/apps/course_metadata/tests/test_query.py
@@ -8,6 +8,7 @@ from course_discovery.apps.course_metadata.tests.factories import CourseRunFacto
 
 
 class CourseQuerySetTests(TestCase):
+
     def test_active(self):
         """ Verify the method filters the Courses to those with active course runs. """
         # Create an active course
@@ -18,4 +19,7 @@ class CourseQuerySetTests(TestCase):
         enrollment_end = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=30)
         CourseRunFactory(enrollment_end=enrollment_end, course__title='ABC Test Course 2')
 
-        self.assertListEqual(list(Course.objects.active()), [active_course])
+        # Create a course with unrestricted enrollment
+        course_without_end = CourseRunFactory(enrollment_end=None).course
+
+        self.assertEqual(set(Course.objects.active()), {active_course, course_without_end})


### PR DESCRIPTION
@clintonb @bderusha An enrollment end date of `None` is treated as active in LMS, so we should do the same in course discovery.
