### PR TITLE
Fix Instructor images that can be changed.

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1138,7 +1138,7 @@ class PersonSerializerTests(TestCase):
             'family_name': self.person.family_name,
             'bio': self.person.bio,
             'profile_image': image_field.to_representation(self.person.profile_image),
-            'profile_image_url': self.person.profile_image_url,
+            'profile_image_url': self.person.profile_image.url,
             'position': PositionSerializer(position).data,
             'works': [work.value for work in self.person.person_works.all()],
             'urls': {

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -298,12 +298,10 @@ class Person(TimeStampedModel):
 
     @property
     def get_profile_image_url(self):
-        url = self.profile_image_url
-        if not url:
-            if self.profile_image and hasattr(self.profile_image, 'url'):
-                url = self.profile_image.url
-
-        return url
+        if self.profile_image and hasattr(self.profile_image, 'url'):
+            return self.profile_image.url
+        else:
+            return self.profile_image_url
 
 
 class Position(TimeStampedModel):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -434,11 +434,15 @@ class PersonTests(TestCase):
         Verify that property returns profile_image_url if profile_image_url
         exists other wise it returns uploaded image url.
         """
-        self.assertEqual(self.person.get_profile_image_url, self.person.profile_image_url)
+        self.assertEqual(self.person.get_profile_image_url, self.person.profile_image.url)
 
         # create another person with out profile_image_url
         person = factories.PersonFactory(profile_image_url=None)
         self.assertEqual(person.get_profile_image_url, person.profile_image.url)
+
+        # create another person with out profile_image
+        person = factories.PersonFactory(profile_image=None)
+        self.assertEqual(person.get_profile_image_url, person.profile_image_url)
 
         # create another person with out profile_image_url and profile_image
         person = factories.PersonFactory(profile_image_url=None, profile_image=None)


### PR DESCRIPTION
## [EDUCATOR-2238](https://openedx.atlassian.net/browse/EDUCATOR-2238)

### Description
This PR fixes that uploaded photos for instructors would change.

### Screenshots

**Instructor image before uploading new pic**
<img width="559" alt="screen shot 2018-02-08 at 11 44 51 pm" src="https://user-images.githubusercontent.com/7627421/35992995-c67228b6-0d2d-11e8-8ca4-00e848dc1a1d.png">

**Instructor image after uploading new pic**

<img width="571" alt="screen shot 2018-02-08 at 11 45 23 pm" src="https://user-images.githubusercontent.com/7627421/35992997-c9af64e4-0d2d-11e8-8cb1-06e3d0419c65.png">

### How to Test?
**Stage**
https://stage-edx-discovery.edx.org/publisher
- Go to any course run edit page
- Edit any instructor
- upload photo of dimension 110 x 110.
- Save the instructor
- it will never update the image 

**Sandbox**
https://discovery-escalation.sandbox.edx.org/publisher/course_runs/1/edit/
-  Edit the instructor
- upload photo
- It will update the instructor image

You can use following credentials
_username : staff
Password: staff_


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @schenedx 
- [x] @asadazam93  


### Post-review
- [x] Rebase and squash commits
