### PR TITLE
Fix the Course run filters in *In Development* tab.

### DIFF
--- a/course_discovery/apps/publisher/templates/publisher/dashboard/_in_progress.html
+++ b/course_discovery/apps/publisher/templates/publisher/dashboard/_in_progress.html
@@ -8,10 +8,10 @@
             <button type="button" class="btn-neutral btn-small btn-filter active" data-filter-column="-1">{% trans "All" %}
                 <span class="filter-count">{{ in_progress_count }}</span>
             </button>
-            <button type="button" class="btn-neutral btn-small btn-filter" data-filter-column="5">{% trans "With Course Team" %}
+            <button type="button" class="btn-neutral btn-small btn-filter" data-search-value="{{ course_team_status }}" data-filter-column="5">{% trans "With Course Team" %}
                 <span class="filter-count">{{ course_team_count }}</span>
             </button>
-            <button type="button" class="btn-neutral btn-small btn-filter" data-filter-column="6">{% trans "With" %} {{ site_name }}
+            <button type="button" class="btn-neutral btn-small btn-filter" data-search-value="{{ internal_user_status }}" data-filter-column="6">{% trans "With" %} {{ site_name }}
                 <span class="filter-count">{{ internal_user_count }}</span>
             </button>
         </div>

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -114,9 +114,9 @@ class CourseRunListView(mixins.LoginRequiredMixin, ListView):
         else:
             studio_request_courses = []
 
-        context['studio_request_courses'] = [CourseRunWrapper(course_run) for course_run in studio_request_courses]
-        context['unpublished_course_runs'] = [CourseRunWrapper(course_run) for course_run in unpublished_course_runs]
-        context['published_course_runs'] = [CourseRunWrapper(course_run) for course_run in published_course_runs]
+        context['studio_request_courses'] = CourseRunWrapper.get_course_run_wrappers(studio_request_courses)
+        context['unpublished_course_runs'] = CourseRunWrapper.get_course_run_wrappers(unpublished_course_runs)
+        context['published_course_runs'] = CourseRunWrapper.get_course_run_wrappers(published_course_runs)
         context['default_published_days'] = self.default_published_days
 
         in_progress_course_runs = course_runs.filter(
@@ -127,8 +127,8 @@ class CourseRunListView(mixins.LoginRequiredMixin, ListView):
             course_run_state__name=CourseRunStateChoices.Approved,
         ).order_by('-course_run_state__modified')
 
-        context['in_progress_course_runs'] = [CourseRunWrapper(course_run) for course_run in in_progress_course_runs]
-        context['preview_course_runs'] = [CourseRunWrapper(course_run) for course_run in preview_course_runs]
+        context['in_progress_course_runs'] = CourseRunWrapper.get_course_run_wrappers(in_progress_course_runs)
+        context['preview_course_runs'] = CourseRunWrapper.get_course_run_wrappers(preview_course_runs)
 
         # shows 'studio request' tab only to project coordinators
         context['is_project_coordinator'] = is_project_coordinator_user(self.request.user)
@@ -136,9 +136,14 @@ class CourseRunListView(mixins.LoginRequiredMixin, ListView):
         site = Site.objects.first()
         context['site_name'] = 'edX' if 'edx' in site.name.lower() else site.name
 
+        context['course_team_status'] = '{}|{}'.format(
+            CourseRunWrapper.Draft, CourseRunWrapper.AwaitingCourseTeamReview
+        )
         context['course_team_count'] = in_progress_course_runs.filter(
             course_run_state__owner_role=PublisherUserRole.CourseTeam
         ).count()
+
+        context['internal_user_status'] = CourseRunWrapper.AwaitingProjectCoordinatorReview
         context['internal_user_count'] = in_progress_course_runs.exclude(
             course_run_state__owner_role=PublisherUserRole.CourseTeam
         ).count()

--- a/course_discovery/apps/publisher/wrappers.py
+++ b/course_discovery/apps/publisher/wrappers.py
@@ -26,6 +26,17 @@ class BaseWrapper(object):
 
 class CourseRunWrapper(BaseWrapper):
     """Decorator for the ``CourseRun`` model."""
