### PR TITLE
Cache search results when requesting facet counts

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -454,6 +454,11 @@ SEARCH_FACET_LIMIT = 10000
 DISTINCT_COUNTS_HIT_PRECISION = 1500
 DISTINCT_COUNTS_FACET_PRECISION = 250
 
+# The number of records that should be requested when warming the SearchQuerySet cache. Set this to equal the
+# number of records typically requested with each search query in order to reduce the number of queries that need
+# to be executed.
+DISTINCT_COUNTS_QUERY_CACHE_WARMING_COUNT = 20
+
 DEFAULT_PARTNER_ID = None
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#site-id


### PR DESCRIPTION
Our search/facets endpoints currently execute three search queries for every one search request. When the drf_haystack facets action initializes its serializer, it calls SearchQuerySet.facet_counts, which executes the query but doesn't cache any of the results. Later, when the serializer creates a paginator object, SearchQuerySet.count is called, which executes another query and doesn't cache any results. Finally, when the paginator object requests the results for the page, a third query is run. This time, the results get cached but by this point three queries have already run.

This fix might not be the most elegant, but it is quick and would allow us to significantly reduce search load. I've already run some loadtests for the new distinct_counts endpoint with these changes and found response times to be 25% lower than they were in prior tests (186 ms vs 263 ms on average). With these changes, the distinct_counts endpoint is actually 8% faster than the original search/all/facets endpoint (186 ms vs 202 ms on average). Without them, it is 30% slower.

@rlucioni 
@edx/ecommerce 