### PR TITLE
Added active and marketable filters to CourseRun and Program models

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -281,7 +281,7 @@ class CourseRunWithProgramsSerializer(CourseRunSerializer):
 
     class Meta(CourseRunSerializer.Meta):
         model = CourseRun
-        fields = CourseRunSerializer.Meta.fields + ('programs', )
+        fields = CourseRunSerializer.Meta.fields + ('programs',)
 
 
 class ContainedCourseRunsSerializer(serializers.Serializer):
@@ -323,12 +323,15 @@ class CourseWithProgramsSerializer(CourseSerializer):
 
     class Meta(CourseSerializer.Meta):
         model = Course
-        fields = CourseSerializer.Meta.fields + ('programs', )
+        fields = CourseSerializer.Meta.fields + ('programs',)
 
 
 class CourseSerializerExcludingClosedRuns(CourseSerializer):
     """A ``CourseSerializer`` which only includes active course runs, as determined by ``CourseQuerySet``."""
-    course_runs = CourseRunSerializer(many=True, source='active_course_runs')
+    course_runs = serializers.SerializerMethodField()
+
+    def get_course_runs(self, course):
+        return CourseRunSerializer(course.course_runs.active().marketable(), many=True, context=self.context).data
 
 
 class ContainedCoursesSerializer(serializers.Serializer):

--- a/course_discovery/apps/api/v1/views.py
+++ b/course_discovery/apps/api/v1/views.py
@@ -157,9 +157,7 @@ class CatalogViewSet(viewsets.ModelViewSet):
         course_runs = []
 
         for course in courses:
-            active_course_runs = course.active_course_runs
-            for acr in active_course_runs:
-                course_runs.append(acr)
+            course_runs += list(course.course_runs.active().marketable())
 
         serializer = serializers.FlattenedCourseRunWithCourseSerializer(
             course_runs, many=True, context={'request': request}
@@ -274,6 +272,20 @@ class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):
               type: string
               paramType: query
               multiple: false
+            - name: active
+              description: Retrieve active course runs. A course is considered active if its end date has not passed,
+                and it is open for enrollment.
+              required: false
+              type: integer
+              paramType: query
+              multiple: false
+            - name: marketable
+              description: Retrieve marketable course runs. A course run is considered marketable if it has a
+                marketing slug.
+              required: false
+              type: integer
+              paramType: query
+              multiple: false
         """
         return super(CourseRunViewSet, self).list(request, *args, **kwargs)
 
@@ -335,6 +347,25 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.ProgramSerializer
     filter_backends = (DjangoFilterBackend,)
     filter_class = filters.ProgramFilter
+
+    def list(self, request, *args, **kwargs):
+        """ List all programs.
+        ---
+        parameters:
+            - name: partner
+              description: Filter by partner
+              required: false
+              type: string
+              paramType: query
+              multiple: false
+            - name: marketable
+              description: Retrieve marketable programs. A program is considered marketable if it has a marketing slug.
+              required: false
+              type: integer
+              paramType: query
+              multiple: false
+        """
+        return super(ProgramViewSet, self).list(request, *args, **kwargs)
 
 
 class ManagementViewSet(viewsets.ViewSet):

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -68,7 +68,6 @@ class ProgramAdmin(admin.ModelAdmin):
     list_filter = ('partner', 'type',)
     ordering = ('uuid', 'title', 'status')
     readonly_fields = ('uuid', 'custom_course_runs_display', 'excluded_course_runs',)
-
     search_fields = ('uuid', 'title', 'marketing_slug')
 
     filter_horizontal = ('job_outlook_items', 'expected_learning_items',)

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -18,7 +18,7 @@ from stdimage.models import StdImageField
 from taggit.managers import TaggableManager
 
 from course_discovery.apps.core.models import Currency, Partner
-from course_discovery.apps.course_metadata.query import CourseQuerySet
+from course_discovery.apps.course_metadata.query import CourseQuerySet, CourseRunQuerySet, ProgramQuerySet
 from course_discovery.apps.course_metadata.utils import UploadToFieldNamePath
 from course_discovery.apps.course_metadata.utils import clean_query
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
@@ -358,6 +358,7 @@ class CourseRun(TimeStampedModel):
     slug = models.CharField(max_length=255, blank=True, null=True, db_index=True)
 
     history = HistoricalRecords()
+    objects = CourseRunQuerySet.as_manager()
 
     @property
     def marketing_url(self):
@@ -602,7 +603,8 @@ class Program(TimeStampedModel):
             'large': (1440, 480),
             'medium': (726, 242),
             'small': (435, 145),
-            'x-small': (348, 116)}
+            'x-small': (348, 116),
+        }
     )
     banner_image_url = models.URLField(null=True, blank=True, help_text=_('Image used atop detail pages'))
     card_image_url = models.URLField(null=True, blank=True, help_text=_('Image used for discovery cards'))
@@ -620,6 +622,8 @@ class Program(TimeStampedModel):
         help_text=_('The description of credit redemption for courses in program'),
         blank=True, null=True
     )
+
+    objects = ProgramQuerySet.as_manager()
 
     def __str__(self):
         return self.title

--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -17,3 +17,47 @@ class CourseQuerySet(models.QuerySet):
                 Q(course_runs__enrollment_end__isnull=True)
             )
         )
+
+
+class CourseRunQuerySet(models.QuerySet):
+    def active(self):
+        """ Returns CourseRuns that have not yet ended and meet the following enrollment criteria:
+            - Open for enrollment
+            - OR will be open for enrollment in the future
+            - OR have no specified enrollment close date (e.g. self-paced courses)
+
+        Returns:
+            QuerySet
+        """
+        now = datetime.datetime.now(pytz.UTC)
+        return self.filter(
+            Q(end__gt=now) &
+            (
+                Q(enrollment_end__gt=now) |
+                Q(enrollment_end__isnull=True)
+            )
+        )
+
+    def marketable(self):
+        """ Returns CourseRuns that can be marketed to learners.
+
+         A CourseRun is considered marketable if it has a defined slug.
+
+         Returns:
+            QuerySet
+         """
+
+        return self.exclude(slug__isnull=True).exclude(slug='')
+
+
+class ProgramQuerySet(models.QuerySet):
+    def marketable(self):
+        """ Returns Programs that can be marketed to learners.
+
+         A Program is considered marketable if it has a defined marketing slug.
+
+         Returns:
+            QuerySet
+         """
+
+        return self.exclude(marketing_slug__isnull=True).exclude(marketing_slug='')

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -1,9 +1,7 @@
-import datetime
 import itertools
 from decimal import Decimal
 
 import ddt
-import pytz
 from dateutil.parser import parse
 from django.conf import settings
 from django.db import IntegrityError
@@ -36,31 +34,6 @@ class CourseTests(TestCase):
     def test_str(self):
         """ Verify casting an instance to a string returns a string containing the key and title. """
         self.assertEqual(str(self.course), '{key}: {title}'.format(key=self.course.key, title=self.course.title))
-
-    def test_active_course_runs(self):
-        """ Verify the property returns only course runs currently open for enrollment or opening in the future. """
-        self.assertListEqual(list(self.course.active_course_runs), [])
-
-        # Create course with end date in future and enrollment_end in past.
-        end = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=2)
-        enrollment_end = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=1)
-        factories.CourseRunFactory(course=self.course, end=end, enrollment_end=enrollment_end)
-
-        # Create course with end date in past and no enrollment_end.
-        end = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=2)
-        factories.CourseRunFactory(course=self.course, end=end, enrollment_end=None)
-
-        self.assertListEqual(list(self.course.active_course_runs), [])
-
-        # Create course with end date in future and enrollment_end in future.
-        end = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=2)
-        enrollment_end = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
-        active_enrollment_end = factories.CourseRunFactory(course=self.course, end=end, enrollment_end=enrollment_end)
-
-        # Create course with end date in future and no enrollment_end.
-        active_no_enrollment_end = factories.CourseRunFactory(course=self.course, end=end, enrollment_end=None)
-
-        self.assertEqual(set(self.course.active_course_runs), {active_enrollment_end, active_no_enrollment_end})
 
     def test_search(self):
         """ Verify the method returns a filtered queryset of courses. """

--- a/course_discovery/apps/course_metadata/tests/test_query.py
+++ b/course_discovery/apps/course_metadata/tests/test_query.py
@@ -1,14 +1,14 @@
 import datetime
 
+import ddt
 import pytz
 from django.test import TestCase
 
-from course_discovery.apps.course_metadata.models import Course
-from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory
+from course_discovery.apps.course_metadata.models import Course, CourseRun, Program
+from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, ProgramFactory
 
 
 class CourseQuerySetTests(TestCase):
-
     def test_active(self):
         """ Verify the method filters the Courses to those with active course runs. """
         now = datetime.datetime.now(pytz.UTC)
@@ -33,3 +33,52 @@ class CourseQuerySetTests(TestCase):
         CourseRunFactory(enrollment_end=None, end=inactive_course_end)
 
         self.assertEqual(set(Course.objects.active()), {active_course, course_without_end})
+
+
+@ddt.ddt
+class CourseRunQuerySetTests(TestCase):
+    def test_active(self):
+        """ Verify the method returns only course runs currently open for enrollment or opening in the future. """
+        # Create course with end date in future and enrollment_end in past.
+        end = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=2)
+        enrollment_end = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=1)
+        CourseRunFactory(end=end, enrollment_end=enrollment_end)
+
+        # Create course with end date in past and no enrollment_end.
+        end = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=2)
+        CourseRunFactory(end=end, enrollment_end=None)
+
+        self.assertEqual(CourseRun.objects.active().count(), 0)
+
+        # Create course with end date in future and enrollment_end in future.
+        end = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=2)
+        enrollment_end = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
+        active_enrollment_end = CourseRunFactory(end=end, enrollment_end=enrollment_end)
+
+        # Create course with end date in future and no enrollment_end.
+        active_no_enrollment_end = CourseRunFactory(end=end, enrollment_end=None)
+
+        self.assertEqual(set(CourseRun.objects.active()), {active_enrollment_end, active_no_enrollment_end})
+
+    def test_marketable(self):
+        """ Verify the method filters CourseRuns to those with slugs. """
+        course_run = CourseRunFactory()
+        self.assertEqual(list(CourseRun.objects.marketable()), [course_run])
+
+    @ddt.data(None, '')
+    def test_marketable_exclusions(self, slug):
+        """ Verify the method excludes CourseRuns without a slug. """
+        CourseRunFactory(slug=slug)
+        self.assertEqual(CourseRun.objects.marketable().count(), 0)
+
+
+class ProgramQuerySetTests(TestCase):
+    def test_marketable(self):
+        """ Verify the method filters Programs to those with marketing slugs. """
+        program = ProgramFactory()
+        self.assertEqual(list(Program.objects.marketable()), [program])
+
+    def test_marketable_exclusions(self):
+        """ Verify the method excludes Programs without a marketing slug. """
+        ProgramFactory(marketing_slug='')
+        self.assertEqual(Program.objects.marketable().count(), 0)


### PR DESCRIPTION
API consumers can now request CourseRuns that are active/marketable and Programs that are marketable.

ECOM-5416
