### PR TITLE
Fixed authorized user can see edit button on course list page.

### DIFF
--- a/course_discovery/apps/publisher/templatetags/publisher_extras.py
+++ b/course_discovery/apps/publisher/templatetags/publisher_extras.py
@@ -1,0 +1,18 @@
+from django import template
+
+from course_discovery.apps.publisher.mixins import check_course_organization_permission
+from course_discovery.apps.publisher.models import OrganizationExtension
+from course_discovery.apps.publisher.utils import has_role_for_course
+
+register = template.Library()
+
+
+def can_edit(course, user, permission):
+    return check_course_organization_permission(
+        user, course, permission
+    ) and has_role_for_course(course, user)
+
+
+@register.filter
+def can_edit_course(course, user):
+    return can_edit(course, user, OrganizationExtension.EDIT_COURSE)

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -1533,10 +1533,16 @@ class CourseListViewTests(TestCase):
 
     def test_page_with_disable_waffle_switch(self):
         """
-        Verify that edit button will be shown if 'publisher_hide_features_for_pilot' dectivated.
+        Verify that edit button will be shown if 'publisher_hide_features_for_pilot' deactivated.
         """
-        self.user.groups.add(Group.objects.get(name=INTERNAL_USER_GROUP_NAME))
-        factories.CourseUserRoleFactory(course=self.course, user=self.user)
+        organization_extension = factories.OrganizationExtensionFactory()
+        self.course.organizations.add(organization_extension.organization)
+        self.user.groups.add(organization_extension.group)
+        factories.CourseUserRoleFactory(course=self.course, user=self.user, role=PublisherUserRole.CourseTeam)
+
+        assign_perm(OrganizationExtension.VIEW_COURSE, organization_extension.group, organization_extension)
+        assign_perm(OrganizationExtension.EDIT_COURSE, organization_extension.group, organization_extension)
+
         toggle_switch('publisher_hide_features_for_pilot', False)
         response = self.client.get(self.courses_url)
         self.assertContains(response, 'Edit')

--- a/course_discovery/templates/publisher/courses.html
+++ b/course_discovery/templates/publisher/courses.html
@@ -1,6 +1,7 @@
 {% extends 'publisher/base.html' %}
 
 {% load i18n %}
+{% load publisher_extras %}
 
 {% block title %}
     {% trans "Courses" %}
@@ -51,13 +52,13 @@
                         <td>
                              {{ course.publisher_course_runs.count }}
                         </td>
-                        {% if not publisher_hide_features_for_pilot %}
-                          <td>
-                            <a href="{% url 'publisher:publisher_courses_edit' course.id %}" class="btn btn-brand btn-small btn-course-edit">
-                              {% trans "Edit" %}
-                            </a>
-                          </td>
-                        {% endif %}
+                        <td>
+                            {% if not publisher_hide_features_for_pilot and course|can_edit_course:request.user %}
+                                <a href="{% url 'publisher:publisher_courses_edit' course.id %}" class="btn btn-brand btn-small btn-course-edit">
+                                  {% trans "Edit" %}
+                                </a>
+                            {% endif %}
+                        </td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
LEARNER-884

Only authorized user can see the `Edit` button against the course in courses table.

<img width="1009" alt="screen shot 2017-05-16 at 3 47 49 pm" src="https://cloud.githubusercontent.com/assets/2851134/26102590/08e44a10-3a4f-11e7-8b65-ad0640741f39.png">