### PR TITLE
Add default site id.

### DIFF
--- a/course_discovery/apps/api/tests/mixins.py
+++ b/course_discovery/apps/api/tests/mixins.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.contrib.sites.models import Site
 from django.test import RequestFactory
 
 from course_discovery.apps.core.tests.factories import PartnerFactory, SiteFactory
@@ -8,8 +10,14 @@ class SiteMixin(object):
         super(SiteMixin, self).setUp()
         domain = 'testserver.fake'
         self.client = self.client_class(SERVER_NAME=domain)
-        self.site = SiteFactory(domain=domain)
-        self.partner = PartnerFactory(site=self.site)
+        Site.objects.all().delete()
+        self.site = SiteFactory(id=settings.SITE_ID, domain=domain)
+        self.partner = PartnerFactory(
+            id=settings.SITE_ID,
+            site=self.site,
+            name='test-partner',
+            short_code='test'
+        )
 
         self.request = RequestFactory(SERVER_NAME=self.site.domain).get('')
         self.request.site = self.site

--- a/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
@@ -128,7 +128,7 @@ class AffiliateWindowViewSetTests(ElasticsearchTestMixin, SerializationMixin, AP
         # Superusers can view all catalogs
         self.client.force_authenticate(superuser)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -217,7 +217,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
 
         url = reverse('api:v1:catalog-csv', kwargs={'id': self.catalog.id})
 
-        with self.assertNumQueries(18):
+        with self.assertNumQueries(17):
             response = self.client.get(url)
 
         course_run = self.serialize_catalog_flat_course_run(self.course_run)

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -32,7 +32,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns the details for a single course. """
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(8):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -44,7 +44,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(9):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data.get('programs') == []
@@ -59,7 +59,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
         url += '?include_deleted_programs=1'
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data == \
@@ -71,7 +71,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(9):
             response = self.client.get(url)
             assert response.status_code == 200
             assert response.data.get('programs') == []
@@ -86,7 +86,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
         url += '?include_unpublished_programs=1'
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data == \
@@ -126,7 +126,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns a list of all course runs. """
         url = reverse('api:v1:course_run-list')
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(9):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -139,7 +139,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns a list of all course runs sorted by start date. """
         url = '{root}?ordering=start'.format(root=reverse('api:v1:course_run-list'))
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(9):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -155,7 +155,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(36):
+        with self.assertNumQueries(34):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])
@@ -240,7 +240,6 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
             'course_run_ids': self.course_run.key,
         })
         url = '{}?{}'.format(reverse('api:v1:course_run-contains'), qs)
-
         response = self.client.get(url)
         assert response.status_code == 200
         self.assertEqual(

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -29,7 +29,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns the details for a single course. """
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.key})
 
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(18):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data, self.serialize_course(self.course))
@@ -38,7 +38,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns no deleted associated programs """
         ProgramFactory(courses=[self.course], status=ProgramStatus.Deleted)
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.key})
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data.get('programs'), [])
@@ -51,7 +51,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         ProgramFactory(courses=[self.course], status=ProgramStatus.Deleted)
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.key})
         url += '?include_deleted_programs=1'
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(22):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(
@@ -187,7 +187,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns a list of all courses. """
         url = reverse('api:v1:course-list')
 
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(24):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertListEqual(
@@ -203,7 +203,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         query = 'title:' + title
         url = '{root}?q={query}'.format(root=reverse('api:v1:course-list'), query=query)
 
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(37):
             response = self.client.get(url)
             self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -214,7 +214,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         keys = ','.join([course.key for course in courses])
         url = '{root}?keys={keys}'.format(root=reverse('api:v1:course-list'), keys=keys)
 
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(37):
             response = self.client.get(url)
             self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
@@ -59,7 +59,7 @@ class OrganizationViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns a list of all organizations. """
         OrganizationFactory.create_batch(3, partner=self.partner)
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(5):
             response = self.client.get(self.list_path)
 
         self.assertEqual(response.status_code, 200)
@@ -71,7 +71,7 @@ class OrganizationViewSetTests(SerializationMixin, APITestCase):
         organizations = OrganizationFactory.create_batch(3, partner=self.partner)
 
         # Test with a single UUID
-        self.assert_list_uuid_filter([organizations[0]], 7)
+        self.assert_list_uuid_filter([organizations[0]], 5)
 
         # Test with multiple UUIDs
         self.assert_list_uuid_filter(organizations, 5)
@@ -83,7 +83,7 @@ class OrganizationViewSetTests(SerializationMixin, APITestCase):
         organizations = OrganizationFactory.create_batch(2, partner=self.partner)
 
         # If no organizations have been tagged, the endpoint should not return any data
-        self.assert_list_tag_filter([], [tag], expected_query_count=5)
+        self.assert_list_tag_filter([], [tag], expected_query_count=3)
 
         # Tagged organizations should be returned
         organizations[0].tags.add(tag)

--- a/course_discovery/apps/api/v1/tests/test_views/test_program_types.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_program_types.py
@@ -27,7 +27,7 @@ class ProgramTypeViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns a list of all program types. """
         ProgramTypeFactory.create_batch(4)
         expected = ProgramType.objects.all()
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(self.list_path)
 
         assert response.status_code == 200
@@ -38,7 +38,7 @@ class ProgramTypeViewSetTests(SerializationMixin, APITestCase):
         program_type = ProgramTypeFactory()
         url = reverse('api:v1:program_type-detail', kwargs={'slug': program_type.slug})
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.client.get(url)
 
         assert response.status_code == 200

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -74,7 +74,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
     def test_retrieve(self):
         """ Verify the endpoint returns the details for a single program. """
         program = self.create_program()
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(37):
             response = self.assert_retrieve_success(program)
         # property does not have the right values while being indexed
         del program._course_run_weeks_to_complete
@@ -100,7 +100,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
             partner=self.partner)
         # property does not have the right values while being indexed
         del program._course_run_weeks_to_complete
