### PR TITLE
Update the Swagger doc label for the catalog API

### DIFF
--- a/course_discovery/templates/rest_framework_swagger/index.html
+++ b/course_discovery/templates/rest_framework_swagger/index.html
@@ -9,7 +9,7 @@
 
 
 {% block branding %}
-    <span id="api-name">edX Course Discovery API</span>
+    <span id="api-name">edX Catalog API</span>
 {% endblock %}
 
 {% block api_selector %}


### PR DESCRIPTION
Update the label that's shown at the top of the swagger doc. It is currently "course discovery API," but I understand that the preferred terminology is "catalog API."

@clintonb Based on our conversation, should this label change to "catalog API"?
