### PR TITLE
Set time to 23:59:59 for Publisher's default upgrade deadline

### DIFF
--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import random
 
@@ -210,7 +209,7 @@ class CourseRunViewSetTests(APITestCase):
         discovery_course_run = CourseRun.objects.get(key=publisher_course_run.lms_course_id)
         DiscoverySeat.objects.get(
             type=DiscoverySeat.VERIFIED,
-            upgrade_deadline=publisher_course_run.end - datetime.timedelta(days=PUBLISHER_UPGRADE_DEADLINE_DAYS),
+            upgrade_deadline=verified_seat.calculated_upgrade_deadline,
             price=verified_seat.price,
             course_run=discovery_course_run
         )

--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -476,8 +476,12 @@ class Seat(TimeStampedModel, ChangedByMixin):
         will be calculated based on the related course run's end date.
         """
         if self.type == self.VERIFIED:
-            return self.upgrade_deadline or (
-                self.course_run.end - datetime.timedelta(days=settings.PUBLISHER_UPGRADE_DEADLINE_DAYS))
+            if self.upgrade_deadline:
+                return self.upgrade_deadline
+
+            deadline = self.course_run.end - datetime.timedelta(days=settings.PUBLISHER_UPGRADE_DEADLINE_DAYS)
+            deadline = deadline.replace(hour=23, minute=59, second=59, microsecond=99999)
+            return deadline
 
         return None
 

--- a/course_discovery/apps/publisher/tests/test_models.py
+++ b/course_discovery/apps/publisher/tests/test_models.py
@@ -374,6 +374,7 @@ class TestSeatModel:
         now = datetime.datetime.utcnow()
         seat = factories.SeatFactory(type=Seat.VERIFIED, upgrade_deadline=None, course_run__end=now)
         expected = now - datetime.timedelta(days=settings.PUBLISHER_UPGRADE_DEADLINE_DAYS)
+        expected = expected.replace(hour=23, minute=59, second=59, microsecond=99999)
         assert seat.calculated_upgrade_deadline == expected
 
         seat = factories.SeatFactory(type=Seat.VERIFIED)


### PR DESCRIPTION
The default upgrade deadline for Publisher course runs now has the time set to 23:59:59.99999 to give learners the entire day to upgrade.

LEARNER-3056