### PR TITLE
ECOM-5264 Make sure the banner image is stored at the correct path in S3

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -15,13 +15,13 @@ from haystack.query import SearchQuerySet
 from simple_history.models import HistoricalRecords
 from sortedm2m.fields import SortedManyToManyField
 from stdimage.models import StdImageField
-from stdimage.utils import UploadToAutoSlugClassNameDir
 from taggit.managers import TaggableManager
 
 from course_discovery.apps.core.models import Currency, Partner
 from course_discovery.apps.course_metadata.query import CourseQuerySet
 from course_discovery.apps.course_metadata.utils import clean_query
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
+from course_discovery.apps.course_metadata.utils import UploadToFieldNamePath
 
 logger = logging.getLogger(__name__)
 
@@ -587,7 +587,7 @@ class Program(TimeStampedModel):
     max_hours_effort_per_week = models.PositiveSmallIntegerField(null=True, blank=True)
     authoring_organizations = SortedManyToManyField(Organization, blank=True, related_name='authored_programs')
     banner_image = StdImageField(
-        upload_to=UploadToAutoSlugClassNameDir(path='/media/programs/banner_images', populate_from='uuid'),
+        upload_to=UploadToFieldNamePath(populate_from='uuid', path='media/programs/banner_images'),
         blank=True,
         null=True,
         variations={

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -362,7 +362,7 @@ class ProgramTests(TestCase):
     def test_banner_image(self):
         self.program.banner_image = make_image_file('test_banner.jpg')
         self.program.save()
-        image_url_prefix = '{}program/'.format(settings.MEDIA_URL)
+        image_url_prefix = '{}media/programs/banner_images/'.format(settings.MEDIA_URL)
         self.assertIn(image_url_prefix, self.program.banner_image.url)
         for size_key in self.program.banner_image.field.variations:
             # Get different sizes specs from the model field

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -1,0 +1,31 @@
+import os
+
+import ddt
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.tests.factories import ProgramFactory
+from course_discovery.apps.course_metadata import utils
+
+
+@ddt.ddt
+class UploadToFieldNamePathTests(TestCase):
+    """
+    Test the utiltity object 'UploadtoFieldNamePath'
+    """
+    def setUp(self):
+        super(UploadToFieldNamePathTests, self).setUp()
+        self.program = ProgramFactory()
+
+    @ddt.data(
+        ('/media/program', 'uuid', '.jpeg'),
+        ('/media/program', 'title', '.jpeg'),
+        ('/media', 'uuid', '.jpeg'),
+        ('/media', 'title', '.txt'),
+        ('', 'title', ''),
+    )
+    @ddt.unpack
+    def test_upload_to(self, path, field, ext):
+        upload_to = utils.UploadToFieldNamePath(populate_from=field, path=path)
+        upload_path = upload_to(self.program, 'name' + ext)
+        expected = os.path.join(path, str(getattr(self.program, field)) + ext)
+        self.assertEqual(upload_path, expected)

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -1,3 +1,5 @@
+from stdimage.utils import UploadTo
+
 RESERVED_ELASTICSEARCH_QUERY_OPERATORS = ('AND', 'OR', 'NOT', 'TO',)
 
 
@@ -24,3 +26,19 @@ def clean_query(query):
         query = query.replace(old, new)
 
     return query
+
+
+class UploadToFieldNamePath(UploadTo):
+    """
+    This is a utility to create file path for uploads based on instance field value
+    """
+    def __init__(self, populate_from, **kwargs):
+        self.populate_from = populate_from
+        super(UploadToFieldNamePath, self).__init__(populate_from, **kwargs)
+
+    def __call__(self, instance, filename):
+        field_value = getattr(instance, self.populate_from)
+        self.kwargs.update({
+            'name': field_value
+        })
+        return super(UploadToFieldNamePath, self).__call__(instance, filename)


### PR DESCRIPTION
@rlucioni @clintonb Please review
This is to change the path where program banner image is stored.
Currently in stage, the program banner image is stored at `/program/<file_name>`
With this change, we will store the program image at `/media/programs/banner_images/<file_name>`
