### PR TITLE
Removed inlines for FAQ and endorsements on Program admin

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -63,27 +63,6 @@ class PersonSocialNetworkInline(admin.TabularInline):
     extra = 0
 
 
-class FaqsInline(admin.TabularInline):
-    model = Program.faq.through
-    exclude = ('sort_value',)
-    extra = 1
-    verbose_name_plural = 'Faqs'
-
-
-class IndividualEndorsementInline(admin.TabularInline):
-    model = Program.individual_endorsements.through
-    exclude = ('sort_value',)
-    extra = 1
-    verbose_name_plural = 'Individual Endorsement'
-
-
-class CorporateEndorsementsInline(admin.TabularInline):
-    model = Program.corporate_endorsements.through
-    exclude = ('sort_value',)
-    extra = 1
-    verbose_name_plural = 'Corporate Endorsement'
-
-
 @admin.register(Course)
 class CourseAdmin(admin.ModelAdmin):
     form = CourseAdminForm
@@ -130,7 +109,6 @@ class CourseRunAdmin(admin.ModelAdmin):
 @admin.register(Program)
 class ProgramAdmin(admin.ModelAdmin):
     form = ProgramAdminForm
-    inlines = [FaqsInline, IndividualEndorsementInline, CorporateEndorsementsInline]
     list_display = ('id', 'uuid', 'title', 'type', 'partner', 'status', 'hidden')
     list_filter = ('partner', 'type', 'status', ProgramEligibilityFilter, 'hidden',)
     ordering = ('uuid', 'title', 'status')
@@ -146,7 +124,8 @@ class ProgramAdmin(admin.ModelAdmin):
         'marketing_slug', 'overview', 'credit_redemption_overview', 'video', 'weeks_to_complete',
         'min_hours_effort_per_week', 'max_hours_effort_per_week', 'courses', 'order_courses_by_start_date',
         'custom_course_runs_display', 'excluded_course_runs', 'authoring_organizations',
-        'credit_backing_organizations', 'one_click_purchase_enabled', 'hidden',
+        'credit_backing_organizations', 'one_click_purchase_enabled', 'hidden', 'corporate_endorsements', 'faq',
+        'individual_endorsements',
     )
     fields += filter_horizontal
     save_error = False

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -290,14 +290,9 @@ class ProgramAdminFunctionalTests(LiveServerTestCase):
             'field-min_hours_effort_per_week', 'field-max_hours_effort_per_week', 'field-courses',
             'field-order_courses_by_start_date', 'field-custom_course_runs_display', 'field-excluded_course_runs',
             'field-authoring_organizations', 'field-credit_backing_organizations', 'field-one_click_purchase_enabled',
-            'field-hidden', 'field-job_outlook_items', 'field-expected_learning_items'
+            'field-hidden', 'field-corporate_endorsements', 'field-faq', 'field-individual_endorsements',
+            'field-job_outlook_items', 'field-expected_learning_items',
         ]
-        self.assertEqual(actual, expected)
-
-        # Check the inline fields
-        expected = ['Program_faq-group', 'Program_individual_endorsements-group',
-                    'Program_corporate_endorsements-group']
-        actual = [element.get_attribute('id') for element in self.browser.find_elements_by_class_name('inline-group')]
         self.assertEqual(actual, expected)
 
     def test_program_creation(self):


### PR DESCRIPTION
Using the default UI for SortedManyToManyField since it properly exposes the sorting capability.

LEARNER-1863