### PR TITLE
fields updated on course run detail page

### DIFF
--- a/course_discovery/templates/publisher/course_run_detail/_all.html
+++ b/course_discovery/templates/publisher/course_run_detail/_all.html
@@ -47,18 +47,6 @@
       </div>
     {% endif %}
 
-
-  <div class="info-item">
-    <div class="heading">
-      {% trans "Expected Learnings" %}
-    </div>
-    <div>
-      {% with  object.expected_learnings as field %}
-        {% include "publisher/_render_required_field.html" %}
-      {% endwith %}
-    </div>
-  </div>
-
   <div class="info-item">
     <div class="heading">
       {% trans "Course Staff" %}
@@ -114,7 +102,7 @@
       {% trans "Video Language Transcript" %}
     </div>
     <div>
-      {% with  object.transcript_language as field %}
+      {% with  object.transcript_languages as field %}
         {% include "publisher/_render_required_field.html" %}
       {% endwith %}
     </div>


### PR DESCRIPTION
[ECOM-7729](https://openedx.atlassian.net/browse/ECOM-7729)

* `transcript languages` field fixed.
* `expected learnings` field removed.

<img width="602" alt="screen shot 2017-04-19 at 2 38 12 pm" src="https://cloud.githubusercontent.com/assets/4245618/25173526/e7bc1ad0-250d-11e7-8b6a-fc66e2f8e40b.png">
