### PR TITLE
EDUCATOR-2597: Roll back Django version to 11.11.3 because of Publisher failures.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.5.1
 boto==2.42.0
 cryptography==1.7.1
-django==1.11.11
+django==1.11.3
 django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-2597