### PR TITLE
Update the script to add short_description_override

### DIFF
--- a/course_discovery/apps/publisher/dataloader/create_courses.py
+++ b/course_discovery/apps/publisher/dataloader/create_courses.py
@@ -98,7 +98,8 @@ def create_course_runs(meta_data_course, publisher_course):
                 'language': canonical_course_run.language, 'pacing_type': canonical_course_run.pacing_type,
                 'length': canonical_course_run.weeks_to_complete,
                 'card_image_url': canonical_course_run.card_image_url,
-                'lms_course_id': canonical_course_run.key
+                'lms_course_id': canonical_course_run.key,
+                'short_description_override': canonical_course_run.short_description_override
             }
 
             publisher_course_run, created = CourseRun.objects.update_or_create(

--- a/course_discovery/apps/publisher/management/commands/tests/test_import_courses.py
+++ b/course_discovery/apps/publisher/management/commands/tests/test_import_courses.py
@@ -106,7 +106,8 @@ class CreateCoursesTests(TestCase):
         # create multiple course-runs against course.
         course_runs = CourseRunFactory.create_batch(
             3, course=self.course, transcript_languages=transcript_languages,
-            language=transcript_languages[0]
+            language=transcript_languages[0],
+            short_description_override='Testing description'
         )
 
         canonical_course_run = course_runs[0]
@@ -274,6 +275,9 @@ class CreateCoursesTests(TestCase):
         self.assertEqual(publisher_course_run.card_image_url, metadata_course_run.card_image_url)
         self.assertEqual(publisher_course_run.language, metadata_course_run.language)
         self.assertEqual(publisher_course_run.lms_course_id, metadata_course_run.key)
+        self.assertEqual(
+            publisher_course_run.short_description_override, metadata_course_run.short_description_override
+        )
 
         # assert ManytoMany fields.
         self.assertEqual(

--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -204,6 +204,15 @@ class Course(TimeStampedModel, ChangedByMixin):
 
         return None
 
+    @property
+    def course_short_description(self):
+        course_run = self.course_runs.filter(course_run_state__name=CourseRunStateChoices.Published).first()
+
+        if course_run and course_run.short_description_override:
+            return course_run.short_description_override
+
+        return self.short_description
+
 
 class CourseRun(TimeStampedModel, ChangedByMixin):
     """ Publisher CourseRun model. It contains fields related to the course run intake form."""

--- a/course_discovery/apps/publisher/tests/factories.py
+++ b/course_discovery/apps/publisher/tests/factories.py
@@ -55,6 +55,7 @@ class CourseRunFactory(factory.DjangoModelFactory):
     preview_url = FuzzyText(prefix='https://example.com/')
     contacted_partner_manager = FuzzyChoice((True, False))
     video_language = factory.Iterator(LanguageTag.objects.all())
+    short_description_override = FuzzyText()
 
     class Meta:
         model = CourseRun

--- a/course_discovery/apps/publisher/tests/test_model.py
+++ b/course_discovery/apps/publisher/tests/test_model.py
@@ -345,6 +345,15 @@ class CourseTests(TestCase):
         # Verify that property returns course image field url.
         self.assertEqual(self.course.course_image_url, self.course.image.url)
 
+    def test_short_description_override(self):
+        """ Verify that the property returns the short_description. """
+        self.assertEqual(self.course.short_description, self.course.course_short_description)
+
+        # Create a published course-run with card_image_url.
+        course_run = factories.CourseRunFactory(course=self.course)
+        factories.CourseRunStateFactory(course_run=course_run, name=CourseRunStateChoices.Published)
+        self.assertEqual(self.course.course_short_description, course_run.short_description_override)
+
 
 class SeatTests(TestCase):
     """ Tests for the publisher `Seat` model. """

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -2011,6 +2011,19 @@ class CourseDetailViewTests(TestCase):
         self.assertEqual(response.context['most_recent_revision_id'], current_user_revision)
         self.assertTrue(response.context['accept_all_button'])
 
+    def test_detail_page_with_override_short_description(self):
+        """
+        Test that pages shows the override short description.
+        """
+        description = 'Testing short description'
+        self._assign_user_permission()
+        course_run = factories.CourseRunFactory(
+            course=self.course, short_description_override=description
+        )
+        factories.CourseRunStateFactory(course_run=course_run, name=CourseRunStateChoices.Published)
+        response = self.client.get(self.detail_page_url)
+        self.assertContains(response, description)
+
     def _assign_user_permission(self):
         """ Assign permissions."""
         self.user.groups.add(self.organization_extension.group)

--- a/course_discovery/templates/publisher/course_detail.html
+++ b/course_discovery/templates/publisher/course_detail.html
@@ -76,7 +76,7 @@
                     {% trans "Short Description" %}
                 </div>
                 <div class="current short_description">
-                    {% with  object.short_description as field %}
+                    {% with  object.course_short_description as field %}
                         {% include "publisher/_render_required_field.html" %}
                     {% endwith %}
                 </div>


### PR DESCRIPTION
Update the import script so that it can fetch the short_description_override.
Property added also to make sure if this value has the priority over the course short description.

https://openedx.atlassian.net/browse/EDUCATOR-704