### PR TITLE
Fix access token retrieval message

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
 
         token_type = 'JWT'
         for partner in partners:
-            logger.info('Retrieving access token for partner [{}]'.format(partner_code))
+            logger.info('Retrieving access token for partner [{}]'.format(partner.short_code))
 
             try:
                 access_token, __ = EdxRestApiClient.get_oauth_access_token(


### PR DESCRIPTION
The metadata refresh command should log the short code of the partner for which an access token is being retrieved instead of always logging the value of the partner_code argument.

@edx/learner FYI.