-        with self.assertNumQueries(28):
+        with self.assertNumQueries(26):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
         self.assertEqual(course_list, list(program.courses.all()))  # pylint: disable=no-member
@@ -109,7 +109,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns data for a program even if the program's courses have no course runs. """
         course = CourseFactory(partner=self.partner)
         program = ProgramFactory(courses=[course], partner=self.partner)
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(20):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 
@@ -139,7 +139,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns a list of all programs. """
         expected = [self.create_program() for __ in range(3)]
         expected.reverse()
-        self.assert_list_results(self.list_path, expected, 14)
+        self.assert_list_results(self.list_path, expected, 12)
 
         # Verify that repeated list requests use the cache.
         self.assert_list_results(self.list_path, expected, 2)
@@ -171,7 +171,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         program_type_name = 'foo'
         program = ProgramFactory(type__name=program_type_name, partner=self.partner)
         url = self.list_path + '?type=' + program_type_name
-        self.assert_list_results(url, [program], 10)
+        self.assert_list_results(url, [program], 8)
 
         url = self.list_path + '?type=bar'
         self.assert_list_results(url, [], 3)
@@ -186,7 +186,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         # Create a third program, which should be filtered out.
         ProgramFactory(partner=self.partner)
 
-        self.assert_list_results(url, expected, 10)
+        self.assert_list_results(url, expected, 8)
 
     def test_filter_by_uuids(self):
         """ Verify that the endpoint filters programs to those matching the provided UUIDs. """
@@ -198,11 +198,11 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         # Create a third program, which should be filtered out.
         ProgramFactory(partner=self.partner)
 
-        self.assert_list_results(url, expected, 10)
+        self.assert_list_results(url, expected, 8)
 
     @ddt.data(
-        (ProgramStatus.Unpublished, False, 5),
-        (ProgramStatus.Active, True, 10),
+        (ProgramStatus.Unpublished, False, 3),
+        (ProgramStatus.Active, True, 8),
     )
     @ddt.unpack
     def test_filter_by_marketable(self, status, is_marketable, expected_query_count):
@@ -222,7 +222,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         retired = ProgramFactory(status=ProgramStatus.Retired, partner=self.partner)
 
         url = self.list_path + '?status=active'
-        self.assert_list_results(url, [active], 10)
+        self.assert_list_results(url, [active], 8)
 
         url = self.list_path + '?status=retired'
         self.assert_list_results(url, [retired], 8)
@@ -236,7 +236,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         not_hidden = ProgramFactory(hidden=False, partner=self.partner)
 
         url = self.list_path + '?hidden=True'
-        self.assert_list_results(url, [hidden], 10)
+        self.assert_list_results(url, [hidden], 8)
 
         url = self.list_path + '?hidden=False'
         self.assert_list_results(url, [not_hidden], 8)
@@ -251,7 +251,7 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         """ Verify the endpoint returns marketing URLs without UTM parameters. """
         url = self.list_path + '?exclude_utm=1'
         program = self.create_program()
-        self.assert_list_results(url, [program], 14, extra_context={'exclude_utm': 1})
+        self.assert_list_results(url, [program], 12, extra_context={'exclude_utm': 1})
 
     def test_minimal_serializer_use(self):
         """ Verify that the list view uses the minimal serializer. """

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -266,7 +266,7 @@ class CourseRunSearchViewSetTests(SerializationMixin, LoginMixin, ElasticsearchT
         )
         self.reindex_courses(program)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.get_response('software', faceted=False)
 
         self.assertEqual(response.status_code, 200)
@@ -290,7 +290,7 @@ class CourseRunSearchViewSetTests(SerializationMixin, LoginMixin, ElasticsearchT
         ProgramFactory(courses=[course_run.course], status=program_status)
         self.reindex_courses(active_program)
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.get_response('software', faceted=False)
 
             self.assertEqual(response.status_code, 200)

--- a/course_discovery/apps/core/tests/test_throttles.py
+++ b/course_discovery/apps/core/tests/test_throttles.py
@@ -1,11 +1,10 @@
-from django.conf import settings
 from django.core.cache import cache
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from course_discovery.apps.api.tests.mixins import SiteMixin
 from course_discovery.apps.core.models import UserThrottleRate
-from course_discovery.apps.core.tests.factories import USER_PASSWORD, PartnerFactory, UserFactory
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from course_discovery.apps.core.throttles import OverridableUserRateThrottle
 
 
@@ -16,8 +15,6 @@ class RateLimitingTest(SiteMixin, APITestCase):
 
     def setUp(self):
         super(RateLimitingTest, self).setUp()
-
-        PartnerFactory(pk=settings.DEFAULT_PARTNER_ID)
 
         self.url = reverse('api_docs')
         self.user = UserFactory()

--- a/course_discovery/apps/publisher/tests/test_model.py
+++ b/course_discovery/apps/publisher/tests/test_model.py
@@ -6,8 +6,7 @@ from django.urls import reverse
 from django_fsm import TransitionNotAllowed
 from guardian.shortcuts import assign_perm
 
-from course_discovery.apps.api.tests.mixins import SiteMixin
-from course_discovery.apps.core.tests.factories import UserFactory
+from course_discovery.apps.core.tests.factories import PartnerFactory, SiteFactory, UserFactory
 from course_discovery.apps.core.tests.helpers import make_image_file
 from course_discovery.apps.course_metadata.tests.factories import OrganizationFactory, PersonFactory
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
@@ -511,7 +510,7 @@ class GroupOrganizationTests(TestCase):
 
 
 @ddt.ddt
-class CourseStateTests(SiteMixin, TestCase):
+class CourseStateTests(TestCase):
     """ Tests for the publisher `CourseState` model. """
 
     @classmethod
@@ -526,6 +525,8 @@ class CourseStateTests(SiteMixin, TestCase):
     def setUp(self):
         super(CourseStateTests, self).setUp()
 
+        self.site = SiteFactory()
+        self.partner = PartnerFactory(site=self.site)
         self.course = self.course_state.course
         self.course.image = make_image_file('test_banner.jpg')
         self.course.save()
@@ -645,7 +646,7 @@ class CourseStateTests(SiteMixin, TestCase):
 
 
 @ddt.ddt
-class CourseRunStateTests(SiteMixin, TestCase):
+class CourseRunStateTests(TestCase):
     """ Tests for the publisher `CourseRunState` model. """
 
     @classmethod
@@ -674,6 +675,9 @@ class CourseRunStateTests(SiteMixin, TestCase):
 
         language_tag = LanguageTag(code='te-st', name='Test Language')
         language_tag.save()
+
+        self.site = SiteFactory()
+        self.partner = PartnerFactory(site=self.site)
         self.course_run.transcript_languages.add(language_tag)
         self.course_run.language = language_tag
         self.course_run.is_micromasters = True

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -1311,7 +1311,7 @@ class DashboardTests(SiteMixin, TestCase):
         self.client.logout()
         self.client.login(username=UserFactory(), password=USER_PASSWORD)
         response = self.assert_dashboard_response(
-            studio_count=0, published_count=0, progress_count=0, preview_count=0, queries_executed=12
+            studio_count=0, published_count=0, progress_count=0, preview_count=0, queries_executed=11
         )
         self._assert_tabs_with_roles(response)
 
@@ -1319,7 +1319,7 @@ class DashboardTests(SiteMixin, TestCase):
     def test_with_internal_group(self, tab):
         """ Verify that internal user can see courses assigned to the groups. """
         response = self.assert_dashboard_response(
-            studio_count=2, published_count=1, progress_count=2, preview_count=1, queries_executed=24
+            studio_count=2, published_count=1, progress_count=2, preview_count=1, queries_executed=23
         )
         self.assertContains(response, '<li role="tab" id="tab-{tab}" class="tab"'.format(tab=tab))
 
@@ -1334,7 +1334,7 @@ class DashboardTests(SiteMixin, TestCase):
         self.course_run_1.course.organizations.add(self.organization_extension.organization)
 
         response = self.assert_dashboard_response(
-            studio_count=0, published_count=0, progress_count=0, preview_count=0, queries_executed=12
+            studio_count=0, published_count=0, progress_count=0, preview_count=0, queries_executed=11
         )
         self._assert_tabs_with_roles(response)
 
@@ -1359,14 +1359,14 @@ class DashboardTests(SiteMixin, TestCase):
         )
 
         response = self.assert_dashboard_response(
-            studio_count=0, published_count=0, progress_count=2, preview_count=1, queries_executed=22
+            studio_count=0, published_count=0, progress_count=2, preview_count=1, queries_executed=21
         )
         self._assert_tabs_with_roles(response)
 
     def test_studio_request_course_runs_as_pc(self):
         """ Verify that PC user can see only those courses on which he is assigned as PC role. """
         response = self.assert_dashboard_response(
-            studio_count=2, published_count=1, progress_count=2, preview_count=1, queries_executed=24
+            studio_count=2, published_count=1, progress_count=2, preview_count=1, queries_executed=23
         )
         self._assert_tabs_with_roles(response)
 
@@ -1374,7 +1374,7 @@ class DashboardTests(SiteMixin, TestCase):
         """ Verify that PC user can see only those courses on which he is assigned as PC role. """
         self.user1.groups.remove(self.group_project_coordinator)
         response = self.assert_dashboard_response(
-            studio_count=0, published_count=1, progress_count=2, preview_count=1, queries_executed=21
+            studio_count=0, published_count=1, progress_count=2, preview_count=1, queries_executed=20
         )
         self._assert_tabs_with_roles(response)
 
@@ -1385,7 +1385,7 @@ class DashboardTests(SiteMixin, TestCase):
         self.course_run_2.lms_course_id = 'test-2'
         self.course_run_2.save()
         response = self.assert_dashboard_response(
-            studio_count=0, published_count=1, progress_count=2, preview_count=1, queries_executed=22
+            studio_count=0, published_count=1, progress_count=2, preview_count=1, queries_executed=21
         )
         self.assertContains(response, 'No courses are currently ready for a Studio URL.')
 
@@ -1394,7 +1394,7 @@ class DashboardTests(SiteMixin, TestCase):
         self.course_run_3.course_run_state.name = CourseRunStateChoices.Draft
         self.course_run_3.course_run_state.save()
         response = self.assert_dashboard_response(
-            studio_count=3, published_count=0, progress_count=3, preview_count=1, queries_executed=25
+            studio_count=3, published_count=0, progress_count=3, preview_count=1, queries_executed=24
         )
         self.assertContains(response, 'No About pages have been published yet')
         self._assert_tabs_with_roles(response)
@@ -1402,7 +1402,7 @@ class DashboardTests(SiteMixin, TestCase):
     def test_published_course_runs(self):
         """ Verify that published tab loads course runs list. """
         response = self.assert_dashboard_response(
-            studio_count=2, published_count=1, progress_count=2, preview_count=1, queries_executed=24
+            studio_count=2, published_count=1, progress_count=2, preview_count=1, queries_executed=23
         )
         self.assertContains(response, self.table_class.format(id='published'))
         self.assertContains(response, 'About pages for the following course runs have been published in the')
@@ -1420,7 +1420,7 @@ class DashboardTests(SiteMixin, TestCase):
 
         # Verify that user cannot see any published course run
         self.assert_dashboard_response(
-            studio_count=0, published_count=0, progress_count=0, preview_count=0, queries_executed=16
+            studio_count=0, published_count=0, progress_count=0, preview_count=0, queries_executed=15
         )
 
         # assign user course role
@@ -1444,14 +1444,14 @@ class DashboardTests(SiteMixin, TestCase):
         publisher_admin.groups.add(Group.objects.get(name=ADMIN_GROUP_NAME))
         self.client.login(username=publisher_admin.username, password=USER_PASSWORD)
         response = self.assert_dashboard_response(
-            studio_count=4, published_count=1, progress_count=3, preview_count=1, queries_executed=21
+            studio_count=4, published_count=1, progress_count=3, preview_count=1, queries_executed=20
         )
         self._assert_tabs_with_roles(response)
 
     def test_with_preview_ready_course_runs(self):
         """ Verify that preview ready tabs loads the course runs list. """
         response = self.assert_dashboard_response(
-            studio_count=2, preview_count=1, progress_count=2, published_count=1, queries_executed=24
+            studio_count=2, preview_count=1, progress_count=2, published_count=1, queries_executed=23
         )
         self.assertContains(response, self.table_class.format(id='preview'))
         self.assertContains(response, 'About page previews for the following course runs are available for course team')
@@ -1463,7 +1463,7 @@ class DashboardTests(SiteMixin, TestCase):
         self.course_run_2.course_run_state.name = CourseRunStateChoices.Draft
         self.course_run_2.course_run_state.save()
         response = self.assert_dashboard_response(
-            studio_count=2, preview_count=0, progress_count=3, published_count=1, queries_executed=23
+            studio_count=2, preview_count=0, progress_count=3, published_count=1, queries_executed=22
         )
         self._assert_tabs_with_roles(response)
 
@@ -1472,7 +1472,7 @@ class DashboardTests(SiteMixin, TestCase):
         preview url is added or not.
         """
         response = self.assert_dashboard_response(
-            studio_count=2, preview_count=1, progress_count=2, published_count=1, queries_executed=24
+            studio_count=2, preview_count=1, progress_count=2, published_count=1, queries_executed=23
         )
         self._assert_tabs_with_roles(response)
 
