### PR TITLE
Deep image copy from publisher to discovery

### DIFF
--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -161,7 +161,8 @@ class CourseRunViewSetTests(APITestCase):
         assert discovery_course.full_description == publisher_course.full_description
         assert discovery_course.level_type == publisher_course.level_type
         assert discovery_course.video == Video.objects.get(src=publisher_course.video_link)
-        assert discovery_course.image == publisher_course.image
+        assert discovery_course.image.name is not None
+        assert discovery_course.image.url is not None
         assert discovery_course.outcome == publisher_course.expected_learnings
         assert discovery_course.prerequisites_raw == publisher_course.prerequisites
         assert discovery_course.syllabus_raw == publisher_course.syllabus

--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -104,12 +104,12 @@ class CourseRunViewSet(viewsets.GenericViewSet):
             'full_description': publisher_course.full_description,
             'level_type': publisher_course.level_type,
             'video': video,
-            'image': publisher_course.image,
             'outcome': publisher_course.expected_learnings,
             'prerequisites_raw': publisher_course.prerequisites,
             'syllabus_raw': publisher_course.syllabus,
         }
         discovery_course, created = Course.objects.update_or_create(partner=partner, key=course_key, defaults=defaults)
+        discovery_course.image.save(publisher_course.image.name, publisher_course.image)
         discovery_course.authoring_organizations.add(*publisher_course.organizations.all())
 
         subjects = [subject for subject in set([


### PR DESCRIPTION
@clintonb Please review

When we move the image from Publisher to discovery, a mere assignment means the image reference is copied.
We should instead create a deep copy of the image into our file storage like what we are doing here