### PR TITLE
Ignoring empty query string parameters sent to search endpoint

### DIFF
--- a/course_discovery/apps/api/tests/test_filters.py
+++ b/course_discovery/apps/api/tests/test_filters.py
@@ -1,0 +1,16 @@
+import ddt
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+from course_discovery.apps.api.filters import HaystackRequestFilterMixin
+
+
+@ddt.ddt
+class HaystackRequestFilterMixinTests(TestCase):
+    def test_get_request_filters(self):
+        """ Verify the method removes query parameters with empty values """
+        request = APIRequestFactory().get('/?q=')
+        request = APIView().initialize_request(request)
+        filters = HaystackRequestFilterMixin.get_request_filters(request)
+        self.assertDictEqual(filters, {})

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -222,3 +222,12 @@ class AggregateSearchViewSet(DefaultPartnerMixin, SerializationMixin, LoginMixin
         response_data = json.loads(response.content.decode('utf-8'))
         self.assertListEqual(response_data['objects']['results'],
                              [self.serialize_course_run(other_course_run), self.serialize_program(other_program)])
+
+    def test_empty_query(self):
+        """ Verify, when the query (q) parameter is empty, the endpoint behaves as if the parameter
+        was not provided. """
+        course_run = CourseRunFactory(course__partner=self.partner, status=CourseRunStatus.Published)
+        response = self.get_search_response({'q': ''})
+        self.assertEqual(response.status_code, 200)
+        response_data = json.loads(response.content.decode('utf-8'))
+        self.assertListEqual(response_data['objects']['results'], [self.serialize_course_run(course_run)])


### PR DESCRIPTION
These empty parameters cause errors, resulting in failed responses.

ECOM-5685
