### PR TITLE
Fix that Enrollment track mandatory.

### DIFF
--- a/course_discovery/apps/publisher/forms.py
+++ b/course_discovery/apps/publisher/forms.py
@@ -384,7 +384,7 @@ class SeatForm(BaseForm):
         (Seat.CREDIT, _('Credit')),
     ]
 
-    type = forms.ChoiceField(choices=TYPE_CHOICES, required=False, label=_('Enrollment Track'))
+    type = forms.ChoiceField(choices=TYPE_CHOICES, required=True, label=_('Enrollment Track'))
     price = forms.DecimalField(max_digits=6, decimal_places=2, required=False, initial=0.00)
     credit_price = forms.DecimalField(max_digits=6, decimal_places=2, required=False, initial=0.00)
 

--- a/course_discovery/apps/publisher/tests/test_forms.py
+++ b/course_discovery/apps/publisher/tests/test_forms.py
@@ -484,3 +484,14 @@ class SeatFormTests(TestCase):
         seat_form = SeatForm(data=form_data)
         self.assertFalse(seat_form.is_valid())
         self.assertEqual(seat_form.errors, {'price': ['Price must be greater than or equal to 0.01']})
+
+    def test_type_is_required(self):
+        """
+        Verify that form raises an error when type is not given
+        """
+        seat_form = SeatForm(data={})
+        self.assertFalse(seat_form.is_valid())
+        self.assertEqual(seat_form.errors, {'type': ['This field is required.']})
+
+        seat_form_with_type = SeatForm(data={'type': Seat.AUDIT})
+        self.assertTrue(seat_form_with_type.is_valid())

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -3090,7 +3090,7 @@ class CourseRunEditViewTests(SiteMixin, TestCase):
 
         # Update the data for course
         data = {'full_description': 'This is testing description.', 'image': ''}
-        self.updated_dict = self._post_data(data, self.new_course, self.new_course_run)
+        self.updated_dict = self._post_data(data, self.new_course, self.new_course_run, self.seat)
 
         # Update the data for course-run
         self.updated_dict['is_xseries'] = True
@@ -3158,7 +3158,7 @@ class CourseRunEditViewTests(SiteMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['organizations_ids'], [])
 
-    def _post_data(self, data, course, course_run):
+    def _post_data(self, data, course, course_run, seat=None):
         course_dict = model_to_dict(course)
         course_dict.update(**data)
         course_dict['team_admin'] = self.user.id
@@ -3171,6 +3171,8 @@ class CourseRunEditViewTests(SiteMixin, TestCase):
             course_dict['start'] = self.start_date_time
             course_dict['end'] = self.end_date_time
             course_dict['organization'] = self.organization_extension.organization.id
+            if seat:
+                course_dict.update(**model_to_dict(seat))
 
         course_dict.pop('id')
         return course_dict
@@ -3633,7 +3635,7 @@ class CourseRunEditViewTests(SiteMixin, TestCase):
         user = self.new_course.course_team_admin
         self.client.login(username=user.username, password=USER_PASSWORD)
 
-        post_data = self._post_data({'image': ''}, self.new_course, self.new_course_run)
+        post_data = self._post_data({'image': ''}, self.new_course, self.new_course_run, self.seat)
         lms_course_id = 'course-v1:edX+DemoX+Demo_Course'
         self.new_course_run.lms_course_id = lms_course_id
         self.new_course_run.save()


### PR DESCRIPTION
## [EDUCATOR-2331](https://openedx.atlassian.net/browse/EDUCATOR-2331)

### Description
This PR fixes that don't allow a publisher to add course run without an Enrollment Track.

### Screenshots

**After adding the validation on course run form**

<img width="1105" alt="screen shot 2018-02-22 at 11 05 17 am" src="https://user-images.githubusercontent.com/7627421/36524256-33f60c2e-17c7-11e8-9468-89b6e0741ef9.png">



### How to Test?
**Stage**
https://stage-edx-discovery.edx.org/publisher

**Sandbox**
https://discovery-escalation.sandbox.edx.org/publisher/course_runs/1/edit/

You can use following credentials
_username: staff
Password: staff_

### Test
- [x] unit test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @awaisdar001 
- [x] @asadazam93 


### Post-review
- [x] Rebase and squash commits
