### PR TITLE
Fixed organization queryset and team admin issues.

### DIFF
--- a/course_discovery/static/js/publisher/publisher.js
+++ b/course_discovery/static/js/publisher/publisher.js
@@ -101,14 +101,26 @@ function loadAdminUsers(org_id) {
     $.getJSON({
         url: '/publisher/api/admins/organizations/'+ org_id +'/users/',
         success: function (data) {
-            var teamAdminDropDown = $('#id_team_admin');
+            var teamAdminDropDown = $('#id_team_admin'),
+                selectedTeamAdmin = $('#id_team_admin option:selected').val(),
+                organizationInputType = $('#id_organization').attr('type');
             teamAdminDropDown.empty();
 
-            // it will looks same like other django model choice fields
-            teamAdminDropDown.append('<option selected="selected">---------</option>');
+            if (organizationInputType == 'hidden' ) {
+                teamAdminDropDown.append('<option>---------</option>');
+            } else {
+                // it will looks same like other django model choice fields
+                teamAdminDropDown.append('<option selected="selected">---------</option>');
+            }
 
             $.each(data.results, function (i, user) {
-                teamAdminDropDown.append($('<option> </option>').val(user.id).html(user.full_name));
+                if (selectedTeamAdmin == user.id && organizationInputType === 'hidden' ) {
+                    teamAdminDropDown.append(
+                        $('<option selected="selected"> </option>').val(user.id).html(user.full_name)
+                    );
+                } else {
+                    teamAdminDropDown.append($('<option> </option>').val(user.id).html(user.full_name));
+                }
             });
         }
     });

--- a/course_discovery/templates/publisher/add_courserun_form.html
+++ b/course_discovery/templates/publisher/add_courserun_form.html
@@ -87,10 +87,10 @@
                                             {{ course_form.team_admin }}
                                         </div>
                                     </div>
-                                    {% if parent_course.team_admin %}
+                                    {% if parent_course.course_team_admin %}
                                         <div class="field-admin-name margin-top20 {% if course_form.team_admin.errors %}hidden{% endif %}">
-                                            <span class="field-readonly">{{ parent_course.team_admin.username }}</span>
-                                            <input id="team-admin-id" type="hidden" value="{{ parent_course.team_admin.id }}">
+                                            <span class="field-readonly">{{ parent_course.course_team_admin.full_name }}</span>
+                                            <input id="team-admin-id" type="hidden" value="{{ parent_course.course_team_admin.id }}">
                                             <div>
                                                 <a id="change-admin" href="#">{% trans "Change" %}</a>
                                             </div>


### PR DESCRIPTION
[ECOM-6969](https://openedx.atlassian.net/browse/ECOM-6969)

Internal user's cannot see any organization on course/course-run create/edit pages.

**AC's:**

- Validate that internal user's can see all organizations in dropdown.
- Validate that on course/course-run edit pages if user belongs to single organization then team admin is pre-populated.
