### PR TITLE
add first paid seat sku to search

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -58,6 +58,7 @@ COURSE_RUN_SEARCH_FIELDS = (
     'number', 'seat_types', 'image_url', 'type', 'level_type', 'availability', 'published', 'partner', 'program_types',
     'authoring_organization_uuids', 'subject_uuids', 'staff_uuids', 'mobile_available', 'logo_image_urls',
     'aggregation_key', 'min_effort', 'max_effort', 'weeks_to_complete', 'has_enrollable_seats',
+    'first_enrollable_paid_seat_sku'
 )
 
 PROGRAM_FACET_FIELD_OPTIONS = {

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1237,6 +1237,7 @@ class CourseRunSearchSerializerTests(ElasticsearchTestMixin, TestCase):
     def test_data(self):
         course_run = CourseRunFactory(transcript_languages=LanguageTag.objects.filter(code__in=['en-us', 'zh-cn']),
                                       authoring_organizations=[OrganizationFactory()])
+        SeatFactory.create(course_run=course_run, type='verified', price=10, sku='ABCDEF')
         program = ProgramFactory(courses=[course_run.course])
         self.reindex_courses(program)
         serializer = self.serialize_course_run(course_run)
@@ -1276,6 +1277,7 @@ class CourseRunSearchSerializerTests(ElasticsearchTestMixin, TestCase):
             'staff_uuids': get_uuids(course_run.staff.all()),
             'aggregation_key': 'courserun:{}'.format(course_run.course.key),
             'has_enrollable_seats': course_run.has_enrollable_seats,
+            'first_enrollable_paid_seat_sku': course_run.first_enrollable_paid_seat_sku(),
         }
         assert serializer.data == expected
 

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -521,6 +521,14 @@ class CourseRun(TimeStampedModel):
         """
         return self.seats.exclude(type__in=Seat.SEATS_WITH_PREREQUISITES).filter(price__gt=0.0)
 
+    def first_enrollable_paid_seat_sku(self):
+        seats = list(self._enrollable_paid_seats().order_by('upgrade_deadline'))
+        if not seats:
+            # Enrollable paid seats are not available for this CourseRun.
+            return None
+        first_enrollable_paid_seat_sku = seats[0].sku
+        return first_enrollable_paid_seat_sku
+
     def has_enrollable_paid_seats(self):
         """
         Return a boolean indicating whether or not enrollable paid Seats (Seats with price > 0 and no prerequisites)

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -168,6 +168,7 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     staff_uuids = indexes.MultiValueField()
     subject_uuids = indexes.MultiValueField()
     has_enrollable_paid_seats = indexes.BooleanField(null=False)
+    first_enrollable_paid_seat_sku = indexes.CharField(null=True)
     paid_seat_enrollment_end = indexes.DateTimeField(null=True)
     license = indexes.MultiValueField(model_attr='license', faceted=True)
     has_enrollable_seats = indexes.BooleanField(model_attr='has_enrollable_seats', null=False)
@@ -179,6 +180,9 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
 
     def prepare_has_enrollable_paid_seats(self, obj):
         return obj.has_enrollable_paid_seats()
+
+    def prepare_first_enrollable_paid_seat_sku(self, obj):
+        return obj.first_enrollable_paid_seat_sku()
 
     def prepare_is_current_and_still_upgradeable(self, obj):
         return obj.is_current_and_still_upgradeable()

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -232,6 +232,14 @@ class CourseRunTests(TestCase):
             factories.SeatFactory.create(course_run=course_run, type=seat_type, price=price)
         self.assertEqual(course_run.has_enrollable_paid_seats(), expected_result)
 
+    def test_first_enrollable_paid_seat_sku(self):
+        """
+        Verify that first_enrollable_paid_seat_sku returns sku of first paid seat.
+        """
+        course_run = factories.CourseRunFactory.create()
+        factories.SeatFactory.create(course_run=course_run, type='verified', price=10, sku='ABCDEF')
+        self.assertEqual(course_run.first_enrollable_paid_seat_sku(), 'ABCDEF')
+
     @ddt.data(
         # Case 1: Return None when there are no enrollable paid Seats.
         ([('audit', 0, None)], '2016-12-31 00:00:00Z', '2016-08-31 00:00:00Z', None),


### PR DESCRIPTION
The products in the marketing site product lists are not currently being associated with the preexisting products that were associated with revenue generating events.

The most likely theory I have is that the product_id doesn't match, we're using course key in marketing site and SKU in ecommerce. If this does not help, you can tell that the name does not match as well - we're using name while ecommerce is using course key.

```
analytics.track('Product List Viewed', {
  category: 'Featured Courses and Programs on Search',
  list_id: 'featured_courses_programs_search',
  products: [
    {
      brand: 'AWS',
      category: 'Seat',
      image_url: 'https://prod-discovery.edx-cdn.org/media/course/image/2925325b-e377-44d5-9868-3ee4fb217740-7eaa84f93c50.small.jpg',
      name: 'AWS Developer: Building on AWS',
      position: 0,
      product_id: 'course-v1:AWS+OTP-AWSD1+1T2018',
      url: 'https://www.edx.org/course/aws-developer-building-on-aws'
    },
    .......
    {
      brand: 'Microsoft',
      category: 'program',
      image_url: 'https://prod-edx-mktg-edit.edx.org/sites/default/files/mpp_illustration_v41_it-support_edx_378x225.png',
      name: 'Microsoft Professional Program in IT Support',
      position: 17,
      product_id: 'c6bf6988-443e-49fb-9a13-44c87ebdfc9c',
      url: 'https://www.edx.org/professional-certificate/microsoft-it-support'
    }
  ]
});
```
vs
```
analytics.track('7979271', 'Order Completed', {
    'coupon': null,
    'currency': 'USD',
    'discount': '0.00',
    'orderId': 'EDX-32137023',
    'products': [
        {
            'category': 'Seat',
            'id': 'C8F2BBC',
            'name': 'course-v1:CatalystX+IL4x+1T2018',
            'price': '50.00',
            'quantity': 1,
            'sku': 'verified'
        }
    ],
    'total': '50.00'
})
```