### PR TITLE
ECOM-5126 create the course-discovery setup for storage backend

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -43,6 +43,7 @@ THIRD_PARTY_APPS = [
     'compressor',
     'django_filters',
     'django_fsm',
+    'storages',
 ]
 
 PROJECT_APPS = [

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -19,6 +19,9 @@ LOGGING['handlers']['local']['level'] = 'INFO'
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ('JWT_AUTH',)
 
+# This may be overridden by the YAML in PROGRAMS_CFG, but it should be here as a default.
+MEDIA_STORAGE_BACKEND = {}
+
 CONFIG_FILE = get_env_setting('COURSE_DISCOVERY_CFG')
 with open(CONFIG_FILE) as f:
     config_from_yaml = yaml.load(f)
@@ -32,6 +35,11 @@ with open(CONFIG_FILE) as f:
             vars()[key].update(value)
 
     vars().update(config_from_yaml)
+
+    # Unpack media storage settings.
+    # It's important we unpack here because of https://github.com/edx/configuration/pull/3307
+    vars().update(MEDIA_STORAGE_BACKEND)
+
 
 if 'EXTRA_APPS' in locals():
     INSTALLED_APPS += EXTRA_APPS

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+boto==2.42.0
 cryptography==1.4
 django==1.8.14
 django-choices==1.4.3
@@ -10,6 +11,7 @@ django-haystack==2.4.1
 django-libsass==0.7
 django-simple-history==1.8.1
 django-sortedm2m==1.3.2
+django-storages==1.5.0
 django-waffle==0.11.1
 djangorestframework==3.3.3
 djangorestframework-csv==1.4.1
@@ -26,6 +28,7 @@ edx-opaque-keys==0.3.1
 edx-rest-api-client==1.6.0
 elasticsearch>=1.0.0,<2.0.0
 html2text==2016.5.29
+pillow==3.3.0
 pycountry==1.20
 python-dateutil==2.5.3
 pytz==2016.4


### PR DESCRIPTION
@clintonb @rlucioni @e0d Please review

This change is to work with https://github.com/edx/configuration/pull/3307 to incorporate django-storage into this IDA
