### PR TITLE
Course Team groups only see the 'In Progress" Tab on the Dashboard.

### DIFF
--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -72,7 +72,6 @@ class Dashboard(mixins.LoginRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super(Dashboard, self).get_context_data(**kwargs)
         course_runs = context.get('object_list')
-
         published_course_runs = course_runs.filter(
             state__name=State.PUBLISHED,
             state__modified__gt=datetime.today() - timedelta(days=self.default_published_days)
@@ -106,6 +105,10 @@ class Dashboard(mixins.LoginRequiredMixin, ListView):
 
         context['in_progress_course_runs'] = [CourseRunWrapper(course_run) for course_run in in_progress_course_runs]
         context['preview_course_runs'] = [CourseRunWrapper(course_run) for course_run in preview_course_runs]
+
+        # If user is course team member only show in-progress tab.
+        if mixins.check_roles_access(self.request.user):
+            context['can_view_all_tabs'] = True
 
         return context
 

--- a/course_discovery/templates/publisher/dashboard.html
+++ b/course_discovery/templates/publisher/dashboard.html
@@ -12,21 +12,23 @@
         <h2 class="hd-2 emphasized">{% trans "Course runs" %}</h2>
         <ul role="tablist" class="tabs">
             <li role="tab" id="tab-progress" class="tab" aria-selected="true" aria-expanded="false"
-                aria-controls="progress" tabindex="0">
-                <span>{{ in_progress_count }}</span>{% trans "IN PROGRESS" %}
+                    aria-controls="progress" tabindex="0">
+                    <span>{{ in_progress_count }}</span>{% trans "IN PROGRESS" %}
             </li>
-            <li role="tab" id="tab-preview" class="tab" aria-selected="false" aria-expanded="false"
-                aria-controls="preview" tabindex="-1">
-                <span>{{ preview_count }}</span>{% trans "PREVIEW READY" %}
-            </li>
-            <li role="tab" id="tab-studio" class="tab" aria-selected="false" aria-expanded="true"
-                aria-controls="studio" tabindex="-1" data-studio-count="{{ studio_count }}">
-                <span id="studio-count">{{ studio_count }}</span>{% trans "STUDIO REQUEST" %}
-            </li>
-            <li role="tab" id="tab-published" class="tab" aria-selected="false" aria-expanded="false"
-                aria-controls="published" tabindex="-1">
-                <span>{{ published_count }}</span>{% trans "PUBLISHED COURSE RUNS" %}
-            </li>
+            {% if can_view_all_tabs %}
+                <li role="tab" id="tab-preview" class="tab" aria-selected="false" aria-expanded="false"
+                    aria-controls="preview" tabindex="-1">
+                    <span>{{ preview_count }}</span>{% trans "PREVIEW READY" %}
+                </li>
+                <li role="tab" id="tab-studio" class="tab" aria-selected="false" aria-expanded="true"
+                    aria-controls="studio" tabindex="-1" data-studio-count="{{ studio_count }}">
+                    <span id="studio-count">{{ studio_count }}</span>{% trans "STUDIO REQUEST" %}
+                </li>
+                <li role="tab" id="tab-published" class="tab" aria-selected="false" aria-expanded="false"
+                    aria-controls="published" tabindex="-1">
+                    <span>{{ published_count }}</span>{% trans "PUBLISHED COURSE RUNS" %}
+                </li>
+            {% endif %}
         </ul>
 
         <div role="tabpanel" id="progress" class="tab-panel" aria-labelledby="tab-progress" aria-hidden="false" tabindex="-1">


### PR DESCRIPTION
If user is publisher admin or internal user he can view all tabs. Otherwise only in-progress tab is visible only.

https://openedx.atlassian.net/browse/ECOM-6795