### PR TITLE
Updated search endpoint to filter by default partner

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -45,7 +45,7 @@ COURSE_RUN_FACET_FIELD_QUERIES = {
 COURSE_RUN_SEARCH_FIELDS = (
     'text', 'key', 'title', 'short_description', 'full_description', 'start', 'end', 'enrollment_start',
     'enrollment_end', 'pacing_type', 'language', 'transcript_languages', 'marketing_url', 'content_type', 'org',
-    'number', 'seat_types', 'image_url', 'type', 'level_type', 'availability', 'published',
+    'number', 'seat_types', 'image_url', 'type', 'level_type', 'availability', 'published', 'partner',
 )
 
 PROGRAM_FACET_FIELD_OPTIONS = {
@@ -57,7 +57,7 @@ PROGRAM_FACET_FIELD_OPTIONS = {
 
 BASE_PROGRAM_FIELDS = (
     'text', 'uuid', 'title', 'subtitle', 'type', 'marketing_url', 'content_type', 'status', 'card_image_url',
-    'published',
+    'published', 'partner',
 )
 
 PROGRAM_SEARCH_FIELDS = BASE_PROGRAM_FIELDS + ('authoring_organizations',)

--- a/course_discovery/apps/api/v1/views.py
+++ b/course_discovery/apps/api/v1/views.py
@@ -12,7 +12,6 @@ from django.db.models import Q
 from django.db.models.functions import Lower
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
-from drf_haystack.filters import HaystackFilter
 from drf_haystack.mixins import FacetMixin
 from drf_haystack.viewsets import HaystackViewSet
 from dry_rest_permissions.generics import DRYPermissions
@@ -455,7 +454,7 @@ class AffiliateWindowViewSet(viewsets.ViewSet):
 
 class BaseHaystackViewSet(FacetMixin, HaystackViewSet):
     document_uid_field = 'key'
-    facet_filter_backends = [filters.HaystackFacetFilterWithQueries, HaystackFilter]
+    facet_filter_backends = [filters.HaystackFacetFilterWithQueries, filters.HaystackFilter]
     load_all = True
     lookup_field = 'key'
     permission_classes = (IsAuthenticated,)
@@ -508,7 +507,7 @@ class BaseHaystackViewSet(FacetMixin, HaystackViewSet):
         return super(BaseHaystackViewSet, self).facets(request)
 
     def filter_facet_queryset(self, queryset):
-        queryset = super(BaseHaystackViewSet, self).filter_facet_queryset(queryset)
+        queryset = super().filter_facet_queryset(queryset)
 
         facet_serializer_cls = self.get_facet_serializer_class()
         field_queries = getattr(facet_serializer_cls.Meta, 'field_queries', {})

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -111,8 +111,11 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     seat_types = indexes.MultiValueField(model_attr='seat_types', null=True, faceted=True)
     type = indexes.CharField(model_attr='type', null=True, faceted=True)
     image_url = indexes.CharField(model_attr='card_image_url', null=True)
-    partner = indexes.CharField(model_attr='course__partner__short_code', null=True, faceted=True)
+    partner = indexes.CharField(null=True, faceted=True)
     published = indexes.BooleanField(null=False, faceted=True)
+
+    def prepare_partner(self, obj):
+        return obj.course.partner.short_code
 
     def prepare_published(self, obj):
         return obj.status == CourseRun.Status.Published


### PR DESCRIPTION
If no partner is specified on the request, all results are filtered so that only items associated with the default partner are returned.

ECOM-5459
