### PR TITLE
Corrected email content sent to PC

### DIFF
--- a/course_discovery/apps/publisher/emails.py
+++ b/course_discovery/apps/publisher/emails.py
@@ -269,8 +269,8 @@ def send_email_for_mark_as_reviewed_course_run(course_run, user, site):
             user (Object): User object
             site (Site): Current site
     """
-    txt_template = 'publisher/email/course_run/mark_as_reviewed.txt'
-    html_template = 'publisher/email/course_run/mark_as_reviewed.html'
+    txt_template = 'publisher/email/course_run/mark_as_reviewed_pc.txt'
+    html_template = 'publisher/email/course_run/mark_as_reviewed_pc.html'
     course = course_run.course
     course_key = CourseKey.from_string(course_run.lms_course_id)
     subject = _('Review complete: {course_name} {run_number}').format(  # pylint: disable=no-member

--- a/course_discovery/apps/publisher/templates/publisher/email/course_run/mark_as_reviewed_pc.html
+++ b/course_discovery/apps/publisher/templates/publisher/email/course_run/mark_as_reviewed_pc.html
@@ -1,0 +1,30 @@
+{% extends "publisher/email/email_base.html" %}
+{% load i18n %}
+{% block body %}
+<!-- Message Body -->
+    <p>
+        {% blocktrans trimmed %}
+            Dear {{ recipient_name }},
+        {% endblocktrans %}
+    <p>
+        {% blocktrans with link_start='<a href="' link_middle='">' link_end='</a>' trimmed %}
+            {{ sender_team }} has reviewed the {{ link_start }}{{ page_url }}{{ link_middle }}{{ run_number }} course run{{ link_end }} of {{ course_name }} and has not added comments or suggested edits. The review for this course run is complete.
+        {% endblocktrans %}
+    </p>
+    <p>
+        <b>
+            {% trans "Additionally, please check the comments in Publisher for information about OFAC blocking." %}
+        </b>
+    </p>
+
+    {% comment %}Translators: It's closing of mail.{% endcomment %}
+    {% trans "Thanks," %}<br>
+    {{ sender_name }}
+
+
+{% blocktrans trimmed %}
+    <p>Note: This email address is unable to receive replies. For questions or comments, contact {{ contact_us_email }}.</p>
+{% endblocktrans %}
+
+<!-- End Message Body -->
+{% endblock body %}

--- a/course_discovery/apps/publisher/templates/publisher/email/course_run/mark_as_reviewed_pc.txt
+++ b/course_discovery/apps/publisher/templates/publisher/email/course_run/mark_as_reviewed_pc.txt
@@ -1,0 +1,16 @@
+{% load i18n %}
+
+{% blocktrans trimmed %}
+    Dear {{ recipient_name }},
+{% endblocktrans %}
+{% blocktrans trimmed %}
+     The {{ sender_team }} has reviewed the {{ run_number }} {{ page_url }} course run of {{ course_name }} and has not added comments or suggested edits. The review for this course run is complete.
+{% endblocktrans %}
+{% trans "Additionally, please check the comments in Publisher for information about OFAC blocking." %}
+
+{% trans "Thanks," %}
+{{ sender_name }}
+
+{% blocktrans trimmed %}
+    Note: This email address is unable to receive replies. For questions or comments, contact {{ contact_us_email }}.
+{% endblocktrans %}


### PR DESCRIPTION
## [EDUCATOR-1849](https://openedx.atlassian.net/browse/EDUCATOR-1849)

### Description
Corrected the content of the email sent to project coordinator when the course team marks the course run as approved. It previously sent the same email to the PC that is sent to publisher.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @noraiz-anwar    
- [x] @awaisdar001

### Post-review
- [ ] Rebase and squash commits
