### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ drf-haystack==1.6.0rc1
 dry-rest-permissions==0.1.6
 edx-auth-backends==0.5.2
 edx-ccx-keys==0.2.0
-edx-django-release-util==0.1.1
+edx-django-release-util==0.1.2
 edx-drf-extensions==1.1.1
 edx-opaque-keys==0.3.1
 edx-rest-api-client==1.6.0


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.1.2.

@edx-ops/pipeline-team Please review and tag appropriate parties.
