### PR TITLE
Cleanup the approvals section on the course run detail page

### DIFF
--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -681,11 +681,11 @@ class CourseRevisionView(mixins.LoginRequiredMixin, DetailView):
 def get_course_role_widgets_data(user, course, state_object, change_state_url, parent_course=False):
     """ Create role widgets list for course user roles. """
     role_widgets = []
-    course_roles = course.course_user_roles
+    course_roles = course.course_user_roles.exclude(role__in = [PublisherUserRole.MarketingReviewer])
     roles = [PublisherUserRole.CourseTeam, PublisherUserRole.ProjectCoordinator]
     if parent_course:
         roles = [PublisherUserRole.CourseTeam, PublisherUserRole.MarketingReviewer]
-        course_roles = course_roles.filter(role__in=roles)
+        course_roles = course.course_user_roles.filter(role__in=roles)
 
     for course_role in course_roles.order_by('role'):
         role_widget = {

--- a/course_discovery/templates/publisher/_approval_widget.html
+++ b/course_discovery/templates/publisher/_approval_widget.html
@@ -6,63 +6,132 @@
         <div class="parent-course-approval">
             {% url 'publisher:publisher_course_detail' object.course.id as course_url %}
             {% with link_start='<a href="' link_middle='">' link_end='</a>' %}
-            {% blocktrans trimmed %}
-              The {{ link_start }}{{ course_url }}{{ link_middle }} parent course {{ link_end }} for this course run has changes that must be approved before you can submit this course run for approval. You can save changes to this course run.
-            {% endblocktrans %}
+                {% blocktrans trimmed %}
+                    The {{ link_start }}{{ course_url }}{{ link_middle }} parent course {{ link_end }} for this course
+                    run has changes that must be approved before you can submit this course run for approval. You can
+                    save changes to this course run.
+                {% endblocktrans %}
             {% endwith %}
         </div>
     {% endif %}
 
     {% for role_widget in  role_widgets %}
+        {% if role_widget.course_role.role == 'publisher' %}
+            <div class="preview-widget">
+                <div class="preview-container">
+                    <div class="layout-1q3q layout-reversed">
+                        <div class="layout-col layout-col-a">
+                            {% if object.preview_url %}
+                                {% if object.preview_url and object.course.course_team_admin == request.user and object.course_run_state.is_approved and not object.course_run_state.is_preview_accepted %}
+                                    <button class="btn btn-neutral btn-preview btn-preview-decline" type="button">
+                                        {% trans "Decline" %}
+                                    </button>
+                                    <button class="btn btn-neutral btn-preview btn-preview-accept" type="button">
+                                        {% trans "Accept" %}
+                                    </button>
+                                    {% elif preview_accepted_date %}
+                                    <span class="state-status">
+                                <span class="icon fa fa-check" aria-hidden="true"></span>
+                                        {% trans "Approved" %}<br>
+                                {{ preview_accepted_date|date:'m/d/y H:i a' }}
+                            </span>
+                                    {% if object.course_run_state.is_ready_to_publish and object.course.publisher == request.user %}
+                                        <button class="btn-brand btn-base btn-publish"
+                                                data-change-state-url="{% url 'publisher:api:change_course_run_state' object.course_run_state.id %}"
+                                                data-state-name="{{ publish_state_name }}" type="button">
+                                            {% trans "Publish" %}
+                                        </button>
+                                    {% endif %}
+                                    {% elif object.course.publisher == request.user %}
+                                    <span class="preview-status">{% trans "Submitted for review" %}</span>
+                                    <button data-url="{% url 'publisher:api:update_course_run' object.id %}"
+                                            class="btn btn-neutral btn-edit-preview-url">{% trans "Edit" %}</button>
+                                {% endif %}
+                            {% elif object.course.publisher == request.user %}
+                                <button data-url="{% url 'publisher:api:update_course_run' object.id %}"
+                                        class="btn btn-neutral btn-save-preview-url">{% trans "Save" %}</button>
+                            {% endif %}
+                        </div>
+                        <div class="layout-col layout-col-b">
+                        <span class="preview-heading">
+                            <strong>{% trans "COURSE PREVIEW" %}</strong>
+                        </span>
+                            <div class="preview-url">
+                                {% if object.preview_url %}
+                                    <span class="preview-url-heading">{% trans "Preview URL" %} - </span>
+                                    <a href="{{ object.preview_url }}"
+                                       target="_blank">{% trans "View course preview live" %}</a>
+                                {% else %}
+                                    {% if object.course.publisher == request.user %}
+                                        <input id="id-review-url" type="text">
+                                        <span class="error-message"></span>
+                                    {% else %}
+                                        <span>{% trans "Not available" %}</span>
+                                    {% endif %}
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <hr>
+        {% endif %}
         <div class="role-widget">
             <div class="role-assignment-container">
                 <div class="layout-1q3q layout-reversed">
                     <div class="layout-col layout-col-a">
                         {% if role_widget.state_button %}
-                            <button class="btn btn-neutral btn-change-state" data-change-state-url="{{ role_widget.change_state_url }}" data-state-name="{{ role_widget.state_button.value }}"{% if role_widget.button_disabled %} disabled{% endif %} type="button">
+                            <button class="btn btn-neutral btn-change-state"
+                                    data-change-state-url="{{ role_widget.change_state_url }}"
+                                    data-state-name="{{ role_widget.state_button.value }}"
+                                    {% if role_widget.button_disabled %} disabled{% endif %} type="button">
                                 {{ role_widget.state_button.text }}
                             </button>
                         {% else %}
                             {% if role_widget.sent_for_review %}
                                 <span class="state-status">
-                                    <span class="icon fa fa-check" aria-hidden="true"></span>
+                                        <span class="icon fa fa-check" aria-hidden="true"></span>
                                     {% trans "Send for Review" %}<br>
-                                    {{ role_widget.sent_for_review|date:'m/d/y H:i a' }}
-                                </span>
-                            {% elif role_widget.reviewed %}
+                                        {{ role_widget.sent_for_review|date:'m/d/y H:i a' }}
+                                    </span>
+                                {% elif role_widget.reviewed %}
                                 <span class="state-status">
-                                    <span class="icon fa fa-check" aria-hidden="true"></span>
+                                        <span class="icon fa fa-check" aria-hidden="true"></span>
                                     {% trans "Reviewed" %}<br>
-                                    {{ role_widget.reviewed|date:'m/d/y H:i a' }}
-                                </span>
+                                        {{ role_widget.reviewed|date:'m/d/y H:i a' }}
+                                    </span>
                             {% endif %}
                         {% endif %}
                     </div>
                     <div class="layout-col layout-col-b">
-                        <span class="role-heading">
-                            <strong>{{ role_widget.heading }}</strong>
-                        </span>
+                            <span class="role-heading">
+                                <strong>{{ role_widget.heading }}</strong>
+                            </span>
                         {% if role_widget.ownership %}
                             <span class="ownership-label">{{ role_widget.ownership.days }} {% trans "day in ownership" %}</span>
                         {% endif %}
                         <div class="role-assignment-container">
                             <div id="userRoleContainer-{{ role_widget.course_role.role }}">
-                                <span id="userFullName-{{ role_widget.course_role.role }}" class="field-readonly user-full-name">
-                                    {% if role_widget.course_role.user.full_name %}
-                                        {{ role_widget.course_role.user.full_name }}
-                                    {% else %}
-                                        {{ role_widget.course_role.user.username }}
-                                    {% endif %}
-                                </span>
+                                    <span id="userFullName-{{ role_widget.course_role.role }}"
+                                          class="field-readonly user-full-name">
+                                        {% if role_widget.course_role.user.full_name %}
+                                            {{ role_widget.course_role.user.full_name }}
+                                        {% else %}
+                                            {{ role_widget.course_role.user.username }}
+                                        {% endif %}
+                                    </span>
                                 {% if role_widget.can_change_role_assignment %}
-                                    <a class="change-role-assignment" data-role="{{ role_widget.course_role.role }}" href="#">
+                                    <a class="change-role-assignment" data-role="{{ role_widget.course_role.role }}"
+                                       href="#">
                                         {% trans "change" %}
                                     </a>
                                 {% endif %}
                             </div>
                             {% if role_widget.can_change_role_assignment %}
-                                <div class="change-role-container" id="changeRoleContainer-{{ role_widget.course_role.role }}">
-                                    <select class="select-users-by-role" id="selectUsers-{{ role_widget.course_role.role }}">
+                                <div class="change-role-container"
+                                     id="changeRoleContainer-{{ role_widget.course_role.role }}">
+                                    <select class="select-users-by-role"
+                                            id="selectUsers-{{ role_widget.course_role.role }}">
                                         <option value="-----------">-----------</option>
                                         {% for user in role_widget.user_list %}
                                             <option value="{{ user.id }}">
@@ -75,7 +144,9 @@
                                         {% endfor %}
                                     </select>
                                     <input type="hidden" id="roleName" value="{{ role_widget.course_role.role }}">
-                                    <button type="button" class="btn-neutral btn-change-assignment" data-role="{{ role_widget.course_role.role }}" data-api-endpoint="{% url 'publisher:api:course_role_assignments' role_widget.course_role.id %}">
+                                    <button type="button" class="btn-neutral btn-change-assignment"
+                                            data-role="{{ role_widget.course_role.role }}"
+                                            data-api-endpoint="{% url 'publisher:api:course_role_assignments' role_widget.course_role.id %}">
                                         {% trans "CHANGE" %}
                                     </button>
                                 </div>

--- a/course_discovery/templates/publisher/course_run_detail/_widgets.html
+++ b/course_discovery/templates/publisher/course_run_detail/_widgets.html
@@ -10,60 +10,7 @@
     {% endif %}
     <div class="approval-widget {% if not publisher_approval_widget_feature %}hidden{% endif %}">
         {% include 'publisher/_approval_widget.html' %}
-
-        <div class="preview-widget">
-            <div class="preview-container">
-                <div class="layout-1q3q layout-reversed">
-                    <div class="layout-col layout-col-a">
-                    {% if object.preview_url %}
-                        {% if object.preview_url and object.course.course_team_admin == request.user and object.course_run_state.is_approved and not object.course_run_state.is_preview_accepted %}
-                            <button class="btn btn-neutral btn-preview btn-preview-decline" type="button">
-                                {% trans "Decline" %}
-                            </button>
-                            <button class="btn btn-neutral btn-preview btn-preview-accept" type="button">
-                                {% trans "Accept" %}
-                            </button>
-                        {% elif preview_accepted_date %}
-                            <span class="state-status">
-                                <span class="icon fa fa-check" aria-hidden="true"></span>
-                                {% trans "Approved" %}<br>
-                                {{ preview_accepted_date|date:'m/d/y H:i a' }}
-                            </span>
-                            {% if object.course_run_state.is_ready_to_publish and object.course.publisher == request.user %}
-                                <button class="btn-brand btn-base btn-publish" data-change-state-url="{% url 'publisher:api:change_course_run_state' object.course_run_state.id %}" data-state-name="{{ publish_state_name }}" type="button">
-                                    {% trans "Publish" %}
-                                </button>
-                            {% endif %}
-                        {% elif object.course.publisher == request.user %}
-                            <span class="preview-status">{% trans "Submitted for review" %}</span>
-                                <button data-url="{% url 'publisher:api:update_course_run' object.id %}" class="btn btn-neutral btn-edit-preview-url">{% trans "Edit" %}</button>
-                        {% endif %}
-                    {% elif object.course.publisher == request.user %}
-                        <button data-url="{% url 'publisher:api:update_course_run' object.id %}" class="btn btn-neutral btn-save-preview-url">{% trans "Save" %}</button>
-                    {% endif %}
-                    </div>
-                    <div class="layout-col layout-col-b">
-                        <span class="preview-heading">
-                            <strong>{% trans "COURSE PREVIEW" %}</strong>
-                        </span>
-                        <div class="preview-url">
-                            {% if object.preview_url %}
-                                <span class="preview-url-heading">{% trans "Preview URL" %} - </span>
-                                <a href="{{ object.preview_url }}" target="_blank">{% trans "View course preview live" %}</a>
-                            {% else %}
-                                {% if object.course.publisher == request.user %}
-                                    <input id="id-review-url" type="text">
-                                    <span class="error-message"></span>
-                                {% else %}
-                                    <span>{% trans "Not available" %}</span>
-                                {% endif %}
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <hr>
+    
         <div id="decline-comment" class="hidden clearfix">
             {% trans 'Reason for declining preview' as decline_reason %}
             {% trans 'Submit' as submit %}


### PR DESCRIPTION
ECOM-7731

On the Course-run detail page, under the Approvals section, the role and names are now listed in the following order:
Course Team, Project Coordinator, Course Preview, Publisher.
Also removed Marketing from this list.