### PR TITLE
adding unpublished check for affiliate window

### DIFF
--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -4,6 +4,7 @@ import pytz
 from django.db import models
 from django.db.models.query_utils import Q
 
+from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 
 
@@ -45,13 +46,13 @@ class CourseRunQuerySet(models.QuerySet):
     def marketable(self):
         """ Returns CourseRuns that can be marketed to learners.
 
-         A CourseRun is considered marketable if it has a defined slug.
+         A CourseRun is considered marketable if it has a defined slug and has been published.
 
          Returns:
             QuerySet
          """
 
-        return self.exclude(slug__isnull=True).exclude(slug='')
+        return self.exclude(slug__isnull=True).exclude(slug='').filter(status=CourseRunStatus.Published)
 
 
 class ProgramQuerySet(models.QuerySet):

--- a/course_discovery/apps/course_metadata/tests/test_query.py
+++ b/course_discovery/apps/course_metadata/tests/test_query.py
@@ -4,6 +4,7 @@ import ddt
 import pytz
 from django.test import TestCase
 
+from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import Course, CourseRun, Program
 from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, ProgramFactory
@@ -77,6 +78,17 @@ class CourseRunQuerySetTests(TestCase):
         """ Verify the method excludes CourseRuns without a slug. """
         CourseRunFactory(slug=slug)
         self.assertEqual(CourseRun.objects.marketable().count(), 0)
+
+    @ddt.data(
+        (CourseRunStatus.Unpublished, 0),
+        (CourseRunStatus.Published, 1)
+    )
+    @ddt.unpack
+    def test_marketable_unpublished_exclusions(self, status, count):
+        """ Verify the method excludes CourseRuns with Unpublished status. """
+        CourseRunFactory(status=status)
+
+        self.assertEqual(CourseRun.objects.marketable().count(), count)
 
 
 @ddt.ddt


### PR DESCRIPTION
ECOM-6282
Affiliate API: Unpublished courses are returned but they should not be there.
@schenedx 
Please review this.
