### PR TITLE
Filter courses on create run POST

### DIFF
--- a/course_discovery/apps/publisher/api/views.py
+++ b/course_discovery/apps/publisher/api/views.py
@@ -3,7 +3,6 @@ import logging
 from dal import autocomplete
 from django.apps import apps
 from django.contrib.auth.mixins import LoginRequiredMixin
-from guardian.shortcuts import get_objects_for_user
 from rest_framework import status
 from rest_framework.generics import ListAPIView, RetrieveAPIView, UpdateAPIView, get_object_or_404
 from rest_framework.permissions import IsAuthenticated
@@ -19,8 +18,7 @@ from course_discovery.apps.publisher.api.serializers import (CourseRevisionSeria
                                                              CourseUserRoleSerializer, GroupUserSerializer)
 from course_discovery.apps.publisher.forms import CourseForm
 from course_discovery.apps.publisher.models import (Course, CourseRun, CourseRunState, CourseState, CourseUserRole,
-                                                    OrganizationExtension)
-from course_discovery.apps.publisher.utils import is_internal_user, is_publisher_admin
+                                                    OrganizationExtension, PublisherUser)
 
 logger = logging.getLogger(__name__)
 
@@ -117,22 +115,8 @@ class CoursesAutoComplete(LoginRequiredMixin, autocomplete.Select2QuerySetView):
 
     def get_queryset(self):
         if self.q:
-            user = self.request.user
-            if is_publisher_admin(user):
-                qs = Course.objects.filter(title__icontains=self.q)
-            elif is_internal_user(user):
-                qs = Course.objects.filter(title__icontains=self.q, course_user_roles__user=user).distinct()
-            else:
-                organizations = get_objects_for_user(
-                    user,
-                    OrganizationExtension.VIEW_COURSE,
-                    OrganizationExtension,
-                    use_groups=True,
-                    with_superuser=False
-                ).values_list('organization')
-                qs = Course.objects.filter(title__icontains=self.q, organizations__in=organizations)
-
-            return qs
+            qs = PublisherUser.get_courses(self.request.user)
+            return qs.filter(title__icontains=self.q)
 
         return []
 

--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -210,7 +210,7 @@ class CourseSearchForm(forms.Form):
     """ Course Type ahead Search Form. """
     course = forms.ModelChoiceField(
         label=_('Find Course'),
-        queryset=Course.objects.all(),
+        queryset=Course.objects.none(),
         widget=autocomplete.ModelSelect2(
             url='publisher:api:course-autocomplete',
             attrs={
@@ -221,11 +221,11 @@ class CourseSearchForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        qs = kwargs.pop('queryset', None)
-        super(CourseSearchForm, self).__init__(*args, **kwargs)
+        user = kwargs.pop('user', None)
+        super().__init__(*args, **kwargs)
 
-        if qs is not None:
-            self.fields['course'].queryset = qs
+        if user:
+            self.fields['course'].queryset = PublisherUser.get_courses(user)
 
 
 class CourseRunForm(BaseForm):


### PR DESCRIPTION
When creating a course run in the Publisher dashboard, only allow the user to create runs for courses they have access to.

https://openedx.atlassian.net/browse/LEARNER-4102

**Notes**
* The big change here is the changes to CourseSearchForm to accept a user (from which we create a validation queryset) and in views.py to pass a user when creating the validation version of the form for POSTs.
* I refactored some of the code to reduce the number of times we create that queryset. We still create a very similar queryset in views.py for course runs, but it was different enough that I didn't touch it.
* I didn't have an obvious place to put the get_user_courses() utility function. Utils.py didn't work because it would have created a circular import. So I just made a static method on the PublisherUser model. I'm open to better places.