### PR TITLE
Updated enrollment date publishing to Studio

### DIFF
--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -250,8 +250,11 @@ class Course(TimeStampedModel, ChangedByMixin):
 
     @cached_property
     def discovery_counterpart(self):
-        course_key = '{org}+{number}'.format(org=self.organizations.first().key, number=self.number)
-        return DiscoveryCourse.objects.get(partner=self.partner, key=course_key)
+        return DiscoveryCourse.objects.get(partner=self.partner, key=self.key)
+
+    @cached_property
+    def key(self):
+        return '{org}+{number}'.format(org=self.organizations.first().key, number=self.number)
 
 
 class CourseRun(TimeStampedModel, ChangedByMixin):

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -533,7 +533,8 @@ class CreateCourseRunView(mixins.LoginRequiredMixin, CreateView):
             # Delete all those fields which cannot be copied from previous run
             del (last_run_data['id'], last_run_data['start'], last_run_data['end'], last_run_data['pacing_type'],
                  last_run_data['preview_url'], last_run_data['lms_course_id'], last_run_data['changed_by'],
-                 last_run_data['course'], last_run_data['sponsor'])
+                 last_run_data['course'], last_run_data['sponsor'], last_run_data['enrollment_start'],
+                 last_run_data['enrollment_end'])
 
             staff = Person.objects.filter(id__in=last_run_data.pop('staff'))
             transcript_languages = LanguageTag.objects.filter(code__in=last_run_data.pop('transcript_languages'))


### PR DESCRIPTION
- When creating a new course run, enrollment dates are no longer copied from the previous run
- Temporary code in signal receiver has been removed. The enrollment dates will always be empty when creating a re-run.
- Added additional exception handling around API call to create images. Errors from this operation will no longer prevent a course run from being saved.

LEARNER-2469