### PR TITLE
Integrating django-ses for sending emails

### DIFF
--- a/course_discovery/apps/publisher_comments/models.py
+++ b/course_discovery/apps/publisher_comments/models.py
@@ -1,8 +1,25 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
-
 from django_comments.models import CommentAbstractModel
 from django_extensions.db.fields import ModificationDateTimeField
+
+import waffle
 
 
 class Comments(CommentAbstractModel):
     modified = ModificationDateTimeField(_('modified'))
+
+
+@receiver(post_save, sender=Comments)
+def send_email(sender, instance, **kwargs):    # pylint: disable=unused-argument
+    """ Send email on new comment. """
+    if waffle.switch_is_active('enable_emails'):
+        from django.core.mail import send_mail
+        send_mail(
+            'Subject here',
+            'Here is the message.',
+            'awais@edx.org',
+            ['awais@edx.org'],
+            fail_silently=False,
+        )

--- a/course_discovery/settings/private.py.example
+++ b/course_discovery/settings/private.py.example
@@ -2,3 +2,11 @@ SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OIDC_SECRET = 'replace-me'
 SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://127.0.0.1:8000/oauth'
 SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = SOCIAL_AUTH_EDX_OIDC_SECRET
+
+django-ses needs following credentials for sending emails. For more details check the
+documentation https://github.com/django-ses/django-ses.
+EMAIL_BACKEND = 'django_ses.SESBackend'
+AWS_ACCESS_KEY_ID ='replace-me'
+AWS_SECRET_ACCESS_KEY = 'replace-me'
+AWS_SES_REGION_NAME = 'replace-me'
+AWS_SES_REGION_ENDPOINT = 'replace-me'

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -19,8 +19,11 @@ LOGGING['handlers']['local']['level'] = 'INFO'
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ('JWT_AUTH',)
 
-# This may be overridden by the YAML in PROGRAMS_CFG, but it should be here as a default.
+# This may be overridden by the YAML in DISCOVERY_CFG, but it should be here as a default.
 MEDIA_STORAGE_BACKEND = {}
+
+# This may be overridden by the YAML in DISCOVERY_CFG, but it should be here as a default.
+EMAIL_CONFIG = {}
 
 CONFIG_FILE = get_env_setting('COURSE_DISCOVERY_CFG')
 with open(CONFIG_FILE) as f:
@@ -39,6 +42,9 @@ with open(CONFIG_FILE) as f:
     # Unpack media storage settings.
     # It's important we unpack here because of https://github.com/edx/configuration/pull/3307
     vars().update(MEDIA_STORAGE_BACKEND)
+
+    # Unpack email backend settings
+    vars().update(EMAIL_CONFIG)
 
 
 if 'EXTRA_APPS' in locals():

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,7 @@ django-fsm==2.4.0
 django-guardian==1.4.5
 django-haystack==2.5.0
 django-libsass==0.7
+django-ses==0.8.1
 django-simple-history==1.8.1
 django-solo==1.1.2
 django-sortedm2m==1.3.2


### PR DESCRIPTION
Testing PR for emails.

Installing the django-ses from base.py.
Updating the required authentication variable for sending emails ( using discovery configuration ).
Add an example of required credentials in private.py.example.

Testing email function
