### PR TITLE
Publisher app global admin flag

### DIFF
--- a/course_discovery/apps/publisher/constants.py
+++ b/course_discovery/apps/publisher/constants.py
@@ -1,0 +1,2 @@
+# Name of the administrative group for the Publisher app
+ADMIN_GROUP_NAME = 'Publisher Admins'

--- a/course_discovery/apps/publisher/migrations/0013_create_admin_group.py
+++ b/course_discovery/apps/publisher/migrations/0013_create_admin_group.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+ADMIN_GROUP_NAME = 'Publisher Admins'
+
+
+def create_admin_group(apps, schema_editor):
+    Group = apps.get_model('auth', 'Group')
+    Group.objects.get_or_create(name=ADMIN_GROUP_NAME)
+
+
+def remove_admin_group(apps, schema_editor):
+    Group = apps.get_model('auth', 'Group')
+    Group.objects.filter(name=ADMIN_GROUP_NAME).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('publisher', '0012_auto_20161020_0718'),
+        ('auth', '0006_require_contenttypes_0002'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_admin_group, remove_admin_group)
+    ]

--- a/course_discovery/apps/publisher/tests/test_utils.py
+++ b/course_discovery/apps/publisher/tests/test_utils.py
@@ -1,10 +1,11 @@
 """ Tests publisher.utils"""
-
+from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from course_discovery.apps.core.tests.factories import UserFactory
+from course_discovery.apps.publisher.constants import ADMIN_GROUP_NAME
 from course_discovery.apps.publisher.tests import factories
-from course_discovery.apps.publisher.utils import is_email_notification_enabled
+from course_discovery.apps.publisher.utils import is_email_notification_enabled, is_global_admin
 
 
 class PublisherUtilsTests(TestCase):
@@ -33,7 +34,18 @@ class PublisherUtilsTests(TestCase):
 
         # Disabled email notification
         user_attribute.enable_email_notification = False
-        user_attribute.save()   # pylint: disable=no-member
+        user_attribute.save()  # pylint: disable=no-member
 
         # Verify that email notifications are disabled for the user
         self.assertEqual(is_email_notification_enabled(self.user), False)
+
+    def test_is_global_admin(self):
+        """ Verify the function returns a boolean indicating if the user
+        is a member of the administrative group.
+        """
+        self.assertFalse(self.user.groups.filter(name=ADMIN_GROUP_NAME).exists())
+        self.assertFalse(is_global_admin(self.user))
+
+        admin_group = Group.objects.get(name=ADMIN_GROUP_NAME)
+        self.user.groups.add(admin_group)
+        self.assertTrue(is_global_admin(self.user))

--- a/course_discovery/apps/publisher/utils.py
+++ b/course_discovery/apps/publisher/utils.py
@@ -1,4 +1,5 @@
 """ Publisher Utils."""
+from course_discovery.apps.publisher.constants import ADMIN_GROUP_NAME
 
 
 def is_email_notification_enabled(user):
@@ -14,3 +15,15 @@ def is_email_notification_enabled(user):
         return user.attributes.enable_email_notification
 
     return True
+
+
+def is_global_admin(user):
+    """ Returns True if the user is a Publisher administrator.
+
+    Arguments:
+        user (:obj:`User`): User whose permissions should be checked.
+
+    Returns:
+        bool: True, if user is an administrator; otherwise, False.
+    """
+    return user.groups.filter(name=ADMIN_GROUP_NAME).exists()


### PR DESCRIPTION
Create the is_global_admin flag in UserAttributes table. 
User having this value will be a super-user for publisher app.
Update the context processor for this new field.

https://openedx.atlassian.net/browse/ECOM-5950
