### PR TITLE
WL-766 Add ability to filter Program list by a comma-separated list of ProgramType names

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -156,6 +156,7 @@ class CourseRunFilter(FilterSetMixin, django_filters.FilterSet):
 class ProgramFilter(FilterSetMixin, django_filters.FilterSet):
     marketable = django_filters.MethodFilter()
     type = django_filters.CharFilter(name='type__name', lookup_expr='iexact')
+    types = CharListFilter(name='type__slug', lookup_expr='in')
     uuids = UUIDListFilter()
 
     class Meta:

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -127,6 +127,18 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         url = self.list_path + '?type=bar'
         self.assert_list_results(url, [], 4)
 
+    def test_filter_by_types(self):
+        """ Verify that the endpoint filters programs to those matching the provided ProgramType slugs. """
+        expected = ProgramFactory.create_batch(2)
+        expected.reverse()
+        type_slugs = [p.type.slug for p in expected]
+        url = self.list_path + '?types=' + ','.join(type_slugs)
+
+        # Create a third program, which should be filtered out.
+        ProgramFactory()
+
+        self.assert_list_results(url, expected, 8)
+
     def test_filter_by_uuids(self):
         """ Verify that the endpoint filters programs to those matching the provided UUIDs. """
         expected = ProgramFactory.create_batch(2)

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -77,6 +77,12 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
               type: integer
               paramType: query
               multiple: false
+            - name: types
+              description: Filter by comma-separated list of program type slugs
+              required: false
+              type: string
+              paramType: query
+              multiple: false
         """
         return super(ProgramViewSet, self).list(request, *args, **kwargs)
 


### PR DESCRIPTION
WL-766

We will use this in the LMS marketing pages to filter the list of Programs by the ProgramTypes that should be display on a given site.