### PR TITLE
Added Top level Object Access.

### DIFF
--- a/course_discovery/apps/publisher/mixins.py
+++ b/course_discovery/apps/publisher/mixins.py
@@ -1,0 +1,33 @@
+from django.http import HttpResponseForbidden
+
+from course_discovery.apps.publisher.models import Course, CourseRun, Seat
+
+
+class ViewPermissionMixin(object):
+    permission_failure_url = ''
+
+    def get_course(self):
+        course_object = self.get_object()
+        if isinstance(course_object, CourseRun):
+            return course_object.course
+        if isinstance(course_object, Seat):
+            return course_object.course_run.course
+
+        return course_object
+
+    def check_user(self, user):
+        course = self.get_course()
+        return check_view_permission(user, course)
+
+    def permission_failed(self):
+        return HttpResponseForbidden()
+
+    def dispatch(self, request, *args, **kwargs):
+        if not self.check_user(request.user):
+            return self.permission_failed()
+
+        return super(ViewPermissionMixin, self).dispatch(request, *args, **kwargs)
+
+
+def check_view_permission(user, course):
+    return user.is_staff or user.has_perm(Course.VIEW_PERMISSION, course)

--- a/course_discovery/apps/publisher/tests/factories.py
+++ b/course_discovery/apps/publisher/tests/factories.py
@@ -70,6 +70,7 @@ class SeatFactory(factory.DjangoModelFactory):
 
 
 class GroupFactory(factory.DjangoModelFactory):
+    name = FuzzyText(prefix="Test Group ")
 
     class Meta:
         model = Group


### PR DESCRIPTION
[ECOM-4978](https://openedx.atlassian.net/browse/ECOM-4978)

As a user, I need access to all courses, course runs, people and organizations within my Group and should not be able to see objects owned by Groups that I'm not part of.

**Acceptance criteria:**
1. Validate staff user can have access to all Objects.
2. Validate that users have access to Objects within their parent Group.
3. Validate a user does NOT have access to objects outside of his/her Group.
