### PR TITLE
ECOM-5635 allow filter of unpublished course_runs

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -13,6 +13,7 @@ from taggit_serializer.serializers import TagListSerializerField, TaggitSerializ
 
 from course_discovery.apps.api.fields import StdImageSerializerField, ImageField
 from course_discovery.apps.catalogs.models import Catalog
+from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.models import (
     Course, CourseRun, Image, Organization, Person, Prerequisite, Seat, Subject, Video, Program, ProgramType, FAQ,
     CorporateEndorsement, Endorsement, Position
@@ -353,6 +354,8 @@ class ProgramCourseSerializer(CourseSerializer):
     def get_course_runs(self, course):
         program = self.context['program']
         course_runs = program.course_runs.filter(course=course)
+        if self.context.get('published_course_runs_only'):
+            course_runs = course_runs.filter(status=CourseRunStatus.Published)
         return CourseRunSerializer(
             course_runs,
             many=True,
@@ -391,7 +394,8 @@ class ProgramSerializer(serializers.ModelSerializer):
             many=True,
             context={
                 'request': self.context.get('request'),
-                'program': program
+                'program': program,
+                'published_course_runs_only': self.context.get('published_course_runs_only'),
             }
         )
 

--- a/course_discovery/apps/api/v1/views.py
+++ b/course_discovery/apps/api/v1/views.py
@@ -397,6 +397,11 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = (DjangoFilterBackend,)
     filter_class = filters.ProgramFilter
 
+    def get_serializer_context(self, *args, **kwargs):
+        context = super().get_serializer_context(*args, **kwargs)
+        context['published_course_runs_only'] = int(self.request.GET.get('published_course_runs_only', 0))
+        return context
+
     def list(self, request, *args, **kwargs):
         """ List all programs.
         ---
@@ -414,6 +419,12 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
               type: integer
               paramType: query
               multiple: false
+            - name: published_course_runs_only
+              description: Filter course runs by published ones only
+              required: false
+              type: integer
+              paramType: query
+              mulitple: false
         """
         return super(ProgramViewSet, self).list(request, *args, **kwargs)
 


### PR DESCRIPTION
@edx/ecommerce Please review

With this change, if the course_run is unpublished, we can filter it out in the program details API endpoint
