### PR TITLE
Removed call to Haystack backend setup method in backend wrapper

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/backends.py
+++ b/course_discovery/apps/edx_haystack_extensions/backends.py
@@ -1,11 +1,6 @@
-import logging
-import traceback
-
 from haystack.backends.elasticsearch_backend import ElasticsearchSearchBackend, ElasticsearchSearchEngine
 
 from course_discovery.apps.edx_haystack_extensions.elasticsearch_boost_config import get_elasticsearch_boost_config
-
-logger = logging.getLogger(__name__)
 
 
 class SimpleQuerySearchBackendMixin(object):
@@ -132,10 +127,6 @@ class EdxElasticsearchSearchBackend(SimpleQuerySearchBackendMixin, NonClearingSe
         self.setup_complete = True
 
         return super().search(query_string, **kwargs)
-
-    def setup(self):
-        logger.info('DEBUG: EdxElasticsearchSearchBackend.setup() called: %s', '\n'.join(traceback.format_stack()))
-        return super().setup()
 
 
 class EdxElasticsearchSearchEngine(ElasticsearchSearchEngine):

--- a/course_discovery/apps/edx_haystack_extensions/distinct_counts/backends.py
+++ b/course_discovery/apps/edx_haystack_extensions/distinct_counts/backends.py
@@ -166,8 +166,9 @@ class DistinctCountsElasticsearchBackendWrapper(object):
         if len(query_string) == 0:
             return {'results': [], 'hits': 0, 'distinct_hits': 0}
 
-        if not self.backend.setup_complete:
-            self.backend.setup()
+        # NOTE (CCB): Haystack by default attempts to read/update the index mapping. Given that our mapping doesn't
+        # frequently change, this is a waste of three API calls. Stop it! We set our mapping when we create the index.
+        self.backend.setup_complete = True
 
         search_kwargs = self._build_search_kwargs(query_string, **kwargs)
         search_kwargs['from'] = kwargs.get('start_offset', 0)


### PR DESCRIPTION
We want to avoid using the setup method when possible as it is broken and makes three useless API calls.

LEARNER-2188