### PR TITLE
Point the image URL index to the correct property on course_run object

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1258,7 +1258,7 @@ class CourseRunSearchSerializerTests(ElasticsearchTestMixin, TestCase):
             'org': course_run_key.org,
             'number': course_run_key.course,
             'seat_types': course_run.seat_types,
-            'image_url': course_run.card_image_url,
+            'image_url': course_run.image_url,
             'type': course_run.type,
             'level_type': course_run.level_type.name,
             'availability': course_run.availability,

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -158,7 +158,7 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     slug = indexes.CharField(model_attr='slug', null=True)
     seat_types = indexes.MultiValueField(model_attr='seat_types', null=True, faceted=True)
     type = indexes.CharField(model_attr='type', null=True, faceted=True)
-    image_url = indexes.CharField(model_attr='card_image_url', null=True)
+    image_url = indexes.CharField(model_attr='image_url', null=True)
     partner = indexes.CharField(null=True, faceted=True)
     program_types = indexes.MultiValueField()
     published = indexes.BooleanField(null=False, faceted=True)


### PR DESCRIPTION
If we don't do this, I believe we have issues displaying the correct images on queries like 
https://prod-edx-discovery.edx.org/api/v1/search/all/facets/?q=support
EDUCATOR-1840
@MatthewPiatetsky @amangano-edx Please review