### PR TITLE
Updated Publisher to always create an audit seat for verified course runs

### DIFF
--- a/course_discovery/apps/publisher/management/commands/add_audit_seats_to_verified_course_runs.py
+++ b/course_discovery/apps/publisher/management/commands/add_audit_seats_to_verified_course_runs.py
@@ -1,0 +1,31 @@
+import logging
+
+from django.core.management import BaseCommand
+
+from course_discovery.apps.publisher.models import CourseRun, Seat
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Adds audit seats to credit/verified course runs'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--commit',
+                            action='store_true',
+                            dest='commit',
+                            default=False,
+                            help='Commit the new seats to the database')
+
+    def handle(self, *args, **options):
+        course_runs = CourseRun.objects.filter(seats__type__in=(Seat.CREDIT, Seat.VERIFIED,)).exclude(
+            seats__type=Seat.AUDIT)
+        if options['commit']:
+            for course_run in course_runs:
+                seat = course_run.seats.create(type=Seat.AUDIT, price=0, upgrade_deadline=None)
+                course_run_id = course_run.lms_course_id or course_run.id
+                logger.info('Created audit seat [%d] for course run [%s]', seat.id, course_run_id)
+        else:
+            logger.info('The following [%d] course runs lack audit seats...', course_runs.count())
+            for course_run in course_runs:
+                logger.info('\t%s', course_run.lms_course_id or course_run.id)

--- a/course_discovery/apps/publisher/management/commands/tests/test_add_audit_seats_to_verified_course_runs.py
+++ b/course_discovery/apps/publisher/management/commands/tests/test_add_audit_seats_to_verified_course_runs.py
@@ -1,0 +1,25 @@
+import pytest
+from django.core.management import call_command
+
+from course_discovery.apps.publisher.models import Seat
+from course_discovery.apps.publisher.tests.factories import SeatFactory
+
+
+@pytest.mark.django_db
+class TestAddAuditSeats:
+    def test_no_commit(self):
+        seats = SeatFactory.create_batch(3, type=Seat.VERIFIED)
+        call_command('add_audit_seats_to_verified_course_runs')
+        assert Seat.objects.count() == len(seats)
+
+    @pytest.mark.parametrize('seat_type', (Seat.CREDIT, Seat.VERIFIED,))
+    def test_commit(self, seat_type):
+        SeatFactory(type=Seat.AUDIT)
+        SeatFactory(type=Seat.NO_ID_PROFESSIONAL)
+        SeatFactory(type=Seat.PROFESSIONAL)
+
+        seat = SeatFactory(type=seat_type)
+        call_command('add_audit_seats_to_verified_course_runs', '--commit')
+
+        assert seat.course_run.seats.count() == 2
+        assert seat.course_run.seats.filter(type=Seat.AUDIT, price=0).exists()

--- a/course_discovery/apps/publisher/tests/test_signals.py
+++ b/course_discovery/apps/publisher/tests/test_signals.py
@@ -17,7 +17,7 @@ from course_discovery.apps.publisher.tests.factories import CourseRunFactory, Or
 
 @freeze_time('2017-01-01T00:00:00Z')
 @pytest.mark.django_db
-class TestSignals:
+class TestCreateCourseRunInStudio:
     @override_switch('enable_publisher_create_course_run_in_studio', active=True)
     def test_create_course_run_in_studio_without_partner(self):
         with mock.patch('course_discovery.apps.publisher.signals.logger.error') as mock_logger:


### PR DESCRIPTION
The SeatForm implements the logic to create an audit seat for verified
and credit course runs. It also removes audit seats for professional
course runs.

In the longterm, this should be implemented on the UI and exposed to the
end user to avoid future confusion.

LEARNER-2876