### PR TITLE
Fix caching of ApiAccessRequest

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -161,6 +161,9 @@ def get_utm_source_for_user(partner, user):
     # use company name from API Access Request as utm_source.
     if waffle.switch_is_active('use_company_name_as_utm_source_value') and partner.lms_url:
         lms = LMSAPIClient(partner.site)
+
+        # This result is not being used to determine access. It is only being
+        # used to create an alternative UTM code parsed from the result.
         api_access_request = lms.get_api_access_request(user)
 
         if api_access_request:

--- a/course_discovery/apps/core/tests/mixins.py
+++ b/course_discovery/apps/core/tests/mixins.py
@@ -82,6 +82,28 @@ class LMSAPIClientMixin(object):
             status=status
         )
 
+    def mock_api_access_request_with_configurable_results(self, lms_url, user, status=200, results=None):
+        """
+        Mock the api access requests endpoint response of the LMS.
+        """
+        data = {
+            'count': len(results),
+            'num_pages': 1,
+            'current_page': 1,
+            'results': results,
+            'next': None,
+            'start': 0,
+            'previous': None
+        }
+
+        responses.add(
+            responses.GET,
+            lms_url.rstrip('/') + '/api-admin/api/v1/api_access_request/?user__username={}'.format(user.username),
+            body=json.dumps(data),
+            content_type='application/json',
+            status=status
+        )
+
     def mock_api_access_request_with_invalid_data(self, lms_url, user, status=200, response_overrides=None):
         """
         Mock the api access requests endpoint response of the LMS.


### PR DESCRIPTION
When a user has no ApiRequestModel results, an exception is raised and the result is never cached. This PR ensures that we cache that result.

https://openedx.atlassian.net/wiki/spaces/~clee/pages/547913828/edx-mktg+investigation

