### PR TITLE
Disabled Haystack's constant updating of index mappings

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/backends.py
+++ b/course_discovery/apps/edx_haystack_extensions/backends.py
@@ -74,7 +74,6 @@ class NonClearingSearchBackendMixin(object):
 
 # pylint: disable=abstract-method
 class ConfigurableElasticBackend(ElasticsearchSearchBackend):
-
     def specify_analyzers(self, mapping, field, index_analyzer, search_analyzer):
         """ Specify separate index and search analyzers for the given field.
           Args:
@@ -122,7 +121,12 @@ class ConfigurableElasticBackend(ElasticsearchSearchBackend):
 # pylint: disable=abstract-method
 class EdxElasticsearchSearchBackend(SimpleQuerySearchBackendMixin, NonClearingSearchBackendMixin,
                                     ConfigurableElasticBackend):
-    pass
+    def search(self, query_string, **kwargs):
+        # NOTE (CCB): Haystack by default attempts to read/update the index mapping. Given that our mapping doesn't
+        # frequently change, this is a waste of three API calls. Stop it! We set our mapping when we create the index.
+        self.setup_complete = True
+
+        return super().search(query_string, **kwargs)
 
 
 class EdxElasticsearchSearchEngine(ElasticsearchSearchEngine):


### PR DESCRIPTION
Haystack attempts to always ensure the index mapping is up-to-date. 
There is a bug in this code (at least when using Elasticsearch 1.x) that
results in an invalid mapping comparison. Given that our mapping is 
static, this feature is simply a waste of resources since we always 
make three API calls to Elasticsearch for every search call.

This commit disables this mapping check/update feature when executing a 
search query.

LEARNER-2188