### PR TITLE
Temporarily remove updating index alias

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
+++ b/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
@@ -28,8 +28,9 @@ class Command(HaystackCommand):
         super(Command, self).handle(*items, **options)
 
         # Set the alias (from settings) to the timestamped catalog.
-        for backend, index, alias in alias_mappings:
-            self.set_alias(backend, alias, index)
+        # Temporarily commenting this out to test if update index command is still broken
+        # for backend, index, alias in alias_mappings:
+        #    self.set_alias(backend, alias, index)
 
     def set_alias(self, backend, alias, index):
         """

--- a/course_discovery/apps/edx_haystack_extensions/tests/test_update_index.py
+++ b/course_discovery/apps/edx_haystack_extensions/tests/test_update_index.py
@@ -1,3 +1,4 @@
+import pytest
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
@@ -7,6 +8,7 @@ from freezegun import freeze_time
 from course_discovery.apps.edx_haystack_extensions.tests.mixins import SearchIndexTestMixin
 
 
+@pytest.mark.skip(reason="Temporarily disabling for testing update index command")
 class UpdateIndexTests(SearchIndexTestMixin, TestCase):
     @freeze_time('2016-06-21')
     def test_handle(self):


### PR DESCRIPTION
@rlucioni @mikedikan @edx/ecommerce 

Renzo and I had the thought to make sure we don't update to a broken index and then test update index command with higher verbosity