### PR TITLE
Validating SSL certificates when connecting to Elasticsearch

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -305,6 +305,9 @@ HAYSTACK_CONNECTIONS = {
         'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
         'URL': ELASTICSEARCH_URL,
         'INDEX_NAME': ELASTICSEARCH_INDEX_NAME,
+        'KWARGS': {
+            'verify_certs': True,
+        },
     },
 }
 


### PR DESCRIPTION
This update resolves the SSL warnings by instructing the Elasticsearch client to validate SSL certificates.

ECOM-4230
