### PR TITLE
Course images pushed to Studio only if they exist

### DIFF
--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -207,21 +207,6 @@ class Course(TimeStampedModel, ChangedByMixin):
             return None
 
     @property
-    def course_image_url(self):
-        """
-        Return course image url.
-        """
-
-        if self.image:
-            return self.image.url
-
-        course_run = self.course_runs.filter(course_run_state__name=CourseRunStateChoices.Published).first()
-        if course_run and course_run.card_image_url:
-            return course_run.card_image_url
-
-        return None
-
-    @property
     def course_short_description(self):
         course_run = self.course_runs.filter(course_run_state__name=CourseRunStateChoices.Published).first()
 

--- a/course_discovery/apps/publisher/studio_api_utils.py
+++ b/course_discovery/apps/publisher/studio_api_utils.py
@@ -80,8 +80,18 @@ class StudioAPI:
         return self._api.course_runs.post(data)
 
     def update_course_run_image_in_studio(self, publisher_course_run):
-        files = {'card_image': publisher_course_run.course.image}
-        return self._api.course_runs(publisher_course_run.lms_course_id).images.post(files=files)
+        course = publisher_course_run.course
+        image = course.image
+
+        if image:
+            files = {'card_image': image}
+            return self._api.course_runs(publisher_course_run.lms_course_id).images.post(files=files)
+        else:
+            logger.warning(
+                'Card image for course run [%d] cannot be updated. The related course [%d] has no image defined.',
+                publisher_course_run.id,
+                course.id
+            )
 
     def update_course_run_details_in_studio(self, publisher_course_run):
         data = self.generate_data_for_studio_api(publisher_course_run)

--- a/course_discovery/apps/publisher/templates/publisher/course_detail.html
+++ b/course_discovery/apps/publisher/templates/publisher/course_detail.html
@@ -146,8 +146,8 @@
                 <div class="heading course-image-heading">
                     {% trans "Course Image" %}
                 </div>
-                {% if object.course_image_url %}
-                    <img class="course-image" src="{{ object.course_image_url }}" alt="{% trans 'Course Image' %}">
+                {% if object.image %}
+                    <img class="course-image" src="{{ object.image.url }}" alt="{% trans 'Course Image' %}">
                 {% else %}
                     {% trans "(Required) Not yet added" %}
                 {% endif %}

--- a/course_discovery/apps/publisher/templates/publisher/course_run_detail/_drupal.html
+++ b/course_discovery/apps/publisher/templates/publisher/course_run_detail/_drupal.html
@@ -207,15 +207,15 @@
             {% trans "Course Image" %}
         </div>
         <div>
-            {% if not object.course_image_url %}
-                {% trans "(Required) Not yet added" %}
-            {% else %}
-                <img class="course-image" src="{{ object.course_image_url }}" alt="{% trans 'Course Image' %}">
+            {% if object.course.image %}
+                <img class="course-image" src="{{ object.course.image.url }}" alt="{% trans 'Course Image' %}">
                 <div class="download-image">
-                    <a download href="{{ object.course_image_url }}">
+                    <a download href="{{ object.course.image.url }}">
                         {% trans "Download" %}
                     </a>
                 </div>
+            {% else %}
+                {% trans "(Required) Not yet added" %}
             {% endif %}
         </div>
     </div>

--- a/course_discovery/apps/publisher/tests/test_models.py
+++ b/course_discovery/apps/publisher/tests/test_models.py
@@ -327,21 +327,6 @@ class CourseTests(TestCase):
 
         self.assertEqual(self.user1, self.course2.publisher)
 
-    def test_course_image_url(self):
-        course = factories.CourseFactory(image=None)
-        assert course.course_image_url is None
-
-        course_run = factories.CourseRunFactory(course=course)
-        factories.CourseRunStateFactory(course_run=course_run, name=CourseRunStateChoices.Published)
-        course_run.card_image_url = 'http://example.com/test.jpg'
-        course_run.save()
-        assert course.course_image_url == course_run.card_image_url
-
-        # Create a course image.
-        course.image = make_image_file('test_banner1.jpg')
-        course.save()
-        assert course.course_image_url == course.image.url
-
     def test_short_description_override(self):
         """ Verify that the property returns the short_description. """
         self.assertEqual(self.course.short_description, self.course.course_short_description)
