### PR TITLE
ECOM-5392 Only publish to drupal for MicroMasters Program

### DIFF
--- a/course_discovery/apps/course_metadata/publishers.py
+++ b/course_discovery/apps/course_metadata/publishers.py
@@ -98,6 +98,10 @@ class MarketingSitePublisher(object):
                 partner=program.partner.short_code)
             raise ProgramPublisherException(msg)
 
+        if program.type.name != 'MicroMasters':
+            # Currently, we should not publish any programs that are not MicroMasters types to Marketing Site
+            return
+
         if self.data_before and \
                 all(self.data_before[key] == getattr(program, key) for key in ['title', 'status', 'type']):
             # We don't need to publish to marketing site because

--- a/course_discovery/apps/course_metadata/tests/test_publishers.py
+++ b/course_discovery/apps/course_metadata/tests/test_publishers.py
@@ -10,7 +10,7 @@ from course_discovery.apps.course_metadata.tests.mixins import (
     MarketingSiteAPIClientTestMixin,
     MarketingSitePublisherTestMixin,
 )
-from course_discovery.apps.course_metadata.models import Program
+from course_discovery.apps.course_metadata.models import Program, ProgramType
 
 
 class MarketingSiteAPIClientTests(MarketingSiteAPIClientTestMixin):
@@ -96,6 +96,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         self.program.partner.marketing_site_url_root = self.api_root
         self.program.partner.marketing_site_api_username = self.username
         self.program.partner.marketing_site_api_password = self.password
+        self.program.type = ProgramType.objects.get(name='MicroMasters')
         self.program.save()  # pylint: disable=no-member
         self.api_client = MarketingSiteAPIClient(
             self.username,
@@ -217,10 +218,16 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         self.assert_responses_call_count(0)
 
     @responses.activate
+    def test_publish_xseries_program(self):
+        self.program.type = ProgramType.objects.get(name='XSeries')
+        publisher = MarketingSitePublisher()
+        publisher.publish_program(self.program)
+        self.assert_responses_call_count(0)
+
+    @responses.activate
     def test_publish_program_no_credential(self):
         self.program.partner.marketing_site_api_password = None
         self.program.partner.marketing_site_api_username = None
-        self.program.save()  # pylint: disable=no-member
         publisher = MarketingSitePublisher()
         with self.assertRaises(ProgramPublisherException):
             publisher.publish_program(self.program)

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from course_discovery.apps.course_metadata.models import ProgramType
 from course_discovery.apps.course_metadata.tests import factories, toggle_switch
 
 
@@ -13,7 +14,7 @@ MARKETING_SITE_PUBLISHERS_MODULE = 'course_discovery.apps.course_metadata.publis
 class SignalsTest(TestCase):
     def setUp(self):
         super(SignalsTest, self).setUp()
-        self.program = factories.ProgramFactory()
+        self.program = factories.ProgramFactory(type=ProgramType.objects.get(name='MicroMasters'))
 
     def test_delete_program_signal_no_publish(self, delete_program_mock):
         toggle_switch('publish_program_to_marketing_site', False)


### PR DESCRIPTION
@rlucioni @bderusha @clintonb Please review
This is the bug in the course catalog because we don't want the publish logic to be associated any non-micromaster programs.
