### PR TITLE
Adding fields on the course run detail page drupal tab

### DIFF
--- a/course_discovery/templates/publisher/course_run_detail/_drupal.html
+++ b/course_discovery/templates/publisher/course_run_detail/_drupal.html
@@ -47,6 +47,17 @@
 
     <div class="info-item">
         <div class="heading">
+        {% trans "MicroMasters" %}
+        </div>
+        <div>
+        {% with  object.micromasters_name as field %}
+            {% include "publisher/_render_optional_field.html" %}
+        {% endwith %}
+        </div>
+    </div>
+
+    <div class="info-item">
+        <div class="heading">
             {% trans "XSeries" %}
            {% include "publisher/course_run_detail/_clipboard.html" %}
         </div>
@@ -56,6 +67,17 @@
             {% else %}
                 {% trans "(Optional) Not yet added" %}
             {% endif %}
+        </div>
+    </div>
+
+    <div class="info-item">
+        <div class="heading">
+            {% trans "Professional Certificate Name" %}
+        </div>
+        <div>
+        {% with  object.professional_certificate_name as field %}
+            {% include "publisher/_render_optional_field.html" %}
+        {% endwith %}
         </div>
     </div>
 


### PR DESCRIPTION
ECOM-7860

Adding fields micromasters and professional certificate on the course run detail page under the drupal tab.
<img width="479" alt="screen shot 2017-06-08 at 2 33 29 pm" src="https://user-images.githubusercontent.com/10988308/26922103-7f96194e-4c57-11e7-9fd8-462f29dd6d65.png">
