### PR TITLE
Fix & cleanup course run seats in publisher

### DIFF
--- a/course_discovery/apps/publisher/constants.py
+++ b/course_discovery/apps/publisher/constants.py
@@ -17,3 +17,4 @@ PARTNER_COORDINATOR_GROUP_NAME = 'Partner Coordinators'
 
 # Waffle flags
 PUBLISHER_ENTITLEMENTS_WAFFLE_SWITCH = 'publisher_entitlements'
+PUBLISHER_CREATE_AUDIT_SEATS_FOR_VERIFIED_COURSE_RUNS = 'publisher_create_audit_seats_for_verified_course_runs'

--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -464,10 +464,11 @@ class SeatForm(BaseForm):
         if not course_run:
             return
         all_course_run_seats = course_run.seats.all()
-        seats_data_is_bogus = all_course_run_seats.count() > 2
+        all_course_run_seats_count = all_course_run_seats.count()
+        seats_data_is_bogus = all_course_run_seats_count > 2
         if seats_data_is_bogus:
-            logger.info('Removing bogus course run [%d] seats [%d]', course_run.id, all_course_run_seats.count())
             all_course_run_seats.delete()
+            logger.info('Removed bogus course run [%d] seats [%d]', course_run.id, all_course_run_seats_count)
 
 
 class CourseEntitlementForm(BaseForm):

--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -25,14 +25,14 @@ from course_discovery.apps.course_metadata.models import LevelType, Organization
 from course_discovery.apps.course_metadata.utils import UploadToFieldNamePath
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher import emails
-from course_discovery.apps.publisher.choices import (CourseRunStateChoices, CourseStateChoices, InternalUserRole,
-                                                     PublisherUserRole)
+from course_discovery.apps.publisher.choices import (
+    CourseRunStateChoices, CourseStateChoices, InternalUserRole, PublisherUserRole
+)
 from course_discovery.apps.publisher.utils import is_email_notification_enabled, is_internal_user, is_publisher_admin
+
 from course_discovery.apps.publisher.validators import ImageMultiSizeValidator
 
 logger = logging.getLogger(__name__)
-
-PAID_SEATS = ['verified', 'professional']
 
 
 class ChangedByMixin(models.Model):
@@ -430,6 +430,11 @@ class CourseRun(TimeStampedModel, ChangedByMixin):
         seats = self.seats.filter(type__in=[Seat.AUDIT, Seat.VERIFIED, Seat.PROFESSIONAL, Seat.CREDIT])
         return all([seat.is_valid_seat for seat in seats]) if seats else False
 
+    @property
+    def paid_seats(self):
+        """ Return course run paid seats """
+        return self.seats.filter(type__in=Seat.PAID_SEATS)
+
     def get_absolute_url(self):
         return reverse('publisher:publisher_course_run_detail', kwargs={'pk': self.id})
 
@@ -441,6 +446,8 @@ class Seat(TimeStampedModel, ChangedByMixin):
     PROFESSIONAL = 'professional'
     NO_ID_PROFESSIONAL = 'no-id-professional'
     CREDIT = 'credit'
+    PAID_SEATS = [VERIFIED, PROFESSIONAL, CREDIT]
+    PAID_AND_AUDIT_APPLICABLE_SEATS = [CREDIT, VERIFIED]
 
     SEAT_TYPE_CHOICES = (
         (HONOR, _('Honor')),

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -3117,7 +3117,6 @@ class CourseRunEditViewTests(SiteMixin, TestCase):
         self.assertContains(response, 'CERTIFICATE TYPE AND PRICE', status_code=200)
 
     def login_with_course_user_role(self, course_run, role=PublisherUserRole.CourseTeam):
-        self.client.logout()
         user = course_run.course.course_user_roles.get(role=role).user
         self.client.login(username=user.username, password=USER_PASSWORD)
         return user


### PR DESCRIPTION
Fixes [EDUCATOR-2330](https://openedx.atlassian.net/browse/EDUCATOR-2330) and [EDUCATOR-2337](https://openedx.atlassian.net/browse/EDUCATOR-2337)

[EDUCATOR-2330](https://openedx.atlassian.net/browse/EDUCATOR-2330)
-
It fixes a bug where course seat does not correctly populate from the previous run. It impacts all courses, but it gives you a drop-down to correctly select before saving course run.
## To Reproduce: 
1. Visit `<course_discovery_url>/admin/waffle/switch` and ensure the `publisher_create_audit_seats_for_verified_course_runs` flag is enabled.
2. Visit `<course_discovery_url>/publisher/courses/<course_id>/course_runs/new` 
3. In the `Certificate Type and Price` section of the form, select `Verified` for the `Enrollment Track`.
Fill in the rest of the form, click submit.
4. Visit `<course_discovery_url>/publisher/courses/<course_id>/course_runs/new` again and observe that the form is pre-filled with data from the run you just created, but the `Enrollment Track` is set to `Audit-only` which should have been a `Verified` seat. 

DEMO: https://youtu.be/JnqBDgn2W80

[EDUCATOR-2337](https://openedx.atlassian.net/browse/EDUCATOR-2337)
-
It fixes an issue where editing a verified seat create duplicate course seats. 
## To Reproduce

1.  Enable the `publisher_create_audit_seats_for_verified_course_runs` waffle flag.
2. Visit `<course_discovery_url>/publisher/course_runs/new`
3. Fill in the form. Make sure to select `Verified` for the `Enrollment Track` and set a valid `price`. Click submit to create the run.
4. Visit the edit page for the course run that you just created (`<course_discovery_url>/publisher/course_runs/<ID>/edit`
5. Find the `CERTIFICATE TYPE AND PRICE` section of the form, and increase the price.
6. Click `Update Course Run` to save your changes.
7. Back on the courserun-details page (`<course_discovery_url>/publisher/course_runs/<ID>`), click the `CAT` tab and observe that there are now two verified seats associated with this courserun where it should be one.

DEMO: https://youtu.be/jfYlspAXwgU