### PR TITLE
Update ecommerce api endpoint example

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -111,7 +111,7 @@ Additional optional attributes can be specified:
 +===============================+=========================================+====================================================+
 | courses-api-url               | LMS Courses API Endpoint                | https://lms.example.com/api/v1/courses/            |
 +-------------------------------+-----------------------------------------+----------------------------------------------------+
-| ecommerce-api-url             | Ecommerce Courses API Endpoint          | https://ecommerce.example.com/api/v1/courses/      |
+| ecommerce-api-url             | Ecommerce API Endpoint                  | https://ecommerce.example.com/api/v2/             |
 +-------------------------------+-----------------------------------------+----------------------------------------------------+
 | organizations-api-url         | Organizations API Endpoint              | https://orgs.example.com/api/v1/organizations/     |
 +-------------------------------+-----------------------------------------+----------------------------------------------------+


### PR DESCRIPTION
@edx/ecommerce @mattdrayer 

This morning, I was following the documentation to setup the local version of the Course Discovery service. I'm proposing this change because it seems to me that `ecommerce_api_url` field in `Partner` should point to the ecommerce API endpoint instead of ecommerce Courses API endpoint.

Can someone please review this change and correct me if I'm wrong? Thanks!
