### PR TITLE
Add exclude_utm querystring parameter

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -11,6 +11,7 @@ from dry_rest_permissions.generics import DRYPermissionFiltersBase
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.exceptions import PermissionDenied, NotFound
 
+from course_discovery.apps.api.utils import cast2int
 from course_discovery.apps.core.models import Partner
 from course_discovery.apps.course_metadata.models import Course, CourseRun, Program
 
@@ -105,14 +106,7 @@ class CharListFilter(django_filters.CharFilter):
 
 class FilterSetMixin:
     def _apply_filter(self, name, queryset, value):
-        try:
-            if int(value):
-                queryset = getattr(queryset, name)()
-        except ValueError:
-            logger.exception('The "%s" filter requires an integer value of either 0 or 1. %s is invalid', name, value)
-            raise
-
-        return queryset
+        return getattr(queryset, name)() if cast2int(value, name) else queryset
 
     def filter_active(self, queryset, value):
         return self._apply_filter('active', queryset, value)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -129,6 +129,14 @@ class CourseSerializerTests(TestCase):
 
         self.assertDictEqual(serializer.data, expected)
 
+    def test_exclude_utm(self):
+        request = make_request()
+        course = CourseFactory()
+        CourseRunFactory.create_batch(3, course=course)
+        serializer = CourseWithProgramsSerializer(course, context={'request': request, 'exclude_utm': 1})
+
+        self.assertEqual(serializer.data['marketing_url'], course.marketing_url)
+
 
 class CourseRunSerializerTests(TestCase):
     def test_data(self):
@@ -173,6 +181,13 @@ class CourseRunSerializerTests(TestCase):
         }
 
         self.assertDictEqual(serializer.data, expected)
+
+    def test_exclude_utm(self):
+        request = make_request()
+        course_run = CourseRunFactory()
+        serializer = CourseRunSerializer(course_run, context={'request': request, 'exclude_utm': 1})
+
+        self.assertEqual(serializer.data['marketing_url'], course_run.marketing_url)
 
 
 class CourseRunWithProgramsSerializerTests(TestCase):

--- a/course_discovery/apps/api/tests/test_utils.py
+++ b/course_discovery/apps/api/tests/test_utils.py
@@ -1,0 +1,30 @@
+import ddt
+from django.test import TestCase
+import mock
+
+from course_discovery.apps.api.utils import cast2int
+
+
+LOGGER_PATH = 'course_discovery.apps.api.utils.logger.exception'
+
+
+@ddt.ddt
+class Cast2IntTests(TestCase):
+    name = 'foo'
+
+    @ddt.data(
+        ('0', 0),
+        ('1', 1),
+        (None, None),
+    )
+    @ddt.unpack
+    def test_cast_success(self, value, expected):
+        self.assertEqual(cast2int(value, self.name), expected)
+
+    @ddt.data('beep', '1.1')
+    def test_cast_failure(self, value):
+        with mock.patch(LOGGER_PATH) as mock_logger:
+            with self.assertRaises(ValueError):
+                cast2int(value, self.name)
+
+        self.assertTrue(mock_logger.called)

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -1,0 +1,29 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def cast2int(value, name):
+    """
+    Attempt to cast the provided value to an integer.
+
+    Arguments:
+        value (str): A value to cast to an integer.
+        name (str): A name to log if casting fails.
+
+    Raises:
+        ValueError, if the provided value can't be converted. A helpful
+            error message is logged first.
+
+    Returns:
+        int | None
+    """
+    if value is None:
+        return value
+
+    try:
+        return int(value)
+    except ValueError:
+        logger.exception('The "%s" parameter requires an integer value. "%s" is invalid.', name, value)
+        raise

--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -8,12 +8,15 @@ from rest_framework.test import APIRequestFactory
 
 from course_discovery.apps.api.serializers import (
     CatalogSerializer, CourseWithProgramsSerializer, CourseSerializerExcludingClosedRuns,
-    FlattenedCourseRunWithCourseSerializer
+    CourseRunWithProgramsSerializer, ProgramSerializer, FlattenedCourseRunWithCourseSerializer
 )
 
 
 class SerializationMixin(object):
     def _get_request(self, format=None):
+        if getattr(self, 'request', None):
+            return self.request
+
         query_data = {}
         if format:
             query_data['format'] = format
@@ -21,20 +24,30 @@ class SerializationMixin(object):
         request.user = self.user
         return request
 
-    def _serialize_object(self, serializer, obj, many=False, format=None):
-        return serializer(obj, many=many, context={'request': self._get_request(format)}).data
+    def _serialize_object(self, serializer, obj, many=False, format=None, extra_context=None):
+        context = {'request': self._get_request(format)}
+        if extra_context:
+            context.update(extra_context)
 
-    def serialize_catalog(self, catalog, many=False, format=None):
-        return self._serialize_object(CatalogSerializer, catalog, many, format)
+        return serializer(obj, many=many, context=context).data
 
-    def serialize_course(self, course, many=False, format=None):
-        return self._serialize_object(CourseWithProgramsSerializer, course, many, format)
+    def serialize_catalog(self, catalog, many=False, format=None, extra_context=None):
+        return self._serialize_object(CatalogSerializer, catalog, many, format, extra_context)
 
-    def serialize_catalog_course(self, course, many=False, format=None):
-        return self._serialize_object(CourseSerializerExcludingClosedRuns, course, many, format)
+    def serialize_course(self, course, many=False, format=None, extra_context=None):
+        return self._serialize_object(CourseWithProgramsSerializer, course, many, format, extra_context)
 
-    def serialize_catalog_flat_course_run(self, course_run, many=False, format=None):
-        return self._serialize_object(FlattenedCourseRunWithCourseSerializer, course_run, many, format)
+    def serialize_course_run(self, run, many=False, format=None, extra_context=None):
+        return self._serialize_object(CourseRunWithProgramsSerializer, run, many, format, extra_context)
+
+    def serialize_program(self, program, many=False, format=None, extra_context=None):
+        return self._serialize_object(ProgramSerializer, program, many, format, extra_context)
+
+    def serialize_catalog_course(self, course, many=False, format=None, extra_context=None):
+        return self._serialize_object(CourseSerializerExcludingClosedRuns, course, many, format, extra_context)
+
+    def serialize_catalog_flat_course_run(self, course_run, many=False, format=None, extra_context=None):
+        return self._serialize_object(FlattenedCourseRunWithCourseSerializer, course_run, many, format, extra_context)
 
 
 class OAuth2Mixin(object):

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -9,6 +9,8 @@ from course_discovery.apps.course_metadata.tests.factories import CourseFactory
 
 
 class CourseViewSetTests(SerializationMixin, APITestCase):
+    maxDiff = None
+
     def setUp(self):
         super(CourseViewSetTests, self).setUp()
         self.user = UserFactory(is_staff=True, is_superuser=True)
@@ -58,3 +60,14 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         with self.assertNumQueries(35):
             response = self.client.get(url)
             self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
+
+    def test_list_exclude_utm(self):
+        """ Verify the endpoint returns marketing URLs without UTM parameters. """
+        url = reverse('api:v1:course-list') + '?exclude_utm=1'
+
+        response = self.client.get(url)
+        context = {'exclude_utm': 1}
+        self.assertEqual(
+            response.data['results'],
+            self.serialize_course([self.course], many=True, extra_context=context)
+        )


### PR DESCRIPTION
Calls to course, course run, and program APIs can use this parameter to prevent UTM parameters from being appended to marketing URLs. ECOM-5782.

@edx/ecommerce please review.
