### PR TITLE
update docs to use port 8183 for the discovery API endpoint

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -48,8 +48,8 @@ A new OAuth 2.0 client can be created at ``http://127.0.0.1:8000/admin/oauth2/cl
     1. Click the :guilabel:`Add client` button.
     2. Leave the user field blank.
     3. Specify the name of this service, ``Course Discovery Service``, as the client name.
-    4. Set the :guilabel:`URL` to the root path of this service: ``http://localhost:8003/``.
-    5. Set the :guilabel:`Redirect URL` to the OIDC client endpoint: ``http://localhost:8003/complete/edx-oidc/``.
+    4. Set the :guilabel:`URL` to the root path of this service: ``http://localhost:18381/``.
+    5. Set the :guilabel:`Redirect URL` to the OIDC client endpoint: ``http://localhost:18381/complete/edx-oidc/``.
     6. Copy the :guilabel:`Client ID` and :guilabel:`Client Secret` values. They will be used later.
     7. Select :guilabel:`Confidential (Web applications)` as the client type.
     8. Click :guilabel:`Save`.


### PR DESCRIPTION
The gunicorn port is 8183, not 8003.  In fact, 8003 is even bound by devstack
which claims it to be "LMS for Bok Choy".
