### PR TITLE
Updated date publishing for E-Commerce API calls

### DIFF
--- a/course_discovery/apps/publisher/api/tests/test_utils.py
+++ b/course_discovery/apps/publisher/api/tests/test_utils.py
@@ -1,0 +1,63 @@
+import datetime
+import random
+
+import pytest
+
+from course_discovery.apps.core.utils import serialize_datetime
+from course_discovery.apps.publisher.api.utils import serialize_seat_for_ecommerce_api
+from course_discovery.apps.publisher.models import Seat
+from course_discovery.apps.publisher.tests.factories import SeatFactory
+
+
+@pytest.mark.django_db
+class TestSerializeSeatForEcommerceApi:
+    def test_serialize_seat_for_ecommerce_api(self):
+        seat = SeatFactory()
+        actual = serialize_seat_for_ecommerce_api(seat)
+        assert actual['price'] == str(seat.price)
+        assert actual['product_class'] == 'Seat'
+
+    def test_serialize_seat_for_ecommerce_api_with_audit_seat(self):
+        seat = SeatFactory(type=Seat.AUDIT)
+        actual = serialize_seat_for_ecommerce_api(seat)
+        expected = {
+            'expires': serialize_datetime(seat.upgrade_deadline),
+            'price': str(seat.price),
+            'product_class': 'Seat',
+            'attribute_values': [
+                {
+                    'name': 'certificate_type',
+                    'value': None,
+                },
+                {
+                    'name': 'id_verification_required',
+                    'value': False,
+                }
+            ]
+        }
+
+        assert actual == expected
+
+    def test_serialize_seat_for_ecommerce_api_without_upgrade_deadline(self, settings):
+        settings.PUBLISHER_UPGRADE_DEADLINE_DAYS = random.randint(1, 21)
+        now = datetime.datetime.utcnow()
+        seat = SeatFactory(upgrade_deadline=None, course_run__end=now)
+        actual = serialize_seat_for_ecommerce_api(seat)
+        assert actual['expires'] == serialize_datetime(
+            now - datetime.timedelta(days=settings.PUBLISHER_UPGRADE_DEADLINE_DAYS))
+
+    @pytest.mark.parametrize('seat_type', (Seat.VERIFIED, Seat.PROFESSIONAL))
+    def test_serialize_seat_for_ecommerce_api_with_id_verification(self, seat_type):
+        seat = SeatFactory(type=seat_type)
+        actual = serialize_seat_for_ecommerce_api(seat)
+        expected_attribute_values = [
+            {
+                'name': 'certificate_type',
+                'value': seat_type,
+            },
+            {
+                'name': 'id_verification_required',
+                'value': True,
+            }
+        ]
+        assert actual['attribute_values'] == expected_attribute_values

--- a/course_discovery/apps/publisher/api/utils.py
+++ b/course_discovery/apps/publisher/api/utils.py
@@ -1,0 +1,28 @@
+import datetime
+
+from django.conf import settings
+
+from course_discovery.apps.core.utils import serialize_datetime
+from course_discovery.apps.publisher.models import Seat
+
+
+def serialize_seat_for_ecommerce_api(seat):
+    upgrade_deadline = seat.upgrade_deadline
+    if not upgrade_deadline:
+        upgrade_deadline = seat.course_run.end - datetime.timedelta(days=settings.PUBLISHER_UPGRADE_DEADLINE_DAYS)
+
+    return {
+        'expires': serialize_datetime(upgrade_deadline),
+        'price': str(seat.price),
+        'product_class': 'Seat',
+        'attribute_values': [
+            {
+                'name': 'certificate_type',
+                'value': None if seat.type == Seat.AUDIT else seat.type,
+            },
+            {
+                'name': 'id_verification_required',
+                'value': seat.type in (Seat.VERIFIED, Seat.PROFESSIONAL),
+            }
+        ]
+    }

--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -11,7 +11,8 @@ from slumber.exceptions import SlumberBaseException
 from course_discovery.apps.core.utils import serialize_datetime
 from course_discovery.apps.course_metadata.models import CourseRun as DiscoveryCourseRun
 from course_discovery.apps.course_metadata.models import Course, Video
-from course_discovery.apps.publisher.models import CourseRun, Seat
+from course_discovery.apps.publisher.api.utils import serialize_seat_for_ecommerce_api
+from course_discovery.apps.publisher.models import CourseRun
 from course_discovery.apps.publisher.studio_api_utils import StudioAPI
 
 logger = logging.getLogger(__name__)
@@ -72,25 +73,10 @@ class CourseRunViewSet(viewsets.GenericViewSet):
         data = {
             'id': course_run.lms_course_id,
             'name': course_run.title_override or course_run.course.title,
-            'verification_deadline': None,
+            'verification_deadline': serialize_datetime(course_run.end),
             'create_or_activate_enrollment_code': False,
-            'products': [
-                {
-                    'expires': serialize_datetime(seat.upgrade_deadline),
-                    'price': str(seat.price),
-                    'product_class': 'Seat',
-                    'attribute_values': [
-                        {
-                            'name': 'certificate_type',
-                            'value': None if seat.type is Seat.AUDIT else seat.type,
-                        },
-                        {
-                            'name': 'id_verification_required',
-                            'value': seat.type in (Seat.VERIFIED, Seat.PROFESSIONAL),
-                        }
-                    ]
-                } for seat in course_run.seats.all()
-            ]
+            # NOTE (CCB): We only order here to aid testing. The E-Commerce API does NOT care about ordering.
+            'products': [serialize_seat_for_ecommerce_api(seat) for seat in course_run.seats.all().order_by('created')],
         }
 
         try:

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -501,6 +501,10 @@ SOLO_CACHE_TIMEOUT = 3600
 
 PUBLISHER_FROM_EMAIL = None
 
+# If no upgrade deadline is specified for a course run seat, when the course is published the deadline will default to
+# the course run end date minus the specified number of days.
+PUBLISHER_UPGRADE_DEADLINE_DAYS = 10
+
 # Django Debug Toolbar settings
 # http://django-debug-toolbar.readthedocs.org/en/latest/installation.html
 if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):


### PR DESCRIPTION
- Verification deadline now defaults to the course end date
- Product expiration date (upgrade deadline) now defaults to course a few days before the course end date

LEARNER-2621