### PR TITLE
Add marketing_url to course runs.

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders.py
+++ b/course_discovery/apps/course_metadata/data_loaders.py
@@ -298,7 +298,6 @@ class DrupalApiDataLoader(AbstractDataLoader):
 
         course.full_description = self.clean_html(body['description'])
         course.short_description = self.clean_html(body['subtitle'])
-        course.marketing_url = urljoin(settings.MARKETING_URL_ROOT, body['course_about_uri'])
 
         level_type, __ = LevelType.objects.get_or_create(name=body['level']['title'])
         course.level_type = level_type
@@ -347,6 +346,7 @@ class DrupalApiDataLoader(AbstractDataLoader):
             return None
         course_run.language = self.get_language_tag(body)
         course_run.course = course
+        course_run.marketing_url = urljoin(settings.MARKETING_URL_ROOT, body['course_about_uri'])
 
         self.set_staff(course_run, body)
 

--- a/course_discovery/apps/course_metadata/migrations/0003_auto_20160523_1422.py
+++ b/course_discovery/apps/course_metadata/migrations/0003_auto_20160523_1422.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_metadata', '0002_auto_20160406_1644'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courserun',
+            name='marketing_url',
+            field=models.URLField(max_length=255, blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='historicalcourserun',
+            name='marketing_url',
+            field=models.URLField(max_length=255, blank=True, null=True),
+        ),
+    ]

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -222,6 +222,7 @@ class CourseRun(TimeStampedModel):
     syllabus = models.ForeignKey(SyllabusItem, default=None, null=True, blank=True)
     image = models.ForeignKey(Image, default=None, null=True, blank=True)
     video = models.ForeignKey(Video, default=None, null=True, blank=True)
+    marketing_url = models.URLField(max_length=255, null=True, blank=True)
 
     history = HistoricalRecords()
 

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -112,6 +112,7 @@ class CourseRunFactory(factory.DjangoModelFactory):
     min_effort = FuzzyInteger(1, 10)
     max_effort = FuzzyInteger(10, 20)
     pacing_type = FuzzyChoice([name for name, __ in CourseRun.PACING_CHOICES])
+    marketing_url = FuzzyText(prefix='https://example.com/test-course-url')
 
     class Meta:
         model = CourseRun

--- a/course_discovery/apps/course_metadata/tests/test_data_loaders.py
+++ b/course_discovery/apps/course_metadata/tests/test_data_loaders.py
@@ -2,7 +2,7 @@
 import datetime
 import json
 from decimal import Decimal
-from urllib.parse import parse_qs, urlparse, urljoin
+from urllib.parse import parse_qs, urlparse
 
 import ddt
 import responses
@@ -612,7 +612,6 @@ class DrupalApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         self.assertEqual(course.title, body['title'])
         self.assertEqual(course.full_description, self.loader.clean_html(body['description']))
         self.assertEqual(course.short_description, self.loader.clean_html(body['subtitle']))
-        self.assertEqual(course.marketing_url, urljoin(settings.MARKETING_URL_ROOT, body['course_about_uri']))
         self.assertEqual(course.level_type.name, body['level']['title'])
 
         self.assert_subjects_loaded(course, body)


### PR DESCRIPTION
# [ECOM-4265](https://openedx.atlassian.net/browse/ECOM-4265)

@clintonb @bderusha I haven't removed `marketing_url` from the `Course` object yet, since it's live in our API right now so it seems best to leave it in. Much of the diff here is just fixing up tests; the real code change is fairly small.
