### PR TITLE
Fix malformed table error

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -111,7 +111,7 @@ Additional optional attributes can be specified:
 +===============================+=========================================+====================================================+
 | courses-api-url               | LMS Courses API Endpoint                | https://lms.example.com/api/v1/courses/            |
 +-------------------------------+-----------------------------------------+----------------------------------------------------+
-| ecommerce-api-url             | Ecommerce API Endpoint                  | https://ecommerce.example.com/api/v2/             |
+| ecommerce-api-url             | Ecommerce API Endpoint                  | https://ecommerce.example.com/api/v2/              |
 +-------------------------------+-----------------------------------------+----------------------------------------------------+
 | organizations-api-url         | Organizations API Endpoint              | https://orgs.example.com/api/v1/organizations/     |
 +-------------------------------+-----------------------------------------+----------------------------------------------------+


### PR DESCRIPTION
@clintonb This will fix the malformed table error. Github didn't show any errors on the preview and I noticed that table is missing when I went to the documentation page. I used an online validator and noticed a space character is missing. Can you take a look?

Thanks!
