### PR TITLE
Fixed course team user cannot change role assignment for CourseTeam role.

### DIFF
--- a/course_discovery/apps/publisher/api/views.py
+++ b/course_discovery/apps/publisher/api/views.py
@@ -12,7 +12,7 @@ from course_discovery.apps.publisher.models import (Course, CourseRun, CourseRun
 
 
 class CourseRoleAssignmentView(UpdateAPIView):
-    permission_classes = (IsAuthenticated, CanViewAssociatedCourse, InternalUserPermission,)
+    permission_classes = (IsAuthenticated, CanViewAssociatedCourse,)
     queryset = CourseUserRole.objects.all()
     serializer_class = CourseUserRoleSerializer
 


### PR DESCRIPTION
[ECOM-7353](https://openedx.atlassian.net/browse/ECOM-7353)

Fixed course team user cannot change role assignment for CourseTeam role. `CanViewAssociatedCourse` was enough to check permission for both type of internal and course team users, removed extra permission class to fix this bug.