### PR TITLE
Fix the bug left in the course run publish module

### DIFF
--- a/course_discovery/apps/course_metadata/publishers.py
+++ b/course_discovery/apps/course_metadata/publishers.py
@@ -288,7 +288,7 @@ class BaseMarketingSitePublisher:
 
         if new_alias != previous_alias or not new_alias_delete_path:
             # Delete old alias before saving the new one.
-            if previous_obj and previous_obj.marketing_slug != obj.marketing_slug:
+            if previous_obj and self.get_marketing_slug(previous_obj) != self.get_marketing_slug(obj):
                 self.get_and_delete_alias(self.get_marketing_slug(previous_obj))
 
             headers = {

--- a/course_discovery/apps/course_metadata/tests/test_publishers.py
+++ b/course_discovery/apps/course_metadata/tests/test_publishers.py
@@ -329,6 +329,15 @@ class CourseRunMarketingSitePublisherTests(MarketingSitePublisherTestMixin):
 
         responses.reset()
 
+        # A previous object is provided, but the marketing slug hasn't changed.
+        # Neither alias creation nor alias deletion should occur.
+        self.mock_api_client()
+        self.mock_get_delete_form(self.obj.slug)
+
+        self.publisher.update_node_alias(self.obj, self.node_id, self.obj)
+
+        responses.reset()
+
         # In this case, similate the fact that alias form retrival returned error
         # FormRetrievalError should be raised
         self.mock_api_client()


### PR DESCRIPTION
The courseRun object do not have `marketing_slug` property. We should've caught this last time around. 

@clintonb Please review.