@@ -1487,7 +1487,7 @@ class DashboardTests(SiteMixin, TestCase):
     def test_with_in_progress_course_runs(self):
         """ Verify that in progress tabs loads the course runs list. """
         response = self.assert_dashboard_response(
-            studio_count=2, preview_count=1, progress_count=2, published_count=1, queries_executed=24
+            studio_count=2, preview_count=1, progress_count=2, published_count=1, queries_executed=23
         )
         self.assertContains(response, self.table_class.format(id='in-progress'))
         self._assert_tabs_with_roles(response)
@@ -1523,7 +1523,7 @@ class DashboardTests(SiteMixin, TestCase):
         self.client.logout()
         self.client.login(username=pc_user.username, password=USER_PASSWORD)
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(11):
             response = self.client.get(self.page_url)
 
         for tab in ['progress', 'preview', 'studio', 'published']:
@@ -1533,7 +1533,7 @@ class DashboardTests(SiteMixin, TestCase):
         """
         Verify that site_name is available in context.
         """
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(23):
             response = self.client.get(self.page_url)
         site = Site.objects.first()
         self.assertEqual(response.context['site_name'], site.name)
@@ -1552,7 +1552,7 @@ class DashboardTests(SiteMixin, TestCase):
         course_run.course_run_state.owner_role = PublisherUserRole.CourseTeam
         course_run.course_run_state.save()
 
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(25):
             response = self.client.get(self.page_url)
 
         self._assert_filter_counts(response, 'All', 3)
