### PR TITLE
updated people api create to use group authentication

### DIFF
--- a/course_discovery/apps/api/v1/views/people.py
+++ b/course_discovery/apps/api/v1/views/people.py
@@ -8,9 +8,9 @@ from rest_framework.response import Response
 
 from course_discovery.apps.api import filters, serializers
 from course_discovery.apps.api.pagination import PageNumberPagination
-
 from course_discovery.apps.course_metadata.exceptions import MarketingSiteAPIClientException, PersonToMarketingException
 from course_discovery.apps.course_metadata.people import MarketingSitePeople
+from course_discovery.apps.publisher.permissions import UserHasGroup
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class PersonViewSet(viewsets.ModelViewSet):
     filter_class = filters.PersonFilter
     lookup_field = 'uuid'
     lookup_value_regex = '[0-9a-f-]+'
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, UserHasGroup,)
     queryset = serializers.PersonSerializer.prefetch_queryset()
     serializer_class = serializers.PersonSerializer
     pagination_class = PageNumberPagination

--- a/course_discovery/apps/publisher/permissions.py
+++ b/course_discovery/apps/publisher/permissions.py
@@ -1,0 +1,16 @@
+import logging
+
+from rest_framework import permissions
+
+logger = logging.getLogger(__name__)
+
+
+class UserHasGroup(permissions.BasePermission):
+    """
+    Global permission to check if request.user has any group
+    """
+    def has_permission(self, request, view):
+        if request.user.groups.all():
+            return True
+        logger.info('Permission denied. User [%s] has no groups', request.user.username)
+        return False


### PR DESCRIPTION
## [EDUCATOR-1383](https://openedx.atlassian.net/browse/EDUCATOR-1383)

### Description
https://github.com/edx/course-discovery/blob/fa251757dae29dbff2380728790116be9a498fe2/course_discovery/apps/api/v1/views/people.py#L26
previously this endpoint allowed any authenticated user to create a new person entity.
I have added one more method of authentication to create a new person. i.e group. The authenticated user has to be part of any group to be able to create a new person. As course team users of the publisher are the people who mostly use this endpoint and they are neither staff nor superusers so using both these permissions was not going be sufficient. The course team users are part of a group so I have used groups as a method of authentication (any non verified or non staff member is not a part of any group)

**Sandbox**
- N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @awaisdar001  
- [x] @attiyaIshaque  

### Post-review
- [ ] Rebase and squash commits
