### PR TITLE
After MKTG reviews a course the label should read: "Reviewed on xx/xx/xxxx".

### DIFF
--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -1822,6 +1822,16 @@ class CourseDetailViewTests(TestCase):
         self.assertContains(response, '<span class="icon fa fa-check" aria-hidden="true">', count=2)
         self.assertContains(response, 'Send for Review', count=1)
 
+        self.course_state.marketing_reviewed = True
+        self.course_state.owner_role = PublisherUserRole.CourseTeam
+        self.course_state.save()
+
+        response = self.client.get(self.detail_page_url)
+
+        # Verify that content is marked as reviewed by both marketing and course team.
+        self.assertNotContains(response, 'Send for Review')
+        self.assertContains(response, 'Reviewed', count=2)
+
     def test_edit_permission_with_owner_role(self):
         """
         Test that user can see edit button if he has permission and has role for course.

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -767,7 +767,10 @@ def get_course_role_widgets_data(user, course, state_object, change_state_url, p
                     name=CourseStateChoices.Review
                 ).order_by('-modified').first()
                 if history_record:
-                    role_widget['sent_for_review'] = history_record.modified
+                    if hasattr(state_object, 'marketing_reviewed') and state_object.marketing_reviewed:
+                        role_widget['reviewed'] = history_record.modified
+                    else:
+                        role_widget['sent_for_review'] = history_record.modified
 
         role_widgets.append(role_widget)
 


### PR DESCRIPTION
[ECOM-7696](https://openedx.atlassian.net/browse/ECOM-7696)

After MKTG reviews a course the label should read: `Reviewed on xx/xx/xxxx` instead of `send for review xx/xx/xxxx`.

<img width="507" alt="screen shot 2017-04-14 at 12 15 18 pm" src="https://cloud.githubusercontent.com/assets/2851134/25036580/0e0f2c12-210e-11e7-8337-0f15b575fe89.png">
