### PR TITLE
WL-966 Allow for use of CourseRunSerializer when calling the programs list endpoint

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -559,7 +559,11 @@ class MinimalProgramCourseSerializer(MinimalCourseSerializer):
         if self.context.get('published_course_runs_only'):
             course_runs = [course_run for course_run in course_runs if course_run.status == CourseRunStatus.Published]
 
-        return MinimalCourseRunSerializer(
+        serializer_class = MinimalCourseRunSerializer
+        if self.context.get('use_full_course_serializer', False):
+            serializer_class = CourseRunSerializer
+
+        return serializer_class(
             course_runs,
             many=True,
             context={
@@ -610,6 +614,7 @@ class MinimalProgramSerializer(serializers.ModelSerializer):
                 'exclude_utm': self.context.get('exclude_utm'),
                 'program': program,
                 'course_runs': course_runs,
+                'use_full_course_serializer': self.context.get('use_full_course_serializer', False),
             }
         )
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -832,6 +832,35 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
         expected = self.get_expected_data(program, request)
         self.assertDictEqual(serializer.data, expected)
 
+    def test_use_full_course_serializer(self):
+        """
+        Verify that we can use the `use_full_course_serializer` parameter to toggle the CourseRun
+        serializer used when returning program data.
+        """
+        request = make_request()
+        program = self.create_program()
+
+        # Assert that the seats are not available when fetched without any flag
+        program_without_seats = self.serializer_class(program, context={'request': request}).data
+        course_run_without_seats = program_without_seats['courses'][0]['course_runs'][0]
+        assert 'seats' not in course_run_without_seats
+
+        # Assert that the seats are not available when fetched with the use_full_course_serializer param set to 0
+        program_without_seats = self.serializer_class(program, context={
+            'request': request,
+            'use_full_course_serializer': 0
+        }).data
+        course_run_without_seats = program_without_seats['courses'][0]['course_runs'][0]
+        assert 'seats' not in course_run_without_seats
+
+        # Assert that the seats are available when fetched with the use_full_course_serializer param set to 1
+        program_with_seats = self.serializer_class(
+            program,
+            context={'request': request, 'use_full_course_serializer': 1}
+        ).data
+        course_run_with_seats = program_with_seats['courses'][0]['course_runs'][0]
+        assert 'seats' in course_run_with_seats
+
 
 class ProgramTypeSerializerTests(TestCase):
     serializer_class = ProgramTypeSerializer

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -37,6 +37,7 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
         context.update({
             'published_course_runs_only': get_query_param(self.request, 'published_course_runs_only'),
             'exclude_utm': get_query_param(self.request, 'exclude_utm'),
+            'use_full_course_serializer': get_query_param(self.request, 'use_full_course_serializer'),
         })
 
         return context
@@ -66,6 +67,12 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
               mulitple: false
             - name: exclude_utm
               description: Exclude UTM parameters from marketing URLs.
+              required: false
+              type: integer
+              paramType: query
+              multiple: false
+            - name: use_full_course_serializer
+              description: Return all serialized course information instead of a minimal amount of information.
               required: false
               type: integer
               paramType: query


### PR DESCRIPTION
This PR allows for the ability to return fully serialized course runs from the program list API endpoint by including the `use_minimal_course_run_serializer` parameter. This is needed so that we can display course run price information on the WL program detail page.

**Sandbox URL**: https://discovery-edx.sandbox.edx.org/api/v1/programs/?use_minimal_course_run_serializer=0