### PR TITLE
Increase the default facet organizations field limit from 100 to 10000

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -4,6 +4,7 @@ import json
 from urllib.parse import urlencode
 
 import pytz
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models.query import Prefetch
 from django.utils.translation import ugettext_lazy as _
@@ -29,7 +30,7 @@ COMMON_SEARCH_FIELD_ALIASES = {
 }
 COURSE_RUN_FACET_FIELD_OPTIONS = {
     'level_type': {},
-    'organizations': {},
+    'organizations': {'size': settings.SEARCH_FACET_LIMIT},
     'prerequisites': {},
     'subjects': {},
     'language': {},

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -362,6 +362,9 @@ HAYSTACK_CONNECTIONS = {
 
 HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 
+# Elasticsearch search query facet "size" option to increase from the default value of "100"
+# See  https://www.elastic.co/guide/en/elasticsearch/reference/1.5/search-facets-terms-facet.html#_accuracy_control
+SEARCH_FACET_LIMIT = 10000
 
 DEFAULT_PARTNER_ID = None
 


### PR DESCRIPTION
Fix the bug where we only load 100 organization in our `Schools and Partners` dropdown on the search results page on the right panel. We have 215 organizations now. We need to load all of them
BM-6105
