### PR TITLE
Call load_all on Course SearchQuerySet.

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
@@ -46,7 +46,7 @@ class AffiliateWindowViewSetTests(ElasticsearchTestMixin, SerializationMixin, AP
 
     def test_affiliate_with_supported_seats(self):
         """ Verify that endpoint returns course runs for verified and professional seats only. """
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9):
             response = self.client.get(self.affiliate_url)
 
         self.assertEqual(response.status_code, 200)
@@ -130,7 +130,7 @@ class AffiliateWindowViewSetTests(ElasticsearchTestMixin, SerializationMixin, AP
         # Superusers can view all catalogs
         self.client.force_authenticate(superuser)
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
 
@@ -140,7 +140,7 @@ class AffiliateWindowViewSetTests(ElasticsearchTestMixin, SerializationMixin, AP
         self.assertEqual(response.status_code, 403)
 
         catalog.viewers = [self.user]
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -172,7 +172,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
                 # to be included.
                 filtered_course_run = CourseRunFactory(course=course)
 
-                with self.assertNumQueries(16):
+                with self.assertNumQueries(17):
                     response = self.client.get(url)
 
                 assert response.status_code == 200
@@ -185,7 +185,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
                 # Any course appearing in the response must have at least one serialized run.
                 assert len(response.data['results'][0]['course_runs']) > 0
             else:
-                with self.assertNumQueries(3):
+                with self.assertNumQueries(4):
                     response = self.client.get(url)
 
                 assert response.status_code == 200
@@ -218,7 +218,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
 
         url = reverse('api:v1:catalog-csv', kwargs={'id': self.catalog.id})
 
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(18):
             response = self.client.get(url)
 
         course_run = self.serialize_catalog_flat_course_run(self.course_run)

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -203,7 +203,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         query = 'title:' + title
         url = '{root}?q={query}'.format(root=reverse('api:v1:course-list'), query=query)
 
-        with self.assertNumQueries(37):
+        with self.assertNumQueries(38):
             response = self.client.get(url)
             self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -333,7 +333,7 @@ class Course(TimeStampedModel):
             QuerySet
         """
         query = clean_query(query)
-        results = SearchQuerySet().models(cls).raw_search(query)
+        results = SearchQuerySet().models(cls).raw_search(query).load_all()
         ids = {result.pk for result in results}
 
         if waffle.switch_is_active('log_course_search_queries'):


### PR DESCRIPTION
Force haystack to make a single elasticsearch query to retrieve
Course search results.

ENT-444