### PR TITLE
Updated django-sortedm2m version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ django-guardian==1.4.4
 django-haystack==2.4.1
 django-libsass==0.7
 django-simple-history==1.8.1
-django-sortedm2m==1.3.0
+django-sortedm2m==1.3.2
 django-waffle==0.11.1
 djangorestframework==3.3.3
 djangorestframework-csv==1.4.1


### PR DESCRIPTION
Updated django-sortedm2m version to fix `'NoneType' object is not iterable`, check following issue for more info: 
1. https://github.com/gregmuellegger/django-sortedm2m/issues/80
2. https://github.com/gregmuellegger/django-sortedm2m/pull/83.
