### PR TITLE
ENT-960 Fix catalogs creation bug due to request data format

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -129,11 +129,10 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
         data = {
             'name': 'Test Catalog',
             'query': '*:*',
-            'viewers': ','.join(viewers)
+            'viewers': str(viewers),
         }
 
-        # NOTE: We explicitly avoid using the JSON data type so that we properly test string parsing.
-        response = self.client.post(self.catalog_list_url, data)
+        response = self.client.post(self.catalog_list_url, data, format='json')
         self.assertEqual(response.status_code, 201)
 
         catalog = Catalog.objects.latest()
@@ -145,10 +144,10 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
         """ Verify no users are created if an error occurs while processing a create request. """
         # The missing name and query fields should trigger an error
         data = {
-            'viewers': ['new-guy']
+            'viewers': str(['new-guy'])
         }
         original_user_count = User.objects.count()
-        response = self.client.post(self.catalog_list_url, data)
+        response = self.client.post(self.catalog_list_url, data, format='json')
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(User.objects.count(), original_user_count)

--- a/course_discovery/apps/api/v1/views/catalogs.py
+++ b/course_discovery/apps/api/v1/views/catalogs.py
@@ -1,3 +1,4 @@
+import ast
 import datetime
 
 from django.db import transaction
@@ -32,13 +33,13 @@ class CatalogViewSet(viewsets.ModelViewSet):
     @transaction.atomic
     def create(self, request, *args, **kwargs):
         """ Create a new catalog. """
-        data = request.data.copy()
+        data = dict(request.data.copy())
         usernames = request.data.get('viewers', ())
 
         # Add support for parsing a comma-separated list from Swagger
         if isinstance(usernames, str):
-            usernames = usernames.split(',')
-            data.setlist('viewers', usernames)
+            usernames = ast.literal_eval(usernames)
+            data['viewers'] = usernames
 
         # Ensure the users exist
         for username in usernames:


### PR DESCRIPTION
@asadiqbal08 @saleem-latif 
Catalogs creation endpoint in discovery was expecting list value for viewers `'viewers': ['user_1', 'user_2']` but catalogs creation page in LMS api-admin was sending serialized value for viewers field `viewers': "['user_1, 'user_2']"`.

* Updated Catalogs creation view to expect request data in json format
* Update tests to reflect the change

**Testing Instructions:**
* Setup edx-platform with discovery service point to the branch `zub/ENT-960-fix-catalogs-creation-bug`.
* Open catalogs creation page in edx-platform `http://localhost:8000/api-admin/catalogs/`
<img width="604" alt="screen shot 2018-04-19 at 4 13 28 pm" src="https://user-images.githubusercontent.com/5072991/38988506-d4b83492-43ec-11e8-9b40-acdb6fe4c67b.png">
* Search catalogs with an existing username.
* View the catalogs list page along with catalog creation form. Provide details on the catalog creation form.
<img width="311" alt="screen shot 2018-04-19 at 4 14 00 pm" src="https://user-images.githubusercontent.com/5072991/38988530-f034b0ba-43ec-11e8-9edd-0874e59be9e6.png">
* Verify that on clicking button "Catalog Creation" the user is redirected to catalog detail page.
<img width="333" alt="screen shot 2018-04-19 at 4 14 22 pm" src="https://user-images.githubusercontent.com/5072991/38988752-d371852e-43ed-11e8-832b-4b09ddd47d10.png">

