### PR TITLE
Fix backend state in SearchIndexTestMixin tearDown method

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/tests/mixins.py
+++ b/course_discovery/apps/edx_haystack_extensions/tests/mixins.py
@@ -36,8 +36,9 @@ class SearchIndexTestMixin(object):
         self.index_prefix = self.backend.index_name
 
     def tearDown(self):
-        """ Remove the indexes we created """
+        """ Remove the indexes we created and reset the backend index_name."""
         self.backend.conn.indices.delete(index=self.index_prefix + '_*')
+        self.backend.index_name = self.index_prefix
         super(SearchIndexTestMixin, self).tearDown()
 
 


### PR DESCRIPTION
The `UpdateIndexTests` modify the backend.index_name variable and do not reset it, which causes future tests to interact with the wrong index and fail. This PR addresses this issue by resetting the index_name after the tests complete.

@edx/ecommerce 