### PR TITLE
Fix the course image resolution so the aspect ratio on course image is maintained

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -586,6 +586,7 @@ class CourseSerializer(MinimalCourseSerializer):
     sponsors = OrganizationSerializer(many=True, source='sponsoring_organizations')
     course_runs = CourseRunSerializer(many=True)
     marketing_url = serializers.SerializerMethodField()
+    original_image = ImageField(read_only=True, source='original_image_url')
 
     @classmethod
     def prefetch_queryset(cls, partner, queryset=None, course_runs=None):
@@ -607,6 +608,7 @@ class CourseSerializer(MinimalCourseSerializer):
         fields = MinimalCourseSerializer.Meta.fields + (
             'short_description', 'full_description', 'level_type', 'subjects', 'prerequisites', 'prerequisites_raw',
             'expected_learning_items', 'video', 'sponsors', 'modified', 'marketing_url', 'syllabus_raw', 'outcome',
+            'original_image',
         )
 
     def get_marketing_url(self, obj):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -165,6 +165,7 @@ class CourseSerializerTests(MinimalCourseSerializerTests):
             'prerequisites_raw': course.prerequisites_raw,
             'syllabus_raw': course.syllabus_raw,
             'outcome': course.outcome,
+            'original_image': ImageField().to_representation(course.original_image_url),
         })
 
         return expected

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -305,7 +305,7 @@ class Course(TimeStampedModel):
         null=True,
         variations={
             'original': (2120, 1192),
-            'small': (318, 210)
+            'small': (318, 178)
         },
         help_text=_('Please provide a course preview image')
     )
@@ -333,9 +333,15 @@ class Course(TimeStampedModel):
     @property
     def image_url(self):
         if self.image:
-            return self.image.url
+            return self.image.small.url
 
         return self.card_image_url
+
+    @property
+    def original_image_url(self):
+        if self.image:
+            return self.image.url
+        return None
 
     @property
     def marketing_url(self):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -45,10 +45,17 @@ class TestCourse:
 
     def test_image_url(self):
         course = factories.CourseFactory()
-        assert course.image_url == course.image.url
+        assert course.image_url == course.image.small.url
 
         course.image = None
         assert course.image_url == course.card_image_url
+
+    def test_original_image_url(self):
+        course = factories.CourseFactory()
+        assert course.original_image_url == course.image.url
+
+        course.image = None
+        assert course.original_image_url is None
 
 
 @ddt.ddt


### PR DESCRIPTION
Currently, the course image uploaded to publisher is of resolution 2120X1192
This translates to 318X179 instead of the old 318X210
We will display this image to the front end and we should have the image size correctly.

@clintonb Please review