### PR TITLE
Changed the marketing_url property to use the slug from the program_t…

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -681,7 +681,7 @@ class Program(TimeStampedModel):
     @property
     def marketing_url(self):
         if self.marketing_slug:
-            path = '{type}/{slug}'.format(type=self.type.name.lower(), slug=self.marketing_slug)
+            path = '{type}/{slug}'.format(type=self.type.slug.lower(), slug=self.marketing_slug)
             return urljoin(self.partner.marketing_site_url_root, path)
 
         return None

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -322,8 +322,12 @@ class ProgramTests(MarketingSitePublisherTestMixin):
 
     def test_marketing_url(self):
         """ Verify the property creates a complete marketing URL. """
+        # In test, the factory will likely have the ProgramType's slug and ProgramType's name be the same, we need
+        # to verify that the ProgramType's slug is used and not the ProgramType's name; therefore, set the name to
+        # something obviously different from the name in order to verify that the correct object is being used.
+        self.program.type.slug = '8675309'
         expected = '{root}/{type}/{slug}'.format(root=self.program.partner.marketing_site_url_root.strip('/'),
-                                                 type=self.program.type.name.lower(), slug=self.program.marketing_slug)
+                                                 type=self.program.type.slug, slug=self.program.marketing_slug)
         self.assertEqual(self.program.marketing_url, expected)
 
     def test_marketing_url_without_slug(self):


### PR DESCRIPTION
Changed the marketing_url property to use the slug from the program_type object instead of the name of the program_type.  Added a unittest to verify that the URL generated by the marketing_url property not only has the elements we're expecting but that it is a valid URL in general.

ECOM-6813

@edx/ecommerce 