### PR TITLE
LEARNER-498 Fix marketing site client login process

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
@@ -77,19 +77,17 @@ class AbstractMarketingSiteDataLoaderTestMixin(DataLoaderTestMixin):
 
     def mock_login_response(self, failure=False):
         url = self.api_url + 'user'
-        landing_url = '{base}users/{username}'.format(base=self.api_url,
-                                                      username=self.partner.marketing_site_api_username)
+        landing_url = '{base}admin'.format(base=self.api_url)
         status = 500 if failure else 302
         adding_headers = {}
 
         if not failure:
             adding_headers['Location'] = landing_url
         responses.add(responses.POST, url, status=status, adding_headers=adding_headers)
-        responses.add(responses.GET, landing_url)
 
         responses.add(
             responses.GET,
-            '{root}admin'.format(root=self.api_url),
+            landing_url,
             status=(500 if failure else 200)
         )
 

--- a/course_discovery/apps/course_metadata/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/tests/mixins.py
@@ -22,9 +22,8 @@ class MarketingSiteAPIClientTestMixin(TestCase):
 
     def mock_login_response(self, status):
         """ Mock the response of the marketing site login """
-        response_url = '{root}/users/{username}'.format(
-            root=self.api_root,
-            username=self.username
+        response_url = '{root}/admin'.format(
+            root=self.api_root
         )
 
         def request_callback(request):  # pylint: disable=unused-argument
@@ -45,15 +44,6 @@ class MarketingSiteAPIClientTestMixin(TestCase):
             response_url,
             body='',
             content_type='text/html',
-            status=status
-        )
-
-    def mock_admin_response(self, status):
-        """ Test that we can access the admin """
-        response_url = '{root}/admin'.format(root=self.api_root)
-        responses.add(
-            responses.GET,
-            response_url,
             status=status
         )
 
@@ -95,7 +85,6 @@ class MarketingSitePublisherTestMixin(MarketingSiteAPIClientTestMixin):
 
     def mock_api_client(self, status):
         self.mock_login_response(status)
-        self.mock_admin_response(status)
         self.mock_csrf_token_response(status)
         self.mock_user_id_response(status)
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -614,7 +614,7 @@ class ProgramTests(MarketingSitePublisherTestMixin):
             with mock.patch.object(MarketingSitePublisher, '_get_form_build_id_and_form_token', return_value={}):
                 with mock.patch.object(MarketingSitePublisher, '_get_delete_alias_url', return_value='/foo'):
                     self.program.save()
-                    self.assert_responses_call_count(9)
+                    self.assert_responses_call_count(8)
 
     @responses.activate
     def test_xseries_program_save(self):
@@ -649,7 +649,7 @@ class ProgramTests(MarketingSitePublisherTestMixin):
         self.mock_node_delete(204)
         toggle_switch('publish_program_to_marketing_site', True)
         self.program.delete()
-        self.assert_responses_call_count(6)
+        self.assert_responses_call_count(5)
 
     @responses.activate
     def test_delete_and_no_marketing_site(self):

--- a/course_discovery/apps/course_metadata/tests/test_publishers.py
+++ b/course_discovery/apps/course_metadata/tests/test_publishers.py
@@ -57,7 +57,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         self.mock_node_retrieval(self.program.uuid)
         publisher = MarketingSitePublisher()
         node_id = publisher._get_node_id(self.api_client, self.program.uuid)  # pylint: disable=protected-access
-        self.assert_responses_call_count(5)
+        self.assert_responses_call_count(4)
         self.assertEqual(node_id, self.node_id)
 
     @responses.activate
@@ -75,7 +75,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         publisher = MarketingSitePublisher()
         publish_data = publisher._get_node_data(self.program, self.user_id)  # pylint: disable=protected-access
         publisher._edit_node(self.api_client, self.node_id, publish_data)  # pylint: disable=protected-access
-        self.assert_responses_call_count(5)
+        self.assert_responses_call_count(4)
 
     @responses.activate
     def test_edit_node_failed(self):
@@ -114,7 +114,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         with mock.patch.object(MarketingSitePublisher, '_get_headers', return_value={}):
             with mock.patch.object(MarketingSitePublisher, '_get_form_build_id_and_form_token', return_value={}):
                 publisher.publish_program(self.program)
-                self.assert_responses_call_count(8)
+                self.assert_responses_call_count(7)
 
     @responses.activate
     def test_publish_program_edit(self):
@@ -126,7 +126,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         with mock.patch.object(MarketingSitePublisher, '_get_headers', return_value={}):
             with mock.patch.object(MarketingSitePublisher, '_get_form_build_id_and_form_token', return_value={}):
                 publisher.publish_program(self.program)
-                self.assert_responses_call_count(8)
+                self.assert_responses_call_count(7)
 
     @responses.activate
     def test_publish_modified_program(self):
@@ -141,7 +141,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
             with mock.patch.object(MarketingSitePublisher, '_get_form_build_id_and_form_token', return_value={}):
                 with mock.patch.object(MarketingSitePublisher, '_get_delete_alias_url', return_value='/foo'):
                     publisher.publish_program(self.program)
-                    self.assert_responses_call_count(9)
+                    self.assert_responses_call_count(8)
 
     @responses.activate
     def test_get_alias_form(self):
@@ -153,7 +153,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         self.mock_get_alias_form()
         with mock.patch.object(MarketingSitePublisher, '_get_headers', return_value={}):
             publisher.publish_program(self.program)
