### PR TITLE
Fix create course run creation issue

### DIFF
--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -505,7 +505,7 @@ class CourseDetailView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMixi
         return context
 
 
-class CreateCourseRunView(mixins.LoginRequiredMixin, CreateView):
+class CreateCourseRunView(mixins.LoginRequiredMixin, mixins.PublisherUserRequiredMixin, CreateView):
     """ Create Course Run View."""
     model = CourseRun
     run_form = CourseRunForm


### PR DESCRIPTION
[EDUCATOR-1790: Unknown Publisher user created course run in Publisher](https://openedx.atlassian.net/browse/EDUCATOR-1790)
-
Background:
-
Course team saw a course run which was created by a non-course team member. The issue was that were no restrictions on the create new course URL, hence it allows any logged in user to create a course run for any course. The fix will enforce `PublisherUserRequiredMixin` to the view.
