### PR TITLE
Update Django comments

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ django==1.11.2
 django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1
-django-contrib-comments==1.7.2
+django-contrib-comments==1.8.0
 django-extensions==1.7.8
 django-filter==1.0.4
 django-fsm==2.6.0


### PR DESCRIPTION
In the 1.8 version they have moved from using the `SITE_ID` settings attribute which we want to remove because of multi-tenancy in https://github.com/edx/course-discovery/pull/977

https://github.com/django/django-contrib-comments/pull/108
https://openedx.atlassian.net/browse/LEARNER-1583

@edx/helio please review.