### PR TITLE
Displaying UUID on program admin change/detail view

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -117,7 +117,7 @@ class ProgramAdmin(admin.ModelAdmin):
 
     # ordering the field display on admin page.
     fields = (
-        'title', 'subtitle', 'status', 'type', 'partner', 'banner_image', 'banner_image_url', 'card_image_url',
+        'uuid', 'title', 'subtitle', 'status', 'type', 'partner', 'banner_image', 'banner_image_url', 'card_image_url',
         'marketing_slug', 'overview', 'credit_redemption_overview', 'video', 'weeks_to_complete',
         'min_hours_effort_per_week', 'max_hours_effort_per_week', 'courses', 'order_courses_by_start_date',
         'custom_course_runs_display', 'excluded_course_runs', 'authoring_organizations',

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -282,9 +282,9 @@ class ProgramAdminFunctionalTests(LiveServerTestCase):
             actual += [_class for _class in element.get_attribute('class').split(' ') if _class.startswith('field-')]
 
         expected = [
-            'field-title', 'field-subtitle', 'field-status', 'field-type', 'field-partner', 'field-banner_image',
-            'field-banner_image_url', 'field-card_image_url', 'field-marketing_slug', 'field-overview',
-            'field-credit_redemption_overview', 'field-video', 'field-weeks_to_complete',
+            'field-uuid', 'field-title', 'field-subtitle', 'field-status', 'field-type', 'field-partner',
+            'field-banner_image', 'field-banner_image_url', 'field-card_image_url', 'field-marketing_slug',
+            'field-overview', 'field-credit_redemption_overview', 'field-video', 'field-weeks_to_complete',
             'field-min_hours_effort_per_week', 'field-max_hours_effort_per_week', 'field-courses',
             'field-order_courses_by_start_date', 'field-custom_course_runs_display', 'field-excluded_course_runs',
             'field-authoring_organizations', 'field-credit_backing_organizations', 'field-one_click_purchase_enabled',


### PR DESCRIPTION
Displaying this value avoids the need to toggle back to the list view
when users need to view the UUID of a program being administered.