### PR TITLE
[ENT-504] Return distinct list of available courses.

### DIFF
--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -50,7 +50,14 @@ class CourseQuerySet(models.QuerySet):
         # runs is published while the other is not. If you used exclude(), the Course
         # would be dropped from the queryset even though it has one run which matches
         # our availability criteria.
-        return self.filter(enrollable & not_ended & marketable)
+        query = self.filter(enrollable & not_ended & marketable)
+
+        # By itself, the query above performs a join across several tables and would return
+        # a copy of the same course multiple times (a separate copy for each available
+        # seat in each available run).
+        # We use distinct() to make sure it only returns a single copy of each available
+        # course.
+        return query.distinct()
 
 
 class CourseRunQuerySet(models.QuerySet):

--- a/course_discovery/apps/course_metadata/tests/test_query.py
+++ b/course_discovery/apps/course_metadata/tests/test_query.py
@@ -30,14 +30,24 @@ class CourseQuerySetTests(TestCase):
 
             if state in self.available_states:
                 course = course_run.course
+                # This course is available, so should be returned by the
+                # available() query.
+                assert list(Course.objects.available()) == [course]
 
                 # This run has no seats, but we still expect its parent course
                 # to be included.
                 CourseRunFactory(course=course)
+                assert list(Course.objects.available()) == [course]
 
-                assert set(Course.objects.available()) == {course}
+                # Generate another course run with available seats.
+                # Only one instance of the course should be included in the result.
+                other_course_run = CourseRunFactory(course=course)
+                for function in state:
+                    function(other_course_run)
+                other_course_run.save()
+                assert list(Course.objects.available()) == [course]
             else:
-                assert set(Course.objects.available()) == set()
+                assert list(Course.objects.available()) == []
 
 
 @ddt.ddt


### PR DESCRIPTION
This fixes Catalog Courses API endpoint to not return multiple copies of the same course.

The reason duplicate courses were being returned is that the [`available()` query method](https://github.com/edx/course-discovery/blob/51757ed8ec99eaf828f39b3b9a2f5537b634eaed/course_discovery/apps/course_metadata/query.py#L11-L53) performs a join over three tables. The generated SQL query looks like this:

```sql
SELECT     "course_metadata_course"."id",
           "course_metadata_course"."created",
           "course_metadata_course"."modified",
           "course_metadata_course"."partner_id",
           "course_metadata_course"."uuid",
           "course_metadata_course"."canonical_course_run_id",
           "course_metadata_course"."key",
           "course_metadata_course"."title",
           "course_metadata_course"."short_description",
           "course_metadata_course"."full_description",
           "course_metadata_course"."level_type_id",
           "course_metadata_course"."card_image_url",
           "course_metadata_course"."slug",
           "course_metadata_course"."video_id",
           "course_metadata_course"."number"
FROM       "course_metadata_course"
INNER JOIN "course_metadata_courserun"
ON         (
                      "course_metadata_course"."id" = "course_metadata_courserun"."course_id")
INNER JOIN "course_metadata_seat"
ON         (
                      "course_metadata_courserun"."id" = "course_metadata_seat"."course_run_id")
WHERE      (
                      "course_metadata_course"."id" IN (1,
                                                        4)
           AND        (
                                 "course_metadata_courserun"."enrollment_start" <= 2017-07-12 08:04:51.591905
                      OR         "course_metadata_courserun"."enrollment_start" IS NULL)
           AND        (
                                 "course_metadata_courserun"."enrollment_end" > 2017-07-12 08:04:51.591905
                      OR         "course_metadata_courserun"."enrollment_end" IS NULL)
           AND        (
                                 "course_metadata_courserun"."end" > 2017-07-12 08:04:51.591905
                      OR         "course_metadata_courserun"."end" IS NULL)
           AND        "course_metadata_courserun"."slug" IS NOT NULL
           AND        NOT (
                                 "course_metadata_course"."id" IN
                                 (
                                        SELECT u1."course_id" AS col1
                                        FROM   "course_metadata_courserun" u1
                                        WHERE  (
                                                      u1."slug" =
                                               AND    u1."id" = ("course_metadata_courserun"."id"))))
           AND        "course_metadata_seat"."id" IS NOT NULL
           AND        "course_metadata_courserun"."status" = published)
```

The join generates a separate row for each course/course_run/seat combination and the django ORM does not eliminate duplicate results by default, as [explained in the `distinct()` docs](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#distinct).

Adding `distinct()` to the `available()` query fixes the problem. The `available()` query is currently only used in the Catalog Courses API endpoint, so this change should not have any side effects on other parts of the system.

**JIRA tickets**: https://openedx.atlassian.net/browse/ENT-504

**Dependencies**: None

**Testing instructions**:

1. Set up a catalog and add a course run to it in your course discovery service.
1. Make sure the course is "available" (course enrollment has started, course has not ended, course is in published status).
1. Add more than one type of seats to the course run (honor, verified, ...)
1. Visit the `api/v1/catalogs/:id/courses` endpoint.
1. Without this patch, you will see multiple copies of the course returned by the API (one copy for each course run/seat combination).
1. With this patch installed, verify that the API only returns a single copy of the course.

**Reviewers**
- [x] @itsjeyd 
- [x] @douglashall 