### PR TITLE
EDUCATOR-1673 Fix sorting on edX status and Last Handoff column.

### DIFF
--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -1909,6 +1909,29 @@ class CourseListViewPaginationTests(PaginationMixin, TestCase):
             assert course['course_team_status'] == ''
             assert course['internal_user_status'] == ''
 
+    @ddt.data(
+        {'column': 6, 'direction': 'asc'},
+        {'column': 6, 'direction': 'desc'},
+    )
+    @ddt.unpack
+    def test_ordering_with_internal_user_status(self, column, direction):
+        """
+        Verify that ordering by internal user status is working as expected.
+        """
+
+        self.course_state = factories.CourseStateFactory(owner_role=PublisherUserRole.CourseTeam)
+        self.course_state.marketing_reviewed = True
+        self.course_state.save()
+
+        for page in (1, 2, 3):
+            courses = self.get_courses(
+                query_params={'sortColumn': column, 'sortDirection': direction, 'pageSize': 4, 'page': page}
+            )
+            internal_users_statuses = [course['internal_user_status'] for course in courses]
+            self.assertEqual(sorted(internal_users_statuses,
+                                    reverse=self.sort_directions[direction]),
+                             internal_users_statuses)
+
 
 class CourseDetailViewTests(TestCase):
     """ Tests for the course detail view. """


### PR DESCRIPTION
## [EDUCATOR-1673](https://openedx.atlassian.net/browse/EDUCATOR-1673)

### Description
This PR fixes the sorting on *edX status* and *Last Handoff* column on the publisher courses page.

### How to Test?

**Production**
- https://prod-edx-discovery.edx.org/publisher/courses/
- Sort the columns *edX status* or *Last handoff*
- Observe columns is not sorting properly.


**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/
- Sort the columns *edX status* or *Last handoff*
- Observe columns are sorting properly.

You can use following credentials
_username : Attiya
Password: attiya_

### Test
- [x] Unit Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @tasawernawaz 
- [x] Code review: @asadazam93 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [x] Rebase and squash commits

