### PR TITLE
Fix that when course start date is null it wouldn't raises error.

### DIFF
--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -3262,6 +3262,11 @@ class CourseEditViewTests(SiteMixin, TestCase):
         response = self.client.post(self.edit_page_url, data=post_data)
         self.assertEqual(response.status_code, 302)
 
+        # Verify that when start date is None it didn't raise server error
+        self.course.course_runs.update(start=None)
+        response = self.client.post(self.edit_page_url, data=post_data)
+        self.assertEqual(response.status_code, 302)
+
         # Failure case
         post_data = self._post_data(self.organization_extension)
         post_data['team_admin'] = self.course_team_role.user.id

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -430,9 +430,10 @@ class CourseEditView(mixins.PublisherPermissionMixin, UpdateView):
         published_runs = set()
         for course_run in self._get_active_course_runs(course):
             if course_run.course_run_state.is_published:
+                start_date = course_run.start.strftime("%B %d, %Y") if course_run.start else None
                 published_runs.add('{type} - {start}'.format(
                     type=course_run.get_pacing_type_display(),
-                    start=course_run.start.strftime("%B %d, %Y")
+                    start=start_date
                 ))
         return published_runs
 


### PR DESCRIPTION
## [EDUCATOR-2735](https://openedx.atlassian.net/browse/EDUCATOR-2735)

### Description
This PR fixes that when start date of any course run is null it wouldn't raise 500 error.

### Test
- [x] unit test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @Rabia23 
- [x] @awaisdar001 
### Post-review
- [x] Rebase and squash commits
