### PR TITLE
Fix republish_course_image management command

### DIFF
--- a/course_discovery/apps/publisher/management/commands/republish_course_images.py
+++ b/course_discovery/apps/publisher/management/commands/republish_course_images.py
@@ -33,7 +33,11 @@ class Command(BaseCommand):
         start_id = options.get('start_id')
         end_id = options.get('end_id')
 
-        publisher_courses = PublisherCourse.objects.filter(id__range=(start_id, end_id), image__isnull=False)
+        publisher_courses = PublisherCourse.objects.filter(
+            id__range=(start_id, end_id),
+            image__isnull=False
+        ).exclude(image='')
+
         for publisher_course in publisher_courses:
             discovery_course = None
             try:


### PR DESCRIPTION
We should filter out those publisher courses without the image stored in the object
@feanil Please review