### PR TITLE
Filtered instructors by org on course-run edit

### DIFF
--- a/course_discovery/apps/course_metadata/lookups.py
+++ b/course_discovery/apps/course_metadata/lookups.py
@@ -65,6 +65,9 @@ class PersonAutocomplete(LoginRequiredMixin, autocomplete.Select2QuerySetView):
         if self.q:
             qs = queryset.filter(Q(given_name__icontains=self.q) | Q(family_name__icontains=self.q),
                                  position__organization__in=get_user_organizations(self.request.user))
+            if self.request.user.is_staff and self.request.user.is_superuser:
+                qs = queryset.filter(Q(given_name__icontains=self.q) | Q(family_name__icontains=self.q))
+
             if not qs:
                 try:
                     q_uuid = uuid.UUID(self.q).hex

--- a/course_discovery/apps/course_metadata/lookups.py
+++ b/course_discovery/apps/course_metadata/lookups.py
@@ -1,8 +1,11 @@
 import uuid
+
 from dal import autocomplete
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
 from django.template.loader import render_to_string
+
+from course_discovery.apps.publisher.mixins import get_user_organizations
 
 from .models import Course, CourseRun, Organization, Person, Video
 
@@ -60,7 +63,8 @@ class PersonAutocomplete(LoginRequiredMixin, autocomplete.Select2QuerySetView):
     def get_queryset(self):
         queryset = Person.objects.all()
         if self.q:
-            qs = queryset.filter(Q(given_name__icontains=self.q) | Q(family_name__icontains=self.q))
+            qs = queryset.filter(Q(given_name__icontains=self.q) | Q(family_name__icontains=self.q),
+                                 position__organization__in=get_user_organizations(self.request.user))
             if not qs:
                 try:
                     q_uuid = uuid.UUID(self.q).hex


### PR DESCRIPTION
ECOM-7774

When searching and adding instructors to a Course-run, the type ahead search only returns instructors from the same Organization as the Course team logged in.