### PR TITLE
upgrade to django 1.11.11

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.5.1
 boto==2.42.0
 cryptography==1.7.1
-django==1.11.3
+django==1.11.11
 django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1


### PR DESCRIPTION
## [EDUCATOR-2608](https://openedx.atlassian.net/browse/EDUCATOR-2608)

### Description

Updates Django. 
Older version: 1.11.3
New version: 1.11.11

This also includes a small change to cover implementation change of `model_to_dict` method. This method now returns evaluated ManytoMany field instead of queryset. 

### Reviewers
- [ ] @asadazam93
- [ ] @attiyaIshaque 
 
### Post-review
- [ ] Rebase and squash commits