### PR TITLE
Update corresponding drupal node on instructor update via publisher

### DIFF
--- a/course_discovery/apps/api/v1/views/people.py
+++ b/course_discovery/apps/api/v1/views/people.py
@@ -28,7 +28,9 @@ class PersonViewSet(viewsets.ModelViewSet):
     pagination_class = PageNumberPagination
 
     def create(self, request, *args, **kwargs):
-        """ Create a new person. """
+        """
+        Create a person in discovery and also create a person node in drupal
+        """
         person_data = request.data
 
         partner = request.site.partner
@@ -36,40 +38,88 @@ class PersonViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(data=person_data)
         serializer.is_valid(raise_exception=True)
 
-        if waffle.switch_is_active('publish_person_to_marketing_site'):
-            try:
-                marketing_person = MarketingSitePeople()
-                response = marketing_person.publish_person(
-                    partner, {
-                        'given_name': serializer.validated_data['given_name'],
-                        'family_name': serializer.validated_data['family_name']
-                    }
-                )
-                serializer.validated_data.pop('uuid')
-                serializer.validated_data['uuid'] = response['uuid']
+        if not waffle.switch_is_active('publish_person_to_marketing_site'):
+            return Response('publish_person_to_marketing_site is disabled.', status=status.HTTP_400_BAD_REQUEST)
+        try:
+            marketing_person = MarketingSitePeople()
+            response = marketing_person.publish_person(
+                partner,
+                self._get_person_data(serializer)
+            )
+            serializer.validated_data.pop('uuid')
+            serializer.validated_data['uuid'] = response['uuid']
 
-            except (PersonToMarketingException, MarketingSiteAPIClientException):
-                logger.exception(
-                    'An error occurred while adding the person [%s]-[%s] to the marketing site.',
-                    serializer.validated_data['given_name'], serializer.validated_data['family_name']
-                )
-                return Response('Failed to add person data to the marketing site.', status=status.HTTP_400_BAD_REQUEST)
+        except (PersonToMarketingException, MarketingSiteAPIClientException):
+            logger.exception(
+                'An error occurred while adding the person [%s]-[%s] to the marketing site.',
+                serializer.validated_data['given_name'], serializer.validated_data['family_name']
+            )
+            return Response('Failed to add person data to the marketing site.', status=status.HTTP_400_BAD_REQUEST)
 
-            try:
-                self.perform_create(serializer)
-            except Exception:  # pylint: disable=broad-except
-                logger.exception(
-                    'An error occurred while adding the person [%s]-[%s]-[%s].',
-                    serializer.validated_data['given_name'], serializer.validated_data['family_name'],
-                    response['id']
-                )
-                marketing_person.delete_person(partner, response['id'])
-                return Response('Failed to add person data.', status=status.HTTP_400_BAD_REQUEST)
+        try:
+            self.perform_create(serializer)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                'An error occurred while adding the person [%s]-[%s]-[%s] in discovery.',
+                serializer.validated_data['given_name'], serializer.validated_data['family_name'],
+                response['id']
+            )
+            marketing_person.delete_person(partner, response['id'])
+            return Response('Failed to add person data.', status=status.HTTP_400_BAD_REQUEST)
 
