### PR TITLE
Allow video object override on course_run level

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -507,7 +507,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         help_text=_('Language in which the course is administered')
     )
     transcript_languages = serializers.SlugRelatedField(many=True, read_only=True, slug_field='code')
-    video = VideoSerializer()
+    video = VideoSerializer(source='get_video')
     seats = SeatSerializer(many=True)
     instructors = serializers.SerializerMethodField(help_text='This field is deprecated. Use staff.')
     staff = PersonSerializer(many=True)

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -731,6 +731,10 @@ class CourseRun(TimeStampedModel):
         else:
             return _('Upcoming')
 
+    @property
+    def get_video(self):
+        return self.video or self.course.video
+
     @classmethod
     def search(cls, query):
         """ Queries the search index.

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -356,6 +356,12 @@ class CourseRunTests(TestCase):
     def test_image_url(self):
         assert self.course_run.image_url == self.course_run.course.image_url
 
+    def test_get_video(self):
+        assert self.course_run.get_video == self.course_run.video
+        self.course_run.video = None
+        self.course_run.save()
+        assert self.course_run.get_video == self.course_run.course.video
+
 
 @ddt.ddt
 class OrganizationTests(TestCase):


### PR DESCRIPTION
This would allow the course level video object to be surfaced to the course_run level for display.
