### PR TITLE
Corrected docs settings

### DIFF
--- a/course_discovery/settings/docs_settings.py
+++ b/course_discovery/settings/docs_settings.py
@@ -25,3 +25,7 @@ HAYSTACK_CONNECTIONS = {
         'INDEX_NAME': '',
     }
 }
+
+LOGGING['handlers']['local'] = {
+    'class': 'logging.NullHandler',
+}


### PR DESCRIPTION
Syslog is not necessary to build documentation.
