### PR TITLE
[ENT-915] Full detail search endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ assets/
 
 # Unit test / coverage reports
 .coverage
+.coverage.*
 htmlcov
 .tox
 nosetests.xml

--- a/course_discovery/apps/api/exceptions.py
+++ b/course_discovery/apps/api/exceptions.py
@@ -1,6 +1,0 @@
-from rest_framework import status
-from rest_framework.exceptions import APIException
-
-
-class InvalidPartnerError(APIException):
-    status_code = status.HTTP_400_BAD_REQUEST

--- a/course_discovery/apps/api/mixins.py
+++ b/course_discovery/apps/api/mixins.py
@@ -1,0 +1,56 @@
+"""
+Mixins for the API application.
+"""
+# pylint: disable=not-callable
+
+from rest_framework.decorators import list_route
+from rest_framework.response import Response
+
+
+class DetailMixin(object):
+    """Mixin for adding in a detail endpoint using a special detail serializer."""
+
+    detail_serializer_class = None
+
+    @list_route(methods=['get'])
+    def details(self, request):  # pylint: disable=unused-argument
+        """
+        List detailed results.
+        ---
+        parameters:
+            - name: q
+              description: Search text
+              paramType: query
+              type: string
+              required: false
+        """
+        queryset = self.filter_queryset(self.get_queryset())
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_detail_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_detail_serializer(queryset, many=True)
+        return Response(serializer.data)
+
+    def get_detail_serializer(self, *args, **kwargs):
+        """
+        Return the serializer instance that should be used for validating and
+        deserializing input, and for serializing output.
+        """
+        serializer_class = self.get_detail_serializer_class()
+        kwargs['context'] = self.get_serializer_context()
+        return serializer_class(*args, **kwargs)
+
+    def get_detail_serializer_class(self):
+        """
+        Return the class to use for the serializer.
+        Defaults to using `self.detail_serializer_class`.
+        """
+        assert self.detail_serializer_class is not None, (
+            "'%s' should either include a `detail_serializer_class` attribute, "
+            "or override the `get_detail_serializer_class()` method."
+            % self.__class__.__name__
+        )
+        return self.detail_serializer_class

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+
 import six
 
 logger = logging.getLogger(__name__)

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -2,7 +2,6 @@ import datetime
 
 import ddt
 import pytz
-
 from django.core.cache import cache
 from django.db.models.functions import Lower
 from rest_framework.reverse import reverse

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -115,7 +115,7 @@ class TestProgramViewSet(SerializationMixin):
             partner=self.partner)
         # property does not have the right values while being indexed
         del program._course_run_weeks_to_complete
-        with django_assert_num_queries(38):
+        with django_assert_num_queries(39):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
         assert course_list == list(program.courses.all())  # pylint: disable=no-member
@@ -124,7 +124,7 @@ class TestProgramViewSet(SerializationMixin):
         """ Verify the endpoint returns data for a program even if the program's courses have no course runs. """
         course = CourseFactory(partner=self.partner)
         program = ProgramFactory(courses=[course], partner=self.partner)
-        with django_assert_num_queries(25):
+        with django_assert_num_queries(26):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 

--- a/course_discovery/apps/api/v1/views/__init__.py
+++ b/course_discovery/apps/api/v1/views/__init__.py
@@ -1,9 +1,6 @@
-from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from course_discovery.apps.api import serializers
-from course_discovery.apps.api.exceptions import InvalidPartnerError
-from course_discovery.apps.core.models import Partner
 
 User = get_user_model()
 

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -11,12 +11,12 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from course_discovery.apps.api import filters, serializers
+from course_discovery.apps.api import filters, mixins, serializers
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import Course, CourseRun, Program
 
 
-class BaseHaystackViewSet(FacetMixin, HaystackViewSet):
+class BaseHaystackViewSet(mixins.DetailMixin, FacetMixin, HaystackViewSet):
     document_uid_field = 'key'
     facet_filter_backends = [filters.HaystackFacetFilterWithQueries, filters.HaystackFilter, OrderingFilter]
     ordering_fields = ('start',)
@@ -93,27 +93,31 @@ class BaseHaystackViewSet(FacetMixin, HaystackViewSet):
 
 
 class CourseSearchViewSet(BaseHaystackViewSet):
-    facet_serializer_class = serializers.CourseFacetSerializer
     index_models = (Course,)