-            self.assert_responses_call_count(9)
+            self.assert_responses_call_count(8)
 
     @responses.activate
     def test_get_delete_form(self):
@@ -167,7 +167,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         with mock.patch.object(MarketingSitePublisher, '_get_headers', return_value={}):
             with mock.patch.object(MarketingSitePublisher, '_get_form_build_id_and_form_token', return_value={}):
                 publisher.publish_program(self.program)
-                self.assert_responses_call_count(10)
+                self.assert_responses_call_count(9)
 
     @responses.activate
     def test_get_alias_form_failed(self):
@@ -236,7 +236,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         self.mock_node_delete(204)
         publisher = MarketingSitePublisher()
         publisher.delete_program(self.program)
-        self.assert_responses_call_count(6)
+        self.assert_responses_call_count(5)
 
     @responses.activate
     def test_publish_delete_non_existent_program(self):
@@ -244,7 +244,7 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         self.mock_node_retrieval(self.program.uuid, exists=False)
         publisher = MarketingSitePublisher()
         publisher.delete_program(self.program)
-        self.assert_responses_call_count(5)
+        self.assert_responses_call_count(4)
 
     @responses.activate
     def test_publish_delete_xseries(self):

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -49,31 +49,27 @@ class MarketingSiteAPIClientTests(MarketingSiteAPIClientTestMixin):
     @responses.activate
     def test_init_session(self):
         self.mock_login_response(200)
-        self.mock_admin_response(200)
         session = self.api_client.init_session
-        self.assert_responses_call_count(3)
+        self.assert_responses_call_count(2)
         self.assertIsNotNone(session)
 
     @responses.activate
     def test_init_session_failed(self):
         self.mock_login_response(500)
-        self.mock_admin_response(500)
         with self.assertRaises(MarketingSiteAPIClientException):
             self.api_client.init_session  # pylint: disable=pointless-statement
 
     @responses.activate
     def test_csrf_token(self):
         self.mock_login_response(200)
-        self.mock_admin_response(200)
         self.mock_csrf_token_response(200)
         csrf_token = self.api_client.csrf_token
-        self.assert_responses_call_count(4)
+        self.assert_responses_call_count(3)
         self.assertEqual(self.csrf_token, csrf_token)
 
     @responses.activate
     def test_csrf_token_failed(self):
         self.mock_login_response(200)
-        self.mock_admin_response(200)
         self.mock_csrf_token_response(500)
         with self.assertRaises(MarketingSiteAPIClientException):
             self.api_client.csrf_token  # pylint: disable=pointless-statement
@@ -81,16 +77,14 @@ class MarketingSiteAPIClientTests(MarketingSiteAPIClientTestMixin):
     @responses.activate
     def test_user_id(self):
         self.mock_login_response(200)
-        self.mock_admin_response(200)
         self.mock_user_id_response(200)
         user_id = self.api_client.user_id
-        self.assert_responses_call_count(4)
+        self.assert_responses_call_count(3)
         self.assertEqual(self.user_id, user_id)
 
     @responses.activate
     def test_user_id_failed(self):
         self.mock_login_response(200)
-        self.mock_admin_response(200)
         self.mock_user_id_response(500)
         with self.assertRaises(MarketingSiteAPIClientException):
             self.api_client.user_id  # pylint: disable=pointless-statement
@@ -98,10 +92,9 @@ class MarketingSiteAPIClientTests(MarketingSiteAPIClientTestMixin):
     @responses.activate
     def test_api_session(self):
         self.mock_login_response(200)
-        self.mock_admin_response(200)
         self.mock_csrf_token_response(200)
         api_session = self.api_client.api_session
-        self.assert_responses_call_count(4)
+        self.assert_responses_call_count(3)
         self.assertIsNotNone(api_session)
         self.assertEqual(api_session.headers.get('Content-Type'), 'application/json')
         self.assertEqual(api_session.headers.get('X-CSRF-Token'), self.csrf_token)
@@ -109,7 +102,6 @@ class MarketingSiteAPIClientTests(MarketingSiteAPIClientTestMixin):
     @responses.activate
     def test_api_session_failed(self):
         self.mock_login_response(500)
-        self.mock_admin_response(500)
         self.mock_csrf_token_response(500)
         with self.assertRaises(MarketingSiteAPIClientException):
             self.api_client.api_session  # pylint: disable=pointless-statement

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -96,12 +96,10 @@ class MarketingSiteAPIClient(object):
             'op': 'Log in',
         }
         response = session.post(login_url, data=login_data)
-        expected_url = '{root}/users/{username}'.format(root=self.api_url, username=self.username)
         admin_url = '{root}/admin'.format(root=self.api_url)
-        # Temporary way of checking whether the user has been logged into marketing site until
-        # the marketing site login flow is fixed
-        can_access_admin = session.get(admin_url)
-        if not (can_access_admin.status_code == 200 and response.url == expected_url):
+        # This is not a RESTful API so checking the status code is not enough
+        # We also check that we were redirected to the admin page
+        if not (response.status_code == 200 and response.url == admin_url):
             raise MarketingSiteAPIClientException('Marketing Site Login failed!')
         return session
 


### PR DESCRIPTION
When you logged in to the marketing site, you used to be taken to the page with the same url, but now you are redirected straight to the admin (so the publishing code was logging in successfully but the expected_url was wrong).
Not sure if someone changed this

@edx/learner-growth 

[](https://openedx.atlassian.net/browse/LEARNER-498)