### PR TITLE
query updated in CourseQuerySet

### DIFF
--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -12,11 +12,13 @@ class CourseQuerySet(models.QuerySet):
         """ Filters Courses to those with CourseRuns that are either currently open for enrollment,
         or will be open for enrollment in the future. """
 
+        now = datetime.datetime.now(pytz.UTC)
         return self.filter(
-            Q(course_runs__end__gt=datetime.datetime.now(pytz.UTC)) &
             (
-                Q(course_runs__enrollment_end__gt=datetime.datetime.now(pytz.UTC)) |
-                Q(course_runs__enrollment_end__isnull=True)
+                Q(course_runs__end__gt=now) | Q(course_runs__end__isnull=True)
+            ) &
+            (
+                Q(course_runs__enrollment_end__gt=now) | Q(course_runs__enrollment_end__isnull=True)
             )
         )
 

--- a/course_discovery/apps/course_metadata/tests/test_query.py
+++ b/course_discovery/apps/course_metadata/tests/test_query.py
@@ -28,12 +28,18 @@ class CourseQuerySetTests(TestCase):
         CourseRunFactory(enrollment_end=closed_enrollment_end, end=inactive_course_end)
 
         # Create an active course with unrestricted enrollment
-        course_without_end = CourseRunFactory(enrollment_end=None, end=active_course_end).course
+        course_without_enrollment_end = CourseRunFactory(enrollment_end=None, end=active_course_end).course
 
         # Create an inactive course with unrestricted enrollment
         CourseRunFactory(enrollment_end=None, end=inactive_course_end)
 
-        self.assertEqual(set(Course.objects.active()), {active_course, course_without_end})
+        # Create course with end date is NULL
+        course_without_end = CourseRunFactory(enrollment_end=open_enrollment_end, end=None).course
+
+        self.assertEqual(
+            set(Course.objects.active()),
+            {active_course, course_without_enrollment_end, course_without_end}
+        )
 
 
 @ddt.ddt


### PR DESCRIPTION
query updated to get courses with course run end date is `NULL`

[ECOM-6168](https://openedx.atlassian.net/browse/ECOM-6165)

@schenedx Please review this.