### PR TITLE
Match other IDAs' requirements installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ requirements.js: ## Install JS requirements for local development
 	npm install
 	$(NODE_BIN)/bower install
 
-requirements: ## Install Python requirements for local development
+requirements: requirements.js ## Install Python and JS requirements for local development
 	pip install -r requirements/local.txt
 
 production-requirements: ## Install Python and JS requirements for production


### PR DESCRIPTION
The credentials and ecommerce services both install development JS dependencies as part of the "requirements" make target, and the `edx_django_service` role in configuration also assumes that it works this way.

For some reason, the discovery Docker images currently being built by Jenkins don't seem to include even the production JS dependencies, even though the Ansible command to install them is completing without errors.  This change might not fix that, but would at least allow the IDA provisioning script in the devstack repo to install them during provisioning before trying to build static assets.  And even if we debug the missing production dependencies issue, this would still be required to install the development dependencies in the image.