### PR TITLE
ECOM-4738 Expose marketing url for typeahead and only show published, non-hidden courses and active programs

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -965,6 +965,7 @@ class TypeaheadCourseRunSearchSerializer(serializers.Serializer):
     org = serializers.CharField()
     title = serializers.CharField()
     key = serializers.CharField()
+    marketing_url = serializers.CharField()
 
     class Meta:
         fields = ['key', 'title']
@@ -975,6 +976,7 @@ class TypeaheadProgramSearchSerializer(serializers.Serializer):
     uuid = serializers.CharField()
     title = serializers.CharField()
     type = serializers.CharField()
+    marketing_url = serializers.CharField()
 
     def get_orgs(self, result):
         authoring_organizations = [json.loads(org) for org in result.authoring_organization_bodies]

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1110,7 +1110,8 @@ class TypeaheadCourseRunSearchSerializerTests(TestCase):
         expected = {
             'key': course_run.key,
             'title': course_run.title,
-            'org': course_run_key.org
+            'org': course_run_key.org,
+            'marketing_url': course_run.marketing_url,
         }
         self.assertDictEqual(serialized_course.data, expected)
 
@@ -1127,7 +1128,8 @@ class TypeaheadProgramSearchSerializerTests(TestCase):
             'uuid': str(program.uuid),
             'title': program.title,
             'type': program.type.name,
-            'orgs': list(program.authoring_organizations.all().values_list('key', flat=True))
+            'orgs': list(program.authoring_organizations.all().values_list('key', flat=True)),
+            'marketing_url': program.marketing_url,
         }
 
     def test_data(self):

--- a/course_discovery/apps/api/v1/views.py
+++ b/course_discovery/apps/api/v1/views.py
@@ -32,6 +32,7 @@ from course_discovery.apps.api.renderers import AffiliateWindowXMLRenderer, Cour
 from course_discovery.apps.api.utils import cast2int
 from course_discovery.apps.catalogs.models import Catalog
 from course_discovery.apps.core.utils import SearchQuerySetWrapper
+from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.constants import COURSE_ID_REGEX, COURSE_RUN_ID_REGEX
 from course_discovery.apps.course_metadata.models import Course, CourseRun, Partner, Program, Seat
 
@@ -688,8 +689,12 @@ class TypeaheadSearchView(APIView):
 
     def get_results(self, query):
         query = '*{}*'.format(query.lower())
-        course_runs = SearchQuerySet().models(CourseRun).raw_search(query)[:self.RESULT_COUNT]
-        programs = SearchQuerySet().models(Program).raw_search(query)[:self.RESULT_COUNT]
+        course_runs = SearchQuerySet().models(CourseRun).raw_search(query)
+        course_runs = course_runs.filter(published=True).exclude(hidden=True)
+        course_runs = course_runs[:self.RESULT_COUNT]
+        programs = SearchQuerySet().models(Program).raw_search(query)
+        programs = programs.filter(status=ProgramStatus.Active)
+        programs = programs[:self.RESULT_COUNT]
         return course_runs, programs
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
@edx/ecommerce 

Two oversights I've found through continued work on this.