### PR TITLE
Added support for filtering programs by marketing slug

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -162,7 +162,7 @@ class ProgramFilter(FilterSetMixin, filters.FilterSet):
 
     class Meta:
         model = Program
-        fields = ('hidden', 'marketable', 'status', 'type', 'types',)
+        fields = ('hidden', 'marketable', 'marketing_slug', 'status', 'type', 'types',)
 
 
 class OrganizationFilter(filters.FilterSet):

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -247,6 +247,22 @@ class ProgramViewSetTests(SerializationMixin, APITestCase):
         url = self.list_path + '?hidden=0'
         self.assert_list_results(url, [not_hidden], 10)
 
+    def test_filter_by_marketing_slug(self):
+        """ The endpoint should support filtering programs by marketing slug. """
+        SLUG = 'test-program'
+
+        # This program should not be included in the results below because it never matches the filter.
+        self.create_program()
+
+        url = '{root}?marketing_slug={slug}'.format(root=self.list_path, slug=SLUG)
+        self.assert_list_results(url, [], 5)
+
+        program = self.create_program()
+        program.marketing_slug = SLUG
+        program.save()
+
+        self.assert_list_results(url, [program], 14)
+
     def test_list_exclude_utm(self):
         """ Verify the endpoint returns marketing URLs without UTM parameters. """
         url = self.list_path + '?exclude_utm=1'


### PR DESCRIPTION
This will ultimately be used by the marketing site to retrieve program data without having to store a separate reference (e.g. UUID).

LEARNER-2053