### PR TITLE
Remove video_translation_languages field from course_run object. 

### DIFF
--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -153,7 +153,6 @@ class CourseRunViewSetTests(APITestCase):
         assert discovery_course_run.learner_testimonials == publisher_course.learner_testimonial
         expected = set(publisher_course_run.transcript_languages.all())
         assert set(discovery_course_run.transcript_languages.all()) == expected
-        assert set(discovery_course_run.video_translation_languages.all()) == {publisher_course_run.video_language}
         assert set(discovery_course_run.staff.all()) == set(publisher_course_run.staff.all())
 
         assert discovery_course.canonical_course_run == discovery_course_run

--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -139,7 +139,6 @@ class CourseRunViewSet(viewsets.GenericViewSet):
         )
         discovery_course_run.transcript_languages.add(*course_run.transcript_languages.all())
         discovery_course_run.staff.add(*course_run.staff.all())
-        discovery_course_run.video_translation_languages.add(course_run.video_language)
 
         for seat in course_run.seats.exclude(type=Seat.CREDIT):
             DiscoverySeat.objects.update_or_create(


### PR DESCRIPTION
The field name is not accurate and the data is not being used.
@clintonb Please help review
Will create the PR for the migration file after this is merged.