### PR TITLE
Updated course and course run API endpoints to use stored images

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -419,7 +419,7 @@ class NestedProgramSerializer(serializers.ModelSerializer):
 
 
 class MinimalCourseRunSerializer(TimestampModelSerializer):
-    image = ImageField(read_only=True, source='card_image_url')
+    image = ImageField(read_only=True, source='image_url')
     marketing_url = serializers.SerializerMethodField()
     seats = SeatSerializer(many=True)
 
@@ -528,7 +528,7 @@ class ContainedCourseRunsSerializer(serializers.Serializer):
 class MinimalCourseSerializer(TimestampModelSerializer):
     course_runs = MinimalCourseRunSerializer(many=True)
     owners = MinimalOrganizationSerializer(many=True, source='authoring_organizations')
-    image = ImageField(read_only=True, source='card_image_url')
+    image = ImageField(read_only=True, source='image_url')
 
     @classmethod
     def prefetch_queryset(cls, queryset=None, course_runs=None):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -111,7 +111,7 @@ class MinimalCourseSerializerTests(SiteMixin, TestCase):
             'title': course.title,
             'course_runs': MinimalCourseRunSerializer(course.course_runs, many=True, context=context).data,
             'owners': MinimalOrganizationSerializer(course.authoring_organizations, many=True, context=context).data,
-            'image': ImageField().to_representation(course.card_image_url),
+            'image': ImageField().to_representation(course.image_url),
             'short_description': course.short_description
         }
 
@@ -220,7 +220,7 @@ class MinimalCourseRunSerializerTests(TestCase):
             'uuid': str(course_run.uuid),
             'title': course_run.title,
             'short_description': course_run.short_description,
-            'image': ImageField().to_representation(course_run.card_image_url),
+            'image': ImageField().to_representation(course_run.image_url),
             'marketing_url': '{url}?{params}'.format(
                 url=course_run.marketing_url,
                 params=urlencode({

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -294,6 +294,7 @@ class Course(TimeStampedModel):
     )
     slug = AutoSlugField(populate_from='key', editable=True)
     video = models.ForeignKey(Video, default=None, null=True, blank=True)
+
     # TODO Remove this field.
     number = models.CharField(
         max_length=50, null=True, blank=True, help_text=_(
@@ -311,6 +312,13 @@ class Course(TimeStampedModel):
 
     def __str__(self):
         return '{key}: {title}'.format(key=self.key, title=self.title)
+
+    @property
+    def image_url(self):
+        if self.image:
+            return self.image.url
+
+        return self.card_image_url
 
     @property
     def marketing_url(self):
@@ -404,6 +412,8 @@ class CourseRun(TimeStampedModel):
     pacing_type = models.CharField(max_length=255, db_index=True, null=True, blank=True,
                                    choices=CourseRunPacing.choices, validators=[CourseRunPacing.validator])
     syllabus = models.ForeignKey(SyllabusItem, default=None, null=True, blank=True)
+
+    # TODO Ditch this, and fallback to the course
     card_image_url = models.URLField(null=True, blank=True)
     video = models.ForeignKey(Video, default=None, null=True, blank=True)
     video_translation_languages = models.ManyToManyField(
@@ -494,6 +504,10 @@ class CourseRun(TimeStampedModel):
                 enrollable_seats.append(seat)
 
         return enrollable_seats
+
+    @property
+    def image_url(self):
+        return self.course.image_url
 
     @property
     def program_types(self):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -59,6 +59,13 @@ class CourseTests(ElasticsearchTestMixin, TestCase):
 
         self.assertEqual(actual, courses)
 
+    def test_image_url(self):
+        course = factories.CourseFactory()
+        assert course.image_url == course.image.url
+
+        course.image = None
+        assert course.image_url == course.card_image_url
+
 
 @ddt.ddt
 class CourseRunTests(TestCase):
@@ -320,6 +327,9 @@ class CourseRunTests(TestCase):
             self.course_run.delete()
             # We don't want to delete course run nodes when CourseRuns are deleted.
             assert not mock_delete_obj.called
+
+    def test_image_url(self):
+        assert self.course_run.image_url == self.course_run.course.image_url
 
 
 class OrganizationTests(TestCase):


### PR DESCRIPTION
If a course has an image on the image field, that image's URL will be
used in the API response. Course runs now use the related course's image.

LEARNER-2751