### PR TITLE
Institution logo removed from base template

### DIFF
--- a/course_discovery/templates/publisher/base.html
+++ b/course_discovery/templates/publisher/base.html
@@ -17,9 +17,6 @@
         {% include 'publisher/_header.html' %}
         <div class="layout-1q3q layout-flush border-top">
             <main class="layout-col layout-col-a layout-col-menu">
-                <div class="institute-logo">
-                    <img width="250" height="200" src="{% static 'images/institute-logo.png' %}">
-                </div>
                 <ul class="list-divided menu-list">
                     <li class="item">
                         {% url 'publisher:publisher_dashboard' as dashboard_url %}


### PR DESCRIPTION
[ECOM-6708](https://openedx.atlassian.net/browse/ECOM-6708)

* Institution logo removed from base template.
* In future we will implement in separate story.

@awais786  Please review this.

**Screenshot**
<img width="1231" alt="screen shot 2016-12-29 at 10 59 16 pm" src="https://cloud.githubusercontent.com/assets/4245618/21550313/86184992-ce1a-11e6-91cf-471c29201806.png">
