### PR TITLE
Optimize queries made by the catalog courses endpoint

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -172,8 +172,11 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
                 # to be included.
                 CourseRunFactory(course=course)
 
-                with self.assertNumQueries(26):
+                with self.assertNumQueries(18):
                     response = self.client.get(url)
+
+                # Prefetched results are assigned to a custom attribute.
+                course.available_course_runs = [course_run]
 
                 assert response.status_code == 200
                 assert response.data['results'] == self.serialize_catalog_course([course], many=True)

--- a/course_discovery/apps/api/v1/views/catalogs.py
+++ b/course_discovery/apps/api/v1/views/catalogs.py
@@ -84,7 +84,8 @@ class CatalogViewSet(viewsets.ModelViewSet):
         """
         Retrieve the list of courses contained within this catalog.
 
-        Only courses with at least one active and marketable course run are returned.
+        Only courses with at least one course run that can be enrolled in immediately,
+        is ongoing or yet to start, and appears on the marketing site are returned.
         ---
         serializer: serializers.CatalogCourseSerializer
         """


### PR DESCRIPTION
filter() and exclude() calls made to narrow the set of course runs after prefetching were causing prefetched data to be discarded. This resulted in the endpoint making many duplicate queries. These expensive duplicate queries are eliminated by prefetching the filtered set of course runs instead of prefetching all course runs and then trying to filter them.

ECOM-6473

I'll be giving the `CourseWithProgramsSerializer` a similar treatment in a subsequent PR. It makes the same mistake as the serializer corrected here: filtering a prefetched result instead of prefetching the filtered result directly.

@edx/ecommerce 