### PR TITLE
Fixed publish button to delete subjects

### DIFF
--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -129,6 +129,7 @@ class CourseRunViewSet(viewsets.GenericViewSet):
             publisher_course.tertiary_subject
         ] if subject]
         subjects = list(OrderedDict.fromkeys(subjects))
+        discovery_course.subjects.clear()
         discovery_course.subjects.add(*subjects)
 
         defaults = {


### PR DESCRIPTION
## [EDUCATOR-2325](https://openedx.atlassian.net/browse/EDUCATOR-2325)

### Description
The publish to discovery method did not remove subjects previously so if a subject was removed from publisher (and assuming that subject already exists in the discovery course) and the publish button was pushed it would not would remove the subject in the discovery course. Updated the method to remove existing subjects.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @attiyaIshaque    
- [ ] @Rabia23 

### Post-review
- [ ] Rebase and squash commits
