### PR TITLE
Display applicable seat types in serializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -820,6 +820,7 @@ class ProgramSerializer(MinimalProgramSerializer):
     )
     subjects = SubjectSerializer(many=True)
     staff = PersonSerializer(many=True)
+    applicable_seat_types = serializers.SerializerMethodField()
 
     @classmethod
     def prefetch_queryset(cls):
@@ -848,6 +849,9 @@ class ProgramSerializer(MinimalProgramSerializer):
             Prefetch('individual_endorsements', queryset=EndorsementSerializer.prefetch_queryset()),
         )
 
+    def get_applicable_seat_types(self, obj):
+        return list(obj.type.applicable_seat_types.values_list('slug', flat=True))
+
     class Meta(MinimalProgramSerializer.Meta):
         model = Program
         fields = MinimalProgramSerializer.Meta.fields + (
@@ -855,7 +859,7 @@ class ProgramSerializer(MinimalProgramSerializer):
             'min_hours_effort_per_week', 'max_hours_effort_per_week', 'video', 'expected_learning_items',
             'faq', 'credit_backing_organizations', 'corporate_endorsements', 'job_outlook_items',
             'individual_endorsements', 'languages', 'transcript_languages', 'subjects', 'price_ranges',
-            'staff', 'credit_redemption_overview',
+            'staff', 'credit_redemption_overview', 'applicable_seat_types'
         )
 
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -621,6 +621,7 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
             'authoring_organizations': OrganizationSerializer(program.authoring_organizations, many=True).data,
             'video': VideoSerializer(program.video).data,
             'credit_redemption_overview': program.credit_redemption_overview,
+            'applicable_seat_types': list(program.type.applicable_seat_types.values_list('slug', flat=True)),
             'corporate_endorsements': CorporateEndorsementSerializer(program.corporate_endorsements, many=True).data,
             'credit_backing_organizations': OrganizationSerializer(
                 program.credit_backing_organizations,
@@ -642,7 +643,7 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
             'overview': program.overview,
             'price_ranges': program.price_ranges,
             'subjects': SubjectSerializer(program.subjects, many=True).data,
-            'transcript_languages': [serialize_language_to_code(l) for l in program.transcript_languages]
+            'transcript_languages': [serialize_language_to_code(l) for l in program.transcript_languages],
         })
 
         return expected

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -64,7 +64,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
     def test_retrieve(self):
         """ Verify the endpoint returns the details for a single program. """
         program = self.create_program()
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(42):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 
@@ -75,7 +75,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         for course in course_list:
             CourseRunFactory(course=course)
         program = ProgramFactory(courses=course_list, order_courses_by_start_date=order_courses_by_start_date)
-        with self.assertNumQueries(28):
+        with self.assertNumQueries(29):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
         self.assertEqual(course_list, list(program.courses.all()))  # pylint: disable=no-member
@@ -84,7 +84,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns data for a program even if the program's courses have no course runs. """
         course = CourseFactory()
         program = ProgramFactory(courses=[course])
-        with self.assertNumQueries(19):
+        with self.assertNumQueries(20):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 


### PR DESCRIPTION
We need the applicable seat types information exposed so that on the marketing site we know which seats' SKUs to use to create the link that would add the seats to the user basket.
https://openedx.atlassian.net/browse/LEARNER-475

@clintonb could this solve our problem?