+    detail_serializer_class = serializers.CourseSearchModelSerializer
+    facet_serializer_class = serializers.CourseFacetSerializer
     serializer_class = serializers.CourseSearchSerializer
 
 
 class CourseRunSearchViewSet(BaseHaystackViewSet):
-    facet_serializer_class = serializers.CourseRunFacetSerializer
     index_models = (CourseRun,)
+    detail_serializer_class = serializers.CourseRunSearchModelSerializer
+    facet_serializer_class = serializers.CourseRunFacetSerializer
     serializer_class = serializers.CourseRunSearchSerializer
 
 
 class ProgramSearchViewSet(BaseHaystackViewSet):
     document_uid_field = 'uuid'
     lookup_field = 'uuid'
-    facet_serializer_class = serializers.ProgramFacetSerializer
     index_models = (Program,)
+    detail_serializer_class = serializers.ProgramSearchModelSerializer
+    facet_serializer_class = serializers.ProgramFacetSerializer
     serializer_class = serializers.ProgramSearchSerializer
 
 
 class AggregateSearchViewSet(BaseHaystackViewSet):
     """ Search all content types. """
+    detail_serializer_class = serializers.AggregateSearchModelSerializer
     facet_serializer_class = serializers.AggregateFacetSearchSerializer
     serializer_class = serializers.AggregateSearchSerializer
 

--- a/course_discovery/apps/core/migrations/0007_auto_20171004_1133.py
+++ b/course_discovery/apps/core/migrations/0007_auto_20171004_1133.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 
-
 SWITCH = 'use_company_name_as_utm_source_value'
 
 

--- a/course_discovery/apps/core/tests/mixins.py
+++ b/course_discovery/apps/core/tests/mixins.py
@@ -3,7 +3,6 @@ import logging
 
 import pytest
 import responses
-
 from django.conf import settings
 from haystack import connections as haystack_connections
 

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -26,14 +26,12 @@ from taggit_autosuggest.managers import TaggableManager
 from course_discovery.apps.core.models import Currency, Partner
 from course_discovery.apps.course_metadata.choices import CourseRunPacing, CourseRunStatus, ProgramStatus, ReportingType
 from course_discovery.apps.course_metadata.publishers import (
-    CourseRunMarketingSitePublisher,
-    ProgramMarketingSitePublisher
+    CourseRunMarketingSitePublisher, ProgramMarketingSitePublisher
 )
 from course_discovery.apps.course_metadata.query import CourseQuerySet, CourseRunQuerySet, ProgramQuerySet
 from course_discovery.apps.course_metadata.utils import UploadToFieldNamePath, clean_query, custom_render_variations
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.utils import VALID_CHARS_IN_COURSE_NUM_AND_ORG_KEY
-
 
 logger = logging.getLogger(__name__)
 

--- a/course_discovery/apps/course_metadata/publishers.py
+++ b/course_discovery/apps/course_metadata/publishers.py
@@ -8,12 +8,7 @@ from django.utils.text import slugify
 
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.exceptions import (
-    AliasCreateError,
-    AliasDeleteError,
-    FormRetrievalError,
-    NodeCreateError,
-    NodeDeleteError,
-    NodeEditError,
+    AliasCreateError, AliasDeleteError, FormRetrievalError, NodeCreateError, NodeDeleteError, NodeEditError,
     NodeLookupError
 )
 from course_discovery.apps.course_metadata.utils import MarketingSiteAPIClient

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -6,6 +6,26 @@ from opaque_keys.edx.keys import CourseKey
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import Course, CourseRun, Program
 
+BASE_SEARCH_INDEX_FIELDS = (
+    'aggregation_key',
+    'content_type',
+    'text',
+)
+
+BASE_PROGRAM_FIELDS = (
+    'card_image_url',
+    'language',
+    'marketing_url',
+    'partner',
+    'published',
+    'status',
+    'subtitle',
+    'text',
+    'title',
+    'type',
+    'uuid'
+)
+
 # http://django-haystack.readthedocs.io/en/v2.5.0/boost.html#field-boost
 # Boost title over all other parameters (multiplicative)
 # The max boost received from our boosting functions is ~6.

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -270,6 +270,7 @@ class ProgramFactory(factory.django.DjangoModelFactory):
     banner_image_url = FuzzyText(prefix='https://example.com/program/banner')
     card_image_url = FuzzyText(prefix='https://example.com/program/card')
     partner = factory.SubFactory(PartnerFactory)
