### PR TITLE
Fix Course Syllabus max length issue

### DIFF
--- a/course_discovery/apps/publisher/tests/test_validators.py
+++ b/course_discovery/apps/publisher/tests/test_validators.py
@@ -1,0 +1,26 @@
+import ddt
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from course_discovery.apps.publisher.validators import validate_text_count
+
+
+@ddt.ddt
+class ValidatorTests(TestCase):
+    """
+    Tests for form validators
+    """
+    @ddt.data(
+        ('<strong>MODULE 0:&nbsp;</strong>', 'MODULE 0:'),
+        ('   <strong>MODULE 0: </strong>  ', 'MODULE 0:'),
+        ('\n\n<strong>MODULE 0: \n\n</strong>\n\n', 'MODULE 0:')
+    )
+    @ddt.unpack
+    def test_validate_text_count(self, text_to_validate, expected_clean_text):
+        """Tests that validate text count work as expected"""
+        max_length_allowed = len(expected_clean_text)
+        validate_text_count(max_length_allowed)(text_to_validate)
+
+        # Verify you get a Validation Error if try go below the max.
+        with self.assertRaises(ValidationError):
+            validate_text_count(max_length_allowed - 1)(text_to_validate)

--- a/course_discovery/apps/publisher/validators.py
+++ b/course_discovery/apps/publisher/validators.py
@@ -62,8 +62,7 @@ def validate_text_count(max_length):
     Custom validator to count the text area characters without html tags.
     """
     def innerfn(raw_html):
-        cleantext = BeautifulSoup(raw_html, 'html.parser').text.strip()
-
+        cleantext = BeautifulSoup(raw_html, 'html.parser').get_text(strip=True)
         if len(cleantext) > max_length:
             # pylint: disable=no-member
             raise forms.ValidationError(


### PR DESCRIPTION
In the frontend, TinyMC is removing `\n`, `&nbsp` which backend wasn't, causing a mismatch between the character counts. Now updated the backend to use `get_text(strip=True)` method which will remove these from the text.