### PR TITLE
Update acceptance tests to verify affiliate cookie domain.

### DIFF
--- a/acceptance_tests/affiliate_cookie_tests.py
+++ b/acceptance_tests/affiliate_cookie_tests.py
@@ -6,7 +6,8 @@ from unittest import TestCase
 from selenium import webdriver
 
 from acceptance_tests.config import (
-    BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, ECOMMERCE_URL_ROOT, MARKETING_SITE_URL_ROOT, LMS_URL_ROOT
+    AFFILIATE_COOKIE_NAME, BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, COOKIE_DOMAIN, ECOMMERCE_URL_ROOT,
+    LMS_URL_ROOT, MARKETING_SITE_URL_ROOT
 )
 
 
@@ -30,12 +31,13 @@ class AffiliateCookieTestMixin(object):
     which will be used to test cookie tracking.
     """
 
-    cookie_name = "affiliate_id"
     cookie_value = "test_partner"
 
     def setUp(self):
         super().setUp()
         self.browser = webdriver.Firefox()
+        self.cookie_name = AFFILIATE_COOKIE_NAME
+        self.cookie_domain = COOKIE_DOMAIN
 
     def tearDown(self):
         super().tearDown()
@@ -56,6 +58,7 @@ class AffiliateCookieTestMixin(object):
         cookie = self.browser.get_cookie(self.cookie_name)
         self.assertIsNotNone(cookie)
         self.assertEqual(cookie['value'], self.cookie_value)
+        self.assertEqual(cookie['domain'], self.cookie_domain)
 
     def test_with_query_wrong_medium(self):
         """Verify that requests without utm_medium=affiliate_partner do not get a cookie."""

--- a/acceptance_tests/config.py
+++ b/acceptance_tests/config.py
@@ -18,3 +18,6 @@ ECOMMERCE_URL_ROOT = os.environ.get('ECOMMERCE_URL_ROOT', 'https://ecommerce.sta
 
 BASIC_AUTH_USERNAME = os.environ.get('BASIC_AUTH_USERNAME', '')
 BASIC_AUTH_PASSWORD = os.environ.get('BASIC_AUTH_PASSWORD', '')
+
+AFFILIATE_COOKIE_NAME = os.environ.get('AFFILIATE_COOKIE_NAME', 'affiliate_id')
+COOKIE_DOMAIN = os.environ.get('COOKIE_DOMAIN', '.edx.org')


### PR DESCRIPTION
# [ECOM-4329](https://openedx.atlassian.net/browse/ECOM-4356)

@bderusha @clintonb I've updated the acceptance tests to verify the affiliate cookie's domain. The GTM changes are now live on stage and prod, and these tests are passing.
