### PR TITLE
Revert publishing entitlements along with seats

### DIFF
--- a/course_discovery/apps/publisher/api/tests/test_utils.py
+++ b/course_discovery/apps/publisher/api/tests/test_utils.py
@@ -1,10 +1,9 @@
 import pytest
 
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.publisher.api.utils import (serialize_entitlement_for_ecommerce_api,
-                                                       serialize_seat_for_ecommerce_api)
+from course_discovery.apps.publisher.api.utils import serialize_seat_for_ecommerce_api
 from course_discovery.apps.publisher.models import Seat
-from course_discovery.apps.publisher.tests.factories import CourseEntitlementFactory, SeatFactory
+from course_discovery.apps.publisher.tests.factories import SeatFactory
 
 
 @pytest.mark.django_db
@@ -51,22 +50,3 @@ class TestSerializeSeatForEcommerceApi:
             }
         ]
         assert actual['attribute_values'] == expected_attribute_values
-
-
-@pytest.mark.django_db
-class TestSerializeEntitlementForEcommerceApi:
-    def test_serialize_entitlement_for_ecommerce_api(self):
-        entitlement = CourseEntitlementFactory()
-        actual = serialize_entitlement_for_ecommerce_api(entitlement)
-        expected = {
-            'price': str(entitlement.price),
-            'product_class': 'Course Entitlement',
-            'attribute_values': [
-                {
-                    'name': 'certificate_type',
-                    'value': entitlement.mode,
-                },
-            ]
-        }
-
-        assert actual == expected

--- a/course_discovery/apps/publisher/api/utils.py
+++ b/course_discovery/apps/publisher/api/utils.py
@@ -18,16 +18,3 @@ def serialize_seat_for_ecommerce_api(seat):
             }
         ]
     }
-
-
-def serialize_entitlement_for_ecommerce_api(entitlement):
-    return {
-        'price': str(entitlement.price),
-        'product_class': 'Course Entitlement',
-        'attribute_values': [
-            {
-                'name': 'certificate_type',
-                'value': entitlement.mode,
-            },
-        ],
-    }

--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -11,17 +11,14 @@ from course_discovery.apps.core.models import Currency, Partner
 from course_discovery.apps.core.tests.factories import StaffUserFactory, UserFactory
 from course_discovery.apps.core.tests.helpers import make_image_file
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.course_metadata.models import CourseEntitlement as DiscoveryCourseEntitlement
 from course_discovery.apps.course_metadata.models import Seat as DiscoverySeat
-from course_discovery.apps.course_metadata.models import CourseRun, SeatType, Video
-from course_discovery.apps.course_metadata.tests import toggle_switch
+from course_discovery.apps.course_metadata.models import CourseRun, Video
 from course_discovery.apps.course_metadata.tests.factories import OrganizationFactory, PersonFactory
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
-from course_discovery.apps.publisher.api.utils import (serialize_entitlement_for_ecommerce_api,
-                                                       serialize_seat_for_ecommerce_api)
+from course_discovery.apps.publisher.api.utils import serialize_seat_for_ecommerce_api
 from course_discovery.apps.publisher.api.v1.views import CourseRunViewSet
-from course_discovery.apps.publisher.models import CourseEntitlement, Seat
-from course_discovery.apps.publisher.tests.factories import CourseEntitlementFactory, CourseRunFactory, SeatFactory
+from course_discovery.apps.publisher.models import Seat
+from course_discovery.apps.publisher.tests.factories import CourseRunFactory, SeatFactory
 
 PUBLISHER_UPGRADE_DEADLINE_DAYS = random.randint(1, 21)
 
@@ -79,23 +76,29 @@ class CourseRunViewSetTests(APITestCase):
         url = '{root}publication/'.format(root=partner.ecommerce_api_url)
         responses.add(responses.POST, url, json=body, status=status)
 
+    def serialize_seat_for_ecommerce_api(self, seat):
+        return {
+            'expires': serialize_datetime(seat.upgrade_deadline or seat.course_run.end),
+            'price': str(seat.price),
+            'product_class': 'Seat',
+            'attribute_values': [
+                {
+                    'name': 'certificate_type',
+                    'value': None if seat.type is Seat.AUDIT else seat.type,
+                },
+                {
+                    'name': 'id_verification_required',
+                    'value': seat.type in (Seat.VERIFIED, Seat.PROFESSIONAL),
+                }
+            ]
+        }
+
     @responses.activate
     @mock.patch.object(Partner, 'access_token', return_value='JWT fake')
     def test_publish(self, mock_access_token):  # pylint: disable=unused-argument,too-many-statements
