### PR TITLE
Use threads to overlap I/O during data loading.

### DIFF
--- a/course_discovery/apps/core/tests/utils.py
+++ b/course_discovery/apps/core/tests/utils.py
@@ -1,4 +1,5 @@
 import json
+import math
 
 from urllib.parse import parse_qs, urlparse
 from factory.fuzzy import (
@@ -68,6 +69,7 @@ def mock_api_callback(url, data, results_key=True, pagination=False):
         body = {
             'count': count,
             'next': next_url,
+            'num_pages': math.ceil(count / page_size),
             'previous': previous_url,
         }
 

--- a/course_discovery/apps/course_metadata/data_loaders/__init__.py
+++ b/course_discovery/apps/course_metadata/data_loaders/__init__.py
@@ -23,7 +23,7 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
     PAGE_SIZE = 50
     SUPPORTED_TOKEN_TYPES = ('bearer', 'jwt',)
 
-    def __init__(self, partner, api_url, access_token=None, token_type=None):
+    def __init__(self, partner, api_url, access_token=None, token_type=None, max_workers=None):
         """
         Arguments:
             partner (Partner): Partner which owns the APIs and data being loaded
@@ -41,6 +41,8 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
         self.token_type = token_type
         self.partner = partner
         self.api_url = api_url.strip('/')
+
+        self.max_workers = max_workers
 
     @cached_property
     def api_client(self):

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -930,7 +930,6 @@ MARKETING_SITE_API_SPONSOR_BODIES = [
         'title': 'Turkcell Akademi',
         'url': 'https://www.edx.org/sponsorer/turkcell-akademi',
         'uuid': 'fcb48e7e-8f1b-4d4b-8bb0-77617aaad9ba'
-
     },
     {
         'body': [],

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import math
 from urllib.parse import parse_qs, urlparse
 from uuid import UUID
 
@@ -45,7 +46,9 @@ class AbstractMarketingSiteDataLoaderTestMixin(DataLoaderTestMixin):
             page_size = 1
 
             body = {
-                'list': [data[page]]
+                'list': [data[page]],
+                'first': '{}?page={}'.format(url, 0),
+                'last': '{}?page={}'.format(url, math.ceil(count / page_size) - 1),
             }
 
             if (page * page_size) < count - 1:

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -43,7 +43,18 @@ class Command(BaseCommand):
             help='The short code for a specific partner to refresh.'
         )
 
+        parser.add_argument(
+            '-w', '--max_workers',
+            type=int,
+            action='store',
+            dest='max_workers',
+            default=7,
+            help='Number of worker threads to use when traversing paginated responses.'
+        )
+
     def handle(self, *args, **options):
+        max_workers = options.get('max_workers')
+
         # For each partner defined...
         partners = Partner.objects.all()
 
@@ -56,7 +67,6 @@ class Command(BaseCommand):
             raise CommandError('No partners available!')
 
         for partner in partners:
-
             access_token = options.get('access_token')
             token_type = options.get('token_type')
 
@@ -94,7 +104,7 @@ class Command(BaseCommand):
             for api_url, loader_class in data_loaders:
                 if api_url:
                     try:
-                        loader_class(partner, api_url, access_token, token_type).ingest()
+                        loader_class(partner, api_url, access_token, token_type, max_workers).ingest()
                     except Exception:  # pylint: disable=broad-except
                         logger.exception('%s failed!', loader_class.__name__)
 


### PR DESCRIPTION
ECOM-5520. @edx/ecommerce please review.

Using my default worker thread count (7), this cuts the time spent waiting on network I/O when loading course data from Drupal from 4 minutes to 50 seconds, an 80% improvement. When loading course data from the LMS, wait time is reduced from 1 minute 15 seconds to 20 seconds, a 73% improvement.

I've tuned the default number of worker threads so that we get significant time savings without taking down the stage marketing site. We can tune it further when running in production, hence the new management command argument.
