### PR TITLE
 Post-merge fixes for Course model and data loader

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                 (partner.marketing_site_url_root, SchoolMarketingSiteDataLoader,),
                 (partner.marketing_site_url_root, SponsorMarketingSiteDataLoader,),
                 (partner.marketing_site_url_root, PersonMarketingSiteDataLoader,),
-                (partner.marketing_site_api_url, CourseMarketingSiteDataLoader,),
+                (partner.marketing_site_url_root, CourseMarketingSiteDataLoader,),
                 (partner.organizations_api_url, OrganizationsApiDataLoader,),
                 (partner.courses_api_url, CoursesApiDataLoader,),
                 (partner.ecommerce_api_url, EcommerceApiDataLoader,),

--- a/course_discovery/apps/course_metadata/migrations/0022_remove_duplicate_courses.py
+++ b/course_discovery/apps/course_metadata/migrations/0022_remove_duplicate_courses.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def remove_duplicate_courses(apps, schema_editor):
+    Course = apps.get_model('course_metadata', 'Course')
+    duplicates = Course.objects.raw('SELECT'
+                                    '   c.* '
+                                    'FROM '
+                                    '  course_metadata_course AS c'
+                                    '  JOIN ('
+                                    '    SELECT'
+                                    '      LOWER(key) AS key,'
+                                    '      COUNT(1)'
+                                    '    FROM'
+                                    '      course_metadata_course'
+                                    '    GROUP BY'
+                                    '      LOWER(key)'
+                                    '    HAVING'
+                                    '      COUNT(1) > 1'
+                                    '  ) AS dupes ON dupes.key = LOWER(c.key)')
+
+    for course in duplicates:
+        course.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('course_metadata', '0021_auto_20160819_2005'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_duplicate_courses, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
This adds an `openedx.yaml` file, as described by OEP-2:
http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html

The data in this file was transformed from the contents of
edx/repo-tools-data:repos.yaml
