### PR TITLE
Updated makefile to only pull reviewed strings from Transifex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ compile_translations: ## Compile translation files, outputting .po files for eac
 fake_translations: extract_translations dummy_translations compile_translations ## Generate and compile dummy translation files
 
 pull_translations: ## Pull translations from Transifex
-	tx pull -af
+	tx pull -af --mode reviewed
 
 start-devstack: ## Run a local development copy of the server
 	docker-compose up


### PR DESCRIPTION
Updated makefile to only pull reviewed strings from Transifex


Full conversation here: https://github.com/edx/credentials/pull/182
The resulting language file changes are here:  https://github.com/edx/course-discovery/pull/723