-            headers = self.get_success_headers(serializer.data)
-            return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
-        return Response('publish_program_to_marketing_site is disabled.', status=status.HTTP_400_BAD_REQUEST)
+    def update(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Updates a person in discovery and the corresponding person node in drupal
+        """
+        person_data = request.data
+
+        partner = request.site.partner
+        person_data['partner'] = partner.id
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=person_data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+
+        if not waffle.switch_is_active('publish_person_to_marketing_site'):
+            return Response('publish_person_to_marketing_site is disabled.', status=status.HTTP_400_BAD_REQUEST)
+        try:
+            marketing_person = MarketingSitePeople()
+            marketing_person.update_person(
+                partner,
+                serializer.validated_data['uuid'],
+                self._get_person_data(serializer)
+            )
+
+        except (PersonToMarketingException, MarketingSiteAPIClientException):
+            logger.exception(
+                'An error occurred while updating the person [%s]-[%s] on the marketing site.',
+                serializer.validated_data['given_name'], serializer.validated_data['family_name']
+            )
+            return Response(
+                'Failed to update person data on the marketing site.',
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            self.perform_update(serializer)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                'An error occurred while updating the person [%s]-[%s] in discovery.',
+                serializer.validated_data['given_name'], serializer.validated_data['family_name']
+            )
+            return Response('Failed to update person data.', status=status.HTTP_400_BAD_REQUEST)
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_200_OK, headers=headers)
+
+    def _get_person_data(self, serializer):
+        return {
+            'given_name': serializer.validated_data['given_name'],
+            'family_name': serializer.validated_data['family_name']
+        }
 
     def list(self, request, *args, **kwargs):
         """ Retrieve a list of all people. """

--- a/course_discovery/apps/course_metadata/people.py
+++ b/course_discovery/apps/course_metadata/people.py
@@ -22,6 +22,7 @@ class MarketingSitePeople(object):
         return {
             'field_person_first_middle_name': person['given_name'],
             'field_person_last_name': person['family_name'],
+            'title': person['given_name'] + ' ' + person['family_name'],
             'type': 'person',
         }
 
@@ -35,6 +36,26 @@ class MarketingSitePeople(object):
             logger.exception('Failed to create person node to marketing site [%s].', response.content)
             raise PersonToMarketingException("Marketing site Person page creation failed!")
 
+    def _get_node_id_from_uuid(self, api_client, uuid):
+        node_url = '{root}/node.json?uuid={uuid}'.format(root=api_client.api_url, uuid=uuid)
+        response = api_client.api_session.get(node_url)
+        if response.status_code == 200:
+            response_json = response.json()
+            person_list = response_json.get('list')
+            return person_list[0].get('nid') if person_list else None
+        else:
+            logger.exception('Failed to update person node on marketing site [%s].', response.content)
+            raise PersonToMarketingException("Marketing site Person page update failed!")
+
+    def update_person(self, partner, person_uuid, person):
+        api_client = self._get_api_client(partner)
+        node_id = self._get_node_id_from_uuid(api_client, person_uuid)
+        if node_id:
+            node_data = self._get_node_data(person)
+            return self._update_node(api_client, node_id, node_data)
+        else:
+            logger.info('Person with UUID [%s] does not exist on the marketing site', person_uuid)
+
     def publish_person(self, partner, person):
         api_client = self._get_api_client(partner)
         node_data = self._get_node_data(person)
@@ -45,6 +66,16 @@ class MarketingSitePeople(object):
         api_client = self._get_api_client(partner)
         if api_client and node_id:
             self._delete_node(api_client, node_id)
+
+    def _update_node(self, api_client, node_id, node_data):
+        node_url = '{root}/node.json/{node_id}'.format(root=api_client.api_url, node_id=node_id)
+        response = api_client.api_session.put(node_url, data=json.dumps(node_data))
+        if response.status_code == 200:
+            response_json = response.json()
+            return response_json
+        else:
+            logger.exception('Failed to update person node on marketing site [%s].', response.content)
+            raise PersonToMarketingException("Marketing site Person page update failed!")
 
     def _delete_node(self, api_client, node_id):
         node_url = '{root}/node.json/{node_id}'.format(root=api_client.api_url, node_id=node_id)

--- a/course_discovery/apps/course_metadata/tests/test_people.py
+++ b/course_discovery/apps/course_metadata/tests/test_people.py
@@ -1,10 +1,14 @@
+import mock
 import responses
+from testfixtures import LogCapture
 
 from course_discovery.apps.core.tests.factories import PartnerFactory
 from course_discovery.apps.course_metadata.exceptions import PersonToMarketingException
 from course_discovery.apps.course_metadata.people import MarketingSitePeople
 from course_discovery.apps.course_metadata.tests.mixins import MarketingSitePublisherTestMixin
 from course_discovery.apps.course_metadata.utils import MarketingSiteAPIClient
+
+LOGGER_NAME = 'course_discovery.apps.course_metadata.people'
 
 
 class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
@@ -23,16 +27,22 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
             self.password,
             self.api_root
         )
+        self.uuid = '18d5542f-fa80-418e-b416-455cfdeb4d4e'
 
         self.expected_node = {
             'resource': 'node', ''
             'id': '28691',
-            'uuid': '18d5542f-fa80-418e-b416-455cfdeb4d4e',
+            'uuid': self.uuid,
             'uri': 'https://stage.edx.org/node/28691'
         }
         self.data = {
             'given_name': 'test',
             'family_name': 'user'
+        }
+        self.updated_node_data = {
+            'given_name': 'updated test',
+            'family_name': 'user',
+            'title': 'updated test user'
         }
 
     @responses.activate
@@ -42,6 +52,68 @@ class MarketingSitePublisherTests(MarketingSitePublisherTestMixin):
         people = MarketingSitePeople()
         data = people._create_node(self.api_client, self.data)  # pylint: disable=protected-access
         self.assertEqual(data, self.expected_node)
+
+    @responses.activate
+    def test_update_node(self):
+        self.mock_api_client(200)
+        self.mock_node_edit(200)
+        people = MarketingSitePeople()
+        data = people._update_node(self.api_client, self.node_id, self.updated_node_data)  # pylint: disable=protected-access
+        self.assertEqual(data, {})
+
+    @responses.activate
+    def test_update_node_failed(self):
+        self.mock_api_client(200)
+        self.mock_node_edit(500)
+        people = MarketingSitePeople()
+        with self.assertRaises(PersonToMarketingException):
+            people._update_node(self.api_client, self.node_id, self.data)  # pylint: disable=protected-access
+
+    @responses.activate
+    def test_update_person(self):
+        self.mock_api_client(200)
+        self.mock_node_edit(200)
+        self.mock_node_retrieval('uuid', self.uuid, status=200)
+        people = MarketingSitePeople()
+        data = people.update_person(self.partner, self.uuid, self.updated_node_data)
+        self.assertEqual(data, {})
+
+    @responses.activate
+    def test_update_person_failed(self):
+        self.mock_api_client(200)
+        self.mock_node_edit(500)
+        self.mock_node_retrieval('uuid', self.uuid, status=200)
+        people = MarketingSitePeople()
+        with self.assertRaises(PersonToMarketingException):
+            people.update_person(self.partner, self.uuid, self.updated_node_data)
+
+    @responses.activate
+    def test_get_node_id_from_uuid(self):
+        self.mock_api_client(200)
+        self.mock_node_retrieval('uuid', self.uuid, status=200)
+        people = MarketingSitePeople()
+        data = people._get_node_id_from_uuid(self.api_client, self.uuid)  # pylint: disable=protected-access
+        self.assertEqual(data, self.node_id)
+
+    @responses.activate
+    def test_get_node_id_from_uuid_failed(self):
+        self.mock_api_client(200)
+        self.mock_node_retrieval('uuid', self.uuid, status=500)
+        people = MarketingSitePeople()
+        with self.assertRaises(PersonToMarketingException):
+            people._get_node_id_from_uuid(self.api_client, self.uuid)  # pylint: disable=protected-access
+
+    @mock.patch(
+        'course_discovery.apps.course_metadata.people.MarketingSitePeople._get_node_id_from_uuid',
+        mock.Mock(return_value=None)
+    )
+    def test_update_uuid_not_found(self):
+        self.mock_api_client(200)
+        people = MarketingSitePeople()
+        with LogCapture(LOGGER_NAME) as log:
+            people.update_person(self.partner, self.uuid, self.updated_node_data)
+            log.check((LOGGER_NAME, 'INFO',
+                       'Person with UUID [{}] does not exist on the marketing site'.format(self.uuid)))
 
     @responses.activate
     def test_create_node_failed(self):


### PR DESCRIPTION
## [EDUCATOR-2518](https://openedx.atlassian.net/browse/EDUCATOR-2518)

### Description
When an instructor is updated via the publisher front end it will update the corresponding person node on the drupal site. Since we do not have the node id in discovery (which is required to update a node in drupal) a get request is first sent to drupal with the uuid to get the corresponding node id and then the node is updated via the node id.
If no node exists for a uuid in that case only discovery will be updated and the drupal update will be skipped. (This is an extreme edge case as for all person created via publisher we always fill the uuid but since there are some instructors that have uuid empty in the existing database I have covered this edge case)

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @schenedx 
- [ ] @awaisdar001 

### Post-review
- [ ] Rebase and squash commits
