### PR TITLE
Removed the installation of JS requirements from the requirements make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ requirement.js:
 	npm install
 	$(NODE_BIN)/bower install
 
-requirements: requirement.js
+requirements:
 	pip install -r requirements/local.txt --exists-action w
 
 production-requirements:


### PR DESCRIPTION
The JS requirements need a configuration change that will be made later. This reverts a portion of #164.
