### PR TITLE
Update factory-boy to version 2.8.1

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ coverage==4.2
 ddt==1.1.0
 django-nose==1.4.4
 edx-lint==0.5.2
-factory-boy==2.7.0
+factory-boy==2.8.1
 freezegun==0.3.7
 lxml==3.6.1
 mock==2.0.0


### PR DESCRIPTION
The factory-boy library has a dependency on faker, which was previously known as fake-factory. Older versions of factory-boy (like the version we have been using, v2.7.0) explicitly list fake-factory, not faker, as a dependency. This is a problem because the latest release of fake-factory, version 9999.9.9, is broken (it raises an error whenever fake-factory is used). Newer versions of factory-boy have replaced fake-factory with faker.

@rlucioni @edx/ecommerce please review.