### PR TITLE
added a message on the course detail page if no run exists

### DIFF
--- a/course_discovery/conf/locale/en/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/en/LC_MESSAGES/django.po
@@ -1636,6 +1636,10 @@ msgstr ""
 msgid "Not yet created"
 msgstr ""
 
+#: templates/publisher/course_detail/_widgets.html
+msgid "No course runs exist for this course"
+msgstr ""
+
 #: templates/publisher/course_edit_form.html
 msgid "Edit Course"
 msgstr ""

--- a/course_discovery/conf/locale/eo/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/eo/LC_MESSAGES/django.po
@@ -1907,6 +1907,12 @@ msgstr "STÛDÌÖ ÛRL Ⱡ'σяєм ιρѕυм ∂σłσ#"
 msgid "Not yet created"
 msgstr "Nöt ýét çréätéd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт α#"
 
+#: templates/publisher/course_detail/_widgets.html
+msgid "No course runs exist for this course"
+msgstr ""
+"Nö çöürsé rüns éxïst för thïs çöürsé Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"¢σηѕє¢тєтυ#"
+
 #: templates/publisher/course_edit_form.html
 msgid "Edit Course"
 msgstr "Édït Çöürsé Ⱡ'σяєм ιρѕυм ∂σłσя #"

--- a/course_discovery/templates/publisher/course_detail/_widgets.html
+++ b/course_discovery/templates/publisher/course_detail/_widgets.html
@@ -12,6 +12,7 @@
         </a>
     </div>
     <div class="course-run-list">
+        {% if course.course_runs %}
         {% for course_run in course.course_runs %}
             <div class="layout-1t2t layout-reversed course-run-item">
                 <div class="layout-col layout-col-a created-by">
@@ -36,6 +37,11 @@
                 </div>
             </div>
         {% endfor %}
+        {% else %}
+        <div class="course-run-item">
+            {% trans "No course runs exist for this course" %}
+        </div>
+        {% endif %}
     </div>
 
     <div class="approval-widget {% if not publisher_approval_widget_feature %}hidden{% endif %}">


### PR DESCRIPTION
ECOM-7813

If a course has no course runs a message "No course runs exist for this course" is displayed under the course runs on the course detail page.