### PR TITLE
Improve developer setup docs

### DIFF
--- a/docs/course_metadata.rst
+++ b/docs/course_metadata.rst
@@ -22,6 +22,12 @@ The ``refresh_course_metadata`` command in :file:`course_discovery/apps/course_m
 loaders should be idempotent -- that is, running this command once will populate the database, and if nothing has
 changed upstream then running it again should not change the database.
 
+For example, if you use the JWT access token "secret-ecommerce-key" to authenticate API calls, run the following:
+
+.. code-block:: bash
+
+    $ ./manage.py refresh_course_metadata --access_token secret-ecommerce-key --token_type jwt
+
 QuerySets
 ---------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,6 +6,14 @@ below is executed within the virtualenv.
 
 .. _virtualenv: https://virtualenvwrapper.readthedocs.org/en/latest/
 
+.. note:: Installing virtualenvwrapper with pip on OS X El Capitan may result
+   in a strange OSError due to `a compatibility issue with the six package
+   <https://github.com/pypa/pip/issues/3165>`_. In this case, instruct pip to
+   ignore six:
+
+   .. code-block:: bash
+
+       $ pip install virtualenvwrapper --upgrade --ignore-installed six
 
 Install dependencies
 --------------------
@@ -47,7 +55,7 @@ A new OAuth 2.0 client can be created at ``http://127.0.0.1:8000/admin/oauth2/cl
     8. Click :guilabel:`Save`.
 
 Now that you have the client credentials, you can update your settings (ideally in
-:file:`course_discovery/settings/local.py`). The table below describes the relevant settings.
+:file:`course_discovery/settings/private.py`). The table below describes the relevant settings.
 
 +-----------------------------------------------------+----------------------------------------------------------------------------+--------------------------------------------------------------------------+
 | Setting                                             | Description                                                                | Value                                                                    |

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -22,4 +22,4 @@ prevents us from using it in this repository. Were you to use `httpretty`, you w
 mock an OAuth2 endpoint, `httpretty` blocks requests to Elasticsearch, leading to test failures.
 
 Given our extensive use of Elasticsearch, and need to mock HTTP endpoints, we use the
-`responses <https://github.com/getsentry/responses>`_ library. It's API is practically the same as that of `httpretty.
+`responses <https://github.com/getsentry/responses>`_ library. Its API is practically the same as that of `httpretty.


### PR DESCRIPTION
Addresses an issue where pip refuses to install virtualenvwrapper on OS X El Capitan, provides an example of how to run the `refresh_course_metadata` command, and fixes minor typos. 
