### PR TITLE
Clean up unused SubjectTranslation fields

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -224,7 +224,6 @@ class OrganizationAdmin(admin.ModelAdmin):
 
 @admin.register(Subject)
 class SubjectAdmin(TranslatableAdmin):
-    exclude = ('name_t', 'subtitle_t', 'description_t')  # TODO Remove in the clean up phase LEARNER-2617
     list_display = ('uuid', 'name', 'slug',)
     list_filter = ('partner',)
     readonly_fields = ('uuid',)

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -146,10 +146,6 @@ class SubjectTranslation(TranslatedFieldsModel):
     subtitle = models.CharField(max_length=255, blank=True, null=True)
     description = models.TextField(blank=True, null=True)
 
-    name_t = models.CharField(max_length=255, blank=False, null=False)
-    subtitle_t = models.CharField(max_length=255, blank=True, null=True)
-    description_t = models.TextField(blank=True, null=True)
-
     class Meta:
         unique_together = ('language_code', 'master')
         verbose_name = _('Subject model translations')


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-2617

Next to last part of https://openedx.atlassian.net/browse/LEARNER-2314

The only part left would be the migration to reflect this change

Remove the unused fields in the SubjectTranslation model