### PR TITLE
Ecom 6815 Add aggregation key to search indexes

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -977,6 +977,7 @@ class BaseHaystackFacetSerializer(HaystackFacetSerializer):
 
 class CourseSearchSerializer(HaystackSerializer):
     content_type = serializers.CharField(source='model_name')
+    aggregation_key = serializers.CharField()
 
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
@@ -1001,6 +1002,7 @@ class CourseFacetSerializer(BaseHaystackFacetSerializer):
 
 class CourseRunSearchSerializer(HaystackSerializer):
     availability = serializers.SerializerMethodField()
+    aggregation_key = serializers.CharField()
 
     def get_availability(self, result):
         return result.object.availability
@@ -1024,6 +1026,7 @@ class CourseRunFacetSerializer(BaseHaystackFacetSerializer):
 
 class ProgramSearchSerializer(HaystackSerializer):
     authoring_organizations = serializers.SerializerMethodField()
+    aggregation_key = serializers.CharField()
 
     def get_authoring_organizations(self, program):
         organizations = program.authoring_organization_bodies
@@ -1064,6 +1067,7 @@ class TypeaheadBaseSearchSerializer(serializers.Serializer):
     orgs = serializers.SerializerMethodField()
     title = serializers.CharField()
     marketing_url = serializers.CharField()
+    aggregation_key = serializers.CharField()
 
     def get_orgs(self, result):
         authoring_organizations = [json.loads(org) for org in result.authoring_organization_bodies]

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -414,6 +414,23 @@ class AggregateSearchViewSet(DefaultPartnerMixin, SerializationMixin, LoginMixin
         expected = [self.serialize_course_run(course_run) for course_run in course_runs]
         self.assertEqual(response.data['objects']['results'], expected)
 
+    def test_results_include_aggregation_key(self):
+        """ Verify the search results only include the aggregation_key for each document. """
+        course_run = CourseRunFactory(course__partner=self.partner, status=CourseRunStatus.Published)
+        program = ProgramFactory(partner=self.partner, status=ProgramStatus.Active)
+
+        response = self.get_response()
+        assert 200 == response.status_code
+        response_data = json.loads(response.content.decode('utf-8'))
+
+        expected = sorted(
+            ['courserun:{}'.format(course_run.course.key), 'program:{}'.format(program.uuid)]
+        )
+        actual = sorted(
+            [obj.get('aggregation_key') for obj in response_data['objects']['results']]
+        )
+        assert expected == actual
+
 
 class TypeaheadSearchViewTests(DefaultPartnerMixin, TypeaheadSerializationMixin, LoginMixin, ElasticsearchTestMixin,
                                SynonymTestMixin, APITestCase):

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -110,6 +110,13 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
 
     prerequisites = indexes.MultiValueField(faceted=True)
 
+    # A key that can be used to group related documents together to enable the computation of distinct facet and hit
+    # counts.
+    aggregation_key = indexes.CharField()
+
+    def prepare_aggregation_key(self, obj):
+        return 'course:{}'.format(obj.key)
+
     def prepare_course_runs(self, obj):
         return [course_run.key for course_run in obj.course_runs.all()]
 
@@ -152,6 +159,13 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     subject_uuids = indexes.MultiValueField()
     has_enrollable_paid_seats = indexes.BooleanField(null=False)
     paid_seat_enrollment_end = indexes.DateTimeField(null=True)
+
+    # A key that can be used to group related documents together to enable the computation of distinct facet and hit
+    # counts.
+    aggregation_key = indexes.CharField()
+
+    def prepare_aggregation_key(self, obj):
+        return 'courserun:{}'.format(obj.course.key)
 
     def prepare_has_enrollable_paid_seats(self, obj):
         return obj.has_enrollable_paid_seats()
@@ -225,6 +239,13 @@ class ProgramIndex(BaseIndex, indexes.Indexable, OrganizationsMixin):
     start = indexes.DateTimeField(model_attr='start', null=True, faceted=True)
     seat_types = indexes.MultiValueField(model_attr='seat_types', null=True, faceted=True)
     published = indexes.BooleanField(null=False, faceted=True)
+
+    # A key that can be used to group related documents together to enable the computation of distinct facet and hit
+    # counts.
+    aggregation_key = indexes.CharField()
+
+    def prepare_aggregation_key(self, obj):
+        return 'program:{}'.format(obj.uuid)
 
     def prepare_published(self, obj):
         return obj.status == ProgramStatus.Active


### PR DESCRIPTION
This PR adds a new field, `aggregation_key`, to the CourseIndex, CourseRunIndex, and ProgramIndex and also includes it in the search serializers. This is necessary for several reasons:
- The `aggregation_key` field allows us to compute accurate counts for distinct records across content types, which will be necessary when we begin filtering duplicate cards from search results on the marketing site.
- By including the `aggregation_key` in the serializers, it will be available in the client-side js code on the marketing site and can be used to filter duplicate cards from the search results page in a way that is consistent with how the distinct counts are computed. We were going to have to add a field to the serializers anyway to support client-side filtering, as course_key is not currently included in the CourseRunSearchSerializer.

This will require running the update_index command after deploy.