### PR TITLE
Refine parallel metadata refresh pipeline

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 data_file = .coverage
 source=course_discovery
+concurrency=multiprocessing
 omit =
     course_discovery/settings*
     course_discovery/conf*

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ production-requirements:
 
 test: clean
 	coverage run ./manage.py test course_discovery --settings=course_discovery.settings.test
+	coverage combine
 	coverage report
 
 quality:

--- a/course_discovery/apps/course_metadata/migrations/0030_create_refresh_command_switches.py
+++ b/course_discovery/apps/course_metadata/migrations/0030_create_refresh_command_switches.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+NAMES = ('threaded_metadata_write', 'parallel_refresh_pipeline')
+
+
+def create_switches(apps, schema_editor):
+    """Create the threaded_metadata_write and parallel_refresh_pipeline switches."""
+    Switch = apps.get_model('waffle', 'Switch')
+
+    for name in NAMES:
+        Switch.objects.get_or_create(name=name, defaults={'active': False})
+
+
+def delete_switches(apps, schema_editor):
+    """Delete the threaded_metadata_write and parallel_refresh_pipeline switches."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name__in=NAMES).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('course_metadata', '0029_auto_20160923_1306'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switches, reverse_code=delete_switches),
+    ]


### PR DESCRIPTION
Force each process to use its own database connection, add a migration creating relevant switches, and simplify the logic determining whether it's safe to use threads.

ECOM-5871

@edx/ecommerce FYI.
