### PR TITLE
Update the instructor API to provide just one profile image property

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -247,7 +247,7 @@ class PositionSerializer(serializers.ModelSerializer):
 class PersonSerializer(serializers.ModelSerializer):
     """Serializer for the ``Person`` model."""
     position = PositionSerializer(required=False)
-    profile_image = StdImageSerializerField(required=False)
+    profile_image = serializers.CharField(read_only=True, source='get_profile_image_url')
     works = serializers.SlugRelatedField(many=True, read_only=True, slug_field='value', source='person_works')
     urls = serializers.SerializerMethodField()
     email = serializers.EmailField(required=True)
@@ -261,7 +261,7 @@ class PersonSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Person
         fields = (
-            'uuid', 'given_name', 'family_name', 'bio', 'profile_image_url', 'slug', 'position', 'profile_image',
+            'uuid', 'given_name', 'family_name', 'bio', 'slug', 'position', 'profile_image',
             'partner', 'works', 'urls', 'email'
         )
         extra_kwargs = {

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1104,35 +1104,38 @@ class SeatSerializerTests(TestCase):
 
 
 class PersonSerializerTests(TestCase):
-    def test_data(self):
+    def setUp(self):
         request = make_request()
-        context = {'request': request}
-        image_field = StdImageSerializerField()
-        image_field._context = context  # pylint: disable=protected-access
+        self.context = {'request': request}
 
         position = PositionFactory()
-        person = position.person
-        serializer = PersonSerializer(person, context=context)
-
-        expected = {
-            'uuid': str(person.uuid),
-            'given_name': person.given_name,
-            'family_name': person.family_name,
-            'bio': person.bio,
-            'profile_image_url': person.profile_image_url,
-            'profile_image': image_field.to_representation(person.profile_image),
+        self.person = position.person
+        self.expected = {
+            'uuid': str(self.person.uuid),
+            'given_name': self.person.given_name,
+            'family_name': self.person.family_name,
+            'bio': self.person.bio,
+            'profile_image': self.person.profile_image_url,
             'position': PositionSerializer(position).data,
-            'works': [work.value for work in person.person_works.all()],
+            'works': [work.value for work in self.person.person_works.all()],
             'urls': {
                 'facebook': None,
                 'twitter': None,
                 'blog': None
             },
-            'slug': person.slug,
-            'email': person.email,
+            'slug': self.person.slug,
+            'email': self.person.email,
         }
 
-        self.assertDictEqual(serializer.data, expected)
+    def test_data(self):
+        serializer = PersonSerializer(self.person, context=self.context)
+        self.assertDictEqual(serializer.data, self.expected)
+
+    def test_profile_image_url_override(self):
+        self.person.profile_image_url = None
+        self.expected['profile_image'] = self.person.profile_image.url
+        serializer = PersonSerializer(self.person, context=self.context)
+        self.assertDictEqual(serializer.data, self.expected)
 
 
 class PositionSerializerTests(TestCase):


### PR DESCRIPTION
Make sure the API `profile_image` property reflect the profile image associated with instructor.

@clintonb Please review.
I am changing the API signature here. But I think no one is using this part of the API. So, I feel ok.
If you don't agree, I can add the `profile_image_url` property back into the API