@@ -1615,12 +1615,12 @@ class CourseListViewTests(SiteMixin, TestCase):
 
     def test_courses_with_no_courses(self):
         """ Verify that user cannot see any course on course list page. """
-        self.assert_course_list_page(course_count=0, queries_executed=9)
+        self.assert_course_list_page(course_count=0, queries_executed=8)
 
     def test_courses_with_admin(self):
         """ Verify that admin user can see all courses on course list page. """
         self.user.groups.add(Group.objects.get(name=ADMIN_GROUP_NAME))
-        self.assert_course_list_page(course_count=10, queries_executed=32)
+        self.assert_course_list_page(course_count=10, queries_executed=31)
 
     def test_courses_with_course_user_role(self):
         """ Verify that internal user can see course on course list page. """
@@ -1628,7 +1628,7 @@ class CourseListViewTests(SiteMixin, TestCase):
         for course in self.courses:
             factories.CourseUserRoleFactory(course=course, user=self.user, role=InternalUserRole.Publisher)
 
-        self.assert_course_list_page(course_count=10, queries_executed=33)
+        self.assert_course_list_page(course_count=10, queries_executed=32)
 
     def test_courses_with_permission(self):
         """ Verify that user can see course with permission on course list page. """
@@ -1639,7 +1639,7 @@ class CourseListViewTests(SiteMixin, TestCase):
             course.organizations.add(organization_extension.organization)
 
         assign_perm(OrganizationExtension.VIEW_COURSE, organization_extension.group, organization_extension)
