### PR TITLE
Storing ingested data as HTML instead of Markdown

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -58,6 +58,17 @@ class AbstractDataLoaderTest(TestCase):
         for instance in instances:
             self.assertFalse(instance.__class__.objects.filter(pk=instance.pk).exists())  # pylint: disable=no-member
 
+    def test_clean_html(self):
+        """ Verify the method removes unnecessary HTML attributes. """
+        data = (
+            ('', '',),
+            ('<p>Hello!</p>', 'Hello!'),
+            ('<em>Testing</em>', '<em>Testing</em>'),
+        )
+
+        for content, expected in data:
+            self.assertEqual(AbstractDataLoader.clean_html(content), expected)
+
 
 @ddt.ddt
 class OrganizationsApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCase):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,6 +35,7 @@ edx-rest-api-client==1.6.0
 elasticsearch>=1.0.0,<2.0.0
 html2text==2016.5.29
 jsonfield==1.0.3
+markdown==2.6.6
 pillow==3.3.0
 pycountry==1.20
 python-dateutil==2.5.3


### PR DESCRIPTION
This removes the burden of conversion from our API clients.

ECOM-5623
