### PR TITLE
ENT-444 Use single shard for catalog index.

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -363,8 +363,15 @@ SWAGGER_SETTINGS = {
 # We are adding the lowercase analyzer and tweaking the ngram analyzers here,
 # so we need to use these settings rather than the index defaults.
 # We are making these changes to enable autocomplete for the typeahead endpoint.
+# In addition we are specifying the number of shards and replicas that indices
+# will be created with as recommended here:
+# https://aws.amazon.com/blogs/database/get-started-with-amazon-elasticsearch-service-how-many-shards-do-i-need/
 ELASTICSEARCH_INDEX_SETTINGS = {
     'settings': {
+        'index': {
+            'number_of_shards': 1,
+            'number_of_replicas': 1
+        },
         'analysis': {
             'tokenizer': {
                 'haystack_edgengram_tokenizer': {


### PR DESCRIPTION
This change will cause newly created catalog indices to be created with a shard size of 1.

The catalog index is small in terms of number of documents (6732) and data
size (87.2mb). There is no reason to prematurely shard the index. In addition,
sharding seems to be affecting our ability to properly score search
results with such a small data set causing inconsistent results when
performing queries which match many documents in the index.

https://aws.amazon.com/blogs/database/get-started-with-amazon-elasticsearch-service-how-many-shards-do-i-need/

Number of shards = 87.2MB / 30GB = 1

ENT-444