### PR TITLE
ECOM-4738 Use ngrams instead of wildcard for autocomplete and set up index settings/mappings

### DIFF
--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -1,6 +1,8 @@
 import datetime
 import logging
 
+from django.conf import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,7 +18,8 @@ class ElasticsearchUtils(object):
             # Create an index with a unique (timestamped) name
             timestamp = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
             index = '{alias}_{timestamp}'.format(alias=alias, timestamp=timestamp)
-            es.indices.create(index=index)
+            index_settings = settings.ELASTICSEARCH_INDEX_SETTINGS
+            es.indices.create(index=index, body=index_settings)
             logger.info('...index [%s] created.', index)
 
             # Point the alias to the new index

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -59,6 +59,7 @@ class BaseIndex(indexes.SearchIndex):
 class BaseCourseIndex(OrganizationsMixin, BaseIndex):
     key = indexes.CharField(model_attr='key', stored=True)
     title = indexes.CharField(model_attr='title', boost=TITLE_FIELD_BOOST)
+    title_autocomplete = indexes.NgramField(model_attr='title', boost=TITLE_FIELD_BOOST)
     short_description = indexes.CharField(model_attr='short_description', null=True)
     full_description = indexes.CharField(model_attr='full_description', null=True)
     subjects = indexes.MultiValueField(faceted=True)
@@ -181,6 +182,7 @@ class ProgramIndex(BaseIndex, indexes.Indexable, OrganizationsMixin):
 
     uuid = indexes.CharField(model_attr='uuid')
     title = indexes.CharField(model_attr='title', boost=TITLE_FIELD_BOOST)
+    title_autocomplete = indexes.NgramField(model_attr='title', boost=TITLE_FIELD_BOOST)
     subtitle = indexes.CharField(model_attr='subtitle')
     type = indexes.CharField(model_attr='type__name', faceted=True)
     marketing_url = indexes.CharField(null=True)

--- a/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
+++ b/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+from django.conf import settings
 from haystack import connections as haystack_connections
 from haystack.management.commands.update_index import Command as HaystackCommand
 
@@ -84,5 +85,6 @@ class Command(HaystackCommand):
         """
         timestamp = datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S')
         index_name = '{alias}_{timestamp}'.format(alias=prefix, timestamp=timestamp)
-        backend.conn.indices.create(index=index_name)
+        index_settings = settings.ELASTICSEARCH_INDEX_SETTINGS
+        backend.conn.indices.create(index=index_name, body=index_settings)
         return index_name

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -350,6 +350,67 @@ SWAGGER_SETTINGS = {
     'permission_denied_handler': 'course_discovery.apps.api.views.api_docs_permission_denied_handler'
 }
 
+# Elasticsearch uses index settings to specify available analyzers.
+# We are adding the lowercase analyzer and tweaking the ngram analyzers here,
+# so we need to use these settings rather than the index defaults.
+# We are making these changes to enable autocomplete for the typeahead endpoint.
+ELASTICSEARCH_INDEX_SETTINGS = {
+    'settings': {
+        'analysis': {
+            'tokenizer': {
+                'haystack_edgengram_tokenizer': {
+                    'type': 'edgeNGram',
+                    'side': 'front',
+                    'min_gram': 2,
+                    'max_gram': 15
+                },
+                'haystack_ngram_tokenizer': {
+                    'type': 'nGram',
+                    'min_gram': 2,
+                    'max_gram': 15
+                }
+            },
+            'analyzer': {
+                'lowercase': {
+                    'type': 'custom',
+                    'tokenizer': 'keyword',
+                    'filter': [
+                        'lowercase'
+                    ]
+                },
+                'ngram_analyzer': {
+                    'type':'custom',
+                    'filter': [
+                        'haystack_ngram',
+                        'lowercase'
+                    ],
+                    'tokenizer': 'standard'
+                },
+                'edgengram_analyzer': {
+                    'type': 'custom',
+                    'filter': [
+                        'haystack_edgengram',
+                        'lowercase'
+                    ],
+                    'tokenizer': 'standard'
+                }
+            },
+            'filter': {
+                'haystack_edgengram': {
+                    'type': 'edgeNGram',
+                    'min_gram': 2,
+                    'max_gram': 15
+                },
+                'haystack_ngram': {
+                    'type': 'nGram',
+                    'min_gram': 2,
+                    'max_gram': 15
+                }
+            }
+        }
+    }
+}
+
 # Haystack configuration (http://django-haystack.readthedocs.io/en/v2.5.0/settings.html)
 HAYSTACK_ITERATOR_LOAD_PER_QUERY = 200
 


### PR DESCRIPTION
@edx/ecommerce 

I finally made a breakthrough last night in understanding how to set up autocomplete correctly.
Previously I had figured out a way to get things to sort of work with wildcards, but the missing pieces for things to really work the way we want were the index settings and mappings which needed to be properly set.
Ensuring that the ngram analyzer and lowercase analyzers are available in index settings and that the ngram analyzer is set as the index_analyzer and the lowercase analyzer is set as the search analyzer in the mappings allows the autocomplete to work much better.
There is quite a bit going on here, so let me know if you have questions.

On the plus side, it should be very simple to do add the synonym analyzers now!