### PR TITLE
fixed comment link in email content

### DIFF
--- a/course_discovery/apps/publisher_comments/emails.py
+++ b/course_discovery/apps/publisher_comments/emails.py
@@ -52,7 +52,7 @@ def send_email_for_comment(comment, created=False):
             )
         else:
             course = publisher_obj
-            object_path = reverse('publisher:publisher_courses_edit', args=[publisher_obj.id])
+            object_path = reverse('publisher:publisher_course_detail', args=[publisher_obj.id])
 
             # Translators: 'subject_desc' will be choice from ('New comment added', 'Comment updated')
             # and 'title' will be the value of course title field.

--- a/course_discovery/apps/publisher_comments/tests/test_emails.py
+++ b/course_discovery/apps/publisher_comments/tests/test_emails.py
@@ -65,7 +65,7 @@ class CommentsEmailTests(SiteMixin, TestCase):
         comment = self.create_comment(content_object=self.course)
         subject = 'Comment added: {title}'.format(title=self.course.title)
         self.assert_comment_email_sent(
-            self.course, comment, reverse('publisher:publisher_courses_edit', args=[self.course.id]),
+            self.course, comment, reverse('publisher:publisher_course_detail', args=[self.course.id]),
             subject
         )
 


### PR DESCRIPTION
## [EDUCATOR-1286](https://openedx.atlassian.net/browse/EDUCATOR-1286)

### Description
When someone adds a comment on the course detail page an email is sent to all related course user roles. The content of the email contains a link to the comment, which was previously incorrect (it was the link of course edit page instead of the course detail page). It has been corrected now.

**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/

**Steps to check**
- Assign yourself as the course team of any course in publisher
- Add a comment on the course detail page
- Check your mail you should receive an email and within its content you should have a link to the comment that was added.


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @awaisdar001  
- [ ] @Rabia23  

### Post-review
- [ ] Rebase and squash commits
