### PR TITLE
EDUCATOR-921 Fix Instructor bio missing paragraph breaks.

### DIFF
--- a/course_discovery/static/sass/publisher/publisher.scss
+++ b/course_discovery/static/sass/publisher/publisher.scss
@@ -272,6 +272,10 @@
         padding-bottom: 2px;
       }
     }
+
+    .pre{
+      white-space: pre;
+      }
   }
 
     textarea {

--- a/course_discovery/templates/publisher/course_run_detail/_instructor_profile.html
+++ b/course_discovery/templates/publisher/course_run_detail/_instructor_profile.html
@@ -52,7 +52,7 @@
             <div class="heading">{% trans "Bio" %}
                 {% include "publisher/course_run_detail/_clipboard.html" %}
             </div>
-            <div class="copy bio"></div>
+            <div class="copy bio pre"></div>
         </div>
 
         <div class="social-links">


### PR DESCRIPTION
## [EDUCATOR-921](https://openedx.atlassian.net/browse/EDUCATOR-921)

### Description
When course team added the bio data it removed the paragraph break I have fixed that it would not delete the paragraph breaks.



### Screenshots
**Before Fix**
<img width="516" alt="screen shot 2017-07-20 at 2 42 16 pm" src="https://user-images.githubusercontent.com/7627421/28411311-d5c2f27e-6d59-11e7-8c06-6d6aa9b8814d.png">


**After Fix**

<img width="547" alt="screen shot 2017-07-20 at 2 42 05 pm" src="https://user-images.githubusercontent.com/7627421/28411316-d9edae98-6d59-11e7-87d4-166f83e55346.png">

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @asadazam93 

FYI: @awais786 

### Post-review
- [x] Rebase and squash commits