-        toggle_switch('publisher_entitlements', True)
-
         publisher_course_run = self._create_course_run_for_publication()
+
         currency = Currency.objects.get(code='USD')
-
-        common_entitlement_kwargs = {
-            'course': publisher_course_run.course,
-            'currency': currency,
-        }
-        professional_entitlement = CourseEntitlementFactory(mode=CourseEntitlement.PROFESSIONAL,
-                                                            **common_entitlement_kwargs)
-        verified_entitlement = CourseEntitlementFactory(mode=CourseEntitlement.VERIFIED,
-                                                        **common_entitlement_kwargs)
-
         common_seat_kwargs = {
             'course_run': publisher_course_run,
             'currency': currency,
@@ -129,8 +132,6 @@ class CourseRunViewSetTests(APITestCase):
             serialize_seat_for_ecommerce_api(audit_seat),
             serialize_seat_for_ecommerce_api(professional_seat),
             serialize_seat_for_ecommerce_api(verified_seat),
-            serialize_entitlement_for_ecommerce_api(professional_entitlement),
-            serialize_entitlement_for_ecommerce_api(verified_entitlement),
         ]
         assert ecommerce_body['products'] == expected
         assert ecommerce_body['verification_deadline'] == serialize_datetime(publisher_course_run.end)
@@ -176,22 +177,6 @@ class CourseRunViewSetTests(APITestCase):
         assert list(discovery_course.authoring_organizations.all()) == expected
         expected = {publisher_course.primary_subject, publisher_course.secondary_subject}
         assert set(discovery_course.subjects.all()) == expected
-
-        common_entitlement_kwargs = {
-            'course': discovery_course,
-            'currency': currency,
-        }
-        self.assertEqual(2, DiscoveryCourseEntitlement.objects.all().count())
-        DiscoveryCourseEntitlement.objects.get(
-            mode=SeatType.objects.get(slug=DiscoverySeat.PROFESSIONAL),
-            price=professional_entitlement.price,
-            **common_entitlement_kwargs
-        )
-        DiscoveryCourseEntitlement.objects.get(
-            mode=SeatType.objects.get(slug=DiscoverySeat.VERIFIED),
-            price=verified_entitlement.price,
-            **common_entitlement_kwargs
-        )
 
         common_seat_kwargs = {
             'course_run': discovery_course_run,

--- a/course_discovery/apps/publisher/tests/factories.py
+++ b/course_discovery/apps/publisher/tests/factories.py
@@ -12,9 +12,8 @@ from course_discovery.apps.course_metadata.choices import CourseRunPacing
 from course_discovery.apps.course_metadata.tests import factories
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.choices import PublisherUserRole
-from course_discovery.apps.publisher.models import (Course, CourseEntitlement, CourseRun, CourseRunState, CourseState,
-                                                    CourseUserRole, OrganizationExtension, OrganizationUserRole, Seat,
-                                                    UserAttributes)
+from course_discovery.apps.publisher.models import (Course, CourseRun, CourseRunState, CourseState, CourseUserRole,
+                                                    OrganizationExtension, OrganizationUserRole, Seat, UserAttributes)
 
 
 class CourseFactory(factory.DjangoModelFactory):
@@ -89,16 +88,6 @@ class SeatFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = Seat
-
-
-class CourseEntitlementFactory(factory.DjangoModelFactory):
-    mode = FuzzyChoice([name for name, __ in CourseEntitlement.COURSE_MODE_CHOICES])
-    price = FuzzyDecimal(1.0, 650.0)
-    currency = factory.Iterator(Currency.objects.all())
-    course = factory.SubFactory(CourseFactory)
-
-    class Meta:
-        model = CourseEntitlement
 
 
 class GroupFactory(factory.DjangoModelFactory):


### PR DESCRIPTION
This reverts commit 130654ab8c6a4a0da85e5e61d127d25c220add78.
And commit 6662b884e664a3385dd5c4fb30b8c9f402973a76.

Couldn't test successfully on stage, so until I can confirm changes,
backing these out to not block others.