### PR TITLE
[ENT-676] Add course run tags to course run serializer.

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -476,7 +476,7 @@ class MinimalCourseRunSerializer(TimestampModelSerializer):
         )
 
 
-class CourseRunSerializer(MinimalCourseRunSerializer):
+class CourseRunSerializer(TaggitSerializer, MinimalCourseRunSerializer):
     """Serializer for the ``CourseRun`` model."""
     course = serializers.SlugRelatedField(read_only=True, slug_field='key')
     content_language = serializers.SlugRelatedField(
@@ -489,6 +489,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
     instructors = serializers.SerializerMethodField(help_text='This field is deprecated. Use staff.')
     staff = PersonSerializer(many=True)
     level_type = serializers.SlugRelatedField(read_only=True, slug_field='name')
+    tags = TagListSerializerField()
 
     @classmethod
     def prefetch_queryset(cls, queryset=None):
@@ -506,6 +507,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
             'course', 'full_description', 'announcement', 'video', 'seats', 'content_language', 'license',
             'transcript_languages', 'instructors', 'staff', 'min_effort', 'max_effort', 'weeks_to_complete', 'modified',
             'level_type', 'availability', 'mobile_available', 'hidden', 'reporting_type', 'eligible_for_financial_aid',
+            'tags',
         )
 
     def get_instructors(self, obj):  # pylint: disable=unused-argument

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -289,6 +289,7 @@ class CourseRunSerializerTests(MinimalCourseRunSerializerTests):
             'reporting_type': course_run.reporting_type,
             'status': course_run.status,
             'license': course_run.license,
+            'tags': [],
         })
 
         return expected

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -179,7 +179,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
             # to be included.
             filtered_course_run = CourseRunFactory(course=course)
 
-            with self.assertNumQueries(20):
+            with self.assertNumQueries(21):
                 response = self.client.get(url)
 
             assert response.status_code == 200

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -32,7 +32,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns the details for a single course. """
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -44,7 +44,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data.get('programs') == []
@@ -59,7 +59,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
         url += '?include_deleted_programs=1'
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(14):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data == \
@@ -71,7 +71,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get(url)
             assert response.status_code == 200
             assert response.data.get('programs') == []
@@ -86,7 +86,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
         url += '?include_unpublished_programs=1'
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(14):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data == \
@@ -126,7 +126,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns a list of all course runs. """
         url = reverse('api:v1:course_run-list')
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(13):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -139,7 +139,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns a list of all course runs sorted by start date. """
         url = '{root}?ordering=start'.format(root=reverse('api:v1:course_run-list'))
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(13):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -155,7 +155,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(36):
+        with self.assertNumQueries(39):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])


### PR DESCRIPTION
We were not previously getting the `tags` detail for course runs when querying for course runs or courses. We want to integrate with Degreed and they optionally ask for course tags to be sent along in the payload. We get our course data from course discovery, so we want this information.

**JIRA tickets**: [ENT-676](https://openedx.atlassian.net/browse/ENT-676)

**Merge deadline**: ASAP

**Testing instructions**:

1. Be on `master`.
1. Go to `/api/v1/courses`, and see no `tags` field in the serialized data.
1. Go to `/api/v1/courses/{course_key}` and see no `tags` field in the serialized data.
1. Go to `/api/v1/course_runs`, and see no `tags` field in the serialized data.
1. Go to `/api/v1/course_runs/{course_run_key}` and see no `tags` field in the serialized data.
1. Checkout this branch for course-discovery and restart the service.
1. Go to `/api/v1/courses/`, and see that `tags` is now serialized.
1. Go to `/api/v1/courses/{course_key}`, and see that `tags` is now serialized.
1. Go to `/api/v1/course_runs/`, and see that `tags` is now serialized.
1. Go to `/api/v1/course_runs/{course_run_key}`, and see that `tags` is now serialized.

**Reviewers**
- [ ] @itsjeyd  
- [ ] @douglashall 