### PR TITLE
Correct date format in course run edit form

### DIFF
--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -63,7 +63,6 @@ class BaseCourseForm(forms.ModelForm):
                 field_classes = 'field-input input-select'
             if isinstance(field, forms.DateTimeField):
                 field_classes = '{} add-pikaday'.format(field_classes)
-                field.input_formats = ['YYYY-MM-DDTHH:mm:ss']
             if isinstance(field, forms.ModelMultipleChoiceField):
                 field_classes = 'field-input'
 

--- a/course_discovery/static/js/publisher/utils.js
+++ b/course_discovery/static/js/publisher/utils.js
@@ -4,11 +4,11 @@ function addDatePicker() {
         if (el.getAttribute('datepicker-initialized') !== 'true') {
             new Pikaday({
                 field: el,
-                format: 'YYYY-MM-DD hh:mm:ss',
+                format: 'YYYY-MM-DD HH:mm:ss',
                 defaultDate: $(el).val(),
                 setDefaultDate: true,
                 showTime: true,
-                use24hour: false,
+                use24hour: true,
                 autoClose: true
             });
             el.setAttribute('datepicker-initialized', 'true');


### PR DESCRIPTION
## [EDUCATOR-718](https://openedx.atlassian.net/browse/EDUCATOR-718)

### Description
Javascript plugin **Pikaday** is used in coordination with date fields of course run edit form. Pikaday was set to return 12 hour format date, and was not able to distinguish between AM and PM due to wrong given format. 
I found it more suitable to use 24 hour format for **Pikaday** instead of 12 hour because form fields (course start and end date) are populated in 24 hours format when form is loaded.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @asadazam93 
- [x] Code review: @Rabia23 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits

