### PR TITLE
Add simple program model

### DIFF
--- a/course_discovery/apps/course_metadata/migrations/0004_program.py
+++ b/course_discovery/apps/course_metadata/migrations/0004_program.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django_extensions.db.fields
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_metadata', '0003_auto_20160523_1422'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Program',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
+                ('created', django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, verbose_name='created')),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(verbose_name='modified', auto_now=True)),
+                ('uuid', models.UUIDField(unique=True, default=uuid.uuid4, blank=True, editable=False)),
+                ('name', models.CharField(max_length=255, help_text='The user-facing display name for this Program.', unique=True)),
+                ('subtitle', models.CharField(help_text='A brief, descriptive subtitle for the Program.', max_length=255, blank=True)),
+                ('category', models.CharField(help_text='The category / type of Program.', max_length=32)),
+                ('status', models.CharField(help_text='The lifecycle status of this Program.', max_length=24)),
+                ('marketing_slug', models.CharField(help_text='Slug used to generate links to the marketing site', max_length=255, blank=True)),
+                ('organizations', models.ManyToManyField(to='course_metadata.Organization', blank=True)),
+            ],
+            options={
+                'ordering': ('-modified', '-created'),
+                'abstract': False,
+                'get_latest_by': 'modified',
+            },
+        ),
+    ]

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from uuid import uuid4
 
 import pytz
 from django.db import models
@@ -380,3 +381,48 @@ class CourseOrganization(TimeStampedModel):
         unique_together = (
             ('course', 'organization', 'relation_type'),
         )
+
+
+class Program(TimeStampedModel):
+    """
+    Representation of a Program.
+    """
+    uuid = models.UUIDField(
+        blank=True,
+        default=uuid4,
+        editable=False,
+        unique=True,
+    )
+
+    name = models.CharField(
+        help_text=_('The user-facing display name for this Program.'),
+        max_length=255,
+        unique=True,
+    )
+
+    subtitle = models.CharField(
+        help_text=_('A brief, descriptive subtitle for the Program.'),
+        max_length=255,
+        blank=True,
+    )
+
+    category = models.CharField(
+        help_text=_('The category / type of Program.'),
+        max_length=32,
+    )
+
+    status = models.CharField(
+        help_text=_('The lifecycle status of this Program.'),
+        max_length=24,
+    )
+
+    marketing_slug = models.CharField(
+        help_text=_('Slug used to generate links to the marketing site'),
+        blank=True,
+        max_length=255
+    )
+
+    organizations = models.ManyToManyField(Organization, blank=True)
+
+    def __str__(self):
+        return self.name

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -9,7 +9,7 @@ from pytz import UTC
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.core.models import Currency
 from course_discovery.apps.course_metadata.models import(
-    Course, CourseRun, Organization, Person, Image, Video, Subject, Seat, Prerequisite, LevelType
+    Course, CourseRun, Organization, Person, Image, Video, Subject, Seat, Prerequisite, LevelType, Program
 )
 
 
@@ -138,3 +138,15 @@ class PersonFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = Person
+
+
+class ProgramFactory(factory.django.DjangoModelFactory):
+    class Meta(object):
+        model = Program
+
+    name = factory.Sequence(lambda n: 'test-program-{}'.format(n))  # pylint: disable=unnecessary-lambda
+    uuid = factory.Sequence(lambda n: n)
+    subtitle = 'test-subtitle'
+    category = 'xseries'
+    status = 'unpublished'
+    marketing_slug = factory.Sequence(lambda n: 'test-slug-{}'.format(n))  # pylint: disable=unnecessary-lambda

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -235,3 +235,14 @@ class AbstractValueModelTests(TestCase):
         value = 'abc'
         instance = TestAbstractValueModel(value=value)
         self.assertEqual(str(instance), value)
+
+
+class ProgramTests(TestCase):
+    """Tests of the Program model."""
+
+    def test_str(self):
+        """Verify that a program is properly converted to a str."""
+        program = factories.ProgramFactory()
+        program_str = program.name
+
+        self.assertEqual(str(program), program_str)


### PR DESCRIPTION
This PR includes only the program model so that it can be indexed in search and unblock downstream work.

We are actively working with product on program use cases current and upcoming that we need to consider in our data model.

@rlucioni please review
