### PR TITLE
Validation checks on calendar start and end dates

### DIFF
--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -6,6 +6,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models.functions import Lower
 from django.template.loader import render_to_string
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -321,8 +322,14 @@ class CustomCourseRunForm(CourseRunForm):
         cleaned_data = self.cleaned_data
         min_effort = cleaned_data.get("min_effort")
         max_effort = cleaned_data.get("max_effort")
+        start = cleaned_data.get("start")
+        end = cleaned_data.get("end")
+        if start and start < timezone.now():
+            raise ValidationError({'start': _('Start date cannot be in the Past')})
+        if start and end and start > end:
+            raise ValidationError({'start': _('Start date cannot be after the End date')})
         if min_effort and max_effort and min_effort > max_effort:
-                raise ValidationError({'min_effort': "Minimum effort cannot be greater than Maximum effort"})
+                raise ValidationError({'min_effort': _('Minimum effort cannot be greater than Maximum effort')})
 
         return cleaned_data
 

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -15,6 +15,7 @@ from django.test import TestCase
 from guardian.shortcuts import assign_perm
 from mock import patch
 from testfixtures import LogCapture
+from pytz import timezone
 
 from course_discovery.apps.core.models import User
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
@@ -285,8 +286,9 @@ class CreateCourseRunViewTests(TestCase):
             self.course_run_dict,
             ['end', 'enrollment_start', 'enrollment_end', 'priority', 'certificate_generation', 'id']
         )
-        self.course_run_dict['start'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        self.course_run_dict['end'] = (datetime.now() + timedelta(days=60)).strftime('%Y-%m-%d %H:%M:%S')
+        current_datetime = datetime.now(timezone('US/Central'))
+        self.course_run_dict['start'] = (current_datetime + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
+        self.course_run_dict['end'] = (current_datetime + timedelta(days=3)).strftime('%Y-%m-%d %H:%M:%S')
         self.site = Site.objects.get(pk=settings.SITE_ID)
         self.client.login(username=self.user.username, password=USER_PASSWORD)
 
@@ -2263,8 +2265,9 @@ class CourseRunEditViewTests(TestCase):
         self.course.organizations.add(self.organization_extension.organization)
         self.site = Site.objects.get(pk=settings.SITE_ID)
         self.client.login(username=self.user.username, password=USER_PASSWORD)
-        self.start_date_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        self.end_date_time = (datetime.now() + timedelta(days=60)).strftime('%Y-%m-%d %H:%M:%S')
+        current_datetime = datetime.now(timezone('US/Central'))
+        self.start_date_time = (current_datetime + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
+        self.end_date_time = (current_datetime + timedelta(days=60)).strftime('%Y-%m-%d %H:%M:%S')
 
         # creating default organizations roles
         factories.OrganizationUserRoleFactory(
@@ -2809,10 +2812,11 @@ class CreateRunFromDashboardViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def _post_data(self):
+        current_datetime = datetime.now(timezone('US/Central'))
         return {
             'course': self.course.id,
-            'start': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            'end': (datetime.now() + timedelta(days=60)).strftime('%Y-%m-%d %H:%M:%S'),
+            'start': (current_datetime + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S'),
+            'end': (current_datetime + timedelta(days=60)).strftime('%Y-%m-%d %H:%M:%S'),
             'pacing_type': 'self_paced',
             'type': Seat.VERIFIED,
             'price': 450

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -14,8 +14,8 @@ from django.forms import model_to_dict
 from django.test import TestCase
 from guardian.shortcuts import assign_perm
 from mock import patch
-from testfixtures import LogCapture
 from pytz import timezone
+from testfixtures import LogCapture
 
 from course_discovery.apps.core.models import User
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory

--- a/course_discovery/conf/locale/en/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/en/LC_MESSAGES/django.po
@@ -664,6 +664,18 @@ msgid "Video Language"
 msgstr ""
 
 #: apps/publisher/forms.py
+msgid "Start date cannot be in the Past"
+msgstr ""
+
+#: apps/publisher/forms.py
+msgid "Start date cannot be after the End date"
+msgstr ""
+
+#: apps/publisher/forms.py
+msgid "Minimum effort cannot be greater than Maximum effort"
+msgstr ""
+
+#: apps/publisher/forms.py
 msgid "Only audit seat can be without price."
 msgstr ""
 

--- a/course_discovery/conf/locale/eo/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/eo/LC_MESSAGES/django.po
@@ -790,6 +790,23 @@ msgid "Video Language"
 msgstr "Vïdéö Längüägé Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
 
 #: apps/publisher/forms.py
+msgid "Start date cannot be in the Past"
+msgstr ""
+"Stärt däté çännöt ßé ïn thé Päst Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тє#"
+
+#: apps/publisher/forms.py
+msgid "Start date cannot be after the End date"
+msgstr ""
+"Stärt däté çännöt ßé äftér thé Énd däté Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"¢σηѕє¢тєтυя#"
+
+#: apps/publisher/forms.py
+msgid "Minimum effort cannot be greater than Maximum effort"
+msgstr ""
+"Mïnïmüm éffört çännöt ßé gréätér thän Mäxïmüm éffört Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт "
+"αмєт, ¢σηѕє¢тєтυя α#"
+
+#: apps/publisher/forms.py
 msgid "Only audit seat can be without price."
 msgstr ""
 "Önlý äüdït séät çän ßé wïthöüt prïçé. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "

--- a/course_discovery/templates/publisher/course_run/edit_run_form.html
+++ b/course_discovery/templates/publisher/course_run/edit_run_form.html
@@ -54,6 +54,9 @@
                     <div class="col col-6">
                         <label class="field-label ">{{ run_form.start.label_tag }}  <span class="required">*</span></label>
                         {{ run_form.start }}
+                        {% if run_form.start.errors %}
+                            {{ run_form.start.errors|escape }}
+                        {% endif %}
                     </div>
                 </div>
 


### PR DESCRIPTION
Learner-854

Validation checks on course-run start and end date.
1. Start date can not be prior to current date.
2. Start date can not be greater than end date.