+    video = factory.SubFactory(VideoFactory)
     overview = FuzzyText()
     total_hours_of_effort = FuzzyInteger(2)
     weeks_to_complete = FuzzyInteger(1)

--- a/course_discovery/apps/course_metadata/tests/test_publishers.py
+++ b/course_discovery/apps/course_metadata/tests/test_publishers.py
@@ -7,18 +7,11 @@ import responses
 from course_discovery.apps.core.tests.factories import PartnerFactory
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.exceptions import (
-    AliasCreateError,
-    AliasDeleteError,
-    FormRetrievalError,
-    NodeCreateError,
-    NodeDeleteError,
-    NodeEditError,
+    AliasCreateError, AliasDeleteError, FormRetrievalError, NodeCreateError, NodeDeleteError, NodeEditError,
     NodeLookupError
 )
 from course_discovery.apps.course_metadata.publishers import (
-    BaseMarketingSitePublisher,
-    CourseRunMarketingSitePublisher,
-    ProgramMarketingSitePublisher
+    BaseMarketingSitePublisher, CourseRunMarketingSitePublisher, ProgramMarketingSitePublisher
 )
 from course_discovery.apps.course_metadata.tests import toggle_switch
 from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, ProgramFactory

--- a/course_discovery/apps/edx_catalog_extensions/api/v1/tests/test_views.py
+++ b/course_discovery/apps/edx_catalog_extensions/api/v1/tests/test_views.py
@@ -4,10 +4,10 @@ import urllib.parse
 import pytz
 from django.urls import reverse
 
