### PR TITLE
Removed partner clause in data loader query

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders.py
+++ b/course_discovery/apps/course_metadata/data_loaders.py
@@ -209,7 +209,8 @@ class CoursesApiDataLoader(AbstractDataLoader):
         # which may not be unique for an organization.
         course_run_key_str = body['id']
         course_run_key = CourseKey.from_string(course_run_key_str)
-        organization, __ = Organization.objects.get_or_create(key=course_run_key.org, partner=self.partner)
+        organization, __ = Organization.objects.get_or_create(key=course_run_key.org,
+                                                              defaults={'partner': self.partner})
         course_key = self.convert_course_run_key(course_run_key_str)
         defaults = {
             'title': body['name'],


### PR DESCRIPTION
Reverting this as it is causing issues with our deployment. This should be restored once we have (a) a migration plan for existing data and (b) a rollout plan.

ECOM-5086
