### PR TITLE
User dropdown typeahead added

### DIFF
--- a/course_discovery/apps/core/lookups.py
+++ b/course_discovery/apps/core/lookups.py
@@ -1,0 +1,14 @@
+from dal import autocomplete
+from course_discovery.apps.core.models import User
+
+
+class UserAutocomplete(autocomplete.Select2QuerySetView):
+    def get_queryset(self):
+        if self.request.user.is_authenticated() and self.request.user.is_staff:
+            qs = User.objects.all()
+            if self.q:
+                qs = qs.filter(username__icontains=self.q)
+
+            return qs
+
+        return []

--- a/course_discovery/apps/core/tests/test_lookups.py
+++ b/course_discovery/apps/core/tests/test_lookups.py
@@ -1,0 +1,46 @@
+import json
+
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from course_discovery.apps.core.tests.factories import UserFactory, USER_PASSWORD
+
+
+class UserAutocompleteTests(TestCase):
+    """ Tests for user autocomplete lookups."""
+
+    def setUp(self):
+        super(UserAutocompleteTests, self).setUp()
+        self.user = UserFactory(username='test_name', is_staff=True)
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+        self.users_list = UserFactory.create_batch(5)
+
+    def test_user_autocomplete(self):
+        """ Verify user autocomplete returns the data. """
+        response = self.client.get(
+            reverse('admin_core:user-autocomplete') + '?q={user}'.format(user='user')
+        )
+        self._assert_response(response, 5)
+
+        # update first user's username
+        self.users_list[0].username = 'dummy_name'
+        self.users_list[0].save()
+        response = self.client.get(
+            reverse('admin_core:user-autocomplete') + '?q={user}'.format(user='dummy')
+        )
+        self._assert_response(response, 1)
+
+    def test_course_autocomplete_un_authorize_user(self):
+        """ Verify user autocomplete returns empty list for un-authorized users. """
+        self.client.logout()
+        self.user.is_staff = False
+        self.user.save()
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+        response = self.client.get(reverse('admin_core:user-autocomplete'))
+        self._assert_response(response, 0)
+
+    def _assert_response(self, response, expected_length):
+        """ Assert autocomplete response. """
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(len(data['results']), expected_length)

--- a/course_discovery/apps/core/urls.py
+++ b/course_discovery/apps/core/urls.py
@@ -1,0 +1,10 @@
+"""
+URLs for the admin autocomplete lookups.
+"""
+from django.conf.urls import url
+
+from course_discovery.apps.core.lookups import UserAutocomplete
+
+urlpatterns = [
+    url(r'^user-autocomplete/$', UserAutocomplete.as_view(), name='user-autocomplete',),
+]

--- a/course_discovery/apps/publisher/admin.py
+++ b/course_discovery/apps/publisher/admin.py
@@ -1,23 +1,33 @@
 from django.contrib import admin
 from guardian.admin import GuardedModelAdmin
 
+from course_discovery.apps.publisher.forms import UserAttributesAdminForm, OrganizationUserRoleForm, CourseUserRoleForm
 from course_discovery.apps.publisher.models import (
     Course, CourseRun, CourseUserRole, OrganizationExtension, OrganizationUserRole, Seat, State, UserAttributes
 )
 
+
 admin.site.register(Course)
 admin.site.register(CourseRun)
-admin.site.register(OrganizationUserRole)
 admin.site.register(Seat)
 admin.site.register(State)
-admin.site.register(UserAttributes)
 
 
 @admin.register(CourseUserRole)
 class CourseUserRoleAdmin(admin.ModelAdmin):
-    raw_id_fields = ('user',)
+    form = CourseUserRoleForm
 
 
 @admin.register(OrganizationExtension)
 class OrganizationExtensionAdmin(GuardedModelAdmin):
     pass
+
+
+@admin.register(UserAttributes)
+class UserAttributesAdmin(admin.ModelAdmin):
+    form = UserAttributesAdminForm
+
+
+@admin.register(OrganizationUserRole)
+class OrganizationUserRoleAdmin(admin.ModelAdmin):
+    form = OrganizationUserRoleForm

--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -8,7 +8,9 @@ from django.utils.translation import ugettext_lazy as _
 from course_discovery.apps.course_metadata.choices import CourseRunPacing
 from course_discovery.apps.course_metadata.models import Person, Organization, Subject
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
-from course_discovery.apps.publisher.models import Course, CourseRun, Seat, User, OrganizationExtension
+from course_discovery.apps.publisher.models import (
+    Course, CourseRun, Seat, User, OrganizationExtension, OrganizationUserRole, CourseUserRole
+)
 
 
 class UserModelChoiceField(forms.ModelChoiceField):
@@ -287,3 +289,31 @@ class CustomSeatForm(SeatForm):
 
     class Meta(SeatForm.Meta):
         fields = ('price', 'type')
+
+
+class BaseUserAdminForm(forms.ModelForm):
+    class Meta:
+        fields = '__all__'
+        widgets = {
+            'user': autocomplete.ModelSelect2(
+                url='admin_core:user-autocomplete',
+                attrs={
+                    'data-minimum-input-length': 3,
+                }
+            ),
+        }
+
+
+class UserAttributesAdminForm(BaseUserAdminForm):
+    class Meta(BaseUserAdminForm.Meta):
+        model = User
+
+
+class OrganizationUserRoleForm(BaseUserAdminForm):
+    class Meta(BaseUserAdminForm.Meta):
+        model = OrganizationUserRole
+
+
+class CourseUserRoleForm(BaseUserAdminForm):
+    class Meta(BaseUserAdminForm.Meta):
+        model = CourseUserRole

--- a/course_discovery/apps/publisher/urls.py
+++ b/course_discovery/apps/publisher/urls.py
@@ -28,5 +28,6 @@ urlpatterns = [
     url(
         r'^user/toggle/email_settings/$',
         views.ToggleEmailNotification.as_view(),
-        name='publisher_toggle_email_settings'),
+        name='publisher_toggle_email_settings'
+    ),
 ]

--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -28,6 +28,7 @@ admin.autodiscover()
 
 urlpatterns = auth_urlpatterns + [
     url(r'^admin/course_metadata/', include('course_discovery.apps.course_metadata.urls', namespace='admin_metadata')),
+    url(r'^admin/core/', include('course_discovery.apps.core.urls', namespace='admin_core')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/', include('course_discovery.apps.api.urls', namespace='api')),
     # Use the same auth views for all logins, including those originating from the browseable API.


### PR DESCRIPTION
[ECOM-6835](https://openedx.atlassian.net/browse/ECOM-6835)

Typeahead field added for `user` in following models in django admin.
* Organization-user-role
* Course-user-role
* User-attributes