### PR TITLE
Send UUID to ecommerce

### DIFF
--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -139,6 +139,9 @@ class CourseRunViewSetTests(APITestCase):
         publisher_course = publisher_course_run.course
         discovery_course = discovery_course_run.course
 
+        assert ecommerce_body['id'] == publisher_course_run.lms_course_id
+        assert ecommerce_body['uuid'] == str(discovery_course.uuid)
+
         # pylint: disable=no-member
         assert discovery_course_run.title_override == publisher_course_run.title_override
         assert discovery_course_run.short_description_override is None


### PR DESCRIPTION
When publishing, we want to give ecommerce the UUID of the course so that it doesn't have to turn around and ask us for that same bit of information.

Related to https://github.com/edx/ecommerce/pull/1658