### PR TITLE
Updated ALLOWED_HOSTS for local development

### DIFF
--- a/course_discovery/settings/local.py
+++ b/course_discovery/settings/local.py
@@ -1,6 +1,7 @@
 from course_discovery.settings.base import *
 
 DEBUG = True
+ALLOWED_HOSTS = ['*']
 
 # CACHE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#caches


### PR DESCRIPTION
The Django 1.9.11 security update changed the default value of ALLOWED_HOSTS. This commit restores the default as we will never use local.py in production.

ECOM-6274