### PR TITLE
Fix Selected instructor display and deletion on editing course run.

### DIFF
--- a/course_discovery/static/js/publisher/instructors.js
+++ b/course_discovery/static/js/publisher/instructors.js
@@ -9,6 +9,16 @@ $(document).ready(function(){
         renderSelectedInstructor(id, name, image_source, uuid);
     });
 
+    $("#id_staff").on("select2:select", function(e) {
+        var $instructorSelector = e.params.data,
+            id = $instructorSelector.id, 
+            selectedInstructorData = $.parseHTML($instructorSelector.text)[0],
+            image_source = $(selectedInstructorData).find('img').attr('src'), 
+            name = $(selectedInstructorData).find('b').text();
+        renderSelectedInstructor(id, name, image_source);
+
+    });
+
     $('#add-new-instructor').click(function(e){
         clearModalError();
         var btnInstructor = $('#add-instructor-btn');
@@ -111,21 +121,6 @@ function loadSelectedImage(input) {
         }
     }
 }
-
-$(document).on('change', '#id_staff', function (e) {
-
-    var $instructorSelector = $('.instructor-select'),
-        $instructor = $instructorSelector.find('.select2-selection__choice'),
-        id = $instructor.find('.instructor-option').last().prop("id"),
-        image_source,
-        name;
-    $instructorSelector.find('.select2-selection__clear').remove();
-    image_source = $instructor.find('img').last().attr('src');
-    name = $instructor.find('b').last().text();
-    renderSelectedInstructor(id, name, image_source);
-    $instructor.remove();
-});
-
 
 $(document).on('click', '.selected-instructor a.delete', function (e) {
     e.preventDefault();


### PR DESCRIPTION
## [EDUCATOR-1381](https://openedx.atlassian.net/browse/EDUCATOR-1381)

### Description
This PR fixes that selected instructor would not display the image of already existing instructor and also its correctly delete the instructor when you delete it. 


### How to Test?
**Stage**
https://stage-edx-discovery.edx.org/publisher/

- Go to any course run and click the course edit run.
- Add the instructor from drop down.
- See selected Instructor would display the image of already selected instructor and name wouldn't display.
- Delete the recently added instructor.(It will delete from the front end)
- Click the *Update Course Run* button
- Observe that delete instructor shown on the course run page. 


**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/course_runs/5/
You can use following credentials
_username : Attiya
Password: attiya_

### Screenshots
**Before Fix**
<img width="546" alt="screen shot 2017-09-21 at 12 47 52 pm" src="https://user-images.githubusercontent.com/7627421/30684570-22d80174-9ecb-11e7-99b8-5908c0ac98a7.png">

**After Fix**
<img width="546" alt="screen shot 2017-09-21 at 12 45 32 pm" src="https://user-images.githubusercontent.com/7627421/30684573-263addd2-9ecb-11e7-8635-7cb0c9885e5c.png">

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @tasawernawaz  


### Post-review
- [x] Rebase and squash commits
