### PR TITLE
Course Run not showing parent course prereqs

### DIFF
--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -716,7 +716,8 @@ class CourseRunDetailTests(SiteMixin, TestCase):
             'Title', 'Number', 'Course ID', 'Price', 'Subtitle', 'Organization', 'Subject', 'XSeries',
             'Start Date (time in UTC)', 'End Date (time in UTC)', 'Self Paced', 'Staff', 'Estimated Effort',
             'Languages', 'Video Transcript Languages', 'Level', 'Full Description', "What You'll Learn",
-            'Keywords', 'Sponsors', 'Enrollment Types', 'Learner Testimonials', 'FAQ', 'Course About Video'
+            'Keywords', 'Sponsors', 'Enrollment Types', 'Learner Testimonials', 'FAQ', 'Course About Video',
+            'Prerequisites'
         ]
         for field in fields:
             self.assertContains(response, field)
@@ -729,7 +730,8 @@ class CourseRunDetailTests(SiteMixin, TestCase):
             self.wrapped_course_run.max_effort, self.wrapped_course_run.language.name,
             self.wrapped_course_run.transcript_languages, self.wrapped_course_run.level_type,
             self.wrapped_course_run.expected_learnings, self.wrapped_course_run.course.learner_testimonial,
-            self.wrapped_course_run.course.faq, self.wrapped_course_run.course.video_link
+            self.wrapped_course_run.course.faq, self.wrapped_course_run.course.video_link,
+            self.wrapped_course_run.course.prerequisites
         ]
         for value in values:
             self.assertContains(response, value)

--- a/course_discovery/templates/publisher/course_run_detail/_drupal.html
+++ b/course_discovery/templates/publisher/course_run_detail/_drupal.html
@@ -223,7 +223,7 @@
             {% include "publisher/course_run_detail/_clipboard.html" %}
         </div>
         <div class="copy">
-            {% with  object.prerequisite as field %}
+            {% with  object.course.prerequisites as field %}
                 {% include "publisher/_render_optional_field.html" %}
             {% endwith %}
         </div>


### PR DESCRIPTION
## [EDUCATOR-1002](https://openedx.atlassian.net/browse/EDUCATOR-1002) 

### Description
Changes made in the parent course level fields do not go through to the existing, unpublished course run info. It was just a syntax error. 

### Sandbox
- [ ] _In Progress_

### Reviewers
- [x] @asadazam93 
- [x] @attiyaIshaque 

List optional/FYI reviewers here:
@awais786 
 
### Post-review
- [ ] Rebase and squash commits