### PR TITLE
Removed autocomplete for the video field on program admin

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -10,7 +10,6 @@ from course_discovery.apps.course_metadata.exceptions import (
 from course_discovery.apps.course_metadata.forms import CourseAdminForm, ProgramAdminForm
 from course_discovery.apps.course_metadata.models import *  # pylint: disable=wildcard-import
 
-
 PUBLICATION_FAILURE_MSG_TPL = _(
     'An error occurred while publishing the {model} to the marketing site. '
     'Please try again. If the error persists, please contact the Engineering Team.'
@@ -136,6 +135,7 @@ class ProgramAdmin(admin.ModelAdmin):
     list_filter = ('partner', 'type', 'status', ProgramEligibilityFilter, 'hidden',)
     ordering = ('uuid', 'title', 'status')
     readonly_fields = ('uuid', 'custom_course_runs_display', 'excluded_course_runs',)
+    raw_id_fields = ('video',)
     search_fields = ('uuid', 'title', 'marketing_slug')
 
     filter_horizontal = ('job_outlook_items', 'expected_learning_items',)
@@ -223,7 +223,6 @@ class FAQAdmin(admin.ModelAdmin):
 
 
 class OrganizationUserRoleInline(admin.TabularInline):
-
     # course-meta-data models are importing in publisher app. So just for safe side
     # to avoid any circular issue importing the publisher model here.
     from course_discovery.apps.publisher.models import OrganizationUserRole
@@ -259,6 +258,12 @@ class PersonAdmin(admin.ModelAdmin):
     search_fields = ('uuid', 'family_name', 'given_name', 'slug',)
 
 
+@admin.register(Video)
+class VideoAdmin(admin.ModelAdmin):
+    list_display = ('src', 'description',)
+    search_fields = ('src', 'description',)
+
+
 class NamedModelAdmin(admin.ModelAdmin):
     list_display = ('name',)
     ordering = ('name',)
@@ -270,6 +275,6 @@ for model in (LevelType, Prerequisite,):
     admin.site.register(model, NamedModelAdmin)
 
 # Register remaining models using basic ModelAdmin classes
-for model in (Image, Video, ExpectedLearningItem, SyllabusItem, PersonSocialNetwork, CourseRunSocialNetwork,
-              JobOutlookItem, DataLoaderConfig):
+for model in (Image, ExpectedLearningItem, SyllabusItem, PersonSocialNetwork, CourseRunSocialNetwork, JobOutlookItem,
+              DataLoaderConfig):
     admin.site.register(model)

--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -54,12 +54,6 @@ class ProgramAdminForm(forms.ModelForm):
                     'class': 'sortable-select',
                 }
             ),
-            'video': autocomplete.ModelSelect2(
-                url='admin_metadata:video-autocomplete',
-                attrs={
-                    'data-minimum-input-length': 3,
-                }
-            ),
         }
 
     def __init__(self, *args, **kwargs):

--- a/course_discovery/apps/course_metadata/lookups.py
+++ b/course_discovery/apps/course_metadata/lookups.py
@@ -6,8 +6,7 @@ from django.db.models import Q
 from django.template.loader import render_to_string
 
 from course_discovery.apps.publisher.mixins import get_user_organizations
-
-from .models import Course, CourseRun, Organization, Person, Video
+from .models import Course, CourseRun, Organization, Person
 
 
 class CourseAutocomplete(autocomplete.Select2QuerySetView):
@@ -41,18 +40,6 @@ class OrganizationAutocomplete(autocomplete.Select2QuerySetView):
 
             if self.q:
                 qs = qs.filter(Q(key__icontains=self.q) | Q(name__icontains=self.q))
-
-            return qs
-
-        return []
-
-
-class VideoAutocomplete(autocomplete.Select2QuerySetView):
-    def get_queryset(self):
-        if self.request.user.is_authenticated() and self.request.user.is_staff:
-            qs = Video.objects.all()
-            if self.q:
-                qs = qs.filter(Q(description__icontains=self.q) | Q(src__icontains=self.q))
 
             return qs
 

--- a/course_discovery/apps/course_metadata/tests/test_lookups.py
+++ b/course_discovery/apps/course_metadata/tests/test_lookups.py
@@ -6,8 +6,9 @@ from django.test import TestCase
 from django.urls import reverse
 
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
-from course_discovery.apps.course_metadata.tests.factories import (CourseFactory, CourseRunFactory, OrganizationFactory,
-                                                                   PersonFactory, PositionFactory)
+from course_discovery.apps.course_metadata.tests.factories import (
+    CourseFactory, CourseRunFactory, OrganizationFactory, PersonFactory, PositionFactory
+)
 from course_discovery.apps.publisher.tests import factories
 
 
@@ -106,34 +107,6 @@ class AutocompleteTests(TestCase):
         """ Verify Organization autocomplete returns empty list for un-authorized users. """
         self._make_user_non_staff()
         response = self.client.get(reverse('admin_metadata:organisation-autocomplete'))
-        data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(data['results'], [])
-
-    @ddt.data('dummyurl', 'testing')
-    def test_video_autocomplete(self, search_key):
-        """ Verify video autocomplete returns the data. """
-        response = self.client.get(reverse('admin_metadata:video-autocomplete'))
-        data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(data['results']), 6)
-
-        self.courses[0].video.src = 'http://www.youtube.com/dummyurl'
-        self.courses[0].video.description = 'testing description'
-        self.courses[0].video.save()
-
-        response = self.client.get(
-            reverse('admin_metadata:video-autocomplete') + '?q={key}'.format(
-                key=search_key
-            )
-        )
-        data = json.loads(response.content.decode('utf-8'))
-        self.assertEqual(data['results'][0]['text'], str(self.courses[0].video))
-        self.assertEqual(len(data['results']), 1)
-
-    def test_video_autocomplete_un_authorize_user(self):
-        """ Verify video autocomplete returns empty list for un-authorized users. """
-        self._make_user_non_staff()
-        response = self.client.get(reverse('admin_metadata:video-autocomplete'))
         data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(data['results'], [])
 

--- a/course_discovery/apps/course_metadata/urls.py
+++ b/course_discovery/apps/course_metadata/urls.py
@@ -4,7 +4,7 @@ URLs for the admin autocomplete lookups.
 from django.conf.urls import url
 
 from course_discovery.apps.course_metadata.lookups import (
-    CourseAutocomplete, CourseRunAutocomplete, OrganizationAutocomplete, PersonAutocomplete, VideoAutocomplete
+    CourseAutocomplete, CourseRunAutocomplete, OrganizationAutocomplete, PersonAutocomplete
 )
 from course_discovery.apps.course_metadata.views import CourseRunSelectionAdmin
 
@@ -13,6 +13,5 @@ urlpatterns = [
     url(r'^course-autocomplete/$', CourseAutocomplete.as_view(), name='course-autocomplete',),
     url(r'^course-run-autocomplete/$', CourseRunAutocomplete.as_view(), name='course-run-autocomplete',),
     url(r'^organisation-autocomplete/$', OrganizationAutocomplete.as_view(), name='organisation-autocomplete',),
-    url(r'^video-autocomplete/$', VideoAutocomplete.as_view(), name='video-autocomplete',),
     url(r'^person-autocomplete/$', PersonAutocomplete.as_view(), name='person-autocomplete',),
 ]


### PR DESCRIPTION
The autocomplete does not allow for the video to be deleted. Since autocomplete is overkill for this field, I have removed it and replaced it with Django's built-in search functionality over raw_id_fields.