### PR TITLE
Asad/educator 2281 admin seat validation

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -183,6 +183,11 @@ class ProgramTypeAdmin(admin.ModelAdmin):
     list_display = ('name', 'slug',)
 
 
+@admin.register(Seat)
+class SeatAdmin(admin.ModelAdmin):
+    list_display = ('course_run', 'type')
+
+
 @admin.register(SeatType)
 class SeatTypeAdmin(admin.ModelAdmin):
     list_display = ('name', 'slug',)

--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -165,7 +165,7 @@ class CourseRunViewSet(viewsets.GenericViewSet):
                     }
                 )
 
-        for seat in course_run.seats.exclude(type=Seat.CREDIT):
+        for seat in course_run.seats.exclude(type=Seat.CREDIT).order_by('created'):
             DiscoverySeat.objects.update_or_create(
                 course_run=discovery_course_run,
                 type=seat.type,


### PR DESCRIPTION
## [EDUCATOR-2281](https://openedx.atlassian.net/browse/EDUCATOR-2281)

### Description
Publisher has duplicate seats of the same type for a single course run. So the seat that was created last should be pushed to discovery on publishing the course run. Order_by ensures that happens.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @attiyaIshaque      
- [ ] @awaisdar001

### Post-review
- [ ] Rebase and squash commits
