### PR TITLE
Upgrade edx-auth-backends to 0.5.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ djangorestframework-xml==1.3.0
 django-rest-swagger[reST]==0.3.10
 drf-haystack==1.6.0rc1
 dry-rest-permissions==0.1.6
-edx-auth-backends==0.5.2
+edx-auth-backends==0.5.3
 edx-ccx-keys==0.2.0
 edx-django-release-util==0.2.0
 edx-drf-extensions==1.1.1


### PR DESCRIPTION
This version of the package limits the installed version of PSA to <0.3.0. 0.3.0 introduced a major breaking change, effectively gutting PSA and moving its Django components to a new social-auth-app-django package.

@edx/ecommerce @jibsheet FYI. This is follow-up to https://github.com/edx/auth-backends/pull/27 and should fix CI builds.