### PR TITLE
query course org using course's first run's org

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_catalog_queries.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalog_queries.py
@@ -12,8 +12,8 @@ class CatalogQueryViewSetTests(APITestCase):
         super(CatalogQueryViewSetTests, self).setUp()
         self.user = UserFactory(is_staff=True, is_superuser=True)
         self.client.force_authenticate(self.user)
-        self.course_run = CourseRunFactory(course__partner=self.partner)
         self.course = CourseFactory(partner=self.partner, key='simple_key')
+        self.course_run = CourseRunFactory(course=self.course)
         self.url_base = reverse('api:v1:catalog-query_contains')
         self.error_message = 'CatalogQueryContains endpoint requires query and identifiers list(s)'
 
@@ -55,8 +55,10 @@ class CatalogQueryViewSetTests(APITestCase):
 
     def test_contains_course_and_run(self):
         """ Verify that both the course and the run are contained in the broadest query. """
+        self.course.course_runs.add(self.course_run)
+        self.course.save()
         qs = urllib.parse.urlencode({
-            'query': 'key:*',
+            'query': 'org:*',
             'course_run_ids': self.course_run.key,
             'course_uuids': self.course.uuid,
         })

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -119,6 +119,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
     model = Course
 
     uuid = indexes.CharField(model_attr='uuid')
+    org = indexes.CharField()
     course_runs = indexes.MultiValueField()
     expected_learning_items = indexes.MultiValueField()
 
@@ -135,6 +136,12 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
 
     def prepare_prerequisites(self, obj):
         return [prerequisite.name for prerequisite in obj.prerequisites.all()]
+
+    def prepare_org(self, obj):
+        course_run = obj.course_runs.all().first()
+        if course_run:
+            return CourseKey.from_string(course_run.key).org
+        return None
 
 
 class CourseRunIndex(BaseCourseIndex, indexes.Indexable):


### PR DESCRIPTION
Allow courses to be found by elasticsearch with a querystring containing "org:*" using the organization key of the course's first course run.

[LEARNER-4166](https://openedx.atlassian.net/browse/LEARNER-4166), [Discovery subtask](https://openedx.atlassian.net/browse/LEARNER-4360)