### PR TITLE
Fixed course declined status on dashboard

### DIFF
--- a/course_discovery/apps/publisher/templates/publisher/dashboard/_in_preview.html
+++ b/course_discovery/apps/publisher/templates/publisher/dashboard/_in_preview.html
@@ -37,7 +37,7 @@
                         <td data-order="{{ course_run.owner_role_modified|date:"Y-m-d" }}" >
                             {% if course_run.course_run_state.preview_accepted %}
                                 {% trans "Approved since " %}
-                            {% elif course_run.preview_declined and not course_run.preview_url %}
+                            {% elif course_run.preview_declined and course_run.owner_role_is_publisher %}
                                 {% trans "Declined since " %}
                             {% elif not course_run.preview_url %}
                                 {% trans "Preview Requested since " %}

--- a/course_discovery/apps/publisher/tests/test_wrapper.py
+++ b/course_discovery/apps/publisher/tests/test_wrapper.py
@@ -225,6 +225,18 @@ class CourseRunWrapperTests(TestCase):
         course_run_state.change_owner_role(PublisherUserRole.CourseTeam)
         assert self.wrapped_course_run.course_team_status == 'Awaiting Course Team Review'
 
+    def test_owner_role_is_publisher(self):
+        """
+        Verify that owner_role_is_publisher returns true if owner is publisher and false otherwise
+        """
+        course_run_state = factories.CourseRunStateFactory(
+            course_run=self.course_run, owner_role=PublisherUserRole.Publisher
+        )
+        self.assertEqual(self.wrapped_course_run.owner_role_is_publisher, True)
+
+        course_run_state.change_owner_role(PublisherUserRole.CourseTeam)
+        self.assertEqual(self.wrapped_course_run.owner_role_is_publisher, False)
+
     def test_internal_user_status(self):
         """
         Verify that internal_user_status returns right statuses.

--- a/course_discovery/apps/publisher/wrappers.py
+++ b/course_discovery/apps/publisher/wrappers.py
@@ -264,6 +264,10 @@ class CourseRunWrapper(BaseWrapper):
             return self.ApprovedByProjectCoordinator
 
     @property
+    def owner_role_is_publisher(self):
+        return self.wrapped_obj.course_run_state.owner_role == PublisherUserRole.Publisher
+
+    @property
     def owner_role_modified(self):
         return self.wrapped_obj.course_run_state.owner_role_modified
 


### PR DESCRIPTION
## [EDUCATOR-2691](https://openedx.atlassian.net/browse/EDUCATOR-2691)

### Description
Previously when a course run was declined the preview url was set to empty. This was changed recently and now the preview url is not set to empty. Just the owner role is changed from course team to publisher. The dashboard was not updated accordingly it still had the old condition where it checks for empty preview url. Changed the condition to check for owner role.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @Rabia23 
- [x] @noraiz-anwar

### Post-review
- [ ] Rebase and squash commits
