### PR TITLE
Using custom Python Social Auth Strategy

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -215,6 +215,8 @@ GUARDIAN_MONKEY_PATCH = False  # Use the mixin on the User model instead of monk
 ENABLE_AUTO_AUTH = False
 AUTO_AUTH_USERNAME_PREFIX = 'auto_auth_'
 
+SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
+
 # Set these to the correct values for your OAuth2/OpenID Connect provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OIDC_SECRET = 'replace-me'

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -20,6 +20,8 @@ HAYSTACK_CONNECTIONS = {
     },
 }
 
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/course_discovery/settings/local.py
+++ b/course_discovery/settings/local.py
@@ -35,6 +35,8 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 INTERNAL_IPS = ('127.0.0.1',)
 
 # AUTHENTICATION
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
+
 # Set these to the correct values for your OAuth2/OpenID Connect provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OIDC_SECRET = 'replace-me'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ djangorestframework-xml==1.3.0
 django-rest-swagger[reST]==0.3.10
 drf-haystack==1.6.0rc1
 dry-rest-permissions==0.1.6
-edx-auth-backends==0.5.3
+edx-auth-backends==0.6.0
 edx-ccx-keys==0.2.0
 edx-django-release-util==0.2.0
 edx-drf-extensions==1.1.1


### PR DESCRIPTION
This strategy incorporates all of the settings we previously set manually (but clearly forgot to set for this project and the cookiecutter template).

ECOM-6842