### PR TITLE
Stop updating title of the course based on the data from Studio

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -112,11 +112,13 @@ class CoursesApiDataLoader(AbstractDataLoader):
             try:
                 body = self.clean_strings(body)
                 course_run = self.get_course_run(body)
-
                 if course_run:
                     self.update_course_run(course_run, body)
                     course = getattr(course_run, 'canonical_for_course', False)
-                    if course:
+                    if course and not self.partner.has_marketing_site:
+                        # If the partner have marketing site,
+                        # we should only update the course information from the marketing site.
+                        # Therefore, we don't need to do the statements below
                         course = self.update_course(course, body)
                         logger.info('Processed course with key [%s].', course.key)
                 else:

--- a/course_discovery/apps/course_metadata/data_loaders/marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/marketing_site.py
@@ -372,7 +372,11 @@ class CourseMarketingSiteDataLoader(AbstractMarketingSiteDataLoader):
                         course = self.update_course(course_run.course, data)
                         self.set_subjects(course, data)
                         self.set_authoring_organizations(course, data)
-                        logger.info('Processed course with key [%s].', course.key)
+                        logger.info(
+                            'Processed course with key [%s] based on the data from courserun [%s]',
+                            course.key,
+                            course_run.key
+                        )
                     except AttributeError:
                         pass
                 else:


### PR DESCRIPTION
EDUCATOR-1818
The title of the studio is not source of truth. The marketing site data is the source of truth for Course Title