### PR TITLE
Remove XSeries data loader

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -18,7 +18,7 @@ from course_discovery.apps.course_metadata.data_loaders.api import (
 )
 from course_discovery.apps.course_metadata.data_loaders.marketing_site import (
     CourseMarketingSiteDataLoader, PersonMarketingSiteDataLoader, SchoolMarketingSiteDataLoader,
-    SponsorMarketingSiteDataLoader, SubjectMarketingSiteDataLoader, XSeriesMarketingSiteDataLoader
+    SponsorMarketingSiteDataLoader, SubjectMarketingSiteDataLoader
 )
 from course_discovery.apps.course_metadata.models import Course, DataLoaderConfig
 
@@ -153,9 +153,6 @@ class Command(BaseCommand):
                 (
                     (EcommerceApiDataLoader, partner.ecommerce_api_url, 1),
                     (ProgramsApiDataLoader, partner.programs_api_url, max_workers),
-                ),
-                (
-                    (XSeriesMarketingSiteDataLoader, partner.marketing_site_url_root, max_workers),
                 ),
             )
 

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
@@ -14,7 +14,7 @@ from course_discovery.apps.course_metadata.data_loaders.api import (
 )
 from course_discovery.apps.course_metadata.data_loaders.marketing_site import (
     CourseMarketingSiteDataLoader, PersonMarketingSiteDataLoader, SchoolMarketingSiteDataLoader,
-    SponsorMarketingSiteDataLoader, SubjectMarketingSiteDataLoader, XSeriesMarketingSiteDataLoader
+    SponsorMarketingSiteDataLoader, SubjectMarketingSiteDataLoader
 )
 from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
 from course_discovery.apps.course_metadata.management.commands.refresh_course_metadata import execute_parallel_loader
@@ -31,16 +31,17 @@ class RefreshCourseMetadataCommandTests(TransactionTestCase):
         super(RefreshCourseMetadataCommandTests, self).setUp()
         self.partner = PartnerFactory()
         partner = self.partner
-        self.pipeline = [(SubjectMarketingSiteDataLoader, partner.marketing_site_url_root, None),
-                         (SchoolMarketingSiteDataLoader, partner.marketing_site_url_root, None),
-                         (SponsorMarketingSiteDataLoader, partner.marketing_site_url_root, None),
-                         (PersonMarketingSiteDataLoader, partner.marketing_site_url_root, None),
-                         (CourseMarketingSiteDataLoader, partner.marketing_site_url_root, None),
-                         (OrganizationsApiDataLoader, partner.organizations_api_url, None),
-                         (CoursesApiDataLoader, partner.courses_api_url, None),
-                         (EcommerceApiDataLoader, partner.ecommerce_api_url, 1),
-                         (ProgramsApiDataLoader, partner.programs_api_url, None),
-                         (XSeriesMarketingSiteDataLoader, partner.marketing_site_url_root, None)]
+        self.pipeline = [
+            (SubjectMarketingSiteDataLoader, partner.marketing_site_url_root, None),
+            (SchoolMarketingSiteDataLoader, partner.marketing_site_url_root, None),
+            (SponsorMarketingSiteDataLoader, partner.marketing_site_url_root, None),
+            (PersonMarketingSiteDataLoader, partner.marketing_site_url_root, None),
+            (CourseMarketingSiteDataLoader, partner.marketing_site_url_root, None),
+            (OrganizationsApiDataLoader, partner.organizations_api_url, None),
+            (CoursesApiDataLoader, partner.courses_api_url, None),
+            (EcommerceApiDataLoader, partner.ecommerce_api_url, 1),
+            (ProgramsApiDataLoader, partner.programs_api_url, None),
+        ]
         self.kwargs = {'username': 'bob'}
         self.mock_access_token_api()
 
@@ -210,7 +211,6 @@ class RefreshCourseMetadataCommandTests(TransactionTestCase):
                     CoursesApiDataLoader,
                     EcommerceApiDataLoader,
                     ProgramsApiDataLoader,
-                    XSeriesMarketingSiteDataLoader,
                 )
                 expected_calls = [mock.call('%s failed!', loader_class.__name__) for loader_class in loader_classes]
                 mock_logger.exception.assert_has_calls(expected_calls)

--- a/course_discovery/apps/course_metadata/publishers.py
+++ b/course_discovery/apps/course_metadata/publishers.py
@@ -233,7 +233,13 @@ class ProgramMarketingSitePublisher(BaseMarketingSitePublisher):
                 determine if publication is necessary. May not exist if the program
                 is being saved for the first time.
         """
-        if obj.type.name in {'MicroMasters', 'Professional Certificate'}:
+        types_to_publish = {
+            'XSeries',
+            'MicroMasters',
+            'Professional Certificate',
+        }
+
+        if obj.type.name in types_to_publish:
             node_data = self.serialize_obj(obj)
 
             node_id = None

--- a/course_discovery/apps/course_metadata/tests/test_publishers.py
+++ b/course_discovery/apps/course_metadata/tests/test_publishers.py
@@ -279,7 +279,13 @@ class ProgramMarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         for mocked_method in mocked_methods:
             assert not mocked_method.called
 
-        for name in ('MicroMasters', 'Professional Certificate'):
+        types_to_publish = (
+            'XSeries',
+            'MicroMasters',
+            'Professional Certificate'
+        )
+
+        for name in types_to_publish:
             for mocked_method in mocked_methods:
                 mocked_method.reset_mock()
 


### PR DESCRIPTION
XSeries will now be managed using discovery's Django admin like all other program types. Changes to XSeries program may now trigger publication to the marketing site.

LEARNER-1148

@edx/learner-growth FYI