### PR TITLE
Use pytest to run tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ concurrency=multiprocessing
 omit =
     course_discovery/settings*
     course_discovery/conf*
+    *conftest.py
     *wsgi.py
     *migrations*
     *admin.py

--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,9 @@ private.py
 
 *.trace
 
-docs/_build/
-course_discovery/static/bower_components/
-node_modules/
-course_discovery/media/
+.cache/
 .dev/
+course_discovery/media/
+course_discovery/static/bower_components/
+docs/_build/
+node_modules/

--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -42,5 +42,6 @@ services:
       DB_PASSWORD: "password"
       DB_PORT: "3306"
       DB_USER: "discov001"
+      DJANGO_SETTINGS_MODULE: "course_discovery.settings.test"
       ENABLE_DJANGO_TOOLBAR: 1
       TEST_ELASTICSEARCH_URL: "http://es:9200"

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -22,8 +22,6 @@ make requirements.js
 cd docs && make html
 cd ..
 
-export DJANGO_SETTINGS_MODULE=course_discovery.settings.test
-
 # Check if translation files are up-to-date
 make validate_translations
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ production-requirements: ## Install Python and JS requirements for production
 	$(NODE_BIN)/bower install --production
 
 test: clean ## Run tests and generate coverage report
-	coverage run ./manage.py test course_discovery --settings=course_discovery.settings.test
+	coverage run -m pytest
 	coverage combine
 	coverage report
 

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ requirements.js: ## Install JS requirements for local development
 	$(NODE_BIN)/bower install
 
 requirements: ## Install Python requirements for local development
-	pip install -r requirements/local.txt --exists-action w
+	pip install -r requirements/local.txt
 
 production-requirements: ## Install Python and JS requirements for production
-	pip install -r requirements.txt --exists-action w
+	pip install -r requirements.txt
 	npm install --production
 	$(NODE_BIN)/bower install --production
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
@@ -63,7 +63,7 @@ class OrganizationViewSetTests(SerializationMixin, APITestCase):
 
         OrganizationFactory.create_batch(3)
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(self.list_path)
 
         self.assertEqual(response.status_code, 200)

--- a/course_discovery/apps/conftest.py
+++ b/course_discovery/apps/conftest.py
@@ -1,0 +1,40 @@
+"""Directory-specific hook implementations for pytest."""
+from django.test import TestCase, TransactionTestCase
+
+
+def pytest_collection_modifyitems(items):
+    def weight_test_case(test):
+        """
+        The default Django test runner gives priority to TestCase subclasses,
+        executing them before all Django-based tests (e.g., TransactionTestCase)
+        and any other unittest.TestCase tests; see
+        https://docs.djangoproject.com/en/1.9/topics/testing/overview/#order-in-which-tests-are-executed.
+
+        pytest-django doesn't preserve this ordering out of the box. For more on
+        this, see https://github.com/pytest-dev/pytest-django/issues/214.
+
+        This isn't a problem if your project's tests can run independently of each
+        other, in any order. Sadly, the majority of this project's tests rely on
+        initial data populated via migrations, which means that TestCase subclasses
+        *must* run before TransactionTestCase subclasses which reset the database
+        by truncating all tables, deleting any initial data. (The serialized_rollback
+        option can be used to remedy this within a given TransactionTestCase, but
+        it has no effect across distinct test cases; once you exit a TransactionTestCase,
+        any initial data is gone.)
+        """
+        # Test are not necessarily methods; they can be functions, in which case
+        # there is no associated class.
+        if test.cls:
+            # If the test is a subclass of TestCase, we want to run it early.
+            if issubclass(test.cls, TestCase):
+                return 0
+            # If the test is a subclass of TransactionTestCase, we want to run it last.
+            elif issubclass(test.cls, TransactionTestCase):
+                return 1
+            # If the test is a subclass of some other class, let it run with TestCases.
+            else:
+                return 0
+
+        return 0
+
+    items.sort(key=weight_test_case)

--- a/course_discovery/settings/devstack_test.py
+++ b/course_discovery/settings/devstack_test.py
@@ -2,9 +2,6 @@ from course_discovery.settings.devstack import *
 # noinspection PyUnresolvedReferences
 from course_discovery.settings.shared.test import *
 
-INSTALLED_APPS += [
-    'django_nose',
-]
 
 JWT_AUTH['JWT_SECRET_KEY'] = 'course-discovery-jwt-secret-key'
 

--- a/course_discovery/settings/shared/test.py
+++ b/course_discovery/settings/shared/test.py
@@ -1,13 +1,5 @@
 import os
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '--with-ignore-docstrings',
-    '--logging-level=DEBUG',
-    '--logging-clear-handlers',
-    '--exclude-dir=course_discovery/settings',
-]
 
 HAYSTACK_CONNECTIONS = {
     'default': {

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -6,7 +6,6 @@ from course_discovery.settings.shared.test import *
 
 
 INSTALLED_APPS += [
-    'django_nose',
     'course_discovery.apps.edx_catalog_extensions',
 ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = course_discovery.settings.test
+testpaths = course_discovery/apps

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,15 +3,14 @@
 
 coverage==4.2
 ddt==1.1.0
-django-nose==1.4.4
 edx-lint==0.5.2
 factory-boy==2.8.1
 freezegun==0.3.7
 lxml==3.6.1
 mock==2.0.0
-nose-exclude==0.5.0
-nose-ignore-docstring==0.2
 pep8==1.7.0
+pytest==3.0.6
+pytest-django==3.1.2
 responses==0.5.1
 selenium==3.0.2
 testfixtures==4.13.1


### PR DESCRIPTION
Having been in maintenance mode for the past several years, nose is effectively dead. edX and the Python community at large are moving towards pytest. pytest is very actively developed and provides several benefits over nose, including detailed introspection of failing assert statements (say goodbye to unittest's assert methods), a rich plugin ecosystem, and modular fixtures (which may help move us away from relying on migrations for initial test data).

@edx/ecommerce the failing test is known to be flaky and should be fixed by https://github.com/edx/course-discovery/pull/595. I'll rebuild this once that merges.