### PR TITLE
Upgrade to DRF 3.4.7

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -185,7 +185,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
                 # Any course appearing in the response must have at least one serialized run.
                 assert len(response.data['results'][0]['course_runs']) > 0
             else:
-                with self.assertNumQueries(3):
+                with self.assertNumQueries(2):
                     response = self.client.get(url)
 
                 assert response.status_code == 200

--- a/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
@@ -85,7 +85,7 @@ class OrganizationViewSetTests(SerializationMixin, APITestCase):
         organizations = OrganizationFactory.create_batch(2)
 
         # If no organizations have been tagged, the endpoint should not return any data
-        self.assert_list_tag_filter([], [tag], expected_query_count=4)
+        self.assert_list_tag_filter([], [tag], expected_query_count=3)
 
         # Tagged organizations should be returned
         organizations[0].tags.add(tag)

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -170,7 +170,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         self.assert_list_results(url, [program], 8)
 
         url = self.list_path + '?type=bar'
-        self.assert_list_results(url, [], 4)
+        self.assert_list_results(url, [], 3)
 
     def test_filter_by_types(self):
         """ Verify that the endpoint filters programs to those matching the provided ProgramType slugs. """
@@ -197,7 +197,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         self.assert_list_results(url, expected, 8)
 
     @ddt.data(
-        (ProgramStatus.Unpublished, False, 4),
+        (ProgramStatus.Unpublished, False, 3),
         (ProgramStatus.Active, True, 8),
     )
     @ddt.unpack

--- a/course_discovery/apps/publisher/api/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/tests/test_views.py
@@ -262,7 +262,7 @@ class UpdateCourseRunViewTests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            response.data.get('lms_course_id'), ['CourseRun with this lms course id already exists.']
+            response.data.get('lms_course_id'), ['course run with this lms course id already exists.']
         )
 
     def test_update_course_key(self):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ django-taggit==0.22.1
 django-taggit-autosuggest==0.3.0
 django-taggit-serializer==0.1.5
 django-waffle==0.11.1
-djangorestframework==3.3.3
+djangorestframework==3.4.7
 djangorestframework-csv==1.4.1
 djangorestframework-jwt==1.8.0
 djangorestframework-xml==1.3.0


### PR DESCRIPTION
DRF 3.4.7 is the same version run by edx/credentials. Release notes are at http://www.django-rest-framework.org/topics/release-notes/#34x-series. Highlights include:

1. [Support for Django 1.10](https://github.com/encode/django-rest-framework/pull/4158) - sigh
2. [Support for schema generation](https://github.com/encode/django-rest-framework/pull/4179) - required for newer versions of django-rest-swagger
3. A change that [prevents paginated views from re-running queries](https://github.com/encode/django-rest-framework/issues/4201) when count queries return 0 - this explains the expected query count changes made in tests

LEARNER-1590

@edx/learner @nedbat FYI. I will be following this with a PR similar to https://github.com/edx/credentials/pull/281 to fix API docs broken by the Django 1.11 upgrade.