### PR TITLE
ENT-529 Populate course run effort values from Drupal API.

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
@@ -335,6 +335,41 @@ class CourseMarketingSiteDataLoaderTests(AbstractMarketingSiteDataLoaderTestMixi
         data = {'field_couse_is_hidden': hidden}
         self.assertEqual(self.loader.get_hidden(data), expected)
 
+    @ddt.data(
+        (None, None, None),
+        ('Browse at your own pace.', None, None),
+        ('1.5 - 3.5 hours/week', None, None),
+        ('8 hours/week', 8, None),
+        ('2.5-5 hours.', 5, None),
+        ('5+ hours per week', 5, None),
+        ('3 horas por semana', 3, None),
+        ('1 - 1.5 hours per week', 1, None),
+        ('6 hours of video/300 multiple choice questions', 6, None),
+        ('6 to 9 hours/week', 6, 9),
+        ('4-6 hours per week', 4, 6),
+        ('About 5-12 hrs/week.', 5, 12),
+        ('4 - 8 hours/week | 小时／周', 4, 8),
+        ('6 horas/semana, 6 hours/week', 6, 6),
+        ('Estimated effort: 4–5 hours per week.', 4, 5),
+        ('4-6 hours per week depending on the background of the student.', 4, 6),
+        ('每周 2-3 小时 | 2-3 hours per week', None, None),
+        ('Part 1: 3 hours; Part 2: 4 hours; Part 3: 2 hours', None, None),
+        ('From 10 - 60 minutes, or as much time as you want.', None, None),
+        ('3-4 hours per unit (recommended pace: 1 unit per week)', None, None),
+        ('5-8 hours/week; 2-3 hours for lectures; 3-5 hours for homework/self-study', None, None),
+    )
+    @ddt.unpack
+    def test_get_min_max_effort_per_week(self, course_effort_string, expected_min_effort, expected_max_effort):
+        """
+        Verify that the method `get_min_max_effort_per_week` correctly parses
+        most of the the effort values which have specific format and maps them
+        to min effort and max effort values.
+        """
+        data = {'field_course_effort': course_effort_string}
+        min_effort, max_effort = self.loader.get_min_max_effort_per_week(data)
+        self.assertEqual(min_effort, expected_min_effort)
+        self.assertEqual(max_effort, expected_max_effort)
+
     def test_get_hidden_missing(self):
         """Verify that the get_hidden method can cope with a missing field."""
         self.assertEqual(self.loader.get_hidden({}), False)


### PR DESCRIPTION
@saleem-latif @asadiqbal08 @douglashall 
Populate "min_effort" and "max_effort" field values for course runs from Drupal API after parsing the effort value from API.

This PR includes the basic regex to get parse maximum drupal "`effort`" string values into integer values for the "`min_effort`" and "`max_effort`" fields from record of 4k+ courses on prod.

**Some of the difficult to map effort values from drupal API are:**
- Part 1: 3 hours; Part 2: 4 hours; Part 3: 2 hours
- 1-1.5 horas por semana
- 45 minutes - 1 hour per week
- 3-4 hours per unit (recommended pace: 1 unit per week)
- From 10 - 60 minutes, or as much time as you want.
- 5 hours per week; 75 hours of material covered
- 9 problem sets (10 to 20 hours each), 1 final project
- 1.5 - 3.5 hours/week
- Most users will find that thoroughly covering the material will take anywhere from  40 to 60 hours
- 5 sections, 1 - 2 hours per section
- 每周3-5小时
- 1h30/semaine
- 1 hour/module; 7 modules
- 12 -18 hours for the entire course
- 12 hours per week (7 weeks)
- 5-8 hours/week; 2-3 hours for lectures; 3-5 hours for homework/self-study

**Testing Instructions:**
* Setup edX Drupal marketing site locally by following this wiki: https://openedx.atlassian.net/wiki/display/LEARNER/How+To+Run+the+Marketing+Site
* Login to mktg site and edit/add a course with your desired course run key and populate the "`Estimated effort`" with value like "`4 - 8 hours/week \| 小时／周`"
* Verify that you can get the course data from the drupal API, e.g. http://localhost:8080/api/catalog/v2/courses/course-v1:edX+DemoX+Demo_Course
* Checkout to branch `zub/ENT-529-populate-min-max-effort-fields-from-drupal` for course discovery.
* Make sure you have provide the `Marketing Site Configuration` values for the partner in discovery service related to your local edx-mktg site.
* Run the django management command "refresh_course_metadata" in discovery.
* Verify that the fields "`min_effort`" and "`max_effort`", related course run in discovery service have been populated.