### PR TITLE
Allow clients requesting courses to filter out unmarketable runs

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -478,6 +478,14 @@ class CourseWithProgramsSerializer(CourseSerializer):
     def get_course_runs(self, course):
         course_runs = course.course_runs.exclude(hidden=True)
 
+        if self.context.get('marketable_course_runs_only'):
+            # A client requesting marketable_course_runs_only should only receive course runs
+            # that are published, have seats, and can still be enrolled in. All other course runs
+            # should be excluded. As an unfortunate side-effect of the way we've marketed course
+            # runs in the past - a course run could be marketed despite enrollment in that run being
+            # closed - achieving this requires applying both the marketable and active filters.
+            course_runs = course_runs.marketable().active()
+
         if self.context.get('published_course_runs_only'):
             course_runs = course_runs.filter(status=CourseRunStatus.Published)
 

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -60,7 +60,7 @@ class CourseRunViewSet(PartnerMixin, viewsets.ReadOnlyModelViewSet):
         return context
 
     def list(self, request, *args, **kwargs):
-        """ List all courses runs.
+        """ List all course runs.
         ---
         parameters:
             - name: q

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -21,16 +21,6 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.CourseWithProgramsSerializer
 
     def get_queryset(self):
-        """ List one course
-        ---
-        parameters:
-            - name: include_deleted_programs
-              description: Will include deleted programs in the associated programs array
-              required: false
-              type: integer
-              paramType: query
-              multiple: false
-        """
         q = self.request.query_params.get('q', None)
 
         if q:
@@ -46,6 +36,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
         context.update({
             'exclude_utm': get_query_param(self.request, 'exclude_utm'),
             'include_deleted_programs': get_query_param(self.request, 'include_deleted_programs'),
+            'marketable_course_runs_only': get_query_param(self.request, 'marketable_course_runs_only'),
             'published_course_runs_only': get_query_param(self.request, 'published_course_runs_only'),
         })
 
@@ -55,24 +46,6 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
         """ List all courses.
          ---
         parameters:
-            - name: q
-              description: Elasticsearch querystring query. This filter takes precedence over other filters.
-              required: false
-              type: string
-              paramType: query
-              multiple: false
-            - name: keys
-              description: Filter by keys (comma-separated list)
-              required: false
-              type: string
-              paramType: query
-              multiple: false
-            - name: published_course_runs_only
-              description: Filter course runs by published ones only
-              required: false
-              type: integer
-              paramType: query
-              mulitple: false
             - name: exclude_utm
               description: Exclude UTM parameters from marketing URLs.
               required: false
@@ -83,6 +56,31 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
               description: Will include deleted programs in the associated programs array
               required: false
               type: integer
+              paramType: query
+              multiple: false
+            - name: keys
+              description: Filter by keys (comma-separated list)
+              required: false
+              type: string
+              paramType: query
+              multiple: false
+            - name: marketable_course_runs_only
+              description: Restrict returned course runs to those that are published, have seats,
+                and can still be enrolled in.
+              required: false
+              type: integer
+              paramType: query
+              mulitple: false
+            - name: published_course_runs_only
+              description: Filter course runs by published ones only
+              required: false
+              type: integer
+              paramType: query
+              mulitple: false
+            - name: q
+              description: Elasticsearch querystring query. This filter takes precedence over other filters.
+              required: false
+              type: string
               paramType: query
               multiple: false
         """


### PR DESCRIPTION
Unmarketable runs are defined as those course runs that are published, have seats, and can still be enrolled in, either now or in the future.

ECOM-6768

@edx/ecommerce please review.