### PR TITLE
Fixed error message displayed on invalid date

### DIFF
--- a/course_discovery/templates/publisher/course_run/edit_run_form.html
+++ b/course_discovery/templates/publisher/course_run/edit_run_form.html
@@ -58,7 +58,9 @@
                         <label class="field-label ">{{ run_form.start.label_tag }}  <span class="required">*</span></label>
                         {{ run_form.start }}
                         {% if run_form.start.errors %}
+                            <div class="field-message-content">
                             {{ run_form.start.errors|escape }}
+                            </div>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
ECOM-7837

When a user enters an invalid date on the course run edit page an error message is displayed under the field regarding that error.