### PR TITLE
Wrap ES search query in parens to perserve semantics

### DIFF
--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -13,6 +13,10 @@ def clean_query(query):
     # Ensure the query is lowercase, since that is how we index our data.
     query = query.lower()
 
+    # Specifying a SearchQuerySet filter will append an explicit AND clause to the query, thus changing its semantics.
+    # So we wrap parentheses around the original query in order to preserve the semantics.
+    query = '({qs})'.format(qs=query)
+
     # Ensure all operators are uppercase
     for operator in RESERVED_ELASTICSEARCH_QUERY_OPERATORS:
         old = ' {0} '.format(operator.lower())


### PR DESCRIPTION
Add parens around query so the addition of the partner filter does not change the query semantics. 
