### PR TITLE
ECOM-7336 Add upgradeable filter to course runs

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -542,7 +542,7 @@ class CourseWithProgramsSerializer(CourseSerializer):
 
         if self.context.get('marketable_enrollable_course_runs_with_archived'):
             # Same as "marketable_course_runs_only", but includes courses with an end date in the past
-            course_runs = course_runs.marketable().enrollable()
+            course_runs = course_runs.marketable().enrollable().upgradeable()
 
         if self.context.get('published_course_runs_only'):
             course_runs = course_runs.filter(status=CourseRunStatus.Published)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -26,7 +26,7 @@ from course_discovery.apps.core.tests.factories import UserFactory
 from course_discovery.apps.core.tests.helpers import make_image_file
 from course_discovery.apps.core.tests.mixins import ElasticsearchTestMixin
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
-from course_discovery.apps.course_metadata.models import Course, CourseRun, Program
+from course_discovery.apps.course_metadata.models import Course, CourseRun, Program, Seat
 from course_discovery.apps.course_metadata.tests.factories import (
     CorporateEndorsementFactory, CourseFactory, CourseRunFactory, EndorsementFactory, ExpectedLearningItemFactory,
     ImageFactory, JobOutlookItemFactory, OrganizationFactory, PersonFactory, PositionFactory, PrerequisiteFactory,
@@ -260,9 +260,9 @@ class CourseWithProgramsSerializerTests(CourseSerializerTests):
             enrollment_end=None,
             course=self.course
         )
-        SeatFactory(course_run=unpublished_course_run)
-        SeatFactory(course_run=enrollable_course_run)
-        SeatFactory(course_run=archived_course_run)
+        SeatFactory(course_run=unpublished_course_run, upgrade_deadline=None, type=Seat.VERIFIED)
+        SeatFactory(course_run=enrollable_course_run, upgrade_deadline=None, type=Seat.VERIFIED)
+        SeatFactory(course_run=archived_course_run, upgrade_deadline=None, type=Seat.VERIFIED)
 
         context = {
             'request': self.request,

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -76,7 +76,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
               mulitple: false
             - name: marketable_enrollable_course_runs_with_archived
               description: Restrict returned course runs to those that are published, have seats,
-                and can be enrolled in now. Includes archived courses.
+              can be enrolled in now and can be upgraded. Includes archived courses.
               required: false
               type: integer
               paramType: query

--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -83,6 +83,22 @@ class CourseRunQuerySet(models.QuerySet):
             status=CourseRunStatus.Published
         )
 
+    def upgradeable(self):
+        """ Returns course runs which have a verified or professional seat and do not have
+        an expired upgrade deadline.
+
+        Returns:
+            QuerySet
+        """
+        now = datetime.datetime.now(pytz.UTC)
+        # Nested to avoid circular import.
+        from course_discovery.apps.course_metadata.models import Seat
+        return self.filter(
+            Q(seats__type__contains=Seat.VERIFIED) | Q(seats__type__contains=Seat.PROFESSIONAL)
+        ).exclude(
+            Q(seats__upgrade_deadline__lt=now)
+        )
+
 
 class ProgramQuerySet(models.QuerySet):
     def marketable(self):


### PR DESCRIPTION
Here is the logic as I understood it for this [ticket](https://openedx.atlassian.net/browse/ECOM-7336).

For the course run dialog, _In addition to current filtering_:
1. Only include a course run if a course run has a verified or professional seat and that seat has an upgrade deadline that is none or in the future.

If we go with this approach, changing the marketing site will not be necessary, since we can modify the existing query param that the marketing site passes.

@edx/ecommerce 