+
+    # course team status
+    Draft = _('Draft')
+    SubmittedForProjectCoordinatorReview = _('Submitted for Project Coordinator Review')
+    AwaitingCourseTeamReview = _('Awaiting Course Team Review')
+
+    # internal user status
+    NotAvailable = _('N/A')
+    AwaitingProjectCoordinatorReview = _('Awaiting Project Coordinator Review')
+    ApprovedByProjectCoordinator = _('Approved by Project Coordinator')
+
     @property
     def title(self):
         return self.wrapped_obj.course.title
@@ -218,23 +229,23 @@ class CourseRunWrapper(BaseWrapper):
     def course_team_status(self):
         course_run_state = self.wrapped_obj.course_run_state
         if course_run_state.is_draft and course_run_state.owner_role == PublisherUserRole.CourseTeam:
-            return _('Draft')
+            return self.Draft
         elif (course_run_state.owner_role == PublisherUserRole.ProjectCoordinator and
               (course_run_state.is_in_review or course_run_state.is_draft)):
-            return _('Submitted for Project Coordinator Review')
+            return self.SubmittedForProjectCoordinatorReview
         elif course_run_state.is_in_review and course_run_state.owner_role == PublisherUserRole.CourseTeam:
-            return _('Awaiting Course Team Review')
+            return self.AwaitingCourseTeamReview
 
     @property
     def internal_user_status(self):
         course_run_state = self.wrapped_obj.course_run_state
         if course_run_state.is_draft and course_run_state.owner_role == PublisherUserRole.CourseTeam:
-            return _('N/A')
+            return self.NotAvailable
         elif (course_run_state.owner_role == PublisherUserRole.ProjectCoordinator and
               (course_run_state.is_in_review or course_run_state.is_draft)):
-            return _('Awaiting Project Coordinator Review')
+            return self.AwaitingProjectCoordinatorReview
         elif course_run_state.is_in_review and course_run_state.owner_role == PublisherUserRole.CourseTeam:
-            return _('Approved by Project Coordinator')
+            return self.ApprovedByProjectCoordinator
 
     @property
     def owner_role_modified(self):
@@ -247,3 +258,13 @@ class CourseRunWrapper(BaseWrapper):
             object_pk=self.wrapped_obj.id,
             comment_type=CommentTypeChoices.Decline_Preview
         ).exists()
+
+    @classmethod
+    def get_course_run_wrappers(cls, course_runs):
+        """
+        Args:
+            course_runs
+        Returns:
+            returns the wrappers of the course runs
+        """
+        return [cls(course_run) for course_run in course_runs]

--- a/course_discovery/static/js/publisher/views/courserun_list.js
+++ b/course_discovery/static/js/publisher/views/courserun_list.js
@@ -65,14 +65,17 @@ $(document).ready(function() {
      });
 
     var inProgressTable = $('.data-table-in-progress').DataTable({
-        "autoWidth": false
+        "autoWidth": false,
+        "search": {
+        "regex": true
+    }
     });
 
     $('.btn-filter').click( function (e) {
-        var searchValue = 'In Review|In Draft',
+        e.preventDefault();
+        var searchValue = $(this).data('search-value'),
             currentFilterColumn = $(this).data('filter-column'),
             oldFilterColumn = $('.btn-filter.active').data('filter-column');
-        e.preventDefault();
         $('.btn-filter').removeClass('active');
         $(this).addClass('active');
 


### PR DESCRIPTION
## [EDUCATOR-1445](https://openedx.atlassian.net/browse/EDUCATOR-1445)

### Description
This PR fixes that filters of course run in *In development* tab not only showing the count also shows the data. 

### How to Test?
**Production**
https://prod-edx-discovery.edx.org/publisher/

- Click on the filters
- Observe there is no data.


**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/
-  Click on the filters
- Observe filters worked correctly

You can use following credentials
_username : Attiya
Password: attiya_


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @noraiz-anwar 
- [x] @waheedahmed  


### Post-review
- [x] Rebase and squash commits
