### PR TITLE
optimize queries for dashboard courses

### DIFF
--- a/course_discovery/templates/publisher/dashboard/_in_preview.html
+++ b/course_discovery/templates/publisher/dashboard/_in_preview.html
@@ -32,7 +32,7 @@
                             <a target="_blank" href="{{ course_run.preview_url }}">{{ course_run.preview_url }}</a>
                         </td>
                         <td>
-                        {% if course_run.course.organizations.first %}{{ course_run.course.organizations.first.key }}{% endif %}
+                        {{ course_run.course.organization_name }}
                         </td>
                         <td>
                             {% if course_run.course_run_state.preview_accepted %}

--- a/course_discovery/templates/publisher/dashboard/_in_progress.html
+++ b/course_discovery/templates/publisher/dashboard/_in_progress.html
@@ -50,7 +50,7 @@
                         {{ course_run.number }}
                     </td>
                     <td>
-                        {% if course_run.course.organizations.first %}{{ course_run.course.organizations.first.key }}{% endif %}
+                        {{ course_run.course.organization_name }}
                     </td>
                     <td>
                          {{ course_run.start|date:"Y-m-d" }}

--- a/course_discovery/templates/publisher/dashboard/_published.html
+++ b/course_discovery/templates/publisher/dashboard/_published.html
@@ -40,7 +40,7 @@
                         {{ course_run.number }}
                     </td>
                     <td>
-                        {% if course_run.course.organizations.first %}{{ course_run.course.organizations.first.key }}{% endif %}
+                        {{ course_run.course.organization_name }}
                     </td>
                     <td>
                          {{ course_run.start|date:"Y-m-d" }}

--- a/course_discovery/templates/publisher/dashboard/_studio_requests.html
+++ b/course_discovery/templates/publisher/dashboard/_studio_requests.html
@@ -39,7 +39,7 @@
                                 <a href="{{ run_page_url }}" id="course-title">{{ course_run.title }}</a>
                             </td>
                             <td>
-                                {% if course_run.course.organizations.first %}{{ course_run.course.organizations.first.key }}{% endif %}
+                                {{ course_run.course.organization_name }}
                             </td>
                             <td id="course-start">
                                  {{ course_run.start|date:"Y-m-d" }}


### PR DESCRIPTION
[**EDUCATOR-829**](https://openedx.atlassian.net/browse/EDUCATOR-829)

These changes will improve the publisher dashboard page(`/publisher`) load time. There is still room for improvement but for now this good enough.

-----------
**Publisher dashboard page load time with queries executed for `1243` courses** 

Before Optimisation
——————————
764.43 ms (2499 queries including 2489 duplicates )

After Optimisation
—————————
245.02 ms (1256 queries including 1246 duplicates )