### PR TITLE
Exclude courses without active, marketable runs from catalogs

### DIFF
--- a/course_discovery/apps/api/v1/views/catalogs.py
+++ b/course_discovery/apps/api/v1/views/catalogs.py
@@ -84,14 +84,12 @@ class CatalogViewSet(viewsets.ModelViewSet):
         """
         Retrieve the list of courses contained within this catalog.
 
-        Only courses with active course runs are returned. A course run is considered active if it is currently
-        open for enrollment, or will open in the future.
+        Only courses with at least one active and marketable course run are returned.
         ---
         serializer: serializers.CourseSerializerExcludingClosedRuns
         """
-
         catalog = self.get_object()
-        queryset = catalog.courses().active()
+        queryset = catalog.courses().active().marketable()
         queryset = prefetch_related_objects_for_courses(queryset)
 
         page = self.paginate_queryset(queryset)

--- a/course_discovery/apps/course_metadata/tests/test_query.py
+++ b/course_discovery/apps/course_metadata/tests/test_query.py
@@ -11,35 +11,67 @@ from course_discovery.apps.course_metadata.tests.factories import CourseRunFacto
 
 class CourseQuerySetTests(TestCase):
     def test_active(self):
-        """ Verify the method filters the Courses to those with active course runs. """
+        """
+        Verify the method filters Courses to those with active CourseRuns.
+        """
         now = datetime.datetime.now(pytz.UTC)
         active_course_end = now + datetime.timedelta(days=60)
         inactive_course_end = now - datetime.timedelta(days=15)
         open_enrollment_end = now + datetime.timedelta(days=30)
         closed_enrollment_end = now - datetime.timedelta(days=30)
 
-        # Create an active enrollable course
+        # Create an active, enrollable course run
         active_course = CourseRunFactory(enrollment_end=open_enrollment_end, end=active_course_end).course
 
-        # Create an active unenrollable course
+        # Create an active, unenrollable course run
         CourseRunFactory(enrollment_end=closed_enrollment_end, end=active_course_end, course__title='ABC Test Course 2')
 
-        # Create an inactive unenrollable course
+        # Create an inactive, unenrollable course run
         CourseRunFactory(enrollment_end=closed_enrollment_end, end=inactive_course_end)
 
-        # Create an active course with unrestricted enrollment
+        # Create an active course run with an unspecified enrollment end
         course_without_enrollment_end = CourseRunFactory(enrollment_end=None, end=active_course_end).course
 
-        # Create an inactive course with unrestricted enrollment
+        # Create an inactive course run with an unspecified enrollment end
         CourseRunFactory(enrollment_end=None, end=inactive_course_end)
 
-        # Create course with end date is NULL
+        # Create an enrollable course run with an unspecified end date
         course_without_end = CourseRunFactory(enrollment_end=open_enrollment_end, end=None).course
 
-        self.assertEqual(
-            set(Course.objects.active()),
-            {active_course, course_without_enrollment_end, course_without_end}
-        )
+        assert set(Course.objects.active()) == {
+            active_course, course_without_enrollment_end, course_without_end
+        }
+
+    def test_marketable(self):
+        """
+        Verify the method filters Courses to those with marketable CourseRuns.
+        """
+        # Courses whose runs have null or empty slugs are excluded, even if
+        # those runs are published and have seats.
+        for invalid_slug in (None, ''):
+            excluded_course_run = CourseRunFactory(slug=invalid_slug)
+            SeatFactory(course_run=excluded_course_run)
+
+        # Courses whose runs have no seats are excluded, even if those runs
+        # are published and have valid slugs.
+        CourseRunFactory()
+
+        # Courses whose runs are unpublished are excluded, even if those runs
+        # have seats and valid slugs.
+        excluded_course_run = CourseRunFactory(status=CourseRunStatus.Unpublished)
+        SeatFactory(course_run=excluded_course_run)
+
+        # Courses with at least one run that is published and has seats and a valid
+        # slug are included.
+        included_course_run = CourseRunFactory()
+        SeatFactory(course_run=included_course_run)
+
+        included_course = included_course_run.course
+        # This run has no seats and will be excluded, but we still expect its parent
+        # course to be included.
+        CourseRunFactory(course=included_course)
+
+        assert set(Course.objects.marketable()) == {included_course}
 
 
 @ddt.ddt


### PR DESCRIPTION
The catalog API should only list courses which have at least one active and marketable course run.

ECOM-6473

@edx/ecommerce FYI.