### PR TITLE
use slug for entitlement mode serialization

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -400,7 +400,7 @@ class CourseEntitlementSerializer(serializers.ModelSerializer):
     )
     currency = serializers.SlugRelatedField(read_only=True, slug_field='code')
     sku = serializers.CharField()
-    mode = serializers.SlugRelatedField(slug_field='name', queryset=SeatType.objects.all())
+    mode = serializers.SlugRelatedField(slug_field='slug', queryset=SeatType.objects.all())
     expires = serializers.DateTimeField()
 
     @classmethod


### PR DESCRIPTION
So that course entitlement modes do not have to be converted to lower case everywhere that they are used programatically, the serializer should use slug rather than name for the related field.

This issue became evident in work on [LEARNER-3082](https://openedx.atlassian.net/browse/LEARNER-3082) in [this PR](https://github.com/edx/edx-platform/pull/16619)