### PR TITLE
Create course about page when course_run saves

### DIFF
--- a/course_discovery/apps/course_metadata/publishers.py
+++ b/course_discovery/apps/course_metadata/publishers.py
@@ -201,6 +201,11 @@ class CourseRunMarketingSitePublisher(BaseMarketingSitePublisher):
             node_data = self.serialize_obj(obj)
 
             self.edit_node(node_id, node_data)
+        elif not previous_obj:
+            # This is a brand new course_run object
+            # let's create it on the marketing site
+            node_data = self.serialize_obj(obj)
+            self.create_node(node_data)
 
     def serialize_obj(self, obj):
         """
@@ -217,6 +222,10 @@ class CourseRunMarketingSitePublisher(BaseMarketingSitePublisher):
         return {
             **data,
             'status': 1 if obj.status == CourseRunStatus.Published else 0,
+            'field_course_uuid': str(obj.uuid),
+            'title': obj.title,
+            'field_course_id': obj.key,
+            'type': 'course',
         }
 
 

--- a/course_discovery/apps/course_metadata/tests/test_publishers.py
+++ b/course_discovery/apps/course_metadata/tests/test_publishers.py
@@ -199,16 +199,19 @@ class CourseRunMarketingSitePublisherTests(MarketingSitePublisherTestMixin):
 
         self.obj = CourseRunFactory()
 
+    @mock.patch.object(CourseRunMarketingSitePublisher, 'serialize_obj', return_value='data')
+    @mock.patch.object(CourseRunMarketingSitePublisher, 'create_node')
+    def test_publish_obj_create(self, mock_create_node, *args):  # pylint: disable=unused-argument
+        self.publisher.publish_obj(self.obj)
+        mock_create_node.assert_called_with('data')
+
     @mock.patch.object(CourseRunMarketingSitePublisher, 'node_id', return_value='node_id')
     @mock.patch.object(CourseRunMarketingSitePublisher, 'serialize_obj', return_value='data')
     @mock.patch.object(CourseRunMarketingSitePublisher, 'edit_node', return_value=None)
-    def test_publish_obj(self, mock_edit_node, *args):  # pylint: disable=unused-argument
+    def test_publish_obj_edit(self, mock_edit_node, *args):  # pylint: disable=unused-argument
         """
         Verify that the publisher attempts to publish when course run status changes.
         """
-        # No previous object. No editing should occur.
-        self.publisher.publish_obj(self.obj)
-        assert not mock_edit_node.called
 
         # A previous object is provided, but the status hasn't changed.
         # No editing should occur.
@@ -231,8 +234,11 @@ class CourseRunMarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         actual = self.publisher.serialize_obj(self.obj)
         expected = {
             'field_course_id': self.obj.key,
+            'field_course_uuid': str(self.obj.uuid),
+            'title': self.obj.title,
             'author': {'id': self.user_id},
             'status': 1,
+            'type': 'course',
         }
 
         assert actual == expected


### PR DESCRIPTION
Create the course about page on marketing site when course_run saves
This does not include the change for URL redirect manipulation yet. Will add later.
@clintonb When you are available, feel free to review