### PR TITLE
ENT-921: Create enrollment codes by default for course publication to ecommerce.

### DIFF
--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -88,7 +88,6 @@ class CourseRunViewSet(viewsets.GenericViewSet):
             'uuid': str(discovery_course.uuid),
             'name': course_run.title_override or course_run.course.title,
             'verification_deadline': serialize_datetime(course_run.end),
-            'create_or_activate_enrollment_code': False,
         }
 
         # NOTE: We only order here to aid testing. The E-Commerce API does NOT care about ordering.


### PR DESCRIPTION
**JIRA Ticket:** [ENT-921](https://openedx.atlassian.net/browse/ENT-921)
 
__Description:__
As part of [ENT-803](https://openedx.atlassian.net/browse/ENT-803), we discovered that Publisher was making a call to ecommerce to create courses, and by default it is sending false for the parameter to create enrollment code products. This needs to be true so that enrollment code products are always created for new courses.
**Acceptance Criteria:**

1.  When the action in Publisher is taken that results in hitting ecommerce to create the course object(s) there, it should create the enrollment code products by default.