### PR TITLE
Catalog API pagination URL domains should be consistant

### DIFF
--- a/acceptance_tests/config.py
+++ b/acceptance_tests/config.py
@@ -1,5 +1,9 @@
 import os
 
+API_COURSES_ROOT = os.environ.get('API_COURSES_ROOT')
+if not API_COURSES_ROOT:
+    raise RuntimeError('API_COURSE_ROOT (e.g. https://api.stage.edx.org/) must be supplied!')
+
 API_GATEWAY_CATALOG_ROOT = os.environ.get('API_GATEWAY_CATALOG_ROOT')
 if not API_GATEWAY_CATALOG_ROOT:
     raise RuntimeError('API_GATEWAY_CATALOG_ROOT (e.g. https://api.stage.edx.org/catalog/v1) must be supplied!')

--- a/acceptance_tests/test_xforwarding_host.py
+++ b/acceptance_tests/test_xforwarding_host.py
@@ -1,0 +1,50 @@
+""" Tests to validate X-Forwarded-Host is enable. """
+import requests
+from django.test import TestCase
+
+from acceptance_tests.config import API_ACCESS_TOKEN, API_COURSES_ROOT
+
+
+class XForwardedHostTest(TestCase):
+    forwarded_host_name = 'api.stage.edx.org'
+    path = 'api/v1/courses'
+
+    def get_discovery_api_url(self, path):
+        """ Returns a complete URL for the given path. """
+        return '{root}/{path}'.format(root=API_COURSES_ROOT.rstrip('/'), path=path)
+
+    def get_expected_paginated_url(self):
+        return "http://{forwarded_host_name}/{path}/".format(forwarded_host_name=self.forwarded_host_name,
+                                                             path=self.path)
+
+    def assert_pagination_url(self, path, expected_status_code=200, **headers):
+        """
+        Verify the API returns HTTP 200 and next and previous pagination url
+        generated with forwarded_host_name.
+
+        Arguments:
+            path(str) -- Path of the API endpoint to call.
+            expected_status_code (int) -- Expected HTTP status code of the API response.
+            headers (dict) -- Headers to pass with the request.
+        """
+        url = self.get_discovery_api_url(path)
+        response = requests.get(url, headers=headers)
+        courses_list = response.json()
+
+        self.assertEqual(response.status_code, expected_status_code)
+
+        if courses_list['next']:
+            self.assertEqual(courses_list['next'].split('?')[0], self.get_expected_paginated_url())
+
+        if courses_list['previous']:
+            self.assertEqual(courses_list['previous'].split('?')[0], self.get_expected_paginated_url())
+
+    def test_xforwarded_generated_pagination(self):
+        """
+        Verify the endpoint returns HTTP 200 for request and generates
+        correct pagination url based on x-forwarded-host header param. """
+        headers = {
+            'Authorization': 'JWT {token}'.format(token=API_ACCESS_TOKEN),
+            'X-Forwarded-Host': self.forwarded_host_name
+        }
+        self.assert_pagination_url(self.path, **headers)

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -18,6 +18,7 @@ DEBUG = False
 
 ALLOWED_HOSTS = []
 
+USE_X_FORWARDED_HOST = True
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
ECOM-5122

Generates pagination url based on gateway passed HOST header params instead of underlying hostname/server e.g. stage-edx-discovery. 