@@ -355,6 +340,7 @@ class CourseTests(TestCase):
         self.assertEqual(self.course.full_description, self.course.course_full_description)
 
         course_run = factories.CourseRunFactory(course=self.course)
+
         factories.CourseRunStateFactory(course_run=course_run, name=CourseRunStateChoices.Published)
         self.assertEqual(self.course.course_full_description, course_run.full_description_override)
 

--- a/course_discovery/apps/publisher/tests/test_studio_api_utils.py
+++ b/course_discovery/apps/publisher/tests/test_studio_api_utils.py
@@ -12,8 +12,11 @@ from course_discovery.apps.publisher.choices import PublisherUserRole
 from course_discovery.apps.publisher.studio_api_utils import StudioAPI
 from course_discovery.apps.publisher.tests.factories import CourseRunFactory, CourseUserRoleFactory
 
-test_data = list(product(range(1, 5), ['1T2017'])) + list(product(range(5, 8), ['2T2017'])) + \
+test_data = (
+    list(product(range(1, 5), ['1T2017'])) +
+    list(product(range(5, 8), ['2T2017'])) +
     list(product(range(9, 13), ['3T2017']))
+)
 
 
 @pytest.mark.django_db
@@ -85,4 +88,18 @@ def test_generate_data_for_studio_api_without_team():
             'No course team admin specified for course [%s]. This may result in a Studio course run '
             'being created without a course team.',
             course_run.course.number
+        )
+
+
+@pytest.mark.django_db
+def test_update_course_run_image_in_studio_without_course_image():
+    publisher_course_run = CourseRunFactory(course__image=None)
+    api = StudioAPI(None)
+
+    with mock.patch('course_discovery.apps.publisher.studio_api_utils.logger') as mock_logger:
+        api.update_course_run_image_in_studio(publisher_course_run)
+        mock_logger.warning.assert_called_with(
+            'Card image for course run [%d] cannot be updated. The related course [%d] has no image defined.',
+            publisher_course_run.id,
+            publisher_course_run.course.id
         )

--- a/course_discovery/apps/publisher/tests/test_wrapper.py
+++ b/course_discovery/apps/publisher/tests/test_wrapper.py
@@ -5,7 +5,6 @@ from unittest import mock
 import ddt
 from django.test import TestCase
 
-from course_discovery.apps.core.tests.helpers import make_image_file
 from course_discovery.apps.course_metadata.choices import CourseRunPacing
 from course_discovery.apps.course_metadata.tests.factories import (OrganizationFactory, PersonFactory,
                                                                    PersonSocialNetworkFactory, PositionFactory)
@@ -160,16 +159,6 @@ class CourseRunWrapperTests(TestCase):
     def test_course_team_admin(self):
         """ Verify that the wrapper return the course team admin. """
         self.assertEqual(self.wrapped_course_run.course_team_admin, self.course.course_team_admin)
-
-    def test_course_image_url(self):
-        course_run = factories.CourseRunFactory(course__image=None)
-        wrapped_course_run = CourseRunWrapper(course_run)
-        assert wrapped_course_run.course_image_url is None
-
-        course = course_run.course
-        course.image = make_image_file('test_banner1.jpg')
-        course.save()
-        assert wrapped_course_run.course_image_url == course.image.url
 
     def test_course_staff(self):
         """Verify that the wrapper return staff list."""

--- a/course_discovery/apps/publisher/wrappers.py
+++ b/course_discovery/apps/publisher/wrappers.py
@@ -187,10 +187,6 @@ class CourseRunWrapper(BaseWrapper):
         return self.wrapped_obj.course.course_team_admin
 
     @property
-    def course_image_url(self):
-        return self.wrapped_obj.course.course_image_url
-
-    @property
     def course_staff(self):
         staff_list = []
         for staff in self.wrapped_obj.staff.all():


### PR DESCRIPTION
If a course has no associated image, a warning will be logged rather than attempting to access a non-existent file.

EDUCATOR-1462