### PR TITLE
Update the marketing api loader to login properly

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/marketing_site.py
@@ -51,7 +51,9 @@ class AbstractMarketingSiteDataLoader(AbstractDataLoader):
         login_url = '{root}/user'.format(root=self.api_url)
         response = session.post(login_url, data=login_data)
         expected_url = '{root}/users/{username}'.format(root=self.api_url, username=username)
-        if not (response.status_code == 200 and response.url == expected_url):
+        admin_url = '{root}/admin'.format(root=self.api_url)
+        can_access_admin = session.get(admin_url)
+        if not (can_access_admin.status_code == 200 and response.url == expected_url):
             raise Exception('Login failed!')
 
         return session


### PR DESCRIPTION
ECOM-6880
Instead of relying on the user page after login to be 200, check whether we can now access the admin panel to determine if we logged in.

@edx/ecommerce Please review