### PR TITLE
Fixed course-key getting blanked.

### DIFF
--- a/course_discovery/apps/publisher/emails.py
+++ b/course_discovery/apps/publisher/emails.py
@@ -28,9 +28,8 @@ def send_email_for_studio_instance_created(course_run, updated_text=_('created')
         to_addresses = [course_run.course.course_team_admin.email]
         from_address = settings.PUBLISHER_FROM_EMAIL
 
-        course_user_roles = course_run.course.course_user_roles.all()
-        course_team = course_user_roles.filter(role=PublisherUserRole.CourseTeam).first()
-        project_coordinator = course_user_roles.filter(role=PublisherUserRole.ProjectCoordinator).first()
+        course_team_admin = course_run.course.course_team_admin
+        project_coordinator = course_run.course.project_coordinator
 
         context = {
             'updated_text': updated_text,
@@ -40,9 +39,9 @@ def send_email_for_studio_instance_created(course_run, updated_text=_('created')
             ),
             'course_name': course_run.course.title,
             'from_address': from_address,
-            'course_team_name': course_team.user.full_name if course_team else '',
-            'project_coordinator_name': project_coordinator.user.full_name if project_coordinator else '',
-            'contact_us_email': project_coordinator.user.email if project_coordinator else ''
+            'course_team_name': course_team_admin.get_full_name() or course_team_admin.username,
+            'project_coordinator_name': project_coordinator.get_full_name() or project_coordinator.username,
+            'contact_us_email': project_coordinator.email
         }
 
         txt_template_path = 'publisher/email/studio_instance_created.txt'

--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -295,12 +295,18 @@ class CustomCourseRunForm(CourseRunForm):
 
             return lms_course_id
 
+        instance = getattr(self, 'instance', None)
+        # If `lms_course_id` is none in `cleaned_data` and user is not project coordinator
+        # return actual value of the instance, it will prevent `lms_course_id` from getting blanked.
+        if instance and instance.pk and hasattr(self, 'is_project_coordinator') and not self.is_project_coordinator:
+            return instance.lms_course_id
+
         return None
 
     def __init__(self, *args, **kwargs):
-        is_project_coordinator = kwargs.pop('is_project_coordinator', None)
+        self.is_project_coordinator = kwargs.pop('is_project_coordinator', None)
         super(CustomCourseRunForm, self).__init__(*args, **kwargs)
-        if not is_project_coordinator:
+        if not self.is_project_coordinator:
             self.fields['lms_course_id'].widget = forms.HiddenInput()
 
 

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -526,7 +526,6 @@ class CreateCourseRunView(mixins.LoginRequiredMixin, CreateView):
 class CourseRunEditView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMixin, UpdateView):
     """ Course Run Edit View."""
     model = CourseRun
-    course_form = CustomCourseForm
     run_form = CustomCourseRunForm
     seat_form = CustomSeatForm
     template_name = 'publisher/course_run/edit_run_form.html'
@@ -582,9 +581,7 @@ class CourseRunEditView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMix
             try:
                 with transaction.atomic():
 
-                    course_run = run_form.save(commit=False)
-                    course_run.changed_by = self.request.user
-                    course_run.save()
+                    course_run = run_form.save(changed_by=user)
 
                     run_form.save_m2m()
 


### PR DESCRIPTION
[ECOM-7723](https://openedx.atlassian.net/browse/ECOM-7723)

There was a bug where the PC entered the course run key in the dashboard and email went out to CT about the Studio instance, but the field got blanked out.

This change will not allow any user except project coordinator to update `lms_course_id`. Also refactored related code.