### PR TITLE
Remove single tab "ALL" from course run detail page.

### DIFF
--- a/course_discovery/templates/publisher/course_run_detail.html
+++ b/course_discovery/templates/publisher/course_run_detail.html
@@ -13,18 +13,16 @@
     <main class="layout-col layout-col-b">
         <nav class="administration-nav">
             <div class="tab-container">
-              {% if can_view_all_tabs %}
-                <button class="selected" data-tab="#tab-1">{% trans "All" %}</button>
-                {% comment %}Translators: Studio is an edX tool for course creation.{% endcomment %}
-                <button data-tab="#tab-2">{% trans "STUDIO" %}</button>
-                {% comment %}Translators: CAT is an acronym for Course Administration Tool.{% endcomment %}
-                <button data-tab="#tab-3">{% trans "CAT" %}</button>
-                {% comment %}Translators: DRUPAL is an edX marketing site.{% endcomment %}
-                <button data-tab="#tab-4">{% trans "DRUPAL" %}</button>
-                <button data-tab="#tab-5">Salesforce</button>
-              {% else %}
-                <button class="selected" disabled="disabled" data-tab="#tab-1">{% trans "All" %}</button>
-              {% endif %}
+                {% if can_view_all_tabs %}
+                    <button class="selected" data-tab="#tab-1">{% trans "All" %}</button>
+                    {% comment %}Translators: Studio is an edX tool for course creation.{% endcomment %}
+                    <button data-tab="#tab-2">{% trans "STUDIO" %}</button>
+                    {% comment %}Translators: CAT is an acronym for Course Administration Tool.{% endcomment %}
+                    <button data-tab="#tab-3">{% trans "CAT" %}</button>
+                    {% comment %}Translators: DRUPAL is an edX marketing site.{% endcomment %}
+                    <button data-tab="#tab-4">{% trans "DRUPAL" %}</button>
+                    <button data-tab="#tab-5">Salesforce</button>
+                {% endif %}
             </div>
         </nav>
 


### PR DESCRIPTION
[ECOM-6824](https://openedx.atlassian.net/browse/ECOM-6824)

Removed "All" tab from course run detail page if user cannot view all tabs. Also fixed indentation.