### PR TITLE
Update django-contrib-comments

### DIFF
--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -158,7 +158,7 @@ class CourseRunDetailView(mixins.LoginRequiredMixin, mixins.PublisherPermissionM
         context['object'] = course_run
         context['comment_object'] = course_run
 
-        # this ulr is used for the comments post back redirection.
+        # this URL is used for the comments post back redirection.
         context['post_back_url'] = reverse('publisher:publisher_course_run_detail', kwargs={'pk': course_run.id})
 
         context['can_edit'] = mixins.check_course_organization_permission(

--- a/course_discovery/apps/publisher_comments/api/tests/test_views.py
+++ b/course_discovery/apps/publisher_comments/api/tests/test_views.py
@@ -5,8 +5,38 @@ from rest_framework.reverse import reverse
 
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from course_discovery.apps.publisher.tests import JSON_CONTENT_TYPE
+from course_discovery.apps.publisher.tests.factories import CourseRunFactory
+from course_discovery.apps.publisher_comments.forms import CommentsForm
 from course_discovery.apps.publisher_comments.models import Comments
 from course_discovery.apps.publisher_comments.tests.factories import CommentFactory
+
+
+class PostCommentTests(TestCase):
+
+    def generate_data(self, obj):
+        """Generate data for the form."""
+        f = CommentsForm(obj)
+        data = {
+            'name': 'Tester',
+            'email': 'tester@example.com',
+            'comment': 'Test comment'
+        }
+        data.update(f.initial)
+        return data
+
+    def test_successful_post(self):
+        """Posting data to the comment post endpoint creates a comment."""
+        path = reverse('comments-post-comment')
+        self.assertEqual(Comments.objects.count(), 0)
+        course_run = CourseRunFactory()
+        generated_data = self.generate_data(course_run)
+        self.client.post(path, data=generated_data)
+
+        self.assertEqual(Comments.objects.count(), 1)
+        comment = Comments.objects.first()
+        self.assertEqual(comment.user_name, generated_data['name'])
+        self.assertEqual(comment.comment, generated_data['comment'])
+        self.assertEqual(comment.user_email, generated_data['email'])
 
 
 class UpdateCommentTests(TestCase):

--- a/course_discovery/apps/publisher_comments/forms.py
+++ b/course_discovery/apps/publisher_comments/forms.py
@@ -15,9 +15,9 @@ class CommentsForm(CommentForm):
     def get_comment_model(self):
         return Comments
 
-    def get_comment_create_data(self):
+    def get_comment_create_data(self, site_id=None):
         # Use the data of the superclass, and add in the title field
-        data = super(CommentsForm, self).get_comment_create_data()
+        data = super(CommentsForm, self).get_comment_create_data(site_id=site_id)
         data['modified'] = self.cleaned_data['modified']
         data['comment_type'] = self.cleaned_data['comment_type']
         return data
@@ -37,7 +37,7 @@ class CommentEditForm(forms.ModelForm):
 
 
 class CommentsAdminForm(forms.ModelForm):
-    """ Comment form for admin.It will load only required content types models in drop down. """
+    """ Comment form for admin. It will load only required content types models in drop down. """
 
     class Meta:
         model = Comments

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ django==1.11.2
 django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1
-django-contrib-comments==1.7.2
+django-contrib-comments==1.8.0
 django-extensions==1.7.8
 django-filter==1.0.4
 django-fsm==2.6.0


### PR DESCRIPTION
Version 1.8.0 of django-contrib-comments moved away from
using the SITE_ID settings attribute in favor of supporting
multi-tenancy.

LEARNER-1583 + EDUCATOR-733

@edx/helio and @awais786 please review.