### PR TITLE
Add the ability to access and filter courses by UUID and not just key.

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -128,10 +128,11 @@ class FilterSetMixin:
 
 class CourseFilter(filters.FilterSet):
     keys = CharListFilter(name='key', lookup_expr='in')
+    uuids = UUIDListFilter()
 
     class Meta:
         model = Course
-        fields = ['keys']
+        fields = ('keys', 'uuids',)
 
 
 class CourseRunFilter(FilterSetMixin, filters.FilterSet):

--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -1,2 +1,3 @@
 COURSE_ID_REGEX = r'[^/+]+(/|\+)[^/+]+'
 COURSE_RUN_ID_REGEX = r'[^/+]+(/|\+)[^/+]+(/|\+)[^/]+'
+COURSE_UUID_REGEX = r'[0-9a-f-]+'


### PR DESCRIPTION
Add to the course API endpoint the ability to access a course directly via the UUID.
Also added a uuid course filter that adds the ability to provide a list of UUIDs and get back the information for the courses.

LEARNER-2882