-        self.assert_course_list_page(course_count=10, queries_executed=65)
+        self.assert_course_list_page(course_count=10, queries_executed=64)
 
     def assert_course_list_page(self, course_count, queries_executed):
         """ Dry method to assert course list page content. """
@@ -1685,7 +1685,7 @@ class CourseListViewTests(SiteMixin, TestCase):
 
         toggle_switch('publisher_hide_features_for_pilot', False)
 
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(21):
             response = self.client.get(self.courses_url)
 
         self.assertContains(response, 'Edit')

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -47,6 +47,7 @@ THIRD_PARTY_APPS = [
     'django_fsm',
     'storages',
     'django_comments',
+    'django_sites_extensions',
     'taggit',
     'taggit_autosuggest',
     'taggit_serializer',
@@ -475,6 +476,10 @@ DISTINCT_COUNTS_FACET_PRECISION = 250
 DISTINCT_COUNTS_QUERY_CACHE_WARMING_COUNT = 20
 
 DEFAULT_PARTNER_ID = None
+
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#site-id
+# edx-django-sites-extensions will fallback to this site if we cannot identify the site from the hostname.
+SITE_ID = 1
 
 COMMENTS_APP = 'course_discovery.apps.publisher_comments'
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,6 +32,7 @@ dry-rest-permissions==0.1.6
 edx-auth-backends==1.1.2
 edx-ccx-keys==0.2.0
 edx-django-release-util==0.3.1
+edx-django-sites-extensions==2.3.0
 edx-drf-extensions==1.2.3
 edx-opaque-keys==0.3.1
 edx-rest-api-client==1.6.0


### PR DESCRIPTION
We are adding a default site ID setting via
the edx-django-sites-extensions package because
requests from outside of saved sites' domains,
like the AWS health check, would return an error.