### PR TITLE
Force Transifex client to download translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ compile_translations:
 fake_translations: extract_translations dummy_translations compile_translations
 
 pull_translations:
-	tx pull -a
+	tx pull -af
 
 push_translations:
 	tx push -s


### PR DESCRIPTION
Transifex's Python client [compares last-modified timestamps](https://github.com/transifex/transifex-client/blob/master/txclib/project.py#L1009) to decide whether to download a file. This comparison might work great if you weren't using version control and only ever worked with one copy of the files. However, if you're using Git and clone this repo any time after new translations have been contributed by translators on Transifex, the client will never download new translations for you, since your files appear to have been modified after those on Transifex.

Forcing the client to download all files is a bit crude, but necessary until we can contribute a patch for the Transifex client.

@edx/ecommerce 