### PR TITLE
Fix URL for context-sensitive Help in Publisher

### DIFF
--- a/course_discovery/templates/publisher/_header.html
+++ b/course_discovery/templates/publisher/_header.html
@@ -17,7 +17,7 @@
                     <li class="nav-item nav-account-help">
                         <h3 class="title">
                             <span class="label">
-                                <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/getting_started/get_started.html" title="{% trans 'Contextual Online Help' %}" target="_blank">
+                                <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/set_up_course/pub_create_ann_course/index.html" title="{% trans 'Contextual Online Help' %}" target="_blank">
                                     {% trans "Help" %}
                                 </a>
                             </span>


### PR DESCRIPTION
The current link on for context-sensitive help in Publisher is https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/getting_started/get_started.html, which is broken. The correct link is http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/set_up_course/pub_create_ann_course/index.html.

I found and updated the link in the templates/publisher/_header.html file. I didn't see it in any test files. If I've missed it, or if any other changes are necessary to merge this PR, please let me know.

Review:
[ ] @awaisdar001 