### PR TITLE
Updated edx-django-release-util to 0.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ drf-haystack==1.6.0rc1
 dry-rest-permissions==0.1.6
 edx-auth-backends==0.5.0
 edx-ccx-keys==0.2.0
-edx-django-release-util==0.0.3
+edx-django-release-util==0.1.0
 edx-drf-extensions==1.1.1
 edx-opaque-keys==0.3.1
 edx-rest-api-client==1.6.0


### PR DESCRIPTION
This version is compatible with Python 3.5.

ECOM-5134
