### PR TITLE
Renamed the Program name field to title

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -45,7 +45,7 @@ COURSE_RUN_SEARCH_FIELDS = (
 )
 
 PROGRAM_SEARCH_FIELDS = (
-    'uuid', 'name', 'subtitle', 'category', 'marketing_url', 'organizations', 'content_type', 'text',
+    'uuid', 'title', 'subtitle', 'category', 'marketing_url', 'organizations', 'content_type', 'text',
 )
 
 
@@ -257,7 +257,7 @@ class ContainedCoursesSerializer(serializers.Serializer):
 class ProgramSerializer(serializers.ModelSerializer):
     class Meta:
         model = Program
-        fields = ('uuid', 'name', 'subtitle', 'category', 'marketing_slug', 'marketing_url',)
+        fields = ('uuid', 'title', 'subtitle', 'category', 'marketing_slug', 'marketing_url',)
         read_only_fields = ('uuid', 'marketing_url',)
 
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -174,7 +174,7 @@ class ProgramSerializerTests(TestCase):
 
         expected = {
             'uuid': str(program.uuid),
-            'name': program.name,
+            'title': program.title,
             'subtitle': program.subtitle,
             'category': program.category,
             'marketing_slug': program.marketing_slug,
@@ -392,7 +392,7 @@ class ProgramSearchSerializerTests(TestCase):
 
         expected = {
             'uuid': str(program.uuid),
-            'name': program.name,
+            'title': program.title,
             'subtitle': program.subtitle,
             'category': program.category,
             'marketing_url': program.marketing_url,

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -34,9 +34,9 @@ class CourseRunAdmin(admin.ModelAdmin):
 
 @admin.register(Program)
 class ProgramAdmin(admin.ModelAdmin):
-    list_display = ('uuid', 'name',)
-    ordering = ('uuid', 'name',)
-    search_fields = ('uuid', 'name', 'marketing_slug')
+    list_display = ('uuid', 'title',)
+    ordering = ('uuid', 'title',)
+    search_fields = ('uuid', 'title', 'marketing_slug')
 
 
 class KeyNameAdmin(admin.ModelAdmin):

--- a/course_discovery/apps/course_metadata/data_loaders.py
+++ b/course_discovery/apps/course_metadata/data_loaders.py
@@ -518,7 +518,7 @@ class ProgramsApiDataLoader(AbstractDataLoader):
 
     def update_program(self, body):
         defaults = {
-            'name': body['name'],
+            'title': body['name'],
             'subtitle': body['subtitle'],
             'category': body['category'],
             'status': body['status'],

--- a/course_discovery/apps/course_metadata/migrations/0006_auto_20160719_2052.py
+++ b/course_discovery/apps/course_metadata/migrations/0006_auto_20160719_2052.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('course_metadata', '0005_auto_20160713_0113'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='program',
+            old_name='name',
+            new_name='title'
+        ),
+        migrations.AlterField(
+            model_name='program',
+            name='title',
+            field=models.CharField(unique=True, help_text='The user-facing display title for this Program.',
+                                   max_length=255),
+        ),
+    ]

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -397,8 +397,8 @@ class Program(TimeStampedModel):
         verbose_name=_('UUID')
     )
 
-    name = models.CharField(
-        help_text=_('The user-facing display name for this Program.'),
+    title = models.CharField(
+        help_text=_('The user-facing display title for this Program.'),
         max_length=255,
         unique=True,
     )
@@ -436,4 +436,4 @@ class Program(TimeStampedModel):
         return None
 
     def __str__(self):
-        return self.name
+        return self.title

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -108,7 +108,7 @@ class ProgramIndex(OrganizationsMixin, BaseIndex, indexes.Indexable):
     model = Program
 
     uuid = indexes.CharField(model_attr='uuid')
-    name = indexes.CharField(model_attr='name')
+    title = indexes.CharField(model_attr='title')
     subtitle = indexes.CharField(model_attr='subtitle')
     category = indexes.CharField(model_attr='category', faceted=True)
     marketing_url = indexes.CharField(model_attr='marketing_url', null=True)

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -142,7 +142,7 @@ class ProgramFactory(factory.django.DjangoModelFactory):
     class Meta(object):
         model = Program
 
-    name = factory.Sequence(lambda n: 'test-program-{}'.format(n))  # pylint: disable=unnecessary-lambda
+    title = factory.Sequence(lambda n: 'test-program-{}'.format(n))  # pylint: disable=unnecessary-lambda
     uuid = factory.LazyFunction(uuid4)
     subtitle = 'test-subtitle'
     category = 'xseries'

--- a/course_discovery/apps/course_metadata/tests/test_data_loaders.py
+++ b/course_discovery/apps/course_metadata/tests/test_data_loaders.py
@@ -1158,7 +1158,8 @@ class ProgramsApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         """ Assert a Program corresponding to the specified data body was properly loaded into the database. """
         program = Program.objects.get(uuid=AbstractDataLoader.clean_string(body['uuid']))
 
-        for attr in ('name', 'subtitle', 'category', 'status', 'marketing_slug',):
+        self.assertEqual(program.title, body['name'])
+        for attr in ('subtitle', 'category', 'status', 'marketing_slug',):
             self.assertEqual(getattr(program, attr), AbstractDataLoader.clean_string(body[attr]))
 
         keys = [org['key'] for org in body['organizations']]

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -244,7 +244,7 @@ class ProgramTests(TestCase):
     def test_str(self):
         """Verify that a program is properly converted to a str."""
         program = factories.ProgramFactory()
-        self.assertEqual(str(program), program.name)
+        self.assertEqual(str(program), program.title)
 
     def test_marketing_url(self):
         """ Verify the property creates a complete marketing URL. """


### PR DESCRIPTION
This is more inline with how we handle courses and course runs.

Note that usage of programs will be temporarily broken between the time it takes to run the migrations and deploy the code. This is acceptable since programs are not yet being used in production.
