### PR TITLE
Display verified seat if it exists over audit

### DIFF
--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -31,6 +31,8 @@ from course_discovery.apps.publisher.validators import ImageSizeValidator
 
 logger = logging.getLogger(__name__)
 
+PAID_SEATS = ['verified', 'professional']
+
 
 class ChangedByMixin(models.Model):
     changed_by = models.ForeignKey(User, null=True, blank=True)

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -2837,6 +2837,17 @@ class CourseRunEditViewTests(SiteMixin, TestCase):
 
         toggle_switch('enable_publisher_email_notifications', True)
 
+    def test_edit_page_with_two_seats(self):
+        """
+        Verify that if a course run has both audit and verified seats, Verified seat is displayed
+        on the course run edit page
+        """
+        factories.SeatFactory(course_run=self.course_run, type=Seat.AUDIT)
+        self.edit_page_url = reverse('publisher:publisher_course_runs_edit', kwargs={'pk': self.course_run.id})
+        response = self.client.get(self.edit_page_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, '<div id="SeatPriceBlock" class="col col-6 hidden" style="display: block;">')
+
     def _post_data(self, data, course, course_run):
         course_dict = model_to_dict(course)
         course_dict.update(**data)

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -31,8 +31,8 @@ from course_discovery.apps.publisher.dataloader.create_courses import process_co
 from course_discovery.apps.publisher.emails import send_email_for_published_course_run_editing
 from course_discovery.apps.publisher.forms import (AdminImportCourseForm, CourseForm, CourseRunForm, CourseSearchForm,
                                                    SeatForm)
-from course_discovery.apps.publisher.models import (Course, CourseRun, CourseRunState, CourseState, CourseUserRole,
-                                                    OrganizationExtension, Seat, UserAttributes)
+from course_discovery.apps.publisher.models import (PAID_SEATS, Course, CourseRun, CourseRunState, CourseState,
+                                                    CourseUserRole, OrganizationExtension, Seat, UserAttributes)
 from course_discovery.apps.publisher.utils import (get_internal_users, has_role_for_course, is_internal_user,
                                                    is_project_coordinator_user, is_publisher_admin, make_bread_crumbs)
 from course_discovery.apps.publisher.wrappers import CourseRunWrapper
@@ -718,7 +718,11 @@ class CourseRunEditView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMix
         context['run_form'] = self.run_form(
             instance=course_run, is_project_coordinator=context.get('is_project_coordinator')
         )
-        context['seat_form'] = self.seat_form(instance=course_run.seats.first())
+        course_run_paid_seat = course_run.seats.filter(type__in=PAID_SEATS).first()
+        if course_run_paid_seat:
+            context['seat_form'] = self.seat_form(instance=course_run_paid_seat)
+        else:
+            context['seat_form'] = self.seat_form(instance=course_run.seats.first())
 
         start_date = course_run.start.strftime("%B %d, %Y") if course_run.start else None
         context['breadcrumbs'] = make_bread_crumbs(


### PR DESCRIPTION
## [EDUCATOR-1602](https://openedx.atlassian.net/browse/EDUCATOR-1602)

### Description
If a course run has more than one seat and if one of those is a paid seat, the paid seat should be displayed over the audit seat in publisher.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @schenedx    
- [ ] @noraiz-anwar

### Post-review
- [ ] Rebase and squash commits
