### PR TITLE
ECOM-4738 Expose marketing url for typeahead

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -965,6 +965,7 @@ class TypeaheadCourseRunSearchSerializer(serializers.Serializer):
     org = serializers.CharField()
     title = serializers.CharField()
     key = serializers.CharField()
+    marketing_url = serializers.CharField()
 
     class Meta:
         fields = ['key', 'title']
@@ -975,6 +976,7 @@ class TypeaheadProgramSearchSerializer(serializers.Serializer):
     uuid = serializers.CharField()
     title = serializers.CharField()
     type = serializers.CharField()
+    marketing_url = serializers.CharField()
 
     def get_orgs(self, result):
         authoring_organizations = [json.loads(org) for org in result.authoring_organization_bodies]

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1110,7 +1110,8 @@ class TypeaheadCourseRunSearchSerializerTests(TestCase):
         expected = {
             'key': course_run.key,
             'title': course_run.title,
-            'org': course_run_key.org
+            'org': course_run_key.org,
+            'marketing_url': course_run.marketing_url
         }
         self.assertDictEqual(serialized_course.data, expected)
 
@@ -1127,7 +1128,8 @@ class TypeaheadProgramSearchSerializerTests(TestCase):
             'uuid': str(program.uuid),
             'title': program.title,
             'type': program.type.name,
-            'orgs': list(program.authoring_organizations.all().values_list('key', flat=True))
+            'orgs': list(program.authoring_organizations.all().values_list('key', flat=True)),
+            'marketing_url': program.marketing_url
         }
 
     def test_data(self):


### PR DESCRIPTION
@edx/ecommerce 

I was working on the front end portion and realized that it generates urls based on drupal nodes, so we need the marketing_url instead

or do we want to use the slug instead?