### PR TITLE
Serialize course run status in program detail responses

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -432,7 +432,7 @@ class MinimalCourseRunSerializer(TimestampModelSerializer):
     class Meta:
         model = CourseRun
         fields = ('key', 'uuid', 'title', 'image', 'short_description', 'marketing_url', 'seats',
-                  'start', 'end', 'enrollment_start', 'enrollment_end', 'pacing_type', 'type',)
+                  'start', 'end', 'enrollment_start', 'enrollment_end', 'pacing_type', 'type', 'status',)
 
     def get_marketing_url(self, obj):
         return get_marketing_url_for_user(

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -226,6 +226,7 @@ class MinimalCourseRunSerializerTests(TestCase):
             'pacing_type': course_run.pacing_type,
             'type': course_run.type,
             'seats': SeatSerializer(course_run.seats, many=True).data,
+            'status': course_run.status,
         }
 
     def test_data(self):
@@ -262,6 +263,7 @@ class CourseRunSerializerTests(MinimalCourseRunSerializerTests):
             'level_type': course_run.level_type.name,
             'availability': course_run.availability,
             'reporting_type': course_run.reporting_type,
+            'status': course_run.status,
         })
 
         return expected


### PR DESCRIPTION
We need this field available to the LMS to help determine when to allow enrollment on the program detail page.

LEARNER-942

@edx/learner-growth FYI.