### PR TITLE
Reduce data returned by programs list view

### DIFF
--- a/course_discovery/apps/api/migrations/0001_create_reduced_program_data_switch.py
+++ b/course_discovery/apps/api/migrations/0001_create_reduced_program_data_switch.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+def create_switch(apps, schema_editor):
+    """Create the reduced_program_data switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+
+    Switch.objects.get_or_create(name='reduced_program_data', defaults={'active': False})
+
+
+def delete_switch(apps, schema_editor):
+    """Delete the reduced_program_data switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name='reduced_program_data').delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, reverse_code=delete_switch),
+    ]


### PR DESCRIPTION
@edx/ecommerce FYI. This combines @clintonb's minimal serializers of old with our new approach to prefetching. With the `MinimalProgramSerializer` plugged in, this reduces queries necessary for the program list view from 33 queries to 10 (no duplicates!), and cuts time spent in CPU from about 6 seconds to 1 second.

This isn't ready for a complete review &mdash; tests still need to be fixed &mdash; but I am looking to get eyes on the removed fields.
