### PR TITLE
Corrected certificate_type value when publishing seats to the E-Commerce Service

### DIFF
--- a/course_discovery/apps/publisher/api/tests/test_utils.py
+++ b/course_discovery/apps/publisher/api/tests/test_utils.py
@@ -24,7 +24,7 @@ class TestSerializeSeatForEcommerceApi:
             'attribute_values': [
                 {
                     'name': 'certificate_type',
-                    'value': None,
+                    'value': '',
                 },
                 {
                     'name': 'id_verification_required',

--- a/course_discovery/apps/publisher/api/utils.py
+++ b/course_discovery/apps/publisher/api/utils.py
@@ -10,7 +10,7 @@ def serialize_seat_for_ecommerce_api(seat):
         'attribute_values': [
             {
                 'name': 'certificate_type',
-                'value': None if seat.type == Seat.AUDIT else seat.type,
+                'value': '' if seat.type == Seat.AUDIT else seat.type,
             },
             {
                 'name': 'id_verification_required',


### PR DESCRIPTION
The correct value for audit seats is an empty string, not None/null.

LEARNER-2876