### PR TITLE
Remove upgradeable filter from serializer  

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -542,7 +542,7 @@ class CourseWithProgramsSerializer(CourseSerializer):
 
         if self.context.get('marketable_enrollable_course_runs_with_archived'):
             # Same as "marketable_course_runs_only", but includes courses with an end date in the past
-            course_runs = course_runs.marketable().enrollable().upgradeable()
+            course_runs = course_runs.marketable().enrollable()
 
         if self.context.get('published_course_runs_only'):
             course_runs = course_runs.filter(status=CourseRunStatus.Published)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -26,7 +26,7 @@ from course_discovery.apps.core.tests.factories import UserFactory
 from course_discovery.apps.core.tests.helpers import make_image_file
 from course_discovery.apps.core.tests.mixins import ElasticsearchTestMixin
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
-from course_discovery.apps.course_metadata.models import Course, CourseRun, Program, Seat
+from course_discovery.apps.course_metadata.models import Course, CourseRun, Program
 from course_discovery.apps.course_metadata.tests.factories import (
     CorporateEndorsementFactory, CourseFactory, CourseRunFactory, EndorsementFactory, ExpectedLearningItemFactory,
     ImageFactory, JobOutlookItemFactory, OrganizationFactory, PersonFactory, PositionFactory, PrerequisiteFactory,
@@ -260,9 +260,9 @@ class CourseWithProgramsSerializerTests(CourseSerializerTests):
             enrollment_end=None,
             course=self.course
         )
-        SeatFactory(course_run=unpublished_course_run, upgrade_deadline=None, type=Seat.VERIFIED)
-        SeatFactory(course_run=enrollable_course_run, upgrade_deadline=None, type=Seat.VERIFIED)
-        SeatFactory(course_run=archived_course_run, upgrade_deadline=None, type=Seat.VERIFIED)
+        SeatFactory(course_run=unpublished_course_run)
+        SeatFactory(course_run=enrollable_course_run)
+        SeatFactory(course_run=archived_course_run)
 
         context = {
             'request': self.request,

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -76,7 +76,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
               mulitple: false
             - name: marketable_enrollable_course_runs_with_archived
               description: Restrict returned course runs to those that are published, have seats,
-              can be enrolled in now and can be upgraded. Includes archived courses.
+                and can be enrolled in now. Includes archived courses.
               required: false
               type: integer
               paramType: query


### PR DESCRIPTION
After some conversations with Jasper and Alasdair I've uncovered some use cases that were not 100% clear previously that may require regrooming/replanning. We will most likely still need the upgradeable filter I added in the previous PR, but I am removing the changes to actually use the filter until we resolve the open questions regarding the story