### PR TITLE
Updated Program.start for search

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -650,9 +650,15 @@ class Program(TimeStampedModel):
     @property
     def start(self):
         """ Start datetime, calculated by determining the earliest start datetime of all related course runs. """
-        if len(self.course_runs) == 0:
-            return None
-        return min([course_run.start for course_run in self.course_runs])
+        course_runs = self.course_runs
+
+        if course_runs:
+            start_dates = [course_run.start for course_run in self.course_runs if course_run.start]
+
+            if start_dates:
+                return min(start_dates)
+
+        return None
 
     @property
     def staff(self):

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -150,6 +150,7 @@ class ProgramIndex(BaseIndex, indexes.Indexable, OrganizationsMixin):
     card_image_url = indexes.CharField(model_attr='card_image_url', null=True)
     status = indexes.CharField(model_attr='status', faceted=True)
     partner = indexes.CharField(model_attr='partner__short_code', null=True, faceted=True)
+    start = indexes.DateTimeField(model_attr='start', null=True, faceted=True)
 
     def prepare_organizations(self, obj):
         return self.prepare_authoring_organizations(obj) + self.prepare_credit_backing_organizations(obj)


### PR DESCRIPTION
- Fixed bug that occurs if no associated course runs have a start datetime
- Updated tests
- Exposed value in search index so that Programs are returned when faceting for availability

ECOM-5316
