### PR TITLE
Remove hack to force a rebuild of node-sass.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ help: ## Display this help message
 	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 
 static: ## Gather all static assets for production
-	npm rebuild node-sass --force
 	$(NODE_BIN)/webpack --config webpack.config.js --display-error-details --progress --optimize-minimize
 	python manage.py collectstatic --noinput
 	python manage.py compress -v3 --force


### PR DESCRIPTION
The line was originally put in to address failures in the Node 8
upgrade where the Node 6 version was getting cached, but caused other
problems in Travis where the process doesn't have the permissions to
create those directories. Hopefully no longer needed.