### PR TITLE
Fix Course Run State storing in Preview dashboard.

### DIFF
--- a/course_discovery/apps/publisher/templates/publisher/dashboard/_in_preview.html
+++ b/course_discovery/apps/publisher/templates/publisher/dashboard/_in_preview.html
@@ -34,7 +34,7 @@
                         <td>
                         {{ course_run.course.organization_name }}
                         </td>
-                        <td>
+                        <td data-order="{{ course_run.owner_role_modified|date:"Y-m-d" }}" >
                             {% if course_run.course_run_state.preview_accepted %}
                                 {% trans "Approved since " %}
                             {% elif course_run.preview_declined and not course_run.preview_url %}


### PR DESCRIPTION
## [EDUCATOR-1453](https://openedx.atlassian.net/browse/EDUCATOR-1453)

### Description
This PR fixes that filter of course run status is chronological not alphabetically.

### How to Test?
**Production**
https://prod-edx-discovery.edx.org/publisher/

- Click to *In preview* tab.
- Filter by status.
- Sorting is alphabetical. 


**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/
- Click to *In preview* tab.
- Filter by status.
- Sorting is chronological. 

You can use following credentials
_username : Attiya
Password: attiya_


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93
- [x] @Rabia23


### Post-review
- [x] Rebase and squash commits
