### PR TITLE
Increase HAYSTACK_ITERATOR_LOAD_PER_QUERY setting.

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -434,7 +434,7 @@ ELASTICSEARCH_INDEX_SETTINGS = {
 SYNONYMS_MODULE = 'course_discovery.settings.synonyms'
 
 # Haystack configuration (http://django-haystack.readthedocs.io/en/v2.5.0/settings.html)
-HAYSTACK_ITERATOR_LOAD_PER_QUERY = 200
+HAYSTACK_ITERATOR_LOAD_PER_QUERY = 5000
 
 HAYSTACK_CONNECTIONS = {
     'default': {


### PR DESCRIPTION
This change will cause Haystack to load up to 5000 results with each
elasticsearch query instead of making multiple round trips to collect
all query results.

ENT-444