### PR TITLE
Replaced python-memcached with pylibmc

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,5 +5,5 @@ gevent==1.1.1
 gunicorn==19.4.5
 mysqlclient==1.3.7
 newrelic==2.64.0.48
-python-memcached==1.57
+pylibmc==1.5.1
 PyYAML==3.11


### PR DESCRIPTION
python-memcached doesn't work consistently with Python 3.5.

ECOM-4370
