### PR TITLE
Course run edit page scope.

### DIFF
--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -1674,3 +1674,52 @@ class CourseEditViewTests(TestCase):
         self.user.groups.add(Group.objects.get(name=ADMIN_GROUP_NAME))
         response = self.client.get(self.edit_page_url)
         self.assertEqual(response.status_code, 200)
+
+
+class CourseRunEditViewTests(TestCase):
+    """ Tests for the course run edit view. """
+
+    def setUp(self):
+        super(CourseRunEditViewTests, self).setUp()
+        self.course_run = factories.CourseRunFactory()
+        self.user = UserFactory()
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+
+        self.organization_extension = factories.OrganizationExtensionFactory()
+        self.course_run.course.organizations.add(self.organization_extension.organization)
+
+        self.edit_page_url = reverse('publisher:publisher_course_runs_edit', args=[self.course_run.id])
+
+    def test_edit_page_without_permission(self):
+        """
+        Verify that user cannot access course run edit page without edit permission.
+        """
+        response = self.client.get(self.edit_page_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_edit_page_with_edit_permission(self):
+        """
+        Verify that user can access course run edit page with edit permission.
+        """
+        self.user.groups.add(self.organization_extension.group)
+        assign_perm(
+            OrganizationExtension.EDIT_COURSE_RUN, self.organization_extension.group, self.organization_extension
+        )
+        response = self.client.get(self.edit_page_url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_edit_page_with_internal_user(self):
+        """
+        Verify that internal user can access course run edit page.
+        """
+        self.user.groups.add(Group.objects.get(name=INTERNAL_USER_GROUP_NAME))
+        response = self.client.get(self.edit_page_url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_edit_page_with_admin(self):
+        """
+        Verify that publisher admin can access course run edit page.
+        """
+        self.user.groups.add(Group.objects.get(name=ADMIN_GROUP_NAME))
+        response = self.client.get(self.edit_page_url)
+        self.assertEqual(response.status_code, 200)

--- a/course_discovery/apps/publisher/urls.py
+++ b/course_discovery/apps/publisher/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
         name='publisher_course_runs_new'
     ),
     url(r'^course_runs/(?P<pk>\d+)/$', views.CourseRunDetailView.as_view(), name='publisher_course_run_detail'),
-    url(r'^course_runs/(?P<pk>\d+)/edit/$', views.UpdateCourseRunView.as_view(), name='publisher_course_runs_edit'),
+    url(r'^course_runs/(?P<pk>\d+)/edit/$', views.CourseRunEditView.as_view(), name='publisher_course_runs_edit'),
     url(
         r'^course_runs/(?P<pk>\d+)/change_state/$', views.ChangeStateView.as_view(),
         name='publisher_change_state'

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -388,17 +388,17 @@ class CreateCourseRunView(mixins.LoginRequiredMixin, CreateView):
         return render(request, self.template_name, context, status=400)
 
 
-class UpdateCourseRunView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMixin, mixins.FormValidMixin, UpdateView):  # pylint: disable=line-too-long
-    """ Update Course Run View."""
+class CourseRunEditView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMixin, mixins.FormValidMixin, UpdateView):
+    """ Course Run Edit View."""
     model = CourseRun
     form_class = CourseRunForm
-    permission = OrganizationExtension.VIEW_COURSE
+    permission = OrganizationExtension.EDIT_COURSE_RUN
     template_name = 'publisher/course_run_form.html'
     success_url = 'publisher:publisher_course_runs_edit'
     change_state = True
 
     def get_context_data(self, **kwargs):
-        context = super(UpdateCourseRunView, self).get_context_data(**kwargs)
+        context = super(CourseRunEditView, self).get_context_data(**kwargs)
         if not self.object:
             self.object = self.get_object()
         context['workflow_state'] = self.object.current_state


### PR DESCRIPTION
[ECOM-6714](https://openedx.atlassian.net/browse/ECOM-6714)

As a Publisher user, I'd like to be able access the Course-run Edit page so that I can edit Course-run details of any course.

**AC's:**

1. Validate that I can access all Course-run Edit pages for courses under my Org. (ex. Harvard Course team can edit Harvard Courses, but not MIT courses)
2. Validate that internal users (Publisher, Marketer, PC) can access all Course-run Edit pages
