### PR TITLE
Add User groups to top level objects

### DIFF
--- a/course_discovery/apps/publisher/migrations/0006_auto_20160902_0726.py
+++ b/course_discovery/apps/publisher/migrations/0006_auto_20160902_0726.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('publisher', '0005_auto_20160901_0003'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='course',
+            options={'permissions': (('view_course', 'Can view course'),), 'ordering': ('-modified', '-created'), 'get_latest_by': 'modified'},
+        ),
+    ]

--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -7,6 +7,7 @@ from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
 from django_fsm import FSMField, transition
+from guardian.shortcuts import assign_perm
 from simple_history.models import HistoricalRecords
 from sortedm2m.fields import SortedManyToManyField
 
@@ -73,6 +74,7 @@ class State(TimeStampedModel, ChangedByMixin):
 
 class Course(TimeStampedModel, ChangedByMixin):
     """ Publisher Course model. It contains fields related to the course intake form."""
+    VIEW_PERMISSION = 'view_course'
 
     title = models.CharField(max_length=255, default=None, null=True, blank=True, verbose_name=_('Course title'))
     number = models.CharField(max_length=50, null=True, blank=True, verbose_name=_('Course number'))
@@ -109,6 +111,15 @@ class Course(TimeStampedModel, ChangedByMixin):
     @property
     def post_back_url(self):
         return reverse('publisher:publisher_courses_edit', kwargs={'pk': self.id})
+
+    class Meta(TimeStampedModel.Meta):
+        permissions = (
+            ('view_course', 'Can view course'),
+        )
+
+    def assign_user_groups(self, user):
+        for group in user.groups.all():
+            assign_perm(self.VIEW_PERMISSION, group, self)
 
 
 class CourseRun(TimeStampedModel, ChangedByMixin):

--- a/course_discovery/apps/publisher/tests/factories.py
+++ b/course_discovery/apps/publisher/tests/factories.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import factory
+from django.contrib.auth.models import Group
 from factory.fuzzy import FuzzyText, FuzzyChoice, FuzzyDecimal, FuzzyDateTime, FuzzyInteger
 from pytz import UTC
 
@@ -66,3 +67,9 @@ class SeatFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = Seat
+
+
+class GroupFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Group

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -18,7 +18,9 @@ class CreateUpdateCourseViewTests(TestCase):
     def setUp(self):
         super(CreateUpdateCourseViewTests, self).setUp()
         self.course = factories.CourseFactory()
+        self.group = factories.GroupFactory()
         self.user = UserFactory(is_staff=True, is_superuser=True)
+        self.user.groups.add(self.group)
         self.site = Site.objects.get(pk=settings.SITE_ID)
         self.client.login(username=self.user.username, password=USER_PASSWORD)
 
@@ -39,6 +41,7 @@ class CreateUpdateCourseViewTests(TestCase):
         )
 
         self.assertEqual(course.number, course_number)
+        self.assertTrue(self.user.has_perm(Course.VIEW_PERMISSION, course))
         response = self.client.get(reverse('publisher:publisher_courses_new'))
         self.assertNotContains(response, 'Add new comment')
         self.assertNotContains(response, 'Total Comments')

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -50,6 +50,7 @@ class CreateCourseView(CreateView):
 
     def form_valid(self, form):
         self.object = form.save()
+        self.object.assign_user_groups(self.request.user)
         return HttpResponseRedirect(self.get_success_url())
 
     def get_success_url(self):


### PR DESCRIPTION
[ECOM-5389](https://openedx.atlassian.net/browse/ECOM-5389)

As a user I want all publisher objects to be owned by a group so that I know which ones to scope to which users.

**Acceptance Criteria:**
1. Validate top level publisher objects created by a user are by default assigned to the Group the user belongs to.
