### PR TITLE
ECOM-6518 add logic to select CourseRun for indexing with Course

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -355,7 +355,7 @@ class Course(TimeStampedModel):
         - Purchasability: A user can purchase a paid Seat.
         """
         def sort_key(course_run):
-            """ 
+            """
             Return a numeric score indicating the priority of this CourseRun relative to others. Lower numbers
             indicate higher priority.
             """

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -382,8 +382,11 @@ class Course(TimeStampedModel):
             else:
                 return 7
 
-        course_runs = sorted(list(self.course_runs.all()), key=sort_key)
-        return course_runs[0] if len(course_runs) > 0 else None
+        course_runs = list(self.course_runs.all())
+        if course_runs:
+            return sorted(course_runs, key=sort_key)[0]
+        else:
+            return None
 
 
 class CourseRun(TimeStampedModel):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -277,7 +277,6 @@ class CourseRunTests(TestCase):
         factories.ProgramFactory(courses=[self.course_run.course], status=ProgramStatus.Deleted)
         self.assertEqual(self.course_run.program_types, [active_program.type.name])
 
-
     @ddt.data(
         # Case 1: Should be True when CourseRun is published, not hidden, and has Seats.
         (True, False, True, True),
@@ -303,7 +302,6 @@ class CourseRunTests(TestCase):
             factories.SeatFactory.create(course_run=course_run)
 
         assert expected_result == course_run.is_publicly_visible
-
 
     @ddt.data(
         # Case 1: Should be True when enrollment_start is unspecified or in the past and

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -1,13 +1,13 @@
-import itertools
 import datetime
-from decimal import Decimal
+import itertools
 import random
+from decimal import Decimal
 
 import ddt
 import mock
+import pytz
 import responses
 from dateutil.parser import parse
-import pytz
 from django.conf import settings
 from django.db import IntegrityError
 from django.db.models.functions import Lower

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -310,7 +310,7 @@ class CourseRunTests(TestCase):
         (None, datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1), True),
         (datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=1), None, True),
         (datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=1),
-            datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1), True),
+         datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1), True),
 
         # Case 2: Should be False when enrollment_start is in the future or enrollment_end is in the past.
         (datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1), None, False),


### PR DESCRIPTION
This PR adds the logic necessary to select the CourseRun to use for indexing a Course. This logic is not currently used anywhere, but will be in a subsequent PR.

JIRA: https://openedx.atlassian.net/browse/ECOM-6815

@edx/ecommerce