### PR TITLE
optimize queries for courses list page

### DIFF
--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -118,6 +118,19 @@ class Course(TimeStampedModel, ChangedByMixin):
         return user_emails
 
     @property
+    def organization_name(self):
+        """
+        Returns organization name for a course.
+        """
+        organization_name = ''
+        try:
+            organization_name = self.organizations.only('key').first().key
+        except AttributeError:
+            pass
+
+        return organization_name
+
+    @property
     def keywords_data(self):
         keywords = self.keywords.all()
         if keywords:
@@ -131,7 +144,7 @@ class Course(TimeStampedModel, ChangedByMixin):
         Return course project coordinator user.
         """
         try:
-            return self.course_user_roles.get(role=PublisherUserRole.ProjectCoordinator).user
+            return self.course_user_roles.only('user').get(role=PublisherUserRole.ProjectCoordinator).user
         except CourseUserRole.DoesNotExist:
             return None
 

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -797,10 +797,14 @@ class CourseListView(mixins.LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         user = self.request.user
+        courses = Course.objects.all().prefetch_related(
+            'organizations', 'course_state', 'publisher_course_runs', 'course_user_roles'
+        )
+
         if is_publisher_admin(user):
-            courses = Course.objects.all()
+            courses = courses
         elif is_internal_user(user):
-            courses = Course.objects.filter(course_user_roles__user=user).distinct()
+            courses = courses.filter(course_user_roles__user=user).distinct()
         else:
             organizations = get_objects_for_user(
                 user,
@@ -809,7 +813,7 @@ class CourseListView(mixins.LoginRequiredMixin, ListView):
                 use_groups=True,
                 with_superuser=False
             ).values_list('organization')
-            courses = Course.objects.filter(organizations__in=organizations)
+            courses = courses.filter(organizations__in=organizations)
 
         return courses
 

--- a/course_discovery/templates/publisher/courses.html
+++ b/course_discovery/templates/publisher/courses.html
@@ -50,7 +50,7 @@
                           {% endif %}
                         </td>
                         <td>
-                            {% if course.organizations.first %}{{ course.organizations.first.key }}{% endif %}
+                            {{ course.organization_name }}
                         </td>
                         <td>
                             {{ course.project_coordinator.full_name }}

--- a/course_discovery/templates/publisher/dashboard/_in_preview.html
+++ b/course_discovery/templates/publisher/dashboard/_in_preview.html
@@ -32,7 +32,7 @@
                             <a target="_blank" href="{{ course_run.preview_url }}">{{ course_run.preview_url }}</a>
                         </td>
                         <td>
-                        {% if course_run.course.organizations.first %}{{ course_run.course.organizations.first.key }}{% endif %}
+                        {{ course_run.course.organization_name }}
                         </td>
                         <td>
                             {% if course_run.course_run_state.preview_accepted %}

--- a/course_discovery/templates/publisher/dashboard/_in_progress.html
+++ b/course_discovery/templates/publisher/dashboard/_in_progress.html
@@ -50,7 +50,7 @@
                         {{ course_run.number }}
                     </td>
                     <td>
-                        {% if course_run.course.organizations.first %}{{ course_run.course.organizations.first.key }}{% endif %}
+                        {{ course_run.course.organization_name }}
                     </td>
                     <td>
                          {{ course_run.start|date:"Y-m-d" }}

--- a/course_discovery/templates/publisher/dashboard/_published.html
+++ b/course_discovery/templates/publisher/dashboard/_published.html
@@ -40,7 +40,7 @@
                         {{ course_run.number }}
                     </td>
                     <td>
-                        {% if course_run.course.organizations.first %}{{ course_run.course.organizations.first.key }}{% endif %}
+                        {{ course_run.course.organization_name }}
                     </td>
                     <td>
                          {{ course_run.start|date:"Y-m-d" }}

--- a/course_discovery/templates/publisher/dashboard/_studio_requests.html
+++ b/course_discovery/templates/publisher/dashboard/_studio_requests.html
@@ -39,7 +39,7 @@
                                 <a href="{{ run_page_url }}" id="course-title">{{ course_run.title }}</a>
                             </td>
                             <td>
-                                {% if course_run.course.organizations.first %}{{ course_run.course.organizations.first.key }}{% endif %}
+                                {{ course_run.course.organization_name }}
                             </td>
                             <td id="course-start">
                                  {{ course_run.start|date:"Y-m-d" }}


### PR DESCRIPTION
[**EDUCATOR-828**](https://openedx.atlassian.net/browse/EDUCATOR-828)

These changes will improve the publisher courses list page(`/publisher/courses`) load time. There is still room for improvement but for now this good enough.

-----------
**Publisher courses page load time with queries executed for `1242` courses** 

Before Optimisation
——————————
1371.67 ms (8875 queries including 8869 duplicates )

After Optimisation
—————————
561.99 ms (3912 queries including 3901 duplicates )

-----------

**Unit test stats shows queries executed before and after the optimization**

|               test                                            | before    |  after|
----------------------------------------|----------|-------|
|test_page_with_enable_waffle_switch    |     13         |   15|
|test_page_with_disable_waffle_switch   |      21        |    21|
|test_courses_with_permission               |    100         |  64|
|test_courses_with_course_user_role      |    60          |  32|
|test_courses_with_admin                        |     58         |   31 |
