### PR TITLE
Course edit page scope.

### DIFF
--- a/course_discovery/apps/publisher/urls.py
+++ b/course_discovery/apps/publisher/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     url(r'^courses/$', views.CourseListView.as_view(), name='publisher_courses'),
     url(r'^courses/new/$', views.CreateCourseView.as_view(), name='publisher_courses_new'),
     url(r'^courses/(?P<pk>\d+)/$', views.CourseDetailView.as_view(), name='publisher_course_detail'),
-    url(r'^courses/(?P<pk>\d+)/edit/$', views.UpdateCourseView.as_view(), name='publisher_courses_edit'),
+    url(r'^courses/(?P<pk>\d+)/edit/$', views.CourseEditView.as_view(), name='publisher_courses_edit'),
     url(
         r'^courses/(?P<parent_course_id>\d+)/course_runs/new/$',
         views.CreateCourseRunView.as_view(),

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -239,11 +239,11 @@ class CreateCourseView(mixins.LoginRequiredMixin, mixins.PublisherUserRequiredMi
         return render(request, self.template_name, ctx, status=400)
 
 
-class UpdateCourseView(mixins.PublisherPermissionMixin, mixins.FormValidMixin, UpdateView):
-    """ Update Course View."""
+class CourseEditView(mixins.PublisherPermissionMixin, mixins.FormValidMixin, UpdateView):
+    """ Course Edit View."""
     model = Course
     form_class = CourseForm
-    permission = OrganizationExtension.VIEW_COURSE
+    permission = OrganizationExtension.EDIT_COURSE
     template_name = 'publisher/course_form.html'
     success_url = 'publisher:publisher_course_detail'
 
@@ -251,7 +251,7 @@ class UpdateCourseView(mixins.PublisherPermissionMixin, mixins.FormValidMixin, U
         return reverse(self.success_url, kwargs={'pk': self.object.id})
 
     def get_context_data(self, **kwargs):
-        context = super(UpdateCourseView, self).get_context_data(**kwargs)
+        context = super(CourseEditView, self).get_context_data(**kwargs)
         context['comment_object'] = self.object
         return context
 


### PR DESCRIPTION
[ECOM-6057](https://openedx.atlassian.net/browse/ECOM-6057)



As a Publisher user, I'd like to be able access the Parent Course Edit page so that I can edit Parent Course details of any course.

**ACs:**

1. Validate that I can access all Course Edit pages for courses under my Org. (ex. Harvard Course team can edit Harvard Courses, but not MIT courses)
2. Validate that internal users (Publisher, Marketer, PC) can access all Course Edit pages

