### PR TITLE
EDUCATOR-1095 Add copy button in course syllabus field.

### DIFF
--- a/course_discovery/templates/publisher/course_run_detail/_drupal.html
+++ b/course_discovery/templates/publisher/course_run_detail/_drupal.html
@@ -257,9 +257,10 @@
 
   <div class="info-item">
     <div class="heading">
-      {% trans "Course Syllabus" %}
+        {% trans "Course Syllabus" %}
+        {% include "publisher/course_run_detail/_clipboard.html" %}
     </div>
-    <div>
+    <div class="copy">
       {% with  object.syllabus as field %}
         {% include "publisher/_render_optional_field.html" %}
       {% endwith %}


### PR DESCRIPTION
## [EDUCATOR-1095](https://openedx.atlassian.net/browse/EDUCATOR-1095)

### Description
Add copy button in course syllabus field in the courses Drupal page.

### How to Test?
**Sandbox**
https://discovery-educator-973.sandbox.edx.org/publisher/course_runs/1/
Click on Drupal tab and see course syllabus field has copy button

### Screenshots
**Before Fix**
<img width="595" alt="screen shot 2017-08-07 at 11 56 55 am" src="https://user-images.githubusercontent.com/7627421/29016230-122c0128-7b6b-11e7-9b3e-2389f4e4642c.png">

**After Fix**
<img width="594" alt="screen shot 2017-08-07 at 11 58 14 am" src="https://user-images.githubusercontent.com/7627421/29016246-1f1b1162-7b6b-11e7-99a2-f0647597893c.png">




### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x]  @asadazam93 

FYI: @awaisdar001 

### Post-review
- [x] Rebase and squash commits






