### PR TITLE
match url to what ecommerce is hitting

### DIFF
--- a/course_discovery/apps/api/v1/urls.py
+++ b/course_discovery/apps/api/v1/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
     url(r'^partners/', include(partners_router.urls, namespace='partners')),
     url(r'search/typeahead', search_views.TypeaheadSearchView.as_view(), name='search-typeahead'),
     url(r'currency', CurrencyView.as_view(), name='currency'),
-    url(r'^catalog/query-contains/?', CatalogQueryContainsViewSet.as_view(), name='catalog-query_contains')
+    url(r'^catalog/query_contains/?', CatalogQueryContainsViewSet.as_view(), name='catalog-query_contains')
 ]
 
 router = routers.SimpleRouter()


### PR DESCRIPTION
I was off by one character in my matching of the ecommerce API call to the new API endpoint I created.

[LEARNER-4166](https://openedx.atlassian.net/browse/LEARNER-4166), [Discovery](https://openedx.atlassian.net/browse/LEARNER-4360)