### PR TITLE
Fix the edX status column sorting on the courses page.

### DIFF
--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -1910,22 +1910,21 @@ class CourseListViewPaginationTests(PaginationMixin, TestCase):
             assert course['internal_user_status'] == ''
 
     @ddt.data(
-        {'column': 6, 'direction': 'asc'},
-        {'column': 6, 'direction': 'desc'},
+        {'direction': 'asc'},
+        {'direction': 'desc'},
     )
     @ddt.unpack
-    def test_ordering_with_internal_user_status(self, column, direction):
+    def test_ordering_with_edx_status_column(self, direction):
         """
-        Verify that ordering by internal user status is working as expected.
+        Verify that ordering by edx status column is working as expected.
         """
-
         self.course_state = factories.CourseStateFactory(owner_role=PublisherUserRole.CourseTeam)
         self.course_state.marketing_reviewed = True
         self.course_state.save()
 
         for page in (1, 2, 3):
             courses = self.get_courses(
-                query_params={'sortColumn': column, 'sortDirection': direction, 'pageSize': 4, 'page': page}
+                query_params={'sortColumn': 6, 'sortDirection': direction, 'pageSize': 4, 'page': page}
             )
             internal_users_statuses = [course['internal_user_status'] for course in courses]
             self.assertEqual(sorted(internal_users_statuses,


### PR DESCRIPTION
## [EDUCATOR-1735](https://openedx.atlassian.net/browse/EDUCATOR-1735)

### Description
This PR fixes the sorting on *edX status* colums on the publisher course page. It wouldn't load all the courses and the pagination would work correctly.

### How to Test?

**Production**
- https://prod-edx-discovery.edx.org/publisher/courses/
- Sort the column *edX status* 
- Observe it loads all the course and pagination does not work properly.


**Sandbox**
- https://discovery-escalation-discovery.sandbox.edx.org/publisher/courses/
- Sort the columns *example.com status* 
- Observe column are sorting properly and pagination works properly.

You can use following credentials
_username : Attiya
Password: attiya_

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @schenedx 
- [x] Code review: @asadazam93 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [x] Rebase and squash commits

