### PR TITLE
Cache program viewset responses

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -14,9 +14,9 @@ services:
   es:
     image: elasticsearch:1.5.2
     container_name: es
-  memcache:
+  memcached:
     image: memcached:1.4.24
-    container_name: memcache
+    container_name: memcached
   course-discovery:
     # Uncomment this line to use the official course-discovery base image
     image: edxops/discovery:latest
@@ -33,8 +33,10 @@ services:
     depends_on:
       - "db"
       - "es"
-      - "memcache"
+      - "memcached"
     environment:
+      CACHE_BACKEND: "django.core.cache.backends.memcached.MemcachedCache"
+      CACHE_LOCATION: "memcached:11211"
       CONN_MAX_AGE: 60
       DB_ENGINE: "django.db.backends.mysql"
       DB_HOST: "db"

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -1,6 +1,7 @@
 from rest_framework import mixins, viewsets
 from rest_framework.filters import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
+from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import filters, serializers
 from course_discovery.apps.api.pagination import ProxiedPagination
@@ -9,7 +10,7 @@ from course_discovery.apps.course_metadata.models import ProgramType
 
 
 # pylint: disable=no-member
-class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
+class ProgramViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
     """ Program resource. """
     lookup_field = 'uuid'
     lookup_value_regex = '[0-9a-f-]+'

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -308,7 +308,6 @@ LOGGING = {
     }
 }
 
-
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
@@ -333,6 +332,12 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'user': '100/hour',
     },
+}
+
+# http://chibisov.github.io/drf-extensions/docs/
+REST_FRAMEWORK_EXTENSIONS = {
+    'DEFAULT_CACHE_ERRORS': False,
+    'DEFAULT_CACHE_RESPONSE_TIMEOUT': 60,
 }
 
 # NOTE (CCB): JWT_SECRET_KEY is intentionally not set here to avoid production releases with a public value.

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -19,6 +19,13 @@ TEST_NON_SERIALIZED_APPS = [
     'django.contrib.auth',
 ]
 
+CACHES = {
+    'default': {
+        'BACKEND': os.environ.get('CACHE_BACKEND', 'django.core.cache.backends.locmem.LocMemCache'),
+        'LOCATION': os.environ.get('CACHE_LOCATION', ''),
+    }
+}
+
 DATABASES = {
     'default': {
         'ENGINE': os.environ.get('DB_ENGINE', 'django.db.backends.sqlite3'),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,9 @@ services:
       - "9200:9200"
       - "9300:9300"
 
-  memcache:
+  memcached:
     image: memcached:1.4.24
-    container_name: memcache
+    container_name: memcached
 
   course-discovery:
     # Uncomment this line to use the official course-discovery base image
@@ -47,7 +47,7 @@ services:
     depends_on:
       - "db"
       - "es"
-      - "memcache"
+      - "memcached"
     environment:
       TEST_ELASTICSEARCH_URL: "http://es:9200"
       ENABLE_DJANGO_TOOLBAR: 1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,6 +26,7 @@ djangorestframework-csv==1.4.1
 djangorestframework-jwt==1.8.0
 djangorestframework-xml==1.3.0
 django-rest-swagger[reST]==0.3.10
+drf-extensions==0.3.1
 drf-haystack==1.6.0rc1
 dry-rest-permissions==0.1.6
 edx-auth-backends==1.0.3


### PR DESCRIPTION
@clintonb @mjfrey @mikedikan @MatthewPiatetsky this is a proof-of-concept showing how we can cache DRF responses using only utilities provided by Django. [cache_page()](https://docs.djangoproject.com/en/1.11/topics/cache/#django.views.decorators.cache.cache_page) uses the request received by the view to construct a cache key, taking headers and querystring parameters into account when doing so.