### PR TITLE
Only check eligible runs that are published

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -805,7 +805,7 @@ class Program(TimeStampedModel):
         applicable_seat_types = [seat_type.name.lower() for seat_type in self.type.applicable_seat_types.all()]
 
         for course in self.courses.all():
-            course_runs = set(course.course_runs.all()) - excluded_course_runs
+            course_runs = set(course.course_runs.filter(status=CourseRunStatus.Published)) - excluded_course_runs
 
             if len(course_runs) != 1:
                 return False

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -387,7 +387,7 @@ class ProgramEligibilityFilterTests(TestCase):
             courses=[course_run.course],
             one_click_purchase_enabled=True,
         )
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             self.assertEqual(
                 list(program_filter.queryset({}, Program.objects.all())),
                 [one_click_purchase_eligible_program]


### PR DESCRIPTION
Programs can contain course runs that are no longer published. We therefore only want to check if published  runs are eligible not all of them.
