### PR TITLE
Updating Django Admin to disallow instructor position delete.

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -256,6 +256,16 @@ class PersonAdmin(admin.ModelAdmin):
 @admin.register(Position)
 class PositionAdmin(admin.ModelAdmin):
     list_display = ('person', 'organization', 'organization_override',)
+    search_fields = ('person__given_name',)
+
+    def has_delete_permission(self, request, obj=None):
+        """Don't allow deletes"""
+        return False
+
+    def get_actions(self, request):
+        actions = super(PositionAdmin, self).get_actions(request)
+        actions.pop('delete_selected', None)
+        return actions
 
 
 @admin.register(Video)


### PR DESCRIPTION
This PR just disallow the delete action on instructor position model in course discovery. 
More context and background at : [EDUCATOR-2239](https://openedx.atlassian.net/browse/EDUCATOR-2239)