### PR TITLE
Fixed add instructor after deleting it once on course run edit page

### DIFF
--- a/course_discovery/static/js/publisher/instructors.js
+++ b/course_discovery/static/js/publisher/instructors.js
@@ -129,10 +129,15 @@ $(document).on('change', '#id_staff', function (e) {
 $(document).on('click', '.selected-instructor a.delete', function (e) {
     e.preventDefault();
     var id = this.id,
-        option = $('#id_staff').find('option[value="' + id + '"]');
-
-    option.prop("selected", false);
+        $staff = $('#id_staff'),
+        option = $staff.find('option[value="' + id + '"]');
+    // This condition is to check for the existence of id or uuid
+    if (option.length == 0) {
+        option = $staff.find('option:contains("' + id + '")');
+    }
+    option.remove();
     this.closest('.selected-instructor, .instructor').remove();
+    $('.instructor-select').find('.select2-selection__choice').remove();
 });
 
 function renderSelectedInstructor(id, name, image, uuid) {


### PR DESCRIPTION
ECOM-7611

When a user removed an instructor from the course run edit page and tried to add again, an incorrect instructor was being added. This issue is now fixed and one can re add an instructor after deleting him.