### PR TITLE
Boost orgs autocomplete in typeahead

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -974,29 +974,23 @@ class AggregateSearchSerializer(HaystackSerializer):
         }
 
 
-class TypeaheadCourseRunSearchSerializer(serializers.Serializer):
-    org = serializers.CharField()
-    title = serializers.CharField()
-    key = serializers.CharField()
-    marketing_url = serializers.CharField()
-
-    class Meta:
-        fields = ['key', 'title']
-
-
-class TypeaheadProgramSearchSerializer(serializers.Serializer):
+class TypeaheadBaseSearchSerializer(serializers.Serializer):
     orgs = serializers.SerializerMethodField()
-    uuid = serializers.CharField()
     title = serializers.CharField()
-    type = serializers.CharField()
     marketing_url = serializers.CharField()
 
     def get_orgs(self, result):
         authoring_organizations = [json.loads(org) for org in result.authoring_organization_bodies]
         return [org['key'] for org in authoring_organizations]
 
-    class Meta:
-        fields = ['uuid', 'title', 'type']
+
+class TypeaheadCourseRunSearchSerializer(TypeaheadBaseSearchSerializer):
+    key = serializers.CharField()
+
+
+class TypeaheadProgramSearchSerializer(TypeaheadBaseSearchSerializer):
+    uuid = serializers.CharField()
+    type = serializers.CharField()
 
 
 class TypeaheadSearchSerializer(serializers.Serializer):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1125,14 +1125,14 @@ class ProgramSearchSerializerTests(TestCase):
 
 class TypeaheadCourseRunSearchSerializerTests(TestCase):
     def test_data(self):
-        course_run = CourseRunFactory()
+        authoring_organization = OrganizationFactory()
+        course_run = CourseRunFactory(authoring_organizations=[authoring_organization])
         serialized_course = self.serialize_course_run(course_run)
-        course_run_key = CourseKey.from_string(course_run.key)
 
         expected = {
             'key': course_run.key,
             'title': course_run.title,
-            'org': course_run_key.org,
+            'orgs': [org.key for org in course_run.authoring_organizations.all()],
             'marketing_url': course_run.marketing_url,
         }
         self.assertDictEqual(serialized_course.data, expected)
@@ -1150,7 +1150,7 @@ class TypeaheadProgramSearchSerializerTests(TestCase):
             'uuid': str(program.uuid),
             'title': program.title,
             'type': program.type.name,
-            'orgs': list(program.authoring_organizations.all().values_list('key', flat=True)),
+            'orgs': [org.key for org in program.authoring_organizations.all()],
             'marketing_url': program.marketing_url,
         }
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -465,3 +465,33 @@ class TypeaheadSearchViewTests(TypeaheadSerializationMixin, LoginMixin, Elastics
             'programs': [self.serialize_program(program)]
         }
         self.assertDictEqual(response.data, expected)
+
+    def test_typeahead_org_course_runs_come_up_first(self):
+        """ Test typeahead response to ensure org is taken into account. """
+        MITx = OrganizationFactory(key='MITx')
+        HarvardX = OrganizationFactory(key='HarvardX')
+        mit_run = CourseRunFactory(
+            authoring_organizations=[MITx, HarvardX],
+            title='MIT Testing1'
+        )
+        harvard_run = CourseRunFactory(
+            authoring_organizations=[HarvardX],
+            title='MIT Testing2'
+        )
+        mit_program = ProgramFactory(
+            authoring_organizations=[MITx, HarvardX],
+            title='MIT Testing1'
+        )
+        harvard_program = ProgramFactory(
+            authoring_organizations=[HarvardX],
+            title='MIT Testing2'
+        )
+        response = self.get_typeahead_response('mit')
+        self.assertEqual(response.status_code, 200)
+        expected = {
+            'course_runs': [self.serialize_course_run(mit_run),
+                            self.serialize_course_run(harvard_run)],
+            'programs': [self.serialize_program(mit_program),
+                         self.serialize_program(harvard_program)]
+        }
+        self.assertDictEqual(response.data, expected)


### PR DESCRIPTION
@edx/ecommerce 

Jasper found yet another issue where a smithsonian course was coming up above a MIT course.
We tested this by reindexing locally and it fixed the issue.
There are no other typeahead issues that we are aware of