### PR TITLE
Fix run boosting test.

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/tests/test_boosting.py
+++ b/course_discovery/apps/edx_haystack_extensions/tests/test_boosting.py
@@ -177,7 +177,7 @@ class TestSearchBoosting:
     six_months = relativedelta(months=6)
     one_week = relativedelta(days=7)
     two_weeks = relativedelta(days=14)
-    one_year = relativedelta(year=1)
+    one_year = relativedelta(years=1)
     thirteen_months = relativedelta(months=13)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
relativedelta(year=1) calculating the wrong date value "1-01-04 13:43:42" with singular argument.

LEARNER-3801