### PR TITLE
[ENT-634] Add course run `weeks_to_complete` to serializer.

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -475,7 +475,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
     class Meta(MinimalCourseRunSerializer.Meta):
         fields = MinimalCourseRunSerializer.Meta.fields + (
             'course', 'full_description', 'announcement', 'video', 'seats', 'content_language',
-            'transcript_languages', 'instructors', 'staff', 'min_effort', 'max_effort', 'modified',
+            'transcript_languages', 'instructors', 'staff', 'min_effort', 'max_effort', 'weeks_to_complete', 'modified',
             'level_type', 'availability', 'mobile_available', 'hidden', 'reporting_type', 'eligible_for_financial_aid'
         )
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -260,6 +260,7 @@ class CourseRunSerializerTests(MinimalCourseRunSerializerTests):
             'transcript_languages': [],
             'min_effort': course_run.min_effort,
             'max_effort': course_run.max_effort,
+            'weeks_to_complete': course_run.weeks_to_complete,
             'instructors': [],
             'staff': [],
             'seats': [],


### PR DESCRIPTION
We were not previously getting the `weeks_to_complete` detail for course runs when querying for course runs or courses. In particular, [ENT-634](https://openedx.atlassian.net/browse/ENT-634) requires us to display this information on the program enrollment landing page, so we need it serialized through the course run serializer.

**JIRA tickets**: [ENT-634](https://openedx.atlassian.net/browse/ENT-634)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP so we don't block [ENT-634](https://openedx.atlassian.net/browse/ENT-634).

**Testing instructions**:

1. Make sure to have a course run in course-discovery with the `weeks_to_complete` field in the admin filled out.
1. Go to `/api/v1/courses`, and see no `weeks_to_complete` field in the serialized data.
1. Go to `/api/v1/courses/{course_key}` and see no `weeks_to_complete` field in the serialized data.
1. Go to `/api/v1/course_runs`, and see no `weeks_to_complete` field in the serialized data.
1. Go to `/api/v1/course_runs/{course_run_key}` and see no `weeks_to_complete` field in the serialized data.
1. Checkout this branch for course-discovery and restart the service.
1. Go to `/api/v1/courses/`, and see that `weeks_to_complete` is now serialized.
1. Go to `/api/v1/courses/{course_key}`, and see that `weeks_to_complete` is now serialized.
1. Go to `/api/v1/course_runs/`, and see that `weeks_to_complete` is now serialized.
1. Go to `/api/v1/course_runs/{course_run_key}`, and see that `weeks_to_complete` is now serialized.

**Reviewers**
- [x] @haikuginger 
- [x] @douglashall @brittneyexline 