### PR TITLE
Use LANG to specify C.UTF-8 as the desired locale

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -5,6 +5,10 @@
 apt update
 apt install -y xvfb firefox gettext wget
 
+# TODO: Fix this in the discovery image
+# http://askubuntu.com/questions/393638/unicodedecodeerror-ascii-codec-cant-decode-byte-0x-in-position-ordinal-n
+export LANG=C.UTF-8
+
 cd /edx/app/discovery/discovery
 export PATH=$PATH:$PWD/node_modules/.bin
 


### PR DESCRIPTION
@clintonb this is shamelessly ripped this from https://github.com/edx/course-discovery/pull/474. I assume fixing this in the image just requires updating the base Dockerfile? Unless you intend to update the image soon, I'd like to merge this to un-break other builds. You could remove it in https://github.com/edx/course-discovery/pull/474 once the image is fixed.