### PR TITLE
Refine start field boosting

### DIFF
--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -11,14 +11,7 @@ LOGGING['handlers']['local'] = {
 # Determine which requests should render Django Debug Toolbar
 INTERNAL_IPS = ('127.0.0.1',)
 
-
-HAYSTACK_CONNECTIONS = {
-    'default': {
-        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
-        'URL': 'http://edx.devstack.elasticsearch:9200/',
-        'INDEX_NAME': 'catalog',
-    },
-}
+HAYSTACK_CONNECTIONS['default']['URL'] = 'http://edx.devstack.elasticsearch:9200/'
 
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 


### PR DESCRIPTION
Decay scales that are too small can cause scores to quickly drop to 0, leaving you with no start field boosting at all. This change also switches to Gaussian start field decay, which better suits our boosting needs. The Gaussian function decays slowly, then rapidly, then slowly again. This creates a cluster of high-scoring results whose start field is near the present, and a spread of results whose starts are further from the present, either in the past or in future.

LEARNER-993

@edx/learner-growth @bderusha @amangano-edx FYI.