### PR TITLE
EDUCATOR-626 Raise validation Error instead of 500 error.

### DIFF
--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -510,13 +510,14 @@ class PublisherUserCreationForm(forms.ModelForm):
         fields = ('username', 'groups',)
 
     def clean(self):
-        groups = self.cleaned_data.get('groups')
+        cleaned_data = super(PublisherUserCreationForm, self).clean()
+        groups = cleaned_data.get('groups')
         if not groups:
             raise forms.ValidationError(
                 {'groups': _('This field is required.')}
             )
 
-        return self.cleaned_data
+        return cleaned_data
 
 
 class CourseRunAdminForm(forms.ModelForm):


### PR DESCRIPTION
## [EDUCATOR-626](https://openedx.atlassian.net/browse/EDUCATOR-626)

### Description
When we trying to enter the existing user in the *Add publisher user* it raised the 500 error. I have fixed that it would raised the validation error rather than showing the server error.

### Screenshots
**After Fix**
<img width="1273" alt="screen shot 2017-07-13 at 6 20 42 pm" src="https://user-images.githubusercontent.com/7627421/28200780-703624c0-6887-11e7-8ff4-867e8cb21f02.png">


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @asadazam93 
- [x] Code review: @Rabia23 

FYI: @waheedahmed 

### Post-review
- [x] Rebase and squash commits

