### PR TITLE
Publish entitlements along with seats

### DIFF
--- a/course_discovery/apps/publisher/api/tests/test_utils.py
+++ b/course_discovery/apps/publisher/api/tests/test_utils.py
@@ -1,9 +1,10 @@
 import pytest
 
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.publisher.api.utils import serialize_seat_for_ecommerce_api
+from course_discovery.apps.publisher.api.utils import (serialize_entitlement_for_ecommerce_api,
+                                                       serialize_seat_for_ecommerce_api)
 from course_discovery.apps.publisher.models import Seat
-from course_discovery.apps.publisher.tests.factories import SeatFactory
+from course_discovery.apps.publisher.tests.factories import CourseEntitlementFactory, SeatFactory
 
 
 @pytest.mark.django_db
@@ -50,3 +51,22 @@ class TestSerializeSeatForEcommerceApi:
             }
         ]
         assert actual['attribute_values'] == expected_attribute_values
+
+
+@pytest.mark.django_db
+class TestSerializeEntitlementForEcommerceApi:
+    def test_serialize_entitlement_for_ecommerce_api(self):
+        entitlement = CourseEntitlementFactory()
+        actual = serialize_entitlement_for_ecommerce_api(entitlement)
+        expected = {
+            'price': str(entitlement.price),
+            'product_class': 'Course Entitlement',
+            'attribute_values': [
+                {
+                    'name': 'certificate_type',
+                    'value': entitlement.mode,
+                },
+            ]
+        }
+
+        assert actual == expected

--- a/course_discovery/apps/publisher/api/utils.py
+++ b/course_discovery/apps/publisher/api/utils.py
@@ -18,3 +18,16 @@ def serialize_seat_for_ecommerce_api(seat):
             }
         ]
     }
+
+
+def serialize_entitlement_for_ecommerce_api(entitlement):
+    return {
+        'price': str(entitlement.price),
+        'product_class': 'Course Entitlement',
+        'attribute_values': [
+            {
+                'name': 'certificate_type',
+                'value': entitlement.mode,
+            },
+        ],
+    }

--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -1,6 +1,7 @@
 import logging
-
 from collections import OrderedDict
+
+import waffle
 from edx_rest_api_client.client import EdxRestApiClient
 from edx_rest_framework_extensions.authentication import JwtAuthentication
 from rest_framework import permissions, serializers, status, viewsets
@@ -10,10 +11,13 @@ from rest_framework.response import Response
 from slumber.exceptions import SlumberBaseException
 
 from course_discovery.apps.core.utils import serialize_datetime
+from course_discovery.apps.course_metadata.models import CourseEntitlement as DiscoveryCourseEntitlement
 from course_discovery.apps.course_metadata.models import CourseRun as DiscoveryCourseRun
 from course_discovery.apps.course_metadata.models import Seat as DiscoverySeat
-from course_discovery.apps.course_metadata.models import Course, Video
-from course_discovery.apps.publisher.api.utils import serialize_seat_for_ecommerce_api
+from course_discovery.apps.course_metadata.models import Course, SeatType, Video
+from course_discovery.apps.publisher.api.utils import (
+    serialize_entitlement_for_ecommerce_api, serialize_seat_for_ecommerce_api
+)
 from course_discovery.apps.publisher.models import CourseRun, Seat
 from course_discovery.apps.publisher.studio_api_utils import StudioAPI
 
@@ -38,8 +42,9 @@ class CourseRunViewSet(viewsets.GenericViewSet):
 
         try:
             publication_status['studio'] = self.publish_to_studio(partner, course_run)
-            publication_status['ecommerce'] = self.publish_to_ecommerce(partner, course_run)
             publication_status['discovery'] = self.publish_to_discovery(partner, course_run)
+            # ecommerce is going to want to ask discovery about the course's UUID, so we do this last
+            publication_status['ecommerce'] = self.publish_to_ecommerce(partner, course_run)
         except SlumberBaseException as ex:
             logger.exception('Failed to publish course run [%s]!', pk)
             content = getattr(ex, 'content', None)
@@ -77,10 +82,15 @@ class CourseRunViewSet(viewsets.GenericViewSet):
             'name': course_run.title_override or course_run.course.title,
             'verification_deadline': serialize_datetime(course_run.end),
             'create_or_activate_enrollment_code': False,
-            # NOTE (CCB): We only order here to aid testing. The E-Commerce API does NOT care about ordering.
-            'products': [serialize_seat_for_ecommerce_api(seat) for seat in
-                         course_run.seats.exclude(type=Seat.CREDIT).order_by('created')],
         }
+
+        # NOTE: We only order here to aid testing. The E-Commerce API does NOT care about ordering.
+        products = [serialize_seat_for_ecommerce_api(seat) for seat in
+                    course_run.seats.exclude(type=Seat.CREDIT).order_by('created')]
+        if waffle.switch_is_active('publisher_entitlements'):
+            products.extend([serialize_entitlement_for_ecommerce_api(entitlement) for entitlement in
+                             course_run.course.entitlements.order_by('created')])
+        data['products'] = products
 
         try:
             api.publication.post(data)
@@ -141,6 +151,18 @@ class CourseRunViewSet(viewsets.GenericViewSet):
         )
         discovery_course_run.transcript_languages.add(*course_run.transcript_languages.all())
         discovery_course_run.staff.add(*course_run.staff.all())
+
+        if waffle.switch_is_active('publisher_entitlements'):
+            for entitlement in publisher_course.entitlements.all():
+                DiscoveryCourseEntitlement.objects.update_or_create(
+                    course=discovery_course,
+                    mode=SeatType.objects.get(slug=entitlement.mode),
+                    defaults={
+                        'partner': partner,
+                        'price': entitlement.price,
+                        'currency': entitlement.currency,
+                    }
+                )
 
         for seat in course_run.seats.exclude(type=Seat.CREDIT):
             DiscoverySeat.objects.update_or_create(

--- a/course_discovery/apps/publisher/tests/factories.py
+++ b/course_discovery/apps/publisher/tests/factories.py
@@ -12,8 +12,9 @@ from course_discovery.apps.course_metadata.choices import CourseRunPacing
 from course_discovery.apps.course_metadata.tests import factories
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.choices import PublisherUserRole
-from course_discovery.apps.publisher.models import (Course, CourseRun, CourseRunState, CourseState, CourseUserRole,
-                                                    OrganizationExtension, OrganizationUserRole, Seat, UserAttributes)
+from course_discovery.apps.publisher.models import (Course, CourseEntitlement, CourseRun, CourseRunState, CourseState,
+                                                    CourseUserRole, OrganizationExtension, OrganizationUserRole, Seat,
+                                                    UserAttributes)
 
 
 class CourseFactory(factory.DjangoModelFactory):
@@ -88,6 +89,16 @@ class SeatFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = Seat
+
+
+class CourseEntitlementFactory(factory.DjangoModelFactory):
+    mode = FuzzyChoice([name for name, __ in CourseEntitlement.COURSE_MODE_CHOICES])
+    price = FuzzyDecimal(1.0, 650.0)
+    currency = factory.Iterator(Currency.objects.all())
+    course = factory.SubFactory(CourseFactory)
+
+    class Meta:
+        model = CourseEntitlement
 
 
 class GroupFactory(factory.DjangoModelFactory):


### PR DESCRIPTION
When publishing a course run to ecommerce and discovery, also push
any entitlements for its course to those same services.

This reverts commit 3db5a5ef3ad00611c3a48a5dbec32591ffe0d1d7 which was
itself a reversion to back out these changes while we fixed our staging
services.

LEARNER-4031