### PR TITLE
Courses appearing in catalogs must be available

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from rest_framework.test import APIRequestFactory
 
 from course_discovery.apps.api.serializers import (
-    CatalogSerializer, CourseRunWithProgramsSerializer, CourseSerializerExcludingClosedRuns,
+    CatalogCourseSerializer, CatalogSerializer, CourseRunWithProgramsSerializer,
     CourseWithProgramsSerializer, FlattenedCourseRunWithCourseSerializer, MinimalProgramSerializer,
     OrganizationSerializer, PersonSerializer, ProgramSerializer, ProgramTypeSerializer
 )
@@ -57,7 +57,7 @@ class SerializationMixin(object):
         return self._serialize_object(ProgramTypeSerializer, program_type, many, format, extra_context)
 
     def serialize_catalog_course(self, course, many=False, format=None, extra_context=None):
-        return self._serialize_object(CourseSerializerExcludingClosedRuns, course, many, format, extra_context)
+        return self._serialize_object(CatalogCourseSerializer, course, many, format, extra_context)
 
     def serialize_catalog_flat_course_run(self, course_run, many=False, format=None, extra_context=None):
         return self._serialize_object(FlattenedCourseRunWithCourseSerializer, course_run, many, format, extra_context)

--- a/course_discovery/apps/api/v1/views/catalogs.py
+++ b/course_discovery/apps/api/v1/views/catalogs.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from course_discovery.apps.api import filters, serializers
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.renderers import CourseRunCSVRenderer
-from course_discovery.apps.api.v1.views import User, prefetch_related_objects_for_courses
+from course_discovery.apps.api.v1.views import User
 from course_discovery.apps.catalogs.models import Catalog
 from course_discovery.apps.course_metadata.models import CourseRun
 
@@ -86,14 +86,14 @@ class CatalogViewSet(viewsets.ModelViewSet):
 
         Only courses with at least one active and marketable course run are returned.
         ---
-        serializer: serializers.CourseSerializerExcludingClosedRuns
+        serializer: serializers.CatalogCourseSerializer
         """
         catalog = self.get_object()
-        queryset = catalog.courses().active().marketable()
-        queryset = prefetch_related_objects_for_courses(queryset)
+        queryset = catalog.courses().available()
+        queryset = serializers.CatalogCourseSerializer.prefetch_queryset(queryset=queryset)
 
         page = self.paginate_queryset(queryset)
-        serializer = serializers.CourseSerializerExcludingClosedRuns(page, many=True, context={'request': request})
+        serializer = serializers.CatalogCourseSerializer(page, many=True, context={'request': request})
         return self.get_paginated_response(serializer.data)
 
     @detail_route()

--- a/course_discovery/conftest.py
+++ b/course_discovery/conftest.py
@@ -1,0 +1,131 @@
+import datetime
+from functools import partial
+from itertools import product
+
+import pytest
+import pytz
+
+from course_discovery.apps.course_metadata.choices import CourseRunStatus
+from course_discovery.apps.course_metadata.tests.factories import SeatFactory
+
+
+@pytest.fixture(scope='class')
+def course_run_states(request):
+    """
+    pytest fixture for providing test classes with attributes necessary to create
+    and test CourseRuns in all states affecting availability.
+    """
+    now = datetime.datetime.now(pytz.UTC)
+    past = now - datetime.timedelta(days=30)
+    future = now + datetime.timedelta(days=30)
+
+    def enrollment_start_null(course_run):
+        course_run.enrollment_start = None
+
+    def enrollment_start_past(course_run):
+        course_run.enrollment_start = past
+
+    def enrollment_start_future(course_run):
+        course_run.enrollment_start = future
+
+    def enrollment_end_null(course_run):
+        course_run.enrollment_end = None
+
+    def enrollment_end_past(course_run):
+        course_run.enrollment_end = past
+
+    def enrollment_end_future(course_run):
+        course_run.enrollment_end = future
+
+    def end_null(course_run):
+        course_run.end = None
+
+    def end_past(course_run):
+        course_run.end = past
+
+    def end_future(course_run):
+        course_run.end = future
+
+    def slug_null(course_run):
+        course_run.slug = None
+
+    def slug_blank(course_run):
+        course_run.slug = ''
+
+    def slug_valid(course_run):
+        course_run.slug = 'foo'
+
+    def seats_null(course_run):  # pylint: disable=unused-argument
+        pass
+
+    def seats_exist(course_run):
+        SeatFactory(course_run=course_run)
+
+    def published(course_run):
+        course_run.status = CourseRunStatus.Published
+
+    def unpublished(course_run):
+        course_run.status = CourseRunStatus.Unpublished
+
+    # The Cartesian product of these lists represents the 324 possible course
+    # run states that affect a parent course's availability.
+    states = [
+        [
+            enrollment_start_null,
+            enrollment_start_past,
+            enrollment_start_future
+        ],
+        [
+            enrollment_end_null,
+            enrollment_end_past,
+            enrollment_end_future
+        ],
+        [
+            end_null,
+            end_past,
+            end_future
+        ],
+        [
+            slug_null,
+            slug_blank,
+            slug_valid
+        ],
+        [
+            seats_null,
+            seats_exist
+        ],
+        [
+            published,
+            unpublished
+        ]
+    ]
+
+    # The Cartesian product of these lists represents the 8 possible course
+    # run states that yield an available parent course.
+    available_states = [
+        [
+            enrollment_start_null,
+            enrollment_start_past
+        ],
+        [
+            enrollment_end_null,
+            enrollment_end_future
+        ],
+        [
+            end_null,
+            end_future
+        ],
+        [
+            slug_valid
+        ],
+        [
+            seats_exist
+        ],
+        [
+            published
+        ]
+    ]
+
+    # Set class attributes on the invoking test context.
+    request.cls.states = partial(product, *states)
+    request.cls.available_states = list(product(*available_states))


### PR DESCRIPTION
A course is considered to be "available" if it contains at least one course run that can be enrolled in immediately, is ongoing or yet to start, and appears on the marketing site. The catalog API should only list courses which are available. An earlier attempt at this fell short because it filtered courses to those which contained at least one active *or* marketable run.

ECOM-6473

@edx/ecommerce