### PR TITLE
ECOM-4738 Add partial term matching to typeahead 

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1110,8 +1110,7 @@ class TypeaheadCourseRunSearchSerializerTests(TestCase):
         expected = {
             'key': course_run.key,
             'title': course_run.title,
-            'content_type': 'courserun',
-            'additional_details': course_run_key.org
+            'org': course_run_key.org
         }
         self.assertDictEqual(serialized_course.data, expected)
 
@@ -1128,16 +1127,13 @@ class TypeaheadProgramSearchSerializerTests(TestCase):
             'uuid': str(program.uuid),
             'title': program.title,
             'type': program.type.name,
-            'content_type': 'program',
-            'additional_details': program.authoring_organizations.first().key
+            'orgs': list(program.authoring_organizations.all().values_list('key', flat=True))
         }
 
     def test_data(self):
         authoring_organization = OrganizationFactory()
         program = ProgramFactory(authoring_organizations=[authoring_organization])
-
         serialized_program = self.serialize_program(program)
-
         expected = self._create_expected_data(program)
         self.assertDictEqual(serialized_program.data, expected)
 
@@ -1145,8 +1141,8 @@ class TypeaheadProgramSearchSerializerTests(TestCase):
         authoring_organizations = OrganizationFactory.create_batch(3)
         program = ProgramFactory(authoring_organizations=authoring_organizations)
         serialized_program = self.serialize_program(program)
-        expected = ', '.join([org.key for org in authoring_organizations])
-        self.assertEqual(serialized_program.data['additional_details'], expected)
+        expected = [org.key for org in authoring_organizations]
+        self.assertEqual(serialized_program.data['orgs'], expected)
 
     def serialize_program(self, program):
         """ Serializes the given `Program` as a typeahead result. """

--- a/course_discovery/apps/api/v1/urls.py
+++ b/course_discovery/apps/api/v1/urls.py
@@ -9,6 +9,7 @@ partners_router.register(r'affiliate_window/catalogs', views.AffiliateWindowView
 partners_urls = partners_router.urls
 urlpatterns = [
     url(r'^partners/', include(partners_urls, namespace='partners')),
+    url(r'search/typeahead', views.TypeaheadSearchView.as_view(), name='search-typeahead')
 ]
 
 router = routers.SimpleRouter()
@@ -18,7 +19,6 @@ router.register(r'course_runs', views.CourseRunViewSet, base_name='course_run')
 router.register(r'management', views.ManagementViewSet, base_name='management')
 router.register(r'programs', views.ProgramViewSet, base_name='program')
 router.register(r'search/all', views.AggregateSearchViewSet, base_name='search-all')
-router.register(r'search/typeahead', views.TypeaheadSearchViewSet, base_name='search-typeahead')
 router.register(r'search/courses', views.CourseSearchViewSet, base_name='search-courses')
 router.register(r'search/course_runs', views.CourseRunSearchViewSet, base_name='search-course_runs')
 router.register(r'search/programs', views.ProgramSearchViewSet, base_name='search-programs')


### PR DESCRIPTION
Tweaking my previous version of this endpoint because I realized I hadn't tested that partial terms returned results (currently our regular search results do not do this).
Talked with Jasper and we discussed searching just on title (and preserving search result boosting).
I'm not sure about whether this is the best way to do this, but it works.
Thoughts?
@edx/ecommerce 