### PR TITLE
Fixed creating new run.

### DIFF
--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -487,6 +487,8 @@ class CreateCourseRunView(mixins.LoginRequiredMixin, CreateView):
             new_run.staff.add(*staff)
             new_run.transcript_languages.add(*transcript_languages)
 
+        new_run.save()
+
     def get_seat_initial_data(self):
         initial_seat_data = {}
         last_run = self.get_last_run()


### PR DESCRIPTION
ECOM-7760

Fixed
```
There was an error saving course run, save() prohibited to prevent data loss due to unsaved related object 'course_run'.

Traceback (most recent call last):
  File "/Users/waheed/devstack/course-discovery/course_discovery/apps/publisher/views.py", line 536, in post
    seat_form.save(course_run=course_run, changed_by=user)
  File "/Users/waheed/devstack/course-discovery/course_discovery/apps/publisher/forms.py", line 343, in save
    seat.save()
  File "/Users/waheed/python_envs/disc_venv/lib/python3.5/site-packages/django_extensions/db/models.py", line 24, in save
    super(TimeStampedModel, self).save(**kwargs)
  File "/Users/waheed/python_envs/disc_venv/lib/python3.5/site-packages/django/db/models/base.py", line 659, in save
    "unsaved related object '%s'." % field.name
ValueError: save() prohibited to prevent data loss due to unsaved related object 'course_run'.
```