### PR TITLE
Avoid running queries on closed connections

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
@@ -4,7 +4,7 @@ import ddt
 import mock
 import responses
 from django.core.management import call_command, CommandError
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from course_discovery.apps.core.tests.factories import PartnerFactory
 from course_discovery.apps.core.tests.utils import mock_api_callback
@@ -24,7 +24,7 @@ JSON = 'application/json'
 
 
 @ddt.ddt
-class RefreshCourseMetadataCommandTests(TestCase):
+class RefreshCourseMetadataCommandTests(TransactionTestCase):
     def setUp(self):
         super(RefreshCourseMetadataCommandTests, self).setUp()
         self.partner = PartnerFactory()


### PR DESCRIPTION
Forking processes with open database connections can lead to some surprising behavior! This change forces the parent process running the refresh command to reconnect to the database before making any queries in case one of its child processes has closed the connection it relies on.

ECOM-5871

This should finally allow us to run the refresh command using both the parallel pipeline and threaded writes. [Jenkins console output](https://tools-edx-jenkins.edx.org/job/Catalog/job/stage-edx-refresh-course-metadata/411/consoleFull) is what tipped me off to this. For some reason, the stacktrace I needed wasn't appearing in Splunk, but surfaced in Jenkins console output.

On a related note, this is why Docker is your best friend. This error can't be reproduced unless you're running MySQL locally!

@edx/ecommerce FYI.
