### PR TITLE
Load Prerequisite and syllabus raw data from marketing site

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/marketing_site.py
@@ -493,6 +493,8 @@ class CourseMarketingSiteDataLoader(AbstractMarketingSiteDataLoader):
             'level_type': self.get_level_type(data['field_course_level']),
             'card_image_url': self._get_nested_url(data.get('field_course_image_promoted')),
             'outcome': (data.get('field_course_what_u_will_learn', {}) or {}).get('value'),
+            'syllabus_raw': (data.get('field_course_syllabus', {}) or {}).get('value'),
+            'prerequisites_raw': (data.get('field_course_prerequisites', {}) or {}).get('value'),
         }
 
         return defaults

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -1333,7 +1333,10 @@ UNIQUE_MARKETING_SITE_API_COURSE_BODIES = [
         'field_course_status': 'past',
         'field_course_start_override': None,
         'field_course_email': None,
-        'field_course_syllabus': [],
+        'field_course_syllabus': {
+            'value': 'Module 1: Introducing Azure Data Catalog \n Module 2:',
+            'format': 'basic_html'
+        },
         'field_course_prerequisites': {
             'value': '<p>None. CS50x is designed for students with or without prior programming experience.</p>',
             'format': 'standard_html'

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
@@ -480,6 +480,8 @@ class CourseMarketingSiteDataLoaderTests(AbstractMarketingSiteDataLoaderTestMixi
             'level_type': self.loader.get_level_type(data['field_course_level']),
             'card_image_url': (data.get('field_course_image_promoted') or {}).get('url'),
             'outcome': (data.get('field_course_what_u_will_learn', {}) or {}).get('value'),
+            'syllabus_raw': (data.get('field_course_syllabus', {}) or {}).get('value'),
+            'prerequisites_raw': (data.get('field_course_prerequisites', {}) or {}).get('value'),
         }
 
         for field, value in expected_values.items():


### PR DESCRIPTION
This is to load the prerequisite and syllabus data from marketing site and populate them into course object in course_metadata
@clintonb Please review