### PR TITLE
Validate course run state via admin

### DIFF
--- a/course_discovery/apps/publisher/admin.py
+++ b/course_discovery/apps/publisher/admin.py
@@ -9,8 +9,10 @@ from course_discovery.apps.publisher.choices import InternalUserRole
 from course_discovery.apps.publisher.constants import (INTERNAL_USER_GROUP_NAME, PARTNER_MANAGER_GROUP_NAME,
                                                        PROJECT_COORDINATOR_GROUP_NAME, PUBLISHER_GROUP_NAME,
                                                        REVIEWER_GROUP_NAME)
-from course_discovery.apps.publisher.forms import (CourseRunAdminForm, OrganizationExtensionForm,
-                                                   PublisherUserCreationForm, UserAttributesAdminForm)
+from course_discovery.apps.publisher.forms import (
+    CourseRunAdminForm, CourseRunStateAdminForm, OrganizationExtensionForm,
+    PublisherUserCreationForm, UserAttributesAdminForm
+)
 from course_discovery.apps.publisher.models import (Course, CourseRun, CourseRunState, CourseState, CourseUserRole,
                                                     OrganizationExtension, OrganizationUserRole, PublisherUser, Seat,
                                                     UserAttributes)
@@ -79,6 +81,7 @@ class CourseStateAdmin(SimpleHistoryAdmin):
 
 @admin.register(CourseRunState)
 class CourseRunStateAdmin(SimpleHistoryAdmin):
+    form = CourseRunStateAdminForm
     raw_id_fields = ('changed_by',)
     list_display = ['id', 'name', 'approved_by_role', 'owner_role',
                     'course_run', 'owner_role_modified', 'preview_accepted']

--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -14,9 +14,11 @@ from opaque_keys.edx.keys import CourseKey
 from course_discovery.apps.course_metadata.choices import CourseRunPacing
 from course_discovery.apps.course_metadata.models import LevelType, Organization, Person, Subject
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
+from course_discovery.apps.publisher.choices import CourseRunStateChoices, PublisherUserRole
 from course_discovery.apps.publisher.mixins import LanguageModelSelect2Multiple, get_user_organizations
 from course_discovery.apps.publisher.models import (
-    Course, CourseRun, CourseUserRole, OrganizationExtension, OrganizationUserRole, PublisherUser, Seat, User
+    Course, CourseRun, CourseRunState, CourseUserRole, OrganizationExtension, OrganizationUserRole, PublisherUser,
+    Seat, User
 )
 from course_discovery.apps.publisher.utils import VALID_CHARS_IN_COURSE_NUM_AND_ORG_KEY, is_internal_user
 from course_discovery.apps.publisher.validators import validate_text_count
@@ -527,6 +529,21 @@ class CourseRunAdminForm(forms.ModelForm):
             return lms_course_id
 
         return None
+
+
+class CourseRunStateAdminForm(forms.ModelForm):
+    class Meta:
+        model = CourseRunState
+        fields = '__all__'
+
+    def clean(self):
+        cleaned_data = self.cleaned_data
+        owner_role = cleaned_data.get('owner_role')
+        course_run_state = cleaned_data.get('name')
+        if owner_role == PublisherUserRole.Publisher and course_run_state in (CourseRunStateChoices.Draft,
+                                                                              CourseRunStateChoices.Review):
+            raise forms.ValidationError(_('Owner role can not be publisher if the state is draft or review'))
+        return cleaned_data
 
 
 class AdminImportCourseForm(forms.Form):

--- a/course_discovery/conf/locale/en/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/en/LC_MESSAGES/django.po
@@ -839,6 +839,10 @@ msgid "Invalid course key."
 msgstr ""
 
 #: apps/publisher/forms.py
+msgid "Owner role can not be publisher if the state is draft or review"
+msgstr ""
+
+#: apps/publisher/forms.py
 msgid "Create initial run for the course"
 msgstr ""
 

--- a/course_discovery/conf/locale/eo/LC_MESSAGES/django.po
+++ b/course_discovery/conf/locale/eo/LC_MESSAGES/django.po
@@ -1010,6 +1010,12 @@ msgid "Invalid course key."
 msgstr "Ìnvälïd çöürsé kéý. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,#"
 
 #: apps/publisher/forms.py
+msgid "Owner role can not be publisher if the state is draft or review"
+msgstr ""
+"Öwnér rölé çän nöt ßé püßlïshér ïf thé stäté ïs dräft ör révïéw Ⱡ'σяєм ιρѕυм"
+" ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: apps/publisher/forms.py
 msgid "Create initial run for the course"
 msgstr ""
 "Çréäté ïnïtïäl rün för thé çöürsé Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тє#"


### PR DESCRIPTION
## [EDUCATOR-1775](https://openedx.atlassian.net/browse/EDUCATOR-1775)

### Description
Added course run state validation on the admin site. If owner role is publisher the state should never be draft or review because that would leave the course run in an invalid state.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @schenedx    
- [ ] @awaisdar001

### Post-review
- [ ] Rebase and squash commits