-from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase
-from course_discovery.apps.api.v1.tests.test_views.test_search import (
-    ElasticsearchTestMixin, LoginMixin, SerializationMixin, SynonymTestMixin
+from course_discovery.apps.api.v1.tests.test_views.mixins import (
+    APITestCase, LoginMixin, SerializationMixin, SynonymTestMixin
 )
+from course_discovery.apps.api.v1.tests.test_views.test_search import ElasticsearchTestMixin
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.tests.factories import CourseFactory, CourseRunFactory, ProgramFactory
 from course_discovery.apps.edx_catalog_extensions.api.serializers import DistinctCountsAggregateFacetSearchSerializer
@@ -125,9 +125,9 @@ class DistinctCountsAggregateSearchViewSetTests(SerializationMixin, LoginMixin,
 
         for record in objects['results']:
             if record['content_type'] == 'courserun':
-                assert record == self.serialize_course_run(course_runs[str(record['key'])])
+                assert record == self.serialize_course_run_search(course_runs[str(record['key'])])
             else:
-                assert record == self.serialize_program(programs[str(record['uuid'])])
+                assert record == self.serialize_program_search(programs[str(record['uuid'])])
 
     def test_response_with_search_query(self):
         """ Verify that the response is accurate when a search query is passed."""

--- a/course_discovery/apps/edx_haystack_extensions/distinct_counts/backends.py
+++ b/course_discovery/apps/edx_haystack_extensions/distinct_counts/backends.py
@@ -1,5 +1,4 @@
 import elasticsearch
-
 from django.conf import settings
 from haystack.backends.elasticsearch_backend import ElasticsearchSearchQuery
 from haystack.models import SearchResult

--- a/course_discovery/apps/edx_haystack_extensions/distinct_counts/query.py
+++ b/course_discovery/apps/edx_haystack_extensions/distinct_counts/query.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from haystack.query import SearchQuerySet
+
 from course_discovery.apps.edx_haystack_extensions.distinct_counts.backends import DistinctCountsSearchQuery
 
 

--- a/course_discovery/apps/edx_haystack_extensions/management/commands/remove_unused_indexes.py
+++ b/course_discovery/apps/edx_haystack_extensions/management/commands/remove_unused_indexes.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from haystack import connections as haystack_connections
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/course_discovery/apps/publisher/admin.py
+++ b/course_discovery/apps/publisher/admin.py
@@ -6,16 +6,18 @@ from simple_history.admin import SimpleHistoryAdmin
 
 from course_discovery.apps.publisher.assign_permissions import assign_permissions
 from course_discovery.apps.publisher.choices import InternalUserRole
-from course_discovery.apps.publisher.constants import (INTERNAL_USER_GROUP_NAME, PARTNER_MANAGER_GROUP_NAME,
-                                                       PROJECT_COORDINATOR_GROUP_NAME, PUBLISHER_GROUP_NAME,
-                                                       REVIEWER_GROUP_NAME)
+from course_discovery.apps.publisher.constants import (
+    INTERNAL_USER_GROUP_NAME, PARTNER_MANAGER_GROUP_NAME, PROJECT_COORDINATOR_GROUP_NAME, PUBLISHER_GROUP_NAME,
+    REVIEWER_GROUP_NAME
+)
 from course_discovery.apps.publisher.forms import (
     CourseRunAdminForm, CourseRunStateAdminForm, CourseStateAdminForm, OrganizationExtensionForm,
     PublisherUserCreationForm, UserAttributesAdminForm
 )
-from course_discovery.apps.publisher.models import (Course, CourseEntitlement, CourseRun, CourseRunState, CourseState,
-                                                    CourseUserRole, OrganizationExtension, OrganizationUserRole,
-                                                    PublisherUser, Seat, UserAttributes)
+from course_discovery.apps.publisher.models import (
+    Course, CourseEntitlement, CourseRun, CourseRunState, CourseState, CourseUserRole, OrganizationExtension,
+    OrganizationUserRole, PublisherUser, Seat, UserAttributes
+)
 
 
 @admin.register(CourseUserRole)

--- a/course_discovery/apps/publisher/api/serializers.py
+++ b/course_discovery/apps/publisher/api/serializers.py
@@ -13,9 +13,10 @@ from rest_framework import serializers
 
 from course_discovery.apps.core.models import User
 from course_discovery.apps.publisher.choices import PublisherUserRole
-from course_discovery.apps.publisher.emails import (send_change_role_assignment_email,
-                                                    send_email_for_studio_instance_created, send_email_preview_accepted,
-                                                    send_email_preview_page_is_available)
+from course_discovery.apps.publisher.emails import (
+    send_change_role_assignment_email, send_email_for_studio_instance_created, send_email_preview_accepted,
+    send_email_preview_page_is_available
+)
 from course_discovery.apps.publisher.models import CourseRun, CourseRunState, CourseState, CourseUserRole
 
 

--- a/course_discovery/apps/publisher/api/tests/test_serializers.py
+++ b/course_discovery/apps/publisher/api/tests/test_serializers.py
@@ -11,14 +11,16 @@ from course_discovery.apps.core.tests.helpers import make_image_file
 from course_discovery.apps.course_metadata.tests import toggle_switch
 from course_discovery.apps.course_metadata.tests.factories import OrganizationFactory, PersonFactory
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
-from course_discovery.apps.publisher.api.serializers import (CourseRevisionSerializer, CourseRunSerializer,
-                                                             CourseRunStateSerializer, CourseStateSerializer,
-                                                             CourseUserRoleSerializer, GroupUserSerializer)
+from course_discovery.apps.publisher.api.serializers import (
+    CourseRevisionSerializer, CourseRunSerializer, CourseRunStateSerializer, CourseStateSerializer,
+    CourseUserRoleSerializer, GroupUserSerializer
+)
 from course_discovery.apps.publisher.choices import CourseRunStateChoices, CourseStateChoices, PublisherUserRole
 from course_discovery.apps.publisher.models import CourseRun, CourseState, Seat
-from course_discovery.apps.publisher.tests.factories import (CourseFactory, CourseRunFactory, CourseRunStateFactory,
-                                                             CourseStateFactory, CourseUserRoleFactory,
-                                                             OrganizationExtensionFactory, SeatFactory)
+from course_discovery.apps.publisher.tests.factories import (
+    CourseFactory, CourseRunFactory, CourseRunStateFactory, CourseStateFactory, CourseUserRoleFactory,
+    OrganizationExtensionFactory, SeatFactory
+)
 
 
 class CourseUserRoleSerializerTests(SiteMixin, TestCase):

--- a/course_discovery/apps/publisher/api/tests/test_utils.py
+++ b/course_discovery/apps/publisher/api/tests/test_utils.py
@@ -1,8 +1,9 @@
 import pytest
 
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.publisher.api.utils import (serialize_entitlement_for_ecommerce_api,
-                                                       serialize_seat_for_ecommerce_api)
+from course_discovery.apps.publisher.api.utils import (
+    serialize_entitlement_for_ecommerce_api, serialize_seat_for_ecommerce_api
+)
 from course_discovery.apps.publisher.models import Seat
 from course_discovery.apps.publisher.tests.factories import CourseEntitlementFactory, SeatFactory
 

--- a/course_discovery/apps/publisher/api/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/tests/test_views.py
@@ -22,8 +22,9 @@ from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.api import views
 from course_discovery.apps.publisher.choices import CourseRunStateChoices, CourseStateChoices, PublisherUserRole
 from course_discovery.apps.publisher.constants import ADMIN_GROUP_NAME, INTERNAL_USER_GROUP_NAME
-from course_discovery.apps.publisher.models import (Course, CourseRun, CourseRunState, CourseState,
-                                                    OrganizationExtension, Seat)
+from course_discovery.apps.publisher.models import (
+    Course, CourseRun, CourseRunState, CourseState, OrganizationExtension, Seat
+)
 from course_discovery.apps.publisher.tests import JSON_CONTENT_TYPE, factories
 
 

--- a/course_discovery/apps/publisher/api/urls.py
+++ b/course_discovery/apps/publisher/api/urls.py
@@ -1,11 +1,11 @@
 """ Publisher API URLs. """
 from django.conf.urls import include, url
 
-from course_discovery.apps.publisher.api.views import (AcceptAllRevisionView, ChangeCourseRunStateView,
-                                                       ChangeCourseStateView, CourseRevisionDetailView,
-                                                       CourseRoleAssignmentView, CoursesAutoComplete,
-                                                       OrganizationGroupUserView, RevertCourseRevisionView,
-                                                       UpdateCourseRunView)
+from course_discovery.apps.publisher.api.views import (
+    AcceptAllRevisionView, ChangeCourseRunStateView, ChangeCourseStateView, CourseRevisionDetailView,
+    CourseRoleAssignmentView, CoursesAutoComplete, OrganizationGroupUserView, RevertCourseRevisionView,
+    UpdateCourseRunView
+)
 
 urlpatterns = [
     url(r'^course_role_assignments/(?P<pk>\d+)/$', CourseRoleAssignmentView.as_view(), name='course_role_assignments'),

--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -18,8 +18,9 @@ from course_discovery.apps.course_metadata.models import Seat as DiscoverySeat
 from course_discovery.apps.course_metadata.models import CourseRun, SeatType, Video
 from course_discovery.apps.course_metadata.tests.factories import OrganizationFactory, PersonFactory
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
-from course_discovery.apps.publisher.api.utils import (serialize_entitlement_for_ecommerce_api,
-                                                       serialize_seat_for_ecommerce_api)
+from course_discovery.apps.publisher.api.utils import (
+    serialize_entitlement_for_ecommerce_api, serialize_seat_for_ecommerce_api
+)
 from course_discovery.apps.publisher.api.v1.views import CourseRunViewSet
 from course_discovery.apps.publisher.models import CourseEntitlement, Seat
 from course_discovery.apps.publisher.tests.factories import CourseEntitlementFactory, CourseRunFactory, SeatFactory

--- a/course_discovery/apps/publisher/api/views.py
+++ b/course_discovery/apps/publisher/api/views.py
@@ -11,14 +11,17 @@ from rest_framework.views import APIView
 
 from course_discovery.apps.core.models import User
 from course_discovery.apps.publisher.api.paginations import LargeResultsSetPagination
-from course_discovery.apps.publisher.api.permissions import (CanViewAssociatedCourse, InternalUserPermission,
-                                                             PublisherUserPermission)
-from course_discovery.apps.publisher.api.serializers import (CourseRevisionSerializer, CourseRunSerializer,
-                                                             CourseRunStateSerializer, CourseStateSerializer,
-                                                             CourseUserRoleSerializer, GroupUserSerializer)
+from course_discovery.apps.publisher.api.permissions import (
+    CanViewAssociatedCourse, InternalUserPermission, PublisherUserPermission
+)
+from course_discovery.apps.publisher.api.serializers import (
+    CourseRevisionSerializer, CourseRunSerializer, CourseRunStateSerializer, CourseStateSerializer,
+    CourseUserRoleSerializer, GroupUserSerializer
+)
 from course_discovery.apps.publisher.forms import CourseForm
-from course_discovery.apps.publisher.models import (Course, CourseRun, CourseRunState, CourseState, CourseUserRole,
-                                                    OrganizationExtension, PublisherUser)
+from course_discovery.apps.publisher.models import (
+    Course, CourseRun, CourseRunState, CourseState, CourseUserRole, OrganizationExtension, PublisherUser
+)
 
 logger = logging.getLogger(__name__)
 

--- a/course_discovery/apps/publisher/assign_permissions.py
+++ b/course_discovery/apps/publisher/assign_permissions.py
@@ -1,9 +1,10 @@
 from django.contrib.auth.models import Group
 from guardian.shortcuts import assign_perm
 
-from course_discovery.apps.publisher.constants import (GENERAL_STAFF_GROUP_NAME, LEGAL_TEAM_GROUP_NAME,
-                                                       PARTNER_SUPPORT_GROUP_NAME, PROJECT_COORDINATOR_GROUP_NAME,
-                                                       REVIEWER_GROUP_NAME)
+from course_discovery.apps.publisher.constants import (
+    GENERAL_STAFF_GROUP_NAME, LEGAL_TEAM_GROUP_NAME, PARTNER_SUPPORT_GROUP_NAME, PROJECT_COORDINATOR_GROUP_NAME,
+    REVIEWER_GROUP_NAME
+)
 from course_discovery.apps.publisher.models import OrganizationExtension
 
 

--- a/course_discovery/apps/publisher/migrations/0019_create_user_groups.py
+++ b/course_discovery/apps/publisher/migrations/0019_create_user_groups.py
@@ -3,8 +3,9 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 
-from course_discovery.apps.publisher.constants import (PARTNER_COORDINATOR_GROUP_NAME, PUBLISHER_GROUP_NAME,
-                                                       REVIEWER_GROUP_NAME)
+from course_discovery.apps.publisher.constants import (
+    PARTNER_COORDINATOR_GROUP_NAME, PUBLISHER_GROUP_NAME, REVIEWER_GROUP_NAME
+)
 
 GROUPS = [PARTNER_COORDINATOR_GROUP_NAME, REVIEWER_GROUP_NAME, PUBLISHER_GROUP_NAME]
 

--- a/course_discovery/apps/publisher/migrations/0061_add_people_permission.py
+++ b/course_discovery/apps/publisher/migrations/0061_add_people_permission.py
@@ -4,8 +4,10 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 
-from course_discovery.apps.publisher.constants import (INTERNAL_USER_GROUP_NAME, PARTNER_COORDINATOR_GROUP_NAME,
-                                                       PUBLISHER_GROUP_NAME, REVIEWER_GROUP_NAME)
+from course_discovery.apps.publisher.constants import (
+    INTERNAL_USER_GROUP_NAME, PARTNER_COORDINATOR_GROUP_NAME, PUBLISHER_GROUP_NAME, REVIEWER_GROUP_NAME
+)
+
 GROUPS = [INTERNAL_USER_GROUP_NAME, PARTNER_COORDINATOR_GROUP_NAME, REVIEWER_GROUP_NAME, PUBLISHER_GROUP_NAME]
 
 

--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -29,7 +29,6 @@ from course_discovery.apps.publisher.choices import (
     CourseRunStateChoices, CourseStateChoices, InternalUserRole, PublisherUserRole
 )
 from course_discovery.apps.publisher.utils import is_email_notification_enabled, is_internal_user, is_publisher_admin
-
 from course_discovery.apps.publisher.validators import ImageMultiSizeValidator
 
 logger = logging.getLogger(__name__)

--- a/course_discovery/apps/publisher/tests/factories.py
+++ b/course_discovery/apps/publisher/tests/factories.py
@@ -12,9 +12,10 @@ from course_discovery.apps.course_metadata.choices import CourseRunPacing
 from course_discovery.apps.course_metadata.tests import factories
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.choices import PublisherUserRole
-from course_discovery.apps.publisher.models import (Course, CourseEntitlement, CourseRun, CourseRunState, CourseState,
-                                                    CourseUserRole, OrganizationExtension, OrganizationUserRole, Seat,
-                                                    UserAttributes)
+from course_discovery.apps.publisher.models import (
+    Course, CourseEntitlement, CourseRun, CourseRunState, CourseState, CourseUserRole, OrganizationExtension,
+    OrganizationUserRole, Seat, UserAttributes
+)
 
 
 class CourseFactory(factory.DjangoModelFactory):

--- a/course_discovery/apps/publisher/tests/test_admin.py
+++ b/course_discovery/apps/publisher/tests/test_admin.py
@@ -8,8 +8,9 @@ from course_discovery.apps.api.tests.mixins import SiteMixin
 from course_discovery.apps.core.tests.factories import UserFactory
 from course_discovery.apps.course_metadata.tests.factories import OrganizationFactory
 from course_discovery.apps.publisher.choices import PublisherUserRole
-from course_discovery.apps.publisher.constants import (PARTNER_MANAGER_GROUP_NAME, PROJECT_COORDINATOR_GROUP_NAME,
-                                                       PUBLISHER_GROUP_NAME, REVIEWER_GROUP_NAME)
+from course_discovery.apps.publisher.constants import (
+    PARTNER_MANAGER_GROUP_NAME, PROJECT_COORDINATOR_GROUP_NAME, PUBLISHER_GROUP_NAME, REVIEWER_GROUP_NAME
+)
 from course_discovery.apps.publisher.forms import CourseRunAdminForm
 from course_discovery.apps.publisher.models import CourseRun, OrganizationExtension
 from course_discovery.apps.publisher.tests import factories

--- a/course_discovery/apps/publisher/tests/test_models.py
+++ b/course_discovery/apps/publisher/tests/test_models.py
@@ -16,8 +16,9 @@ from course_discovery.apps.course_metadata.tests.factories import OrganizationFa
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.choices import CourseRunStateChoices, CourseStateChoices, PublisherUserRole
 from course_discovery.apps.publisher.mixins import check_course_organization_permission
-from course_discovery.apps.publisher.models import (Course, CourseUserRole, OrganizationExtension,
-                                                    OrganizationUserRole, Seat)
+from course_discovery.apps.publisher.models import (
+    Course, CourseUserRole, OrganizationExtension, OrganizationUserRole, Seat
+)
 from course_discovery.apps.publisher.tests import factories
 
 

--- a/course_discovery/apps/publisher/tests/test_utils.py
+++ b/course_discovery/apps/publisher/tests/test_utils.py
@@ -9,16 +9,18 @@ from guardian.shortcuts import assign_perm
 from mock import Mock
 
 from course_discovery.apps.core.tests.factories import UserFactory
-from course_discovery.apps.publisher.constants import (ADMIN_GROUP_NAME, INTERNAL_USER_GROUP_NAME,
-                                                       PROJECT_COORDINATOR_GROUP_NAME, REVIEWER_GROUP_NAME)
-from course_discovery.apps.publisher.mixins import (check_course_organization_permission, check_roles_access,
-                                                    publisher_user_required)
+from course_discovery.apps.publisher.constants import (
+    ADMIN_GROUP_NAME, INTERNAL_USER_GROUP_NAME, PROJECT_COORDINATOR_GROUP_NAME, REVIEWER_GROUP_NAME
+)
+from course_discovery.apps.publisher.mixins import (
+    check_course_organization_permission, check_roles_access, publisher_user_required
+)
 from course_discovery.apps.publisher.models import OrganizationExtension
 from course_discovery.apps.publisher.tests import factories
-from course_discovery.apps.publisher.utils import (get_internal_users, has_role_for_course,
-                                                   is_email_notification_enabled, is_internal_user,
-                                                   is_project_coordinator_user, is_publisher_admin, is_publisher_user,
-                                                   make_bread_crumbs, parse_datetime_field)
+from course_discovery.apps.publisher.utils import (
+    get_internal_users, has_role_for_course, is_email_notification_enabled, is_internal_user,
+    is_project_coordinator_user, is_publisher_admin, is_publisher_user, make_bread_crumbs, parse_datetime_field
+)
 
 
 @ddt.ddt

--- a/course_discovery/apps/publisher/tests/test_wrapper.py
+++ b/course_discovery/apps/publisher/tests/test_wrapper.py
@@ -6,8 +6,9 @@ import ddt
 from django.test import TestCase
 
 from course_discovery.apps.course_metadata.choices import CourseRunPacing
-from course_discovery.apps.course_metadata.tests.factories import (OrganizationFactory, PersonFactory,
-                                                                   PersonSocialNetworkFactory, PositionFactory)
+from course_discovery.apps.course_metadata.tests.factories import (
+    OrganizationFactory, PersonFactory, PersonSocialNetworkFactory, PositionFactory
+)
 from course_discovery.apps.publisher.choices import CourseRunStateChoices, PublisherUserRole
 from course_discovery.apps.publisher.models import Seat
 from course_discovery.apps.publisher.tests import factories

--- a/course_discovery/apps/publisher/utils.py
+++ b/course_discovery/apps/publisher/utils.py
@@ -1,10 +1,12 @@
 """ Publisher Utils."""
 import re
+
 from dateutil import parser
 
 from course_discovery.apps.core.models import User
-from course_discovery.apps.publisher.constants import (ADMIN_GROUP_NAME, INTERNAL_USER_GROUP_NAME,
-                                                       PROJECT_COORDINATOR_GROUP_NAME)
+from course_discovery.apps.publisher.constants import (
+    ADMIN_GROUP_NAME, INTERNAL_USER_GROUP_NAME, PROJECT_COORDINATOR_GROUP_NAME
+)
 
 VALID_CHARS_IN_COURSE_NUM_AND_ORG_KEY = re.compile(r'^[a-zA-Z0-9._-]*$')
 

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -32,8 +32,8 @@ from course_discovery.apps.publisher.forms import (
     AdminImportCourseForm, CourseEntitlementForm, CourseForm, CourseRunForm, CourseSearchForm, SeatForm
 )
 from course_discovery.apps.publisher.models import (
-    Course, CourseEntitlement, CourseRun, CourseRunState, CourseState, CourseUserRole,
-    OrganizationExtension, PublisherUser, Seat, UserAttributes
+    Course, CourseEntitlement, CourseRun, CourseRunState, CourseState, CourseUserRole, OrganizationExtension,
+    PublisherUser, Seat, UserAttributes
 )
 from course_discovery.apps.publisher.utils import (
     get_internal_users, has_role_for_course, is_internal_user, is_project_coordinator_user, is_publisher_admin,

--- a/course_discovery/apps/publisher_comments/models.py
+++ b/course_discovery/apps/publisher_comments/models.py
@@ -1,4 +1,5 @@
 import logging
+
 import waffle
 from django.db import models, transaction
 from django.utils.translation import ugettext_lazy as _

--- a/course_discovery/apps/publisher_comments/urls.py
+++ b/course_discovery/apps/publisher_comments/urls.py
@@ -3,7 +3,6 @@ URLs for the course publisher comments views.
 """
 from django.conf.urls import include, url
 
-
 urlpatterns = [
     url(r'^api/', include('course_discovery.apps.publisher_comments.api.urls', namespace='api')),
 ]

--- a/course_discovery/settings/devstack_test.py
+++ b/course_discovery/settings/devstack_test.py
@@ -1,4 +1,5 @@
 from course_discovery.settings.devstack import *
+
 # noinspection PyUnresolvedReferences
 from course_discovery.settings.shared.test import *     # isort:skip
 


### PR DESCRIPTION
This PR introduces 4 new endpoints in total:

- `/api/v1/search/all/details`
- `/api/v1/search/courses/details`
- `/api/v1/search/course_runs/details`
- `/api/v1/search/programs/details`

These are all searchable, however the current implementation does not add any `search_fields` to actually search in -- that can be added pretty easily later.

This implementation also re-uses existing model serializers (to make it way cheaper to implement dev-time wise) and thus the search is retrieving the underlying object through the SQL DB. This is something to watch out for performance-wise, and eventually a move can be made to using just the search index.

They all return _detailed_ versions of their respective resources, using the most detailed version of the model serializers that were already available.

The `all` endpoint in particular aggregates the resources and presents detailed content type-generic responses, which is the whole point of ENT-915.

*Test instructions*:

1. Make a bunch of different courses, course runs, and programs, any way you like.
1. Run course discovery's reindex management command to make sure this data is available to the API.
1. Ensure that the level of detail retrieved from `/api/v1/search/courses/details` matches `/api/v1/courses/`.
1. Ensure that the level of detail retrieved from `/api/v1/search/course_runs/details` matches `/api/v1/course_runs`.
1. Ensure that the level of detail retrieved from `/api/v1/search/programs/details` matches `/api/v1/programs/{uuid}` for a specific program.
1. Ensure that `/api/v1/search/all/details` retrieves everything you'd get from the 3 other endpoints in aggregated form, with the addition of a `content_type` key which tells what type of content that object is.