### PR TITLE
ECOM-4738 Verify typeahead result boosting and only apply partial search on title and course key

### DIFF
--- a/course_discovery/apps/api/v1/views.py
+++ b/course_discovery/apps/api/v1/views.py
@@ -688,7 +688,7 @@ class TypeaheadSearchView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def get_results(self, query):
-        query = '*{}*'.format(query.lower())
+        query = '(title:*{query}* OR course_key:*{query}*)'.format(query=query.lower())
         course_runs = SearchQuerySet().models(CourseRun).raw_search(query)
         course_runs = course_runs.filter(published=True).exclude(hidden=True)
         course_runs = course_runs[:self.RESULT_COUNT]


### PR DESCRIPTION
@edx/ecommerce 

After discussion with Jasper we decided to try to only search against title and course number since searching against the whole document was not giving us the results we wanted (partial searches were resulting in too many false positives that we were not interested in)
Also, I realized we had no testing of boosting, so I added unit tests of boosting