### PR TITLE
Add search by course run title capability in publisher admin - EDUCATOR-890

### DIFF
--- a/course_discovery/apps/publisher/admin.py
+++ b/course_discovery/apps/publisher/admin.py
@@ -80,7 +80,8 @@ class CourseRunStateAdmin(admin.ModelAdmin):
     raw_id_fields = ('changed_by',)
     list_display = ['id', 'name', 'approved_by_role', 'owner_role',
                     'course_run', 'owner_role_modified', 'preview_accepted']
-    search_fields = ['id', 'name']
+    list_filter = ('name',)
+    search_fields = ['id', 'course_run__course__title']
     ordering = ['id']
 
 


### PR DESCRIPTION
## [EDUCATOR-890](https://openedx.atlassian.net/browse/EDUCATOR-890)

### Description

* Publisher admin `CourseRunState` table should have a search by course run title. 
* Add a filter on `CourseRunState` model admin list view with the state name. 

### Screenshots

**Course run state Model**
<img width="1174" alt="screen shot 2017-07-13 at 1 53 07 pm" src="https://user-images.githubusercontent.com/4252738/28159725-543550ee-67d7-11e7-92bd-1ca3880f0328.png">


### Testing
- [ ] N/A

### Reviewers
- [x] @asadazam93 
- [x] @noraiz-anwar 

List optional/FYI reviewers here:
@sstack22 
### Post-review
- [ ] Rebase and squash commits