### PR TITLE
Reduce course run view's query count

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -429,7 +429,9 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         queryset = super().prefetch_queryset(queryset=queryset)
 
         return queryset.select_related('language', 'video').prefetch_related(
+            'course__level_type',
             'transcript_languages',
+            'video__image',
             Prefetch('staff', queryset=PersonSerializer.prefetch_queryset()),
         )
 
@@ -453,7 +455,7 @@ class CourseRunWithProgramsSerializer(CourseRunSerializer):
     def prefetch_queryset(cls, queryset=None):
         queryset = super().prefetch_queryset(queryset=queryset)
 
-        return queryset.prefetch_related('course__programs')
+        return queryset.prefetch_related('course__programs__excluded_course_runs')
 
     def get_programs(self, obj):
         programs = []

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -172,7 +172,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
                 # to be included.
                 filtered_course_run = CourseRunFactory(course=course)
 
-                with self.assertNumQueries(18):
+                with self.assertNumQueries(19):
                     response = self.client.get(url)
 
                 assert response.status_code == 200

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -51,7 +51,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data.get('programs') == []
@@ -133,7 +133,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns a list of all course runs. """
         url = reverse('api:v1:course_run-list')
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -146,7 +146,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns a list of all course runs sorted by start date. """
         url = '{root}?ordering=start'.format(root=reverse('api:v1:course_run-list'))
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
 
         assert response.status_code == 200

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -64,7 +64,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
     def test_retrieve(self):
         """ Verify the endpoint returns the details for a single program. """
         program = self.create_program()
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(41):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 
@@ -75,7 +75,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         for course in course_list:
             CourseRunFactory(course=course)
         program = ProgramFactory(courses=course_list, order_courses_by_start_date=order_courses_by_start_date)
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(28):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
         self.assertEqual(course_list, list(program.courses.all()))  # pylint: disable=no-member


### PR DESCRIPTION
Prefetching of course run video image, course level type, and program excluded runs further reduces the number of queries required to service requests for course runs.

@jibsheet FYI. This should help smooth the response time of this endpoint. I found these by looking at the [NR transaction breakdown](https://rpm.newrelic.com/accounts/88178/applications/15120497/transactions?tw%5Bend%5D=1490820510&tw%5Bstart%5D=1490816910#id=5b225765625472616e73616374696f6e2f46756e6374696f6e2f636f757273655f646973636f766572792e617070732e6170692e76312e76696577732e636f757273655f72756e733a436f7572736552756e566965775365742e6c697374222c22225d) for this endpoint on stage.