### PR TITLE
Updated catalog viewer creation logic

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1,7 +1,6 @@
 from urllib.parse import urlencode
 
 from django.contrib.auth import get_user_model
-from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
@@ -96,27 +95,10 @@ class CatalogSerializer(serializers.ModelSerializer):
                                            allow_null=True, allow_empty=True, required=False,
                                            help_text=_('Usernames of users with explicit access to view this catalog'))
 
-    def is_valid(self, **kwargs):
-        # Ensure that the catalog's viewers actually exist in the
-        # DB. We keep this in a transaction so that users are only
-        # created if the data is valid.
-        sid = transaction.savepoint()
-        for username in self.initial_data.get('viewers', ()):  # pylint: disable=no-member
-            User.objects.get_or_create(username=username)
-        if super().is_valid(**kwargs):
-            # Data is good; commit the transaction.
-            transaction.savepoint_commit(sid)
-            return True
-        else:
-            # Invalid data; roll back the user creation.
-            transaction.savepoint_rollback(sid)
-            return False
-
     def create(self, validated_data):
-        viewers = set()
-        for username in validated_data.pop('viewers'):
-            user = User.objects.get(username=username)
-            viewers.add(user)
+        viewers = validated_data.pop('viewers')
+        viewers = User.objects.filter(username__in=viewers)
+
         # Set viewers after the model has been saved
         instance = super(CatalogSerializer, self).create(validated_data)
         instance.viewers = viewers

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -39,21 +39,6 @@ class CatalogSerializerTests(TestCase):
         }
         self.assertDictEqual(serializer.data, expected)
 
-    def test_create_new_user(self):
-        username = 'test-user'
-        data = {
-            'viewers': [username],
-            'id': None,
-            'name': 'test new catalog',
-            'query': '*',
-        }
-        self.assertEqual(User.objects.filter(username=username).count(), 0)  # pylint: disable=no-member
-        serializer = CatalogSerializer(data=data)
-        self.assertTrue(serializer.is_valid())
-        catalog = serializer.save()
-        self.assertEqual([viewer.username for viewer in catalog.viewers], [username])
-        self.assertEqual(User.objects.filter(username=username).count(), 1)  # pylint: disable=no-member
-
     def test_invalid_data_user_create(self):
         """Verify that users are not created if the serializer data is invalid."""
         username = 'test-user'


### PR DESCRIPTION
The logic for creating viewers has been moved to the view. This allows us to correct the data passed to the serializer when the viewers field is set to a comma-delimited list (e.g. for Swagger).

 ECOM-4489
