### PR TITLE
Fixed autocomplete queryset for LanguageTag.

### DIFF
--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -8,6 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from course_discovery.apps.course_metadata.choices import CourseRunPacing
 from course_discovery.apps.course_metadata.models import Person, Organization, Subject
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
+from course_discovery.apps.publisher.mixins import LanguageModelSelect2Multiple
 from course_discovery.apps.publisher.models import (
     Course, CourseRun, Seat, User, OrganizationExtension, OrganizationUserRole, CourseUserRole
 )
@@ -174,7 +175,7 @@ class CustomCourseRunForm(CourseRunForm):
 
     transcript_languages = forms.ModelMultipleChoiceField(
         queryset=LanguageTag.objects.all(),
-        widget=autocomplete.ModelSelect2Multiple(
+        widget=LanguageModelSelect2Multiple(
             url='language_tags:language-tag-autocomplete',
             attrs={
                 'data-minimum-input-length': 2
@@ -202,7 +203,8 @@ class CustomCourseRunForm(CourseRunForm):
         fields = (
             'length', 'transcript_languages', 'language', 'min_effort', 'max_effort',
             'contacted_partner_manager', 'target_content', 'pacing_type', 'video_language',
-            'staff', 'start', 'end', 'is_xseries', 'xseries_name', 'is_micromasters', 'micromasters_name',
+            'staff', 'start', 'end', 'is_xseries', 'xseries_name', 'is_micromasters',
+            'micromasters_name', 'lms_course_id',
         )
 
     def save(self, commit=True, course=None, changed_by=None):  # pylint: disable=arguments-differ

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -22,6 +22,7 @@ from course_discovery.apps.core.tests.factories import UserFactory, USER_PASSWOR
 from course_discovery.apps.core.tests.helpers import make_image_file
 from course_discovery.apps.course_metadata.tests import toggle_switch
 from course_discovery.apps.course_metadata.tests.factories import OrganizationFactory
+from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.choices import PublisherUserRole
 from course_discovery.apps.publisher.constants import (
     INTERNAL_USER_GROUP_NAME, ADMIN_GROUP_NAME, PARTNER_COORDINATOR_GROUP_NAME, REVIEWER_GROUP_NAME
@@ -1721,5 +1722,18 @@ class CourseRunEditViewTests(TestCase):
         Verify that publisher admin can access course run edit page.
         """
         self.user.groups.add(Group.objects.get(name=ADMIN_GROUP_NAME))
+        response = self.client.get(self.edit_page_url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_edit_page_with_language_tags(self):
+        """
+        Verify that publisher user can access course run edit page.
+        """
+        self.user.groups.add(Group.objects.get(name=ADMIN_GROUP_NAME))
+
+        language_tag = LanguageTag(code='te-st', name='Test Language')
+        language_tag.save()
+        self.course_run.transcript_languages.add(language_tag)
+        self.course_run.save()
         response = self.client.get(self.edit_page_url)
         self.assertEqual(response.status_code, 200)

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -20,8 +20,7 @@ from course_discovery.apps.core.models import User
 from course_discovery.apps.publisher.choices import PublisherUserRole
 from course_discovery.apps.publisher.emails import send_email_for_course_creation
 from course_discovery.apps.publisher.forms import (
-    CourseForm, CourseRunForm, SeatForm, CustomCourseForm, CustomCourseRunForm,
-    CustomSeatForm, UpdateCourseForm
+    CourseForm, SeatForm, CustomCourseForm, CustomCourseRunForm, CustomSeatForm, UpdateCourseForm
 )
 from course_discovery.apps.publisher import mixins
 from course_discovery.apps.publisher.models import (
@@ -393,7 +392,7 @@ class CreateCourseRunView(mixins.LoginRequiredMixin, CreateView):
 class CourseRunEditView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMixin, mixins.FormValidMixin, UpdateView):
     """ Course Run Edit View."""
     model = CourseRun
-    form_class = CourseRunForm
+    form_class = CustomCourseRunForm
     permission = OrganizationExtension.EDIT_COURSE_RUN
     template_name = 'publisher/course_run_form.html'
     success_url = 'publisher:publisher_course_runs_edit'

--- a/course_discovery/templates/publisher/course_run_form.html
+++ b/course_discovery/templates/publisher/course_run_form.html
@@ -43,3 +43,7 @@
         </div>
     </div>
 {% endblock %}
+
+{% block extra_js %}
+    {{ form.media }}
+{% endblock %}


### PR DESCRIPTION
[ECOM-6885](https://openedx.atlassian.net/browse/ECOM-6885)

autocomplete queryset expects ```pk``` field but ```LanguageTag``` have ```code``` as primary key instead of ```id```.