### PR TITLE
Further accelerate metadata refresh

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/__init__.py
+++ b/course_discovery/apps/course_metadata/data_loaders/__init__.py
@@ -26,13 +26,15 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
     SUPPORTED_TOKEN_TYPES = ('bearer', 'jwt',)
     MARKDOWN_CLEANUP_REGEX = re.compile(r'^<p>(.*)</p>$')
 
-    def __init__(self, partner, api_url, access_token=None, token_type=None, max_workers=None):
+    def __init__(self, partner, api_url, access_token=None, token_type=None, max_workers=None, is_threadsafe=False):
         """
         Arguments:
             partner (Partner): Partner which owns the APIs and data being loaded
             api_url (str): URL of the API from which data is loaded
             access_token (str): OAuth2 access token
             token_type (str): The type of access token passed in (e.g. Bearer, JWT)
+            max_workers (int): Number of worker threads to use when traversing paginated responses.
+            is_threadsafe (bool): True if multiple threads can be used to write data.
         """
         if token_type:
             token_type = token_type.lower()
@@ -46,6 +48,7 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
         self.api_url = api_url.strip('/')
 
         self.max_workers = max_workers
+        self.is_threadsafe = is_threadsafe
 
     @cached_property
     def api_client(self):

--- a/course_discovery/apps/course_metadata/tests/__init__.py
+++ b/course_discovery/apps/course_metadata/tests/__init__.py
@@ -1,18 +1,21 @@
 from waffle.models import Switch
 
 
-def toggle_switch(name, active):
+def toggle_switch(name, active=True):
     """
-    Activate or deactivate a feature switch.
-    The switch is created if it does not exist.
+    Activate or deactivate a feature switch. The switch is created if it does not exist.
+
     Arguments:
-        name (str): name of the switch to be toggled
-        active (bool): boolean indicating if the switch should be activated or deactivated
+        name (str): name of the switch to be toggled.
+
+    Keyword Arguments:
+        active (bool): Whether the switch should be on or off.
+
     Returns:
         Switch: Waffle Switch
     """
-    switch, __ = Switch.objects.get_or_create(name=name,
-                                              defaults={'active': active})
+    switch, __ = Switch.objects.get_or_create(name=name, defaults={'active': active})
     switch.active = active
     switch.save()
+
     return switch


### PR DESCRIPTION
A Waffle switch can now be used to toggle parallelized execution of the data loading pipeline. The pipeline is structured so that stages that can run independently of others are interleaved using separate processes.

A separate Waffle switch can be used to toggle threaded writes to the database. Instead of using threads to request all data, then writing it all serially, use this switch to spawn separate threads responsible for reading and writing each page of data.

ECOM-5871

This was getting stale, so I decided to wrap it up while it was still fresh. @edx/ecommerce please review.
