### PR TITLE
Increase Haystack connection timeout

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -427,6 +427,7 @@ HAYSTACK_CONNECTIONS = {
         'ENGINE': 'course_discovery.apps.edx_haystack_extensions.backends.EdxElasticsearchSearchEngine',
         'URL': 'http://localhost:9200/',
         'INDEX_NAME': 'catalog',
+        'TIMEOUT': 30,
     },
 }
 


### PR DESCRIPTION
This was previously unspecified, causing us to use the default of 10 seconds. We've seen sporadic Elasticsearch timeouts while updating new indices. In an attempt to resolve this, we've lowered the batch size used for bulk updates. Increasing this timeout should further help reduce timeouts.

LEARNER-370