### PR TITLE
Fix Courses Without End Date Not Visible via API. ECOM-7444

### DIFF
--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -35,8 +35,10 @@ class CourseRunQuerySet(models.QuerySet):
         """
         now = datetime.datetime.now(pytz.UTC)
         return self.filter(
-            Q(end__gt=now) &
             (
+                Q(end__gt=now) |
+                Q(end__isnull=True)
+            ) & (
                 Q(enrollment_end__gt=now) |
                 Q(enrollment_end__isnull=True)
             )


### PR DESCRIPTION
## [ECOM-7444](https://openedx.atlassian.net/browse/ECOM-7444) -  Courses Without End Date Not Visible via API

### Description
We have noticed that there is a number of open and available courses missing from csv catalogs generated by our catalog API by using either

### Fix
Courses were filtered which were missing `end` dates, I have changed the `active` method to include those runs as well. 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Style and readability review: @Ayub-Khan 
- [x] Code review: @clintonb 
- [x] Code review: @schenedx 

FYI: @adampalay @rlucioni 

### Post-review
- [ ] Rebase and squash commits