### PR TITLE
Don't show history widget for single object.

### DIFF
--- a/course_discovery/static/sass/publisher/publisher.scss
+++ b/course_discovery/static/sass/publisher/publisher.scss
@@ -630,3 +630,7 @@
     padding-bottom: 20px;
     font-size: 14px;
 }
+
+#id_select_revisions {
+    max-width: 50%;
+}

--- a/course_discovery/templates/publisher/_history_widget.html
+++ b/course_discovery/templates/publisher/_history_widget.html
@@ -1,8 +1,7 @@
 {% load i18n %}
 <div class="margin-top20">
-<h5 class="hd-5 emphasized course-runs-heading">{% trans "REVISION HISTORY" %}</h5>
-<br>
-{% with object.history.all as history_list %}
+    <h5 class="hd-5 emphasized course-runs-heading">{% trans "REVISION HISTORY" %}</h5>
+    <br>
     <select id="id_select_revisions">
         {% for history in history_list %}
             {% if forloop.first %}
@@ -17,6 +16,4 @@
         {% endfor %}
     </select>
     <a id="id_open_revision" class="btn btn-brand btn-small btn-courserun-add" href="{% url 'publisher:publisher_course_revision' course.id history_list.first.history_id %}" target="_blank">{% trans "Open Selected Version" %}</a>
-{% endwith %}
 </div>
-

--- a/course_discovery/templates/publisher/course_detail/_widgets.html
+++ b/course_discovery/templates/publisher/course_detail/_widgets.html
@@ -40,9 +40,14 @@
             </div>
         {% endfor %}
     </div>
-    <div class="history-widget {% if not publisher_history_widget_feature %}hidden{% endif %}">
-      {% include 'publisher/_history_widget.html' %}
-    </div>
+
+    {% with object.history.all as history_list %}
+        {% if history_list.count > 1 %}
+            <div class="history-widget {% if not publisher_history_widget_feature %}hidden{% endif %}">
+              {% include 'publisher/_history_widget.html' %}
+            </div>
+        {% endif %}
+    {% endwith %}
     <div class="approval-widget {% if not publisher_approval_widget_feature %}hidden{% endif %}">
       {% include 'publisher/_approval_widget.html' %}
     </div>


### PR DESCRIPTION
[ECOM-7501](https://openedx.atlassian.net/browse/ECOM-7501)

As a publisher user, I don't want to see the revision history module unless there is actual history so that I don't get confused with a wrong display.

**AC:**

- Validate that the revision history drop down is only shown when there is more than one version.