### PR TITLE
ownership and course state does not change on pc edit

### DIFF
--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -117,6 +117,15 @@ class Course(TimeStampedModel, ChangedByMixin):
 
         return user_emails
 
+    def get_user_role(self, user):
+        """
+        Returns the role of a user in the course if it exists
+        """
+        try:
+            return self.course_user_roles.get(user=user).role
+        except CourseUserRole.DoesNotExist:
+            return None
+
     @property
     def organization_name(self):
         """

--- a/course_discovery/apps/publisher/tests/test_model.py
+++ b/course_discovery/apps/publisher/tests/test_model.py
@@ -241,6 +241,13 @@ class CourseTests(TestCase):
         self.assertIn('abc', self.course.keywords_data)
         self.assertIn('def', self.course.keywords_data)
 
+    def test_get_user_role(self):
+        """
+        Verify that method 'get_user_role' returns the correct role if it exists
+        """
+        self.assertEqual(self.course.get_user_role(user=self.user1), PublisherUserRole.ProjectCoordinator)
+        self.assertEqual(self.course2.get_user_role(user=self.user1), None)
+
     def test_project_coordinator(self):
         """ Verify that the project_coordinator property returns user if exist. """
         self.assertIsNone(self.course2.project_coordinator)


### PR DESCRIPTION
## [EDUCATOR-1008](https://openedx.atlassian.net/browse/EDUCATOR-1008)

### Description
There are fields in the course that only PCs have the ability to fill in namely (About Video Link), but since the project coordinator has no role in the actual workflow of the course so when the project coordinator makes an edit to the course the ownership is changed to PC along with the course state changed to Draft and that disturbs the actual workflow between the course team and the marketing team.
Solution 
So now when a project coordinator edits a course the course state will not be changed and neither the ownership (however a history object for that edit would be created) hence the workflow of the course that involves the course team and marketing team would not be disturbed. A project coordinator is only making edits on behalf of the course team, he is not a part of the workflow of sending the course for review neither marking the course as reviewed so it does not make sense to transfer ownership to the PC.

### How to Test?

- Login as project coordinator of a course.
- Edit the course
- Confirm that the ownership and state of the course did not change but a history object for that edit was created

**Sandbox**
- https://discovery-educator-973.sandbox.edx.org/publisher/courses/3/

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @attiyaIshaque 
- [ ] Code review: @awaisdar001  

FYI: @sstack22 

### Post-review
- [ ] Rebase and squash commits