### PR TITLE
Validate organization key field

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1,6 +1,7 @@
 import datetime
 import itertools
 import logging
+import re
 from collections import defaultdict
 from urllib.parse import urljoin
 from uuid import uuid4
@@ -175,7 +176,7 @@ class Organization(TimeStampedModel):
     """ Organization model. """
     partner = models.ForeignKey(Partner, null=True, blank=False)
     uuid = models.UUIDField(blank=False, null=False, default=uuid4, editable=False, verbose_name=_('UUID'))
-    key = models.CharField(max_length=255)
+    key = models.CharField(max_length=255, help_text=_('Only ascii characters allowed (a-zA-Z0-9)'))
     name = models.CharField(max_length=255)
     marketing_url_path = models.CharField(max_length=255, null=True, blank=True)
     description = models.TextField(null=True, blank=True)
@@ -191,6 +192,10 @@ class Organization(TimeStampedModel):
         blank=True,
         help_text=_('Pick a tag from the suggestions. To make a new tag, add a comma after the tag name.'),
     )
+
+    def clean(self):
+        if not re.match("^[a-zA-Z0-9_-]*$", self.key):
+            raise ValidationError(_('Please do not use any spaces or special characters in the key field'))
 
     class Meta:
         unique_together = (

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -331,12 +331,37 @@ class CourseRunTests(TestCase):
         assert self.course_run.image_url == self.course_run.course.image_url
 
 
+@ddt.ddt
 class OrganizationTests(TestCase):
     """ Tests for the `Organization` model. """
 
     def setUp(self):
         super(OrganizationTests, self).setUp()
         self.organization = factories.OrganizationFactory()
+
+    @ddt.data(
+        "key with space",
+        "key[with,special",
+        "keyó"
+    )
+    def test_clean_error(self, key):
+        """
+        Verify that the clean method raises validation error if key consists of special characters
+        """
+        self.organization.key = key
+        self.assertRaises(ValidationError, self.organization.clean)
+
+    @ddt.data(
+        "keywithoutspace",
+        "correctkey",
+        "correct_key"
+    )
+    def test_clean_success(self, key):
+        """
+        Verify that the clean method returns None if key is valid
+        """
+        self.organization.key = key
+        self.assertEqual(self.organization.clean(), None)
 
     def test_str(self):
         """ Verify casting an instance to a string returns a string containing the key and name. """

--- a/course_discovery/conf/locale/en/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/en/LC_MESSAGES/django.po
@@ -294,6 +294,10 @@ msgid "Subject model translations"
 msgstr ""
 
 #: apps/course_metadata/models.py
+msgid "Only ascii characters allowed (a-zA-Z0-9)"
+msgstr ""
+
+#: apps/course_metadata/models.py
 msgid ""
 "Logo to be displayed on certificates. If this logo is the same as "
 "logo_image_url, copy and paste the same value to both fields."
@@ -303,6 +307,10 @@ msgstr ""
 msgid ""
 "Pick a tag from the suggestions. To make a new tag, add a comma after the "
 "tag name."
+msgstr ""
+
+#: apps/course_metadata/models.py
+msgid "Please do not use any spaces or special characters in the key field"
 msgstr ""
 
 #: apps/course_metadata/models.py

--- a/course_discovery/conf/locale/eo/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/eo/LC_MESSAGES/django.po
@@ -347,6 +347,12 @@ msgid "Subject model translations"
 msgstr "Süßjéçt mödél tränslätïöns Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
 
 #: apps/course_metadata/models.py
+msgid "Only ascii characters allowed (a-zA-Z0-9)"
+msgstr ""
+"Önlý äsçïï çhäräçtérs ällöwéd (ä-zÀ-Z0-9) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"¢σηѕє¢тєтυя #"
+
+#: apps/course_metadata/models.py
 msgid ""
 "Logo to be displayed on certificates. If this logo is the same as "
 "logo_image_url, copy and paste the same value to both fields."
@@ -361,6 +367,12 @@ msgid ""
 msgstr ""
 "Pïçk ä täg fröm thé süggéstïöns. Tö mäké ä néw täg, ädd ä çömmä äftér thé "
 "täg nämé. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
+
+#: apps/course_metadata/models.py
+msgid "Please do not use any spaces or special characters in the key field"
+msgstr ""
+"Pléäsé dö nöt üsé äný späçés ör spéçïäl çhäräçtérs ïn thé kéý fïéld Ⱡ'σяєм "
+"ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
 
 #: apps/course_metadata/models.py
 msgid "People"


### PR DESCRIPTION
## [EDUCATOR-1666](https://openedx.atlassian.net/browse/EDUCATOR-1666)

### Description
Validate Key field in Course metadata Organization model to allow only ascii characters (no special characters or unicode characters allowed)

**Sandbox**
- N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001   
- [ ] @attiyaIshaque  

### Post-review
- [ ] Rebase and squash commits
