### PR TITLE
EDUCATOR-973 Fix Instructor bio missing line breaks.

### DIFF
--- a/course_discovery/static/sass/publisher/publisher.scss
+++ b/course_discovery/static/sass/publisher/publisher.scss
@@ -274,7 +274,7 @@
     }
 
     .pre{
-      white-space: pre;
+      white-space: pre-line;
       }
   }
 


### PR DESCRIPTION
## [EDUCATOR-973](https://openedx.atlassian.net/browse/EDUCATOR-973)

### Description
When course team added the bio data it removed the lines break I have fixed that it would not delete the lines breaks.




### Screenshots
**Before Fix**

<img width="1095" alt="screen shot 2017-07-24 at 11 36 16 am" src="https://user-images.githubusercontent.com/7627421/28518029-f00e4fec-707f-11e7-9526-08bc3f646b1a.png">

**After Fix**
<img width="581" alt="screen shot 2017-07-24 at 11 35 57 am" src="https://user-images.githubusercontent.com/7627421/28518059-09d2bc2e-7080-11e7-919c-9b26dbb091d6.png">



### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @asadazam93 

FYI: @awais786 

### Post-review
- [x] Rebase and squash commits

