### PR TITLE
Programs endpoint fixes

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -333,6 +333,7 @@ class ContainedCourseRunsSerializer(serializers.Serializer):
 
 
 class MinimalCourseSerializer(TimestampModelSerializer):
+    course_runs = MinimalCourseRunSerializer(many=True)
     owners = MinimalOrganizationSerializer(many=True, source='authoring_organizations')
 
     class Meta:

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -238,7 +238,7 @@ class OrganizationSerializer(TaggitSerializer, MinimalOrganizationSerializer):
     class Meta(MinimalOrganizationSerializer.Meta):
         model = Organization
         fields = MinimalOrganizationSerializer.Meta.fields + (
-            'description', 'homepage_url', 'tags', 'logo_image_url', 'marketing_url'
+            'description', 'homepage_url', 'tags', 'logo_image_url', 'marketing_url',
         )
 
 

--- a/course_discovery/apps/api/tests/test_fields.py
+++ b/course_discovery/apps/api/tests/test_fields.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 
-from course_discovery.apps.api.fields import ImageField
+from course_discovery.apps.api.fields import ImageField, StdImageSerializerField
+from course_discovery.apps.api.tests.test_serializers import make_request
+from course_discovery.apps.core.tests.helpers import make_image_file
+from course_discovery.apps.course_metadata.tests.factories import ProgramFactory
 
 
 class ImageFieldTests(TestCase):
@@ -13,3 +16,27 @@ class ImageFieldTests(TestCase):
             'width': None
         }
         self.assertEqual(ImageField().to_representation(value), expected)
+
+
+# pylint: disable=no-member
+class StdImageSerializerFieldTests(TestCase):
+    def test_to_representation(self):
+        request = make_request()
+        # TODO Create test-only model to avoid unnecessary dependency on Program model.
+        program = ProgramFactory(banner_image=make_image_file('test.jpg'))
+        field = StdImageSerializerField()
+        field._context = {'request': request}  # pylint: disable=protected-access
+
+        expected = {
+            size_key: {
+                'url': '{}{}'.format(
+                    'http://testserver',
+                    getattr(program.banner_image, size_key).url
+                ),
+                'width': program.banner_image.field.variations[size_key]['width'],
+                'height': program.banner_image.field.variations[size_key]['height']
+            }
+            for size_key in program.banner_image.field.variations
+        }
+
+        self.assertDictEqual(field.to_representation(program.banner_image), expected)

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -2,7 +2,7 @@ import ddt
 from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase, APIRequestFactory
 
-from course_discovery.apps.api.serializers import ProgramSerializer, MinimalProgramSerializer
+from course_discovery.apps.api.serializers import ProgramSerializer
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import Program
@@ -69,21 +69,21 @@ class ProgramViewSetTests(APITestCase):
 
         self.assertEqual(
             response.data['results'],
-            MinimalProgramSerializer(expected, many=True, context={'request': self.request}).data
+            ProgramSerializer(expected, many=True, context={'request': self.request}).data
         )
 
     def test_list(self):
         """ Verify the endpoint returns a list of all programs. """
         expected = ProgramFactory.create_batch(3)
         expected.reverse()
-        self.assert_list_results(self.list_path, expected, 7)
+        self.assert_list_results(self.list_path, expected, 40)
 
     def test_filter_by_type(self):
         """ Verify that the endpoint filters programs to those of a given type. """
         program_type_name = 'foo'
         program = ProgramFactory(type__name=program_type_name)
         url = self.list_path + '?type=' + program_type_name
-        self.assert_list_results(url, [program], 7)
+        self.assert_list_results(url, [program], 18)
 
         url = self.list_path + '?type=bar'
         self.assert_list_results(url, [], 4)
@@ -98,11 +98,11 @@ class ProgramViewSetTests(APITestCase):
         # Create a third program, which should be filtered out.
         ProgramFactory()
 
-        self.assert_list_results(url, expected, 7)
+        self.assert_list_results(url, expected, 29)
 
     @ddt.data(
         (ProgramStatus.Unpublished, False, 4),
-        (ProgramStatus.Active, True, 7),
+        (ProgramStatus.Active, True, 40),
     )
     @ddt.unpack
     def test_filter_by_marketable(self, status, is_marketable, expected_query_count):

--- a/course_discovery/apps/api/v1/views.py
+++ b/course_discovery/apps/api/v1/views.py
@@ -395,6 +395,7 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_value_regex = '[0-9a-f-]+'
     queryset = prefetch_related_objects_for_programs(Program.objects.all())
     permission_classes = (IsAuthenticated,)
+    serializer_class = serializers.ProgramSerializer
     filter_backends = (DjangoFilterBackend,)
     filter_class = filters.ProgramFilter
 
@@ -402,12 +403,6 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
         context = super().get_serializer_context(*args, **kwargs)
         context['published_course_runs_only'] = int(self.request.GET.get('published_course_runs_only', 0))
         return context
-
-    def get_serializer_class(self):
-        if self.action == 'list':
-            return serializers.MinimalProgramSerializer
-
-        return serializers.ProgramSerializer
 
     def list(self, request, *args, **kwargs):
         """ List all programs.

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -239,13 +239,17 @@ class ProgramFactory(factory.django.DjangoModelFactory):
 
     title = factory.Sequence(lambda n: 'test-program-{}'.format(n))  # pylint: disable=unnecessary-lambda
     uuid = factory.LazyFunction(uuid4)
-    subtitle = 'test-subtitle'
+    subtitle = FuzzyText()
     type = factory.SubFactory(ProgramTypeFactory)
     status = ProgramStatus.Unpublished
     marketing_slug = factory.Sequence(lambda n: 'test-slug-{}'.format(n))  # pylint: disable=unnecessary-lambda
     banner_image_url = FuzzyText(prefix='https://example.com/program/banner')
     card_image_url = FuzzyText(prefix='https://example.com/program/card')
     partner = factory.SubFactory(PartnerFactory)
+    overview = FuzzyText()
+    weeks_to_complete = FuzzyInteger(1)
+    min_hours_effort_per_week = FuzzyInteger(2)
+    max_hours_effort_per_week = FuzzyInteger(4)
     credit_redemption_overview = FuzzyText()
 
     @factory.post_generation
@@ -287,11 +291,6 @@ class ProgramFactory(factory.django.DjangoModelFactory):
     def individual_endorsements(self, create, extracted, **kwargs):
         if create:  # pragma: no cover
             add_m2m_data(self.individual_endorsements, extracted)
-
-    @factory.post_generation
-    def staff(self, create, extracted, **kwargs):
-        if create:  # pragma: no cover
-            add_m2m_data(self.staff, extracted)
 
     @factory.post_generation
     def job_outlook_items(self, create, extracted, **kwargs):


### PR DESCRIPTION
- Fixed tests
- Restored usage of `ProgramSerializer` for all calls to `/api/v1/programs/`
