### PR TITLE
ECOM-7346 Turn off index updates on model save

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -3,6 +3,7 @@ import datetime
 from urllib.parse import urlencode
 
 import ddt
+import pytest
 import pytz
 from django.test import TestCase
 from haystack.query import SearchQuerySet
@@ -1191,6 +1192,7 @@ class CourseSearchSerializerTests(TestCase):
 
 
 class CourseRunSearchSerializerTests(TestCase):
+    @pytest.mark.skip(reason="turning off temporarily for experiment - ECOM-7346")
     def test_data(self):
         course_run = CourseRunFactory(transcript_languages=LanguageTag.objects.filter(code__in=['en-us', 'zh-cn']),
                                       authoring_organizations=[OrganizationFactory()])

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -3,6 +3,7 @@ import json
 import urllib.parse
 
 import ddt
+import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from haystack.query import SearchQuerySet
@@ -234,14 +235,17 @@ class CourseRunSearchViewSetTests(DefaultPartnerMixin, SerializationMixin, Login
         }
         self.assertDictContainsSubset(expected, response_data['queries'])
 
+    @pytest.mark.skip(reason="turning off temporarily for experiment - ECOM-7346")
     def test_exclude_deleted_program_types(self):
         """ Verify the deleted programs do not show in the program_types representation. """
         self._test_exclude_program_types(ProgramStatus.Deleted)
 
+    @pytest.mark.skip(reason="turning off temporarily for experiment - ECOM-7346")
     def test_exclude_unpublished_program_types(self):
         """ Verify the unpublished programs do not show in the program_types representation. """
         self._test_exclude_program_types(ProgramStatus.Unpublished)
 
+    @pytest.mark.skip(reason="turning off temporarily for experiment - ECOM-7346")
     @ddt.data(
         [{'title': 'Software Testing', 'excluded': True}],
         [{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True}],

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -333,13 +333,14 @@ class Course(TimeStampedModel):
         ids = [result.pk for result in results]
         return cls.objects.filter(pk__in=ids)
 
-    def save(self, *args, **kwargs):
-        super(Course, self).save(*args, **kwargs)
-        try:
-            self.reindex_course_runs()
-        except Exception:  # pylint: disable=broad-except
-            logger.exception("An error occurred while attempting to reindex the course runs"
-                             "of Course with key: [{key}].".format(key=self.key))
+    # This is commented out for a temporary experiment for ECOM-7346
+    # def save(self, *args, **kwargs):
+    #     super(Course, self).save(*args, **kwargs)
+    #     try:
+    #         self.reindex_course_runs()
+    #     except Exception:  # pylint: disable=broad-except
+    #         logger.exception("An error occurred while attempting to reindex the course runs"
+    #                          "of Course with key: [{key}].".format(key=self.key))
 
     def reindex_course_runs(self):
         index = connections['default'].get_unified_index().get_index(CourseRun)
@@ -938,7 +939,8 @@ class Program(TimeStampedModel):
                 publisher.publish_program(self)
         else:
             super(Program, self).save(*args, **kwargs)
-        self.reindex_courses()
+        # This is commented out for a temporary experiment for ECOM-7346
+        # self.reindex_courses()
 
     def reindex_courses(self):
         try:


### PR DESCRIPTION
Tested this by running refresh with es off before changes (which gave indexing errors) and after changes (which did not give errors)

plan was to merge this today and then revert today after running refresh_course_metadata