### PR TITLE
EDUCATOR-1305 Fixed that user is able to edit and save instructor field.

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -210,7 +210,7 @@ class PositionSerializer(serializers.ModelSerializer):
 
     class Meta(object):
         model = Position
-        fields = ('title', 'organization_name', 'organization')
+        fields = ('title', 'organization_name', 'organization', 'organization_id')
         extra_kwargs = {
             'organization': {'write_only': True}
         }

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1117,10 +1117,10 @@ class PositionSerializerTests(TestCase):
     def test_data(self):
         position = PositionFactory()
         serializer = PositionSerializer(position)
-
         expected = {
             'title': str(position.title),
             'organization_name': position.organization_name,
+            'organization_id': position.organization_id,
         }
 
         self.assertDictEqual(serializer.data, expected)

--- a/course_discovery/static/js/publisher/instructors.js
+++ b/course_discovery/static/js/publisher/instructors.js
@@ -227,6 +227,8 @@ $(document).on('click', '.selected-instructor a.edit', function (e) {
             $('#given-name').val(data['given_name']);
             $('#family-name').val(data['family_name']);
             $('#title').val(data['position']['title']);
+            $('#email').val(data['email']);
+            $('#id_organization').val(data['position']['organization_id']);
             $('#bio').val(data['bio']);
             $('#majorWorks').val(data['works'].join('\n'));
             $('#facebook').val(data['urls']['facebook']);

--- a/course_discovery/templates/publisher/_add_instructor_popup.html
+++ b/course_discovery/templates/publisher/_add_instructor_popup.html
@@ -31,7 +31,7 @@
                 </label>
                 <input class="field-input input-text" type="text" id="title" name="title" />
 
-                <label class="field-label" for="title">{% trans "Email" %}
+                <label class="field-label" for="email">{% trans "Email" %}
                     <span class="required">* {% trans "required" %}</span>
                 </label>
                 <div class="email-field">


### PR DESCRIPTION
## [EDUCATOR-1305](https://openedx.atlassian.net/browse/EDUCATOR-1305)

### Description
This PR fixes that When clicking edit for an instructor within Publisher, email and organization filed would not be blank and would able to save and edit.

### How to Test?
**Stage**
https://stage-edx-discovery.edx.org/publisher/

- Go to any course run and click the course edit run.
- Edit the instructor bio.
- See email and organization field is not filled.
- Unable to edit and save. 


**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/course_runs/
- Create any course run and edit the course run.
- Edit the instructor bio.
- See email and organization field is filled. 
- Able to save

You can use following credentials
_username : Attiya
Password: attiya_

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @Rabia23 

FYI: @awaisdar001 

### Post-review
- [x] Rebase and squash commits
