### PR TITLE
Fix that don't allow Publisher to add negative prices for course run.

### DIFF
--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -384,7 +384,7 @@ class SeatForm(BaseForm):
     ]
 
     type = forms.ChoiceField(choices=TYPE_CHOICES, required=False, label=_('Enrollment Track'))
-    price = forms.DecimalField(max_digits=6, decimal_places=2, required=False, initial=0.00)
+    price = forms.DecimalField(max_digits=6, min_value=0.01, decimal_places=2, required=False, initial=0.00)
     credit_price = forms.DecimalField(max_digits=6, decimal_places=2, required=False, initial=0.00)
 
     class Meta:
@@ -458,7 +458,7 @@ class CourseEntitlementForm(BaseForm):
 
     mode = forms.ChoiceField(choices=MODE_CHOICES, required=False, label=_('Enrollment Track'),
                              initial=CourseEntitlement.VERIFIED)
-    price = forms.DecimalField(max_digits=6, decimal_places=2, required=False, initial=0.00)
+    price = forms.DecimalField(max_digits=6, min_value=0.01, decimal_places=2, required=False, initial=0.00)
 
     class Meta:
         fields = ('mode', 'price')

--- a/course_discovery/apps/publisher/tests/test_forms.py
+++ b/course_discovery/apps/publisher/tests/test_forms.py
@@ -391,6 +391,17 @@ class PublisherCourseEntitlementFormTests(TestCase):
 
         self.assertEqual(entitlement_form.clean(), entitlement_form.cleaned_data)
 
+    def test_negative_price(self):
+        """
+        Verify that form raises an error when price is in -ive
+        """
+        form_data = {'mode': CourseEntitlement.VERIFIED, 'price': -0.05}
+        entitlement_form = CourseEntitlementForm(data=form_data)
+        self.assertFalse(entitlement_form.is_valid())
+        self.assertEqual(entitlement_form.errors,
+                         {'price': ['Ensure this value is greater than or equal to 0.01.', '']}
+                         )
+
 
 @pytest.mark.django_db
 class TestSeatForm:


### PR DESCRIPTION
## [EDUCATOR-2329](https://openedx.atlassian.net/browse/EDUCATOR-2329)

### Description
This PR fixes that don't allow a publisher to add negative prices for course run and also while creating the course if `publisher_entitlements` switch is on.

### Screenshots

** After adding the validation on course form **
<img width="1128" alt="screen shot 2018-02-19 at 2 44 01 pm" src="https://user-images.githubusercontent.com/7627421/36371565-5566dde2-1584-11e8-83ef-0d08749582d1.png">


**After adding the validation on course run form **

<img width="1102" alt="screen shot 2018-02-19 at 2 47 36 pm" src="https://user-images.githubusercontent.com/7627421/36371569-58934fc8-1584-11e8-9dcd-1690703c6ef4.png">

### How to Test?
**Stage**
https://stage-edx-discovery.edx.org/publisher
- Go to any course run edit page
- Edit any instructor
- In the 'Certificate Type and Price' section of the form, select 'Verified' for the 'Enrollment Track' and set 'Price' to a negative number.
- Fill in the rest of the form, click submit, and observe that the run is created with a seat that has a negative price.

**Sandbox**
https://discovery-escalation.sandbox.edx.org/publisher/course_runs/1/edit/

You can use following credentials
_username : staff
Password: staff_

### Test
- [x] unit test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @Rabia23 


### Post-review
- [x] Rebase and squash commits
