### PR TITLE
Added synonyms for Global Freshman Academy

### DIFF
--- a/course_discovery/settings/synonyms.py
+++ b/course_discovery/settings/synonyms.py
@@ -9,6 +9,7 @@ SYNONYMS = [
     ['ASU', 'ASUx', 'Arizona State', 'Arizona State University'],
     ['Berkeley', 'UC BerkeleyX', 'UCBerkeleyX'],
     ['Georgia Institute of Technology', 'Georgia Tech', 'GTx'],
+    ['GFA', 'Global Freshman Academy'],
     ['Instituto Tecnologico y De Estudios Superiores De Monterrey', 'Monterrey', 'TecdeMonterreyX'],
     ['Microsoft', 'MicrosoftX', 'msft'],
     ['MIT', 'MITx'],


### PR DESCRIPTION
**[LEARNER-2579](https://openedx.atlassian.net/browse/LEARNER-2579)** : 
**Description**:
As a learner, when I search "GFA" or "Global Freshman Academy", I expect to see all courses provided by the institution ASUx that are credit-eligible. These would be the same as the courses that appear on the GFA landing page www.edx.org/gfa.
the reason GFA & Global Freshman Academy doesn't return in search results today, is that those words aren't present in the course description, or title.
To get the behavior that Kathleen is requesting in her second point, the easiest would be to modify the course description to include the words "GFA" & "Global Freshman Academy", in addition to setting up a synonym for GFA = Global Freshman Academy.
Some data, in the past year, ~15 million unique searches were performed on our site. Global Freshman Academy was searched for 242 times and GFA was searched for 360 times.
