### PR TITLE
Allow ProgramSearchSerializer to deal with missing organization bodies

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -547,7 +547,7 @@ class ProgramSearchSerializer(HaystackSerializer):
 
     def get_authoring_organizations(self, program):
         organizations = program.organization_bodies
-        return [json.loads(organization) for organization in organizations]
+        return [json.loads(organization) for organization in organizations] if organizations else []
 
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -548,3 +548,23 @@ class ProgramSearchSerializerTests(TestCase):
             'status': program.status,
         }
         self.assertDictEqual(serializer.data, expected)
+
+    def test_organization_bodies_missing(self):
+        program = ProgramFactory()
+
+        result = SearchQuerySet().models(Program).filter(uuid=program.uuid)[0]
+        result.organization_bodies = None
+        serializer = ProgramSearchSerializer(result)
+
+        expected = {
+            'uuid': str(program.uuid),
+            'title': program.title,
+            'subtitle': program.subtitle,
+            'type': program.type.name,
+            'marketing_url': program.marketing_url,
+            'authoring_organizations': [],
+            'content_type': 'program',
+            'card_image_url': program.card_image_url,
+            'status': program.status,
+        }
+        self.assertDictEqual(serializer.data, expected)


### PR DESCRIPTION
@clintonb please review. The scenario this fix addresses only arises if code is deployed before `update_index` is run.
