### PR TITLE
Caching the program endpoints

### DIFF
--- a/course_discovery/apps/api/v1/views.py
+++ b/course_discovery/apps/api/v1/views.py
@@ -20,6 +20,7 @@ from rest_framework.exceptions import PermissionDenied, ParseError
 from rest_framework.filters import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import filters
 from course_discovery.apps.api import serializers
@@ -389,7 +390,7 @@ class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):
         return Response(status=status.HTTP_400_BAD_REQUEST)
 
 
-class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
+class ProgramViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
     """ Program resource. """
     lookup_field = 'uuid'
     lookup_value_regex = '[0-9a-f-]+'

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -331,6 +331,11 @@ REST_FRAMEWORK = {
     },
 }
 
+REST_FRAMEWORK_EXTENSIONS = {
+    'DEFAULT_CACHE_ERRORS': False,
+    'DEFAULT_CACHE_RESPONSE_TIMEOUT': 1800,
+}
+
 # NOTE (CCB): JWT_SECRET_KEY is intentionally not set here to avoid production releases with a public value.
 # Set a value in a downstream settings file.
 JWT_AUTH = {

--- a/course_discovery/settings/devstack_test.py
+++ b/course_discovery/settings/devstack_test.py
@@ -9,3 +9,5 @@ INSTALLED_APPS += [
 JWT_AUTH['JWT_SECRET_KEY'] = 'course-discovery-jwt-secret-key'
 
 LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
+
+REST_FRAMEWORK_EXTENSIONS['DEFAULT_CACHE_RESPONSE_TIMEOUT'] = 0

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -23,3 +23,5 @@ DATABASES = {
 JWT_AUTH['JWT_SECRET_KEY'] = 'course-discovery-jwt-secret-key'
 
 LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
+
+REST_FRAMEWORK_EXTENSIONS['DEFAULT_CACHE_RESPONSE_TIMEOUT'] = 0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,6 +24,7 @@ djangorestframework-csv==1.4.1
 djangorestframework-jwt==1.8.0
 djangorestframework-xml==1.3.0
 django-rest-swagger[reST]==0.3.10
+drf-extensions==0.2.8
 drf-haystack==1.6.0rc1
 dry-rest-permissions==0.1.6
 edx-auth-backends==0.5.2


### PR DESCRIPTION
These endpoints are quite slow. Until they have been optimized, the responses must be cached.

ECOM-5709
