### PR TITLE
Leave Publisher modified time stamp unchanged with import_courses management command

### DIFF
--- a/course_discovery/apps/publisher/dataloader/update_course_runs.py
+++ b/course_discovery/apps/publisher/dataloader/update_course_runs.py
@@ -29,7 +29,7 @@ def update_course_run(publisher_course_run):
                 publisher_course_run.full_description_override = course_run_metadata.full_description_override
                 publisher_course_run.title_override = course_run_metadata.title_override
 
-                publisher_course_run.save()
+                publisher_course_run.save(update_modified=False)
                 logger.info(
                     'Update course-run import with id [%s], lms_course_id [%s].',
                     publisher_course_run.id, publisher_course_run.lms_course_id

--- a/course_discovery/apps/publisher/management/commands/tests/test_import_courses.py
+++ b/course_discovery/apps/publisher/management/commands/tests/test_import_courses.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import ddt
 import mock
@@ -290,6 +291,18 @@ class CreateCoursesTests(TestCase):
                     )
                 ),
             )
+
+    def test_course_without_modified_updated(self):
+        call_command(self.command_name, *self.command_args)
+        publisher_course = Publisher_Course.objects.all().first()
+        modified_timestamp = publisher_course.modified
+        assert modified_timestamp != self.course.modified
+        self.course.short_description = 'random'
+        self.course.save()
+        call_command(self.command_name, *self.command_args)
+        publisher_course = Publisher_Course.objects.all().first()
+        assert publisher_course.short_description == 'random'
+        assert publisher_course.modified == modified_timestamp
 
     def _assert_course_image(self, publisher_course):
         if self.course.image or self.course.card_image_url:


### PR DESCRIPTION
We do not want to change the modified time stamp because the "published date" in Publisher associated with course_run is based on the modified time stamp.
EDUCATOR-1923