### PR TITLE
ECOM-6815 Add aggregation_key to indices

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/tests/test_backends.py
+++ b/course_discovery/apps/edx_haystack_extensions/tests/test_backends.py
@@ -1,3 +1,4 @@
+import haystack
 from django.test import TestCase
 
 from course_discovery.apps.edx_haystack_extensions.backends import EdxElasticsearchSearchBackend
@@ -10,3 +11,13 @@ class EdxElasticsearchSearchBackendTests(NonClearingSearchBackendMixinTestMixin,
                                          TestCase):
     """ Tests for EdxElasticsearchSearchBackend.  """
     backend_class = EdxElasticsearchSearchBackend
+
+    def test_build_schema_handles_aggregation_key(self):
+        """Verify that build_schema marks the aggregation_key field as not_analyzed."""
+        backend = self.get_backend()
+        index = haystack.connections[backend.connection_alias].get_unified_index()
+        fields = index.all_searchfields()
+        mapping = backend.build_schema(fields)[1]
+        assert mapping.get('aggregation_key')
+        assert mapping['aggregation_key']['index'] == 'not_analyzed'
+        assert 'analyzer' not in mapping['aggregation_key']


### PR DESCRIPTION
This PR adds a new field, `aggregation_key`, to the CourseIndex, CourseRunIndex, and ProgramIndex. This is necessary as it allows us to compute accurate counts for distinct records across content types, which will be necessary when we begin filtering duplicate cards from search results on the marketing site.

This will require running the update_index command after deploy.

@edx/ecommerce 