### PR TITLE
Support PSA 0.3.0

### DIFF
--- a/course_discovery/apps/core/tests/test_models.py
+++ b/course_discovery/apps/core/tests/test_models.py
@@ -1,7 +1,7 @@
 """ Tests for core models. """
 import ddt
 from django.test import TestCase
-from social.apps.django_app.default.models import UserSocialAuth
+from social_django.models import UserSocialAuth
 
 from course_discovery.apps.core.models import Currency
 from course_discovery.apps.core.tests.factories import UserFactory, PartnerFactory

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -37,7 +37,7 @@ THIRD_PARTY_APPS = [
     'release_util',
     'rest_framework',
     'rest_framework_swagger',
-    'social.apps.django_app.default',
+    'social_django',
     'waffle',
     'sortedm2m',
     'simple_history',
@@ -80,7 +80,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
 )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,3 +42,5 @@ python-dateutil==2.5.3
 pytz==2016.6.1
 # Pinning `requests` at 2.9.1 because the latest version of the package causes test failures with mocked requests
 requests==2.9.1
+# Temporary. An upgraded version of edx-auth-backends will require this for installation.
+social-auth-app-django==0.1.0


### PR DESCRIPTION
PSA moved its Django components to a new package. These changes will be accompanied by an auth-backends upgrade.

@clintonb @vkaracic here's what the settings changes will need to look like to support split social. If https://github.com/edx/auth-backends/pull/28 is merged, I can bump the auth-backends version here.