### PR TITLE
EDUCATOR-807 Fix Course Start date storing in Preview dashboard.

### DIFF
--- a/course_discovery/templates/publisher/dashboard/_in_preview.html
+++ b/course_discovery/templates/publisher/dashboard/_in_preview.html
@@ -46,7 +46,7 @@
                             {% endif %}
                             {{ course_run.owner_role_modified }}
                         </td>
-                        <td>
+                        <td data-order="{{ course_run.start|date:"Y-m-d" }}">
                             {{ course_run.start }}
                         </td>
                     </tr>


### PR DESCRIPTION
## [EDUCATOR-807](https://openedx.atlassian.net/browse/EDUCATOR-807)

### Description
This PR fixes that filter of course start date is chronological not alphabetically.

### How to Test?
**Production**
https://prod-edx-discovery.edx.org/publisher/

- Click to *In preview* tab.
- Filter by Course start date.
- Sorting is alphabetical. 


**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/
- Click to *In preview* tab.
- Filter by Course start date.
- Sorting is chronological. 

You can use following credentials
_username : Attiya
Password: attiya_


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @Rabia23 

FYI: @sstack22 

### Post-review
- [x] Rebase and squash commits
