### PR TITLE
Allow course runs to be saved when publication fails

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -608,9 +608,12 @@ class CourseRun(TimeStampedModel):
             publisher = CourseRunMarketingSitePublisher(self.course.partner)
             previous_obj = CourseRun.objects.get(id=self.id) if self.id else None
 
-            with transaction.atomic():
-                super(CourseRun, self).save(*args, **kwargs)
+            super(CourseRun, self).save(*args, **kwargs)
+
+            try:
                 publisher.publish_obj(self, previous_obj=previous_obj)
+            except:  # pylint: disable=bare-except
+                logger.exception('Unable to publish course run {key} to the marketing site.'.format(key=self.key))
         else:
             super(CourseRun, self).save(*args, **kwargs)
 


### PR DESCRIPTION
Preventing course runs from being saved unless they are are successfully published to the marketing site makes the Django admin difficult to use for those who don't need data published to Drupal. It's not reasonable to couple saving and publication without also supporting node creation. We shouldn't expect everyone using the admin to create a node on the marketing site before saving course run status changes.

[LEARNER-904](https://openedx.atlassian.net/browse/LEARNER-904)

@brittneyexline @mikedikan @schenedx 