### PR TITLE
ENT-201: Add support for course run key in catalog contains endpoint

### DIFF
--- a/course_discovery/apps/api/v1/views/catalogs.py
+++ b/course_discovery/apps/api/v1/views/catalogs.py
@@ -113,12 +113,25 @@ class CatalogViewSet(viewsets.ModelViewSet):
               type: string
               paramType: query
               multiple: true
+            - name: course_run_id
+              description: Course run IDs to check for existence in the Catalog.
+              required: false
+              type: string
+              paramType: query
+              multiple: true
         """
         course_ids = request.query_params.get('course_id')
-        course_ids = course_ids.split(',')
+        course_run_ids = request.query_params.get('course_run_id')
 
         catalog = self.get_object()
-        courses = catalog.contains(course_ids)
+        courses = {}
+        if course_ids:
+            course_ids = course_ids.split(',')
+            courses.update(catalog.contains(course_ids))
+
+        if course_run_ids:
+            course_run_ids = course_run_ids.split(',')
+            courses.update(catalog.contains_course_runs(course_run_ids))
 
         instance = {'courses': courses}
         serializer = serializers.ContainedCoursesSerializer(instance)

--- a/course_discovery/apps/catalogs/models.py
+++ b/course_discovery/apps/catalogs/models.py
@@ -7,7 +7,7 @@ from guardian.shortcuts import get_users_with_perms
 from haystack.query import SearchQuerySet
 
 from course_discovery.apps.core.mixins import ModelPermissionsMixin
-from course_discovery.apps.course_metadata.models import Course
+from course_discovery.apps.course_metadata.models import Course, CourseRun
 
 
 class Catalog(ModelPermissionsMixin, TimeStampedModel):
@@ -53,6 +53,23 @@ class Catalog(ModelPermissionsMixin, TimeStampedModel):
         results = self._get_query_results().filter(key__in=course_ids)
         for result in results:
             contains[result.get_stored_fields()['key']] = True
+
+        return contains
+
+    def contains_course_runs(self, course_run_ids):  # pylint: disable=unused-argument
+        """
+        Determines if the given course runs are contained in this catalog.
+
+        Arguments:
+            course_run_ids (str[]): List of course run IDs
+
+        Returns:
+            dict: Mapping of course IDs to booleans indicating if course run is
+                  contained in this catalog.
+        """
+        contains = {course_run_id: False for course_run_id in course_run_ids}
+        course_runs = CourseRun.search(self.query).filter(key__in=course_run_ids).values_list('key', flat=True)
+        contains.update({course_run_id: course_run_id in course_runs for course_run_id in course_run_ids})
 
         return contains
 

--- a/course_discovery/apps/catalogs/tests/test_models.py
+++ b/course_discovery/apps/catalogs/tests/test_models.py
@@ -5,7 +5,7 @@ from course_discovery.apps.catalogs.models import Catalog
 from course_discovery.apps.catalogs.tests import factories
 from course_discovery.apps.core.tests.factories import UserFactory
 from course_discovery.apps.core.tests.mixins import ElasticsearchTestMixin
-from course_discovery.apps.course_metadata.tests.factories import CourseFactory
+from course_discovery.apps.course_metadata.tests.factories import CourseFactory, CourseRunFactory
 
 
 @ddt.ddt
@@ -37,6 +37,15 @@ class CatalogTests(ElasticsearchTestMixin, TestCase):
         self.assertDictEqual(
             self.catalog.contains([self.course.key, uncontained_course.key]),
             {self.course.key: True, uncontained_course.key: False}
+        )
+
+    def test_contains_course_runs(self):
+        """ Verify the method returns a mapping of course run IDs to booleans. """
+        course_run = CourseRunFactory(course=self.course)
+        uncontained_course_run = CourseRunFactory(title_override='ABD')
+        self.assertDictEqual(
+            self.catalog.contains_course_runs([course_run.key, uncontained_course_run.key]),
+            {course_run.key: True, uncontained_course_run.key: False}
         )
 
     def test_courses_count(self):


### PR DESCRIPTION
ENT-201

@saleem-latif @asadiqbal08 @mattdrayer @clintonb @cpennington 
Update the endpoint `contains` of `CatalogViewSet` to accept a new optional parameter `course_run_id`. This new parameter will be used for validating if the course run keys of the format `org/course/run` or `course-v1:org+course+run` exists in a catalog.

For example in `Ecom` we can use this endpoint like this:
```python
>>> course_ids = 'edX+TEST_01'
>>> course_run_ids = 'org/course/run,course-v1:edX+DemoX+Demo_Course'
>>> catalog_id = 1
>>> response = site.siteconfiguration.course_catalog_api_client.catalogs(catalog_id).contains.get(
    course_id=course_ids,
    course_run_id=course_run_ids,
)
>>> response
{u'courses': {u'edX+TEST_01': True, u'org/course/run': False, u'course-v1:edX+DemoX+Demo_Course': True}}
```

**Related PR:** [ENT-211 add aggregate course key](https://github.com/edx/opaque-keys/pull/87)