### PR TITLE
Publisher admin CourseState table changes

### DIFF
--- a/course_discovery/apps/publisher/admin.py
+++ b/course_discovery/apps/publisher/admin.py
@@ -71,8 +71,9 @@ class OrganizationUserRoleAdmin(admin.ModelAdmin):
 @admin.register(CourseState)
 class CourseStateAdmin(admin.ModelAdmin):
     raw_id_fields = ('changed_by',)
-    list_display = ['name', 'approved_by_role', 'owner_role', 'course', 'marketing_reviewed']
-    search_fields = ['name']
+    list_display = ['id', 'name', 'approved_by_role', 'owner_role', 'course', 'marketing_reviewed']
+    search_fields = ['id', 'course__title']
+    list_filter = ('name',)
 
 
 @admin.register(CourseRunState)


### PR DESCRIPTION
## [EDUCATOR-894](https://openedx.atlassian.net/browse/EDUCATOR-894)

### Description
* Publisher admin `CourseState` list view should be searchable by course title and state id (pk)
* Publisher admin `CourseState` list view should display id column
### Screenshots

**CourseState Model**
<img width="1198" alt="screen shot 2017-07-13 at 3 48 28 pm" src="https://user-images.githubusercontent.com/4252738/28163019-c8f038bc-67e2-11e7-96a3-a230e3abef35.png">


### Testing
- [ ] N/A

### Reviewers
- [x] @asadazam93 
- [x] @noraiz-anwar 

List optional/FYI reviewers here:
@sstack22 
### Post-review
- [x] Rebase and squash commits