### PR TITLE
Fix text formatting for course title.

### DIFF
--- a/course_discovery/static/js/publisher/tinymce-init.js
+++ b/course_discovery/static/js/publisher/tinymce-init.js
@@ -88,10 +88,6 @@ $(document).ready(function () {
 
     tinymceConfig["selector"] = "textarea";
     tinymce.init(tinymceConfig);
-
-    tinymceConfig["selector"] = "#id_title";
-
-    tinymce.init(tinymceConfig);
 });
 
 $(document).on('click', 'a#close-comparison', function(e){


### PR DESCRIPTION
## [EDUCATOR-2526](https://openedx.atlassian.net/browse/EDUCATOR-2526)

### Description
This PR fixes that Course teams should not be able to customize the course title in Publisher.


### Screenshots

**Before Fix**
<img width="1098" alt="screen shot 2018-03-21 at 12 17 56 pm" src="https://user-images.githubusercontent.com/7627421/37698037-68f7f9e6-2d02-11e8-9c2c-cf79c503d77d.png">



**After Fix**
<img width="1095" alt="screen shot 2018-03-21 at 11 40 01 am" src="https://user-images.githubusercontent.com/7627421/37698044-763227b2-2d02-11e8-972d-f279af4d4a08.png">


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @awaisdar001 


### Post-review
- [x] Rebase and squash commits
