### PR TITLE
After MKT has reviewed a COURSE, any CT edits doesn't have to be approved by MKT again.

### DIFF
--- a/course_discovery/apps/publisher/api/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/tests/test_views.py
@@ -441,7 +441,7 @@ class ChangeCourseStateViewTests(TestCase):
 
     def test_change_course_state(self):
         """
-        Verify that if marketing user change course workflow state, owner role will be changed to `CourseTeam`.
+        Verify that if marketing user change course state, owner role will be changed to `CourseTeam`.
         """
         self.assertNotEqual(self.course_state.name, CourseStateChoices.Review)
         factories.CourseUserRoleFactory(
@@ -465,6 +465,8 @@ class ChangeCourseStateViewTests(TestCase):
 
         self.assertEqual(self.course_state.name, CourseStateChoices.Review)
         self.assertEqual(self.course_state.owner_role, PublisherUserRole.CourseTeam)
+        # Verify that course is marked as reviewed by marketing.
+        self.assertTrue(self.course_state.marketing_reviewed)
 
         subject = 'Changes to {title} are ready for review'.format(title=self.course.title)
         self._assert_email_sent(course_team_user, subject)

--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -522,11 +522,10 @@ class CourseState(TimeStampedModel, ChangedByMixin):
         elif state == CourseStateChoices.Review:
             user_role = self.course.course_user_roles.get(user=user)
             if user_role.role == PublisherUserRole.MarketingReviewer:
-                self.owner_role = PublisherUserRole.CourseTeam
-                self.owner_role_modified = timezone.now()
+                self.change_owner_role(PublisherUserRole.CourseTeam)
+                self.marketing_reviewed = True
             elif user_role.role == PublisherUserRole.CourseTeam:
-                self.owner_role = PublisherUserRole.MarketingReviewer
-                self.owner_role_modified = timezone.now()
+                self.change_owner_role(PublisherUserRole.MarketingReviewer)
 
             self.review()
 
@@ -536,7 +535,6 @@ class CourseState(TimeStampedModel, ChangedByMixin):
         elif state == CourseStateChoices.Approved:
             user_role = self.course.course_user_roles.get(user=user)
             self.approved_by_role = user_role.role
-            self.owner_role_modified = timezone.now()
             self.approved()
 
             if waffle.switch_is_active('enable_publisher_email_notifications'):
@@ -618,11 +616,9 @@ class CourseRunState(TimeStampedModel, ChangedByMixin):
         elif state == CourseRunStateChoices.Review:
             user_role = self.course_run.course.course_user_roles.get(user=user)
             if user_role.role == PublisherUserRole.ProjectCoordinator:
-                self.owner_role = PublisherUserRole.CourseTeam
-                self.owner_role_modified = timezone.now()
+                self.change_owner_role(PublisherUserRole.CourseTeam)
             elif user_role.role == PublisherUserRole.CourseTeam:
-                self.owner_role = PublisherUserRole.ProjectCoordinator
-                self.owner_role_modified = timezone.now()
+                self.change_owner_role(PublisherUserRole.ProjectCoordinator)
 
             self.review()
 
@@ -632,8 +628,7 @@ class CourseRunState(TimeStampedModel, ChangedByMixin):
         elif state == CourseRunStateChoices.Approved:
             user_role = self.course_run.course.course_user_roles.get(user=user)
             self.approved_by_role = user_role.role
-            self.owner_role = PublisherUserRole.Publisher
-            self.owner_role_modified = timezone.now()
+            self.change_owner_role(PublisherUserRole.Publisher)
             self.approved()
 
             if waffle.switch_is_active('enable_publisher_email_notifications'):


### PR DESCRIPTION
[ECOM-7538](https://openedx.atlassian.net/browse/ECOM-7538)

Once MKT submits changes for review, a subsequent CT edit does not change the state and the "Mark as reviewed" button stays the same.