### PR TITLE
Added searchable courseruns filter

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -150,7 +150,7 @@ class CourseRunFilter(FilterSetMixin, django_filters.FilterSet):
 
     class Meta:
         model = CourseRun
-        fields = ['keys']
+        fields = ['keys', 'hidden']
 
 
 class ProgramFilter(FilterSetMixin, django_filters.FilterSet):

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -173,6 +173,16 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         url = reverse('api:v1:course_run-list') + '?marketable=1'
         self.assert_list_results(url, expected)
 
+    def test_filter_by_hidden(self):
+        """ Verify the endpoint filters course runs that are hidden. """
+        CourseRun.objects.all().delete()
+        course_runs = CourseRunFactory.create_batch(3, course__partner=self.partner)
+        hidden_course_runs = CourseRunFactory.create_batch(3, hidden=True, course__partner=self.partner)
+        url = reverse('api:v1:course_run-list')
+        self.assert_list_results(url, course_runs + hidden_course_runs)
+        url = reverse('api:v1:course_run-list') + '?hidden=False'
+        self.assert_list_results(url, course_runs)
+
     def test_filter_by_active(self):
         """ Verify the endpoint filters course runs to those that are active. """
         CourseRun.objects.all().delete()

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -81,6 +81,12 @@ class CourseRunViewSet(PartnerMixin, viewsets.ReadOnlyModelViewSet):
               type: string
               paramType: query
               multiple: false
+            - name: hidden
+              description: Filter based on wether the course run is hidden from search.
+              required: false
+              type: Boolean
+              paramType: query
+              multiple: false
             - name: active
               description: Retrieve active course runs. A course is considered active if its end date has not passed,
                 and it is open for enrollment.

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -127,6 +127,7 @@ class CourseRunFactory(factory.DjangoModelFactory):
     max_effort = FuzzyInteger(10, 20)
     pacing_type = FuzzyChoice([name for name, __ in CourseRunPacing.choices])
     slug = FuzzyText()
+    hidden = False
     weeks_to_complete = FuzzyInteger(1)
 
     @factory.post_generation


### PR DESCRIPTION
Added searchable filter for course runs so we can use to send data to the sailthru. Related to https://github.com/edx/ecommerce-scripts/pull/34

@clintonb @mikedikan please review