### PR TITLE
Course team would be able to edit existing instructor of same org.

### DIFF
--- a/course_discovery/apps/course_metadata/lookups.py
+++ b/course_discovery/apps/course_metadata/lookups.py
@@ -71,7 +71,9 @@ class PersonAutocomplete(LoginRequiredMixin, autocomplete.Select2QuerySetView):
                 'uuid': result.uuid,
                 'profile_image': result.get_profile_image_url,
                 'full_name': result.full_name,
-                'position': result.position if hasattr(result, 'position') else None
+                'position': result.position if hasattr(result, 'position') else None,
+                'organization_id': result.position.organization_id if hasattr(result, 'position') else None
+
             }
 
             return render_to_string('publisher/_personLookup.html', context=context)

--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -29,7 +29,8 @@ class PersonModelMultipleChoice(forms.ModelMultipleChoiceField):
         context = {
             'profile_image': obj.get_profile_image_url,
             'full_name': obj.full_name,
-            'uuid': obj.uuid if not obj.profile_image_url else None
+            'uuid': obj.uuid,
+            'organization_id': obj.position.organization_id if hasattr(obj, 'position') else None
         }
         return str(render_to_string('publisher/_personFieldLabel.html', context=context))
 

--- a/course_discovery/apps/publisher/templates/publisher/_personFieldLabel.html
+++ b/course_discovery/apps/publisher/templates/publisher/_personFieldLabel.html
@@ -1,1 +1,1 @@
-<img src="{{ profile_image }}"/><span{% if uuid %} data-uuid="{{ uuid }}" {% endif %}>{{ full_name }}</span>
+<img src="{{ profile_image }}"/><span{% if uuid %} data-uuid="{{ uuid }}" {% endif %}>{{ full_name }}</span>{% if organization_id %}<span>{{ organization_id }}</span>{% endif %}

--- a/course_discovery/apps/publisher/templates/publisher/_personLookup.html
+++ b/course_discovery/apps/publisher/templates/publisher/_personLookup.html
@@ -5,6 +5,7 @@
       <b>{{ full_name }}</b>
       {% if position %}
         <p>{{ position }}</p>
+        <span class="hidden">{{ organization_id }}</span>
       {% endif %}
     </td>
   </tr>

--- a/course_discovery/apps/publisher/templates/publisher/course_run/edit_run_form.html
+++ b/course_discovery/apps/publisher/templates/publisher/course_run/edit_run_form.html
@@ -208,6 +208,8 @@
                     <div class="col col-6 help-text">
                         {% trans "The primary instructor or instructors for the course." %}
                     </div>
+                    <div id="user_organizations_ids" class="hidden">{{ organizations_ids|safe }}</div>
+                    <div id="course_user_role" class="hidden">{{ course_user_role }}</div>
                     <div class="col col-6 instructor-select">
                         <label class="field-label ">{{ run_form.staff.label_tag }} <span class="required">*</span></label>
                         {{ run_form.staff }}

--- a/course_discovery/apps/publisher/tests/test_forms.py
+++ b/course_discovery/apps/publisher/tests/test_forms.py
@@ -58,8 +58,9 @@ class PersonModelMultipleChoiceTests(TestCase):
 
         # we need to loop through choices because it is a ModelChoiceIterator
         for __, choice_label in course_form.fields['staff'].choices:
-            expected = '<img src="{url}"/><span>{full_name}</span>'.format(
+            expected = '<img src="{url}"/><span data-uuid="{uuid}" >{full_name}</span>'.format(
                 full_name=person.full_name,
+                uuid=person.uuid,
                 url=person.get_profile_image_url
             )
             self.assertEqual(choice_label.strip(), expected)

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -702,7 +702,12 @@ class CourseRunEditView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMix
         context = self.get_context_data()
         course_run = context.get('course_run')
         course = course_run.course
+        course_user_role = course.get_user_role(user=self.request.user)
+        if course_user_role == PublisherUserRole.CourseTeam:
+            context['organizations_ids'] = list(mixins.get_user_organizations(self.request.user).
+                                                values_list('id', flat=True))
 
+        context['course_user_role'] = course_user_role
         context['run_form'] = self.run_form(
             instance=course_run, is_project_coordinator=context.get('is_project_coordinator')
         )

--- a/course_discovery/static/sass/publisher/publisher.scss
+++ b/course_discovery/static/sass/publisher/publisher.scss
@@ -216,6 +216,9 @@
   .field-value {
     margin-bottom: 20px;
   }
+  .hidden {
+    display : none;
+  }
   .help-text {
       p {
         margin-bottom: 0;


### PR DESCRIPTION
## [EDUCATOR-1255](https://openedx.atlassian.net/browse/EDUCATOR-1255)

### Description
This PR fixes that Course team should be able to edit existing instructor information for all instructors that belong to their organization.


### How to Test?
**Stage**
https://stage-edx-discovery.edx.org/publisher/

- Go to any course run and click the course edit run.
- Add the instructor from the drop down that belongs to the same organization of course team. 
- See selected Instructor would n't have the edit button.


**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/course_runs/5/
You can use following credentials
_username : Attiya
Password: attiya_
-  Add the instructor from the drop down that belongs to the same organization of course team. you can add _"Chris Terman"_
- See selected Instructor would have an edit button. Now you can update the information.



### Screenshots
**Before Fix**
<img width="574" alt="screen shot 2017-09-26 at 2 32 46 pm" src="https://user-images.githubusercontent.com/7627421/30855325-fa713398-a2cd-11e7-8ab1-94840fbf61fb.png">


**After Fix**
<img width="544" alt="screen shot 2017-09-26 at 3 17 58 pm" src="https://user-images.githubusercontent.com/7627421/30855367-26ece03e-a2ce-11e7-9f55-fa9a2a82fa1a.png">


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the:+1:.
- [x] @tasawernawaz 
- [x] @asadazam93 

### Post-review
- [x] Rebase and squash commits
