### PR TITLE
Remove HistoricalRecords from course metadata models

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -2,7 +2,6 @@ from django.contrib import admin, messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
-from simple_history.admin import SimpleHistoryAdmin
 from course_discovery.apps.course_metadata.forms import ProgramAdminForm
 from course_discovery.apps.course_metadata.models import *  # pylint: disable=wildcard-import
 from course_discovery.apps.course_metadata.publishers import ProgramPublisherException
@@ -40,7 +39,7 @@ class CorporateEndorsementsInline(admin.TabularInline):
 
 
 @admin.register(Course)
-class CourseAdmin(SimpleHistoryAdmin):
+class CourseAdmin(admin.ModelAdmin):
     list_display = ('uuid', 'key', 'title',)
     list_filter = ('partner',)
     ordering = ('key', 'title',)
@@ -49,7 +48,7 @@ class CourseAdmin(SimpleHistoryAdmin):
 
 
 @admin.register(CourseRun)
-class CourseRunAdmin(SimpleHistoryAdmin):
+class CourseRunAdmin(admin.ModelAdmin):
     inlines = (SeatInline,)
     list_display = ('uuid', 'key', 'title',)
     list_filter = (
@@ -143,7 +142,7 @@ class FAQAdmin(admin.ModelAdmin):
 
 
 @admin.register(Organization)
-class OrganizationAdmin(SimpleHistoryAdmin):
+class OrganizationAdmin(admin.ModelAdmin):
     list_display = ('uuid', 'key', 'name',)
     list_filter = ('partner',)
     readonly_fields = ('uuid',)
@@ -159,7 +158,7 @@ class SubjectAdmin(admin.ModelAdmin):
 
 
 @admin.register(Person)
-class PersonAdmin(SimpleHistoryAdmin):
+class PersonAdmin(admin.ModelAdmin):
     inlines = (PositionInline,)
     list_display = ('uuid', 'family_name', 'given_name', 'slug',)
     list_filter = ('partner',)

--- a/course_discovery/apps/course_metadata/migrations/0027_auto_20160915_2038.py
+++ b/course_discovery/apps/course_metadata/migrations/0027_auto_20160915_2038.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_metadata', '0026_auto_20160912_2146'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalcourse',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourse',
+            name='level_type',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourse',
+            name='partner',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourse',
+            name='video',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourserun',
+            name='course',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourserun',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourserun',
+            name='language',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourserun',
+            name='syllabus',
+        ),
+        migrations.RemoveField(
+            model_name='historicalcourserun',
+            name='video',
+        ),
+        migrations.RemoveField(
+            model_name='historicalorganization',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalorganization',
+            name='partner',
+        ),
+        migrations.RemoveField(
+            model_name='historicalperson',
+            name='history_user',
+        ),
+        migrations.RemoveField(
+            model_name='historicalperson',
+            name='partner',
+        ),
+        migrations.RemoveField(
+            model_name='historicalseat',
+            name='course_run',
+        ),
+        migrations.RemoveField(
+            model_name='historicalseat',
+            name='currency',
+        ),
+        migrations.RemoveField(
+            model_name='historicalseat',
+            name='history_user',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalCourse',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalCourseRun',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalOrganization',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalPerson',
+        ),
+        migrations.DeleteModel(
+            name='HistoricalSeat',
+        ),
+    ]

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -12,7 +12,6 @@ from django_extensions.db.fields import AutoSlugField
 from django_extensions.db.models import TimeStampedModel
 from haystack import connections
 from haystack.query import SearchQuerySet
-from simple_history.models import HistoricalRecords
 from sortedm2m.fields import SortedManyToManyField
 from stdimage.models import StdImageField
 from taggit.managers import TaggableManager
@@ -161,7 +160,6 @@ class Organization(TimeStampedModel):
     logo_image_url = models.URLField(null=True, blank=True)
     banner_image_url = models.URLField(null=True, blank=True)
 
-    history = HistoricalRecords()
     tags = TaggableManager(blank=True)
 
     class Meta:
@@ -190,8 +188,6 @@ class Person(TimeStampedModel):
     bio = models.TextField(null=True, blank=True)
     profile_image_url = models.URLField(null=True, blank=True)
     slug = AutoSlugField(populate_from=('given_name', 'family_name'), editable=True)
-
-    history = HistoricalRecords()
 
     class Meta:
         unique_together = (
@@ -253,7 +249,6 @@ class Course(TimeStampedModel):
         )
     )
 
-    history = HistoricalRecords()
     objects = CourseQuerySet.as_manager()
 
     class Meta:
@@ -365,7 +360,6 @@ class CourseRun(TimeStampedModel):
     video = models.ForeignKey(Video, default=None, null=True, blank=True)
     slug = models.CharField(max_length=255, blank=True, null=True, db_index=True)
 
-    history = HistoricalRecords()
     objects = CourseRunQuerySet.as_manager()
 
     @property
@@ -525,8 +519,6 @@ class Seat(TimeStampedModel):
     upgrade_deadline = models.DateTimeField(null=True, blank=True)
     credit_provider = models.CharField(max_length=255, null=True, blank=True)
     credit_hours = models.IntegerField(null=True, blank=True)
-
-    history = HistoricalRecords()
 
     class Meta(object):
         unique_together = (


### PR DESCRIPTION
django-simple-history's HistoricalRecords conflict with django-extensions' AutoSlugField. Briefly: AutoSlugField tries to automatically generate a unique slug any time a new model instance is saved. This includes the addition of rows to historical tables. AutoSlugField attempts to generate a unique slug 100 times by appending '-i' where i is between 2 and 99, inclusive, then raises an exception, preventing a historical row from being created.

This happened very quickly for models whose slug field source(s) slugify to the empty string, but would have eventually happened for all models using HistoricalRecords. This behavior renders the historical tables (which we weren't using in the first place) useless until we can exclude specific fields from historical tracking: https://github.com/treyhunner/django-simple-history/issues/165. Note that the migration included here will drop the historical tables currently in place. This is fine - the data is not useful - and should not incur downtime.

An added benefit of fixing this issue by removing HistoricalRecords from course metadata models: a refresh with production data takes 11 minutes on my local machine.

ECOM-5579. @edx/ecommerce @fredsmith @jibsheet.
