### PR TITLE
Upgrade Django to 1.8.15

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 boto==2.42.0
 cryptography==1.4
-django==1.8.14
+django==1.8.15
 django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.0


### PR DESCRIPTION
Django 1.8.15 fixes a security issue in 1.8.14. Release notes are at https://docs.djangoproject.com/en/1.10/releases/1.8.15.

@edx/ecommerce FYI.
