### PR TITLE
Fixed incorrect commenter identification

### DIFF
--- a/course_discovery/apps/publisher/templates/publisher/email/comment.html
+++ b/course_discovery/apps/publisher/templates/publisher/email/comment.html
@@ -4,7 +4,7 @@
 <!-- Message Body -->
         <p>
             {% blocktrans with date=comment_date|date:'m/d/y' time=comment_date.time trimmed %}
-                The {{ team_name }} made the following comment on {{ course_name }} on {{ date }} at {{ time }}
+                {{ user_name }} made the following comment on {{ course_name }} on {{ date }} at {{ time }}
             {% endblocktrans %}
         </p>
         <p style="font-style: italic;">

--- a/course_discovery/apps/publisher/templates/publisher/email/comment.txt
+++ b/course_discovery/apps/publisher/templates/publisher/email/comment.txt
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% blocktrans with date=comment_date|date:'m/d/y' time=comment_date.time trimmed %}
-The {{ team_name }} made the following comment on {{ course_name }} {{ date }} at {{ time }}.
+{{ user_name }} made the following comment on {{ course_name }} {{ date }} at {{ time }}.
 {% endblocktrans %}
 
 {{ comment_message }}

--- a/course_discovery/apps/publisher_comments/emails.py
+++ b/course_discovery/apps/publisher_comments/emails.py
@@ -72,7 +72,7 @@ def send_email_for_comment(comment, created=False):
 
         context = {
             'comment_message': comment.comment,
-            'team_name': 'course team' if comment.user == course.course_team_admin else 'marketing team',
+            'user_name': comment.user.username,
             'course_name': course_name,
             'comment_date': comment_date,
             'page_url': 'https://{host}{path}'.format(host=comment.site.domain.strip('/'), path=object_path)

--- a/course_discovery/apps/publisher_comments/tests/test_emails.py
+++ b/course_discovery/apps/publisher_comments/tests/test_emails.py
@@ -135,7 +135,8 @@ class CommentsEmailTests(SiteMixin, TestCase):
         else:
             course_name = content_object.title
 
-        expected = 'The marketing team made the following comment on {course_name}'.format(course_name=course_name)
+        expected = '{username} made the following comment on {course_name}'.format(username=comment.user.username,
+                                                                                   course_name=course_name)
         self.assertIn(expected, body)
         page_url = 'https://{host}{path}'.format(host=comment.site.domain.strip('/'), path=object_path)
         self.assertIn(comment.comment, body)


### PR DESCRIPTION
## [EDUCATOR-1373](https://openedx.atlassian.net/browse/EDUCATOR-1373)

### Description
When someone adds a comment on the course detail page or on the course run page an email is sent to all related course user roles. The content of the email misidentifies the person who added the comment. It has been fixed and now the content of the email contains the username of the person who add the comment instead of the team name.
**Sandbox**
- N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001  
- [ ] @attiyaIshaque  

### Post-review
- [ ] Rebase and squash commits
