### PR TITLE
Removed unused partner parameter from Swagger view for programs list endpoint

### DIFF
--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -47,12 +47,6 @@ class ProgramViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
         """ List all programs.
         ---
         parameters:
-            - name: partner
-              description: Filter by partner
-              required: false
-              type: string
-              paramType: query
-              multiple: false
             - name: marketable
               description: Retrieve marketable programs. A program is considered marketable if it is active
                 and has a marketing slug.


### PR DESCRIPTION
We haven't used this parameter for quite some time. It doesn't work, and should not be shown on the Swagger page.