### PR TITLE
Fix enables person family name in discovery to be empty.

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -222,7 +222,10 @@ class Person(TimeStampedModel):
 
     @property
     def full_name(self):
-        return ' '.join((self.given_name, self.family_name,))
+        if self.family_name:
+            return ' '.join((self.given_name, self.family_name,))
+        else:
+            return self.given_name
 
     @property
     def get_profile_image_url(self):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -358,6 +358,12 @@ class PersonTests(TestCase):
         expected = self.person.given_name + ' ' + self.person.family_name
         self.assertEqual(self.person.full_name, expected)
 
+    def test_empty_family_name(self):
+        """ Verify the property returns the person's given name when family name is set None. """
+        self.person.family_name = None
+        expected = self.person.given_name
+        self.assertEqual(self.person.full_name, expected)
+
     def test_get_profile_image_url(self):
         """
         Verify that property returns profile_image_url if profile_image_url


### PR DESCRIPTION
Adding person in discovery throws 500 if family name is
empty. Person expects family name to generate full name.
This Fix would enable family name to be empty as its not a
required field.

LEARNER-1701