### PR TITLE
EDUCATOR-831 Correct course title format in publisher course update.

### DIFF
--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -1,6 +1,8 @@
 """
 Course publisher forms.
 """
+import html
+
 from dal import autocomplete
 from django import forms
 from django.core.exceptions import ValidationError
@@ -192,6 +194,13 @@ class CustomCourseForm(CourseForm):
 
         if user and not is_internal_user(user):
             self.fields['video_link'].widget = forms.HiddenInput()
+
+    def clean_title(self):
+        """
+        Convert all named and numeric character references in the string
+        to the corresponding unicode characters
+        """
+        return html.unescape(self.cleaned_data.get("title"))
 
     def clean(self):
         cleaned_data = self.cleaned_data


### PR DESCRIPTION
## [EDUCATOR-831](https://openedx.atlassian.net/browse/EDUCATOR-831)

### Description
All Three non-English characters an **accent mark [á]**, a **tilde [ã]** and a **cedilla [ç]** not appeared properly in the Course title after updating the Course. 

### Screenshots
**Before Fix**
<img width="628" alt="screen shot 2017-07-11 at 4 09 34 pm" src="https://user-images.githubusercontent.com/7627421/28065748-7129d6b4-6653-11e7-9de0-ac6525309132.png">
**After Fix**
<img width="624" alt="screen shot 2017-07-11 at 4 09 49 pm" src="https://user-images.githubusercontent.com/7627421/28065753-781bd54e-6653-11e7-99f8-ce88e17e1f3d.png">



### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @asadazam93 
- [x] Code review: @awaisdar001 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [x] Rebase and squash commits

