### PR TITLE
Removed Organization filter when searching for instructors

### DIFF
--- a/course_discovery/apps/course_metadata/lookups.py
+++ b/course_discovery/apps/course_metadata/lookups.py
@@ -5,7 +5,6 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
 from django.template.loader import render_to_string
 
-from course_discovery.apps.publisher.mixins import get_user_organizations
 from .models import Course, CourseRun, Organization, Person
 
 
@@ -50,10 +49,7 @@ class PersonAutocomplete(LoginRequiredMixin, autocomplete.Select2QuerySetView):
     def get_queryset(self):
         queryset = Person.objects.all()
         if self.q:
-            qs = queryset.filter(Q(given_name__icontains=self.q) | Q(family_name__icontains=self.q),
-                                 position__organization__in=get_user_organizations(self.request.user))
-            if self.request.user.is_staff and self.request.user.is_superuser:
-                qs = queryset.filter(Q(given_name__icontains=self.q) | Q(family_name__icontains=self.q))
+            qs = queryset.filter(Q(given_name__icontains=self.q) | Q(family_name__icontains=self.q))
 
             if not qs:
                 try:


### PR DESCRIPTION
Educator-879

Removed Organization filter for Instructors i.e When a course team tries to add an instructor to a course run, the system searches ALL existing instructors in Drupal, regardless of institution or organization.