### PR TITLE
LEARNER-1925 add the PIL setting to allow image of smaller size

### DIFF
--- a/course_discovery/apps/course_metadata/apps.py
+++ b/course_discovery/apps/course_metadata/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from PIL import ImageFile
 
 
 class CourseMetadataConfig(AppConfig):
@@ -7,5 +8,9 @@ class CourseMetadataConfig(AppConfig):
 
     def ready(self):
         super(CourseMetadataConfig, self).ready()
+        # We need to add this setting because, since MM programs we are accepting banner
+        # images with height less than 480 max. In order to accept those images, we need
+        # to allow PIL to work with these images correctly by setting this variable true
+        ImageFile.LOAD_TRUNCATED_IMAGES = True
         # noinspection PyUnresolvedReferences
         import course_discovery.apps.course_metadata.signals  # pylint: disable=unused-variable


### PR DESCRIPTION
[LEARNER-1925](https://openedx.atlassian.net/browse/LEARNER-1925)

We want to allow banner image of smaller size than 1440X480.
Currently we suffer from the "IOError: image file is truncated" error when adding new programs or updating existing program with a banner image smaller than that size.
All new programs are having banner images at 1440X260. This change would allow this banner image size to be saved with the program. See https://github.com/python-pillow/Pillow/blob/master/PIL/ImageFile.py#L227 and 

@rlucioni @clintonb please review