### PR TITLE
Remove CT from reviewed email when PC approves course-run.

### DIFF
--- a/course_discovery/apps/publisher/emails.py
+++ b/course_discovery/apps/publisher/emails.py
@@ -271,22 +271,22 @@ def send_email_for_mark_as_reviewed_course_run(course_run, user):
     )
 
     try:
-        page_path = reverse('publisher:publisher_course_run_detail', kwargs={'pk': course_run.id})
-        recipient_user = course.project_coordinator
         user_role = course.course_user_roles.get(user=user)
-        if user_role.role == PublisherUserRole.ProjectCoordinator:
-            recipient_user = course.course_team_admin
+        # Send this email only to PC if approving person is course team member
+        if user_role.role == PublisherUserRole.CourseTeam:
+            page_path = reverse('publisher:publisher_course_run_detail', kwargs={'pk': course_run.id})
+            recipient_user = course.project_coordinator
 
-        context = {
-            'course_name': course.title,
-            'run_number': course_key.run,
-            'sender_team': 'course team' if user_role.role == PublisherUserRole.CourseTeam else 'project coordinators',
-            'page_url': 'https://{host}{path}'.format(
-                host=Site.objects.get_current().domain.strip('/'), path=page_path
-            )
-        }
+            context = {
+                'course_name': course.title,
+                'run_number': course_key.run,
+                'sender_team': 'course team',
+                'page_url': 'https://{host}{path}'.format(
+                    host=Site.objects.get_current().domain.strip('/'), path=page_path
+                )
+            }
 
-        send_course_workflow_email(course, user, subject, txt_template, html_template, context, recipient_user)
+            send_course_workflow_email(course, user, subject, txt_template, html_template, context, recipient_user)
     except Exception:  # pylint: disable=broad-except
         logger.exception('Failed to send email notifications for mark as reviewed of course-run %s', course_run.id)
 

--- a/course_discovery/apps/publisher/tests/test_emails.py
+++ b/course_discovery/apps/publisher/tests/test_emails.py
@@ -303,13 +303,13 @@ class CourseRunMarkAsReviewedEmailTests(TestCase):
 
         toggle_switch('enable_publisher_email_notifications', True)
 
-    def test_email_sent_by_marketing_reviewer(self):
-        """ Verify that email works successfully for marketing user."""
+    def test_email_not_sent_by_project_coordinator(self):
+        """ Verify that no email is sent if approving person is project coordinator. """
         factories.CourseUserRoleFactory(
             course=self.course, role=PublisherUserRole.ProjectCoordinator, user=self.user
         )
         emails.send_email_for_mark_as_reviewed_course_run(self.course_run_state.course_run, self.user)
-        self.assert_email_sent(self.user_2)
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_email_sent_by_course_team(self):
         """ Verify that email works successfully for course team user."""


### PR DESCRIPTION
ECOM-7767

**AC:**

- Validate when PC approves the course-run and it's sent to the Publisher role to create preview, no email is sent to the CT