### PR TITLE
Extend CourseRunQuerySet marketable filter to exclude runs without seats

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -13,7 +13,9 @@ from course_discovery.apps.core.tests.factories import UserFactory
 from course_discovery.apps.core.tests.mixins import ElasticsearchTestMixin
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import CourseRun
-from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, PartnerFactory, ProgramFactory
+from course_discovery.apps.course_metadata.tests.factories import (
+    CourseRunFactory, PartnerFactory, ProgramFactory, SeatFactory
+)
 
 
 @ddt.ddt
@@ -168,8 +170,12 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint filters course runs to those that are marketable. """
         CourseRun.objects.all().delete()
         expected = CourseRunFactory.create_batch(3, course__partner=self.partner)
+        for course_run in expected:
+            SeatFactory(course_run=course_run)
+
         CourseRunFactory.create_batch(3, slug=None, course__partner=self.partner)
         CourseRunFactory.create_batch(3, slug='', course__partner=self.partner)
+
         url = reverse('api:v1:course_run-list') + '?marketable=1'
         self.assert_list_results(url, expected)
 

--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -46,13 +46,22 @@ class CourseRunQuerySet(models.QuerySet):
     def marketable(self):
         """ Returns CourseRuns that can be marketed to learners.
 
-         A CourseRun is considered marketable if it has a defined slug and has been published.
+         A CourseRun is considered marketable if it has a defined slug, has seats, and has been published.
 
          Returns:
             QuerySet
          """
 
-        return self.exclude(slug__isnull=True).exclude(slug='').filter(status=CourseRunStatus.Published)
+        return self.exclude(
+            slug__isnull=True
+        ).exclude(
+            slug=''
+        ).exclude(
+            # This will exclude any course run without seats (e.g., CCX runs).
+            seats__isnull=True
+        ).filter(
+            status=CourseRunStatus.Published
+        )
 
 
 class ProgramQuerySet(models.QuerySet):


### PR DESCRIPTION
Runs without seats should not be considered marketable.

ECOM-6768.

@edx/ecommerce