### PR TITLE
Resolved language warnings

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders.py
+++ b/course_discovery/apps/course_metadata/data_loaders.py
@@ -371,6 +371,12 @@ class DrupalApiDataLoader(AbstractDataLoader):
         iso_code = body['current_language']
         if iso_code is None:
             return None
+
+        # NOTE (CCB): Default to U.S. English for edx.org to avoid spewing
+        # unnecessary warnings.
+        if iso_code == 'en':
+            iso_code = 'en-us'
+
         try:
             return LanguageTag.objects.get(code=iso_code)
         except LanguageTag.DoesNotExist:

--- a/course_discovery/apps/course_metadata/tests/test_data_loaders.py
+++ b/course_discovery/apps/course_metadata/tests/test_data_loaders.py
@@ -26,10 +26,11 @@ from course_discovery.apps.course_metadata.tests.factories import (
 ACCESS_TOKEN = 'secret'
 ACCESS_TOKEN_TYPE = 'Bearer'
 COURSES_API_URL = 'https://lms.example.com/api/courses/v1'
-ORGANIZATIONS_API_URL = 'https://lms.example.com/api/organizations/v0'
-MARKETING_API_URL = 'https://example.com/api/catalog/v2/'
 ECOMMERCE_API_URL = 'https://ecommerce.example.com/api/v2'
+ENGLISH_LANGUAGE_TAG = LanguageTag(code='en-us', name='English - United States')
 JSON = 'application/json'
+MARKETING_API_URL = 'https://example.com/api/catalog/v2/'
+ORGANIZATIONS_API_URL = 'https://lms.example.com/api/organizations/v0'
 
 
 class AbstractDataLoaderTest(TestCase):
@@ -681,7 +682,8 @@ class DrupalApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     @ddt.data(
         ({'current_language': ''}, None),
         ({'current_language': 'not-real'}, None),
-        ({'current_language': 'en-us'}, LanguageTag(code='en-us', name='English - United States')),
+        ({'current_language': 'en-us'}, ENGLISH_LANGUAGE_TAG),
+        ({'current_language': 'en'}, ENGLISH_LANGUAGE_TAG),
         ({'current_language': None}, None),
     )
     @ddt.unpack


### PR DESCRIPTION
Defaulting to en-us when loading courses from Drupal with the en language. This resolves the proliferation of warnings we see when running the data loaders.
