### PR TITLE
Update remove index approach to match AWS

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/management/commands/remove_unused_indexes.py
+++ b/course_discovery/apps/edx_haystack_extensions/management/commands/remove_unused_indexes.py
@@ -66,7 +66,10 @@ class Command(BaseCommand):
         Returns:
             sorted_indexes_by_timestamp (list): The sorted listing of index names
         """
-        all_index_settings = indices_client.get_settings()
-        all_indexes = list(all_index_settings.keys())
+        # Elasticsearch in AWS is not a full implementation of ES, and we need to use the (more verbose) status
+        # endpoint instead of the (more succinct) settings endpoint. For more information, see
+        # http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es_version_1_5.html
+        all_index_status = indices_client.status()
+        all_indexes = list(all_index_status['indices'].keys())
         all_current_indexes = [index_name for index_name in all_indexes if index_name.startswith(index_prefix + '_')]
         return sorted(all_current_indexes)


### PR DESCRIPTION
ECOM-7297

AWS ES doesn't support the settings request. We need to update the way we fetch the indexes to use something else that is supported.

@edx/ecommerce & @feanil for review 