### PR TITLE
ECOM-7392 Turn off real time index updates

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -430,7 +430,8 @@ HAYSTACK_CONNECTIONS = {
     },
 }
 
-HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
+# We are using BaseSignalProcessor to avoid overloading our production ES instance
+HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.BaseSignalProcessor'
 HAYSTACK_INDEX_RETENTION_LIMIT = 3
 
 # Elasticsearch search query facet "size" option to increase from the default value of "100"

--- a/course_discovery/settings/shared/test.py
+++ b/course_discovery/settings/shared/test.py
@@ -8,6 +8,10 @@ HAYSTACK_CONNECTIONS = {
     },
 }
 
+# We are using RealtimeSignalProcessor because our tests depend on it being enabled
+# and it does not cause performance issues for testing
+HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
+
 SYNONYMS_MODULE = 'course_discovery.settings.test_synonyms'
 
 EDX_DRF_EXTENSIONS = {


### PR DESCRIPTION
@edx/ecommerce 

My plan was to:
1. merge this tomorrow morning
2. deploy to prod
3. run refresh course metadata
4. run update index
5. when that is done, merge a PR to turn this back on
6. deploy to prod again