### PR TITLE
Logging missing instructor when generating Studio API data

### DIFF
--- a/course_discovery/apps/publisher/studio_api_utils.py
+++ b/course_discovery/apps/publisher/studio_api_utils.py
@@ -53,6 +53,9 @@ class StudioAPI:
                     'role': 'instructor',
                 },
             ]
+        else:
+            logger.warning('No course team admin specified for course [%s]. This may result in a Studio '
+                           'course run being created without a course team.', course.number)
 
         return {
             'title': publisher_course_run.title_override or course.title,


### PR DESCRIPTION
If a course lacks a course team admin, the Studio instance will be created/updated without a team. This can result in confusion to course team members. This case is now logged to aid future debugging.