### PR TITLE
Move mysqlclient back to production settings

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,6 @@ elasticsearch>=1.0.0,<2.0.0
 html2text==2016.9.19
 jsonfield==1.0.3
 markdown==2.6.6
-mysqlclient==1.3.9
 pillow==3.4.2
 pycountry==1.20
 python-dateutil==2.5.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,6 +5,7 @@ certifi==2016.9.26
 django-ses==0.8.1
 gevent==1.1.2
 gunicorn==19.6.0
+mysqlclient==1.3.9
 newrelic==2.74.0.54
 nodeenv==1.0.0
 python-memcached==1.58


### PR DESCRIPTION
Installing this requires installation of the libmysqlclient-dev package. We only run MySQL in Docker containers; developers shouldn't need to install this package on their hosts.

@edx/ecommerce FYI.