### PR TITLE
Upgrade to DRF 3.5.4

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1034,7 +1034,7 @@ class QueryFacetFieldSerializer(serializers.Serializer):
 
         path = '{path}?{query}'.format(path=request.path_info, query=query_params.urlencode())
         url = request.build_absolute_uri(path)
-        return serializers.Hyperlink(url, name='narrow-url')
+        return serializers.Hyperlink(url, 'narrow-url')
 
 
 class BaseHaystackFacetSerializer(HaystackFacetSerializer):

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -1,7 +1,8 @@
 from django.db.models.functions import Lower
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
 from rest_framework.decorators import list_route
-from rest_framework.filters import DjangoFilterBackend, OrderingFilter
+from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
 from rest_framework.response import Response
 

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -1,6 +1,6 @@
 from django.db.models.functions import Lower
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
-from rest_framework.filters import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
 
 from course_discovery.apps.api import filters, serializers

--- a/course_discovery/apps/api/v1/views/organizations.py
+++ b/course_discovery/apps/api/v1/views/organizations.py
@@ -1,5 +1,5 @@
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
-from rest_framework.filters import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
 
 from course_discovery.apps.api import filters, serializers

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -1,5 +1,5 @@
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
-from rest_framework.filters import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework_extensions.cache.mixins import CacheResponseMixin

--- a/course_discovery/apps/api/views.py
+++ b/course_discovery/apps/api/views.py
@@ -18,17 +18,10 @@ class SwaggerSchemaView(APIView):
         SwaggerUIRenderer,
     ]
 
-    # Added in DRF 3.5.0. Does nothing until we upgrade.
     exclude_from_schema = True
 
     def get(self, request):
-        generator = SchemaGenerator(
-            title='Discovery API',
-            # TODO: Remove these kwargs after upgrading to DRF 3.5. exclude_from_schema
-            # will be sufficient at that point.
-            url='/api',
-            urlconf='course_discovery.apps.api.urls',
-        )
+        generator = SchemaGenerator(title='Discovery API')
         schema = generator.get_schema(request=request)
 
         if not schema:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,13 +21,13 @@ django-taggit==0.22.1
 django-taggit-autosuggest==0.3.0
 django-taggit-serializer==0.1.5
 django-waffle==0.11.1
-djangorestframework==3.4.7
+djangorestframework==3.5.4
 djangorestframework-csv==1.4.1
 djangorestframework-jwt==1.8.0
 djangorestframework-xml==1.3.0
-django-rest-swagger==2.0.7
+django-rest-swagger==2.1.2
 drf-extensions==0.3.1
-drf-haystack==1.6.0rc1
+drf-haystack==1.6.1
 dry-rest-permissions==0.1.6
 edx-auth-backends==1.1.2
 edx-ccx-keys==0.2.0


### PR DESCRIPTION
3.5.4 features improved schema generation, including the ability to exclude views from generated schemas. 3.5.4 deprecates DjangoFilterBackend in favor of the implementation provided by the django-filter package.

LEARNER-1590

@edx/learner FYI.