### PR TITLE
ECOM-5740 Only include programs for which the course runs are not excluded

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -190,6 +190,23 @@ class CourseRunWithProgramsSerializerTests(TestCase):
 
         self.assertDictEqual(serializer.data, expected)
 
+    def test_data_excluded_course_run(self):
+        """
+        If a course run is excluded on a program, that program should not be
+        returned for that course run on the course run endpoint.
+        """
+        request = make_request()
+        course_run = CourseRunFactory()
+        serializer_context = {'request': request}
+        serializer = CourseRunWithProgramsSerializer(course_run, context=serializer_context)
+        ProgramFactory(courses=[course_run.course], excluded_course_runs=[course_run])
+        expected = CourseRunSerializer(course_run, context=serializer_context).data
+        expected.update({
+            'programs': [],
+        })
+
+        self.assertDictEqual(serializer.data, expected)
+
 
 class FlattenedCourseRunWithCourseSerializerTests(TestCase):  # pragma: no cover
     def serialize_seats(self, course_run):


### PR DESCRIPTION
@edx/ecommerce 

This change does add an additional query, but I've verified that with the prefetch it does not scale with the size of the input, in that adding more programs does not add more queries (though it did before I added the prefetch).
Initially I tried using the django queryset exclude but that wasn't working with this prefetch.
