### PR TITLE
Learner-780 -Display price of only active courses on prog cert page

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -881,6 +881,15 @@ class Program(TimeStampedModel):
                     yield seat
 
     @property
+    def canonical_seats(self):
+        applicable_seat_types = set(seat_type.slug for seat_type in self.type.applicable_seat_types.all())
+
+        for run in self.canonical_course_runs:
+            for seat in run.seats.all():
+                if seat.type in applicable_seat_types:
+                    yield seat
+
+    @property
     def seat_types(self):
         return set(seat.type for seat in self.seats)
 
@@ -912,7 +921,7 @@ class Program(TimeStampedModel):
         """
         currencies_with_total = defaultdict()
         course_map = defaultdict(list)
-        for seat in self.seats:
+        for seat in self.canonical_seats:
             course_uuid = seat.course_run.course.uuid
             # Identify the most relevant course_run seat for a course.
             # And use the price of the seat to represent the price of the course
@@ -959,7 +968,7 @@ class Program(TimeStampedModel):
     @property
     def price_ranges(self):
         currencies = defaultdict(list)
-        for seat in self.seats:
+        for seat in self.canonical_seats:
             currencies[seat.currency].append(seat.price)
 
         total_by_currency = self._get_total_price_by_currency()


### PR DESCRIPTION
Learner-780

**Description:**
prof cert program pages are displaying costs in the right sidebar under "price" for inactive, published runs (from years past), giving current or prospective learners confusing information.

**Expected Behavior:**
pricing in the right sidebar should display cost information associated only with current / published runs

**Acceptance Criteria:**
The desired behavior on the Prof Cert landing page is to display a price range for all course runs in the program, excluding course runs that are either unpublished or published, but whose start and end dates are in the past.
