### PR TITLE
Downgrade opaque keys package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ edx-auth-backends==0.5.2
 edx-ccx-keys==0.2.0
 edx-django-release-util==0.1.0
 edx-drf-extensions==1.1.1
-edx-opaque-keys==0.3.2
+edx-opaque-keys==0.3.1
 edx-rest-api-client==1.6.0
 elasticsearch>=1.0.0,<2.0.0
 html2text==2016.5.29


### PR DESCRIPTION
0.3.2 has been removed from PyPI because of a bug.
