### PR TITLE
Fix course run image in serializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -475,7 +475,7 @@ class NestedProgramSerializer(serializers.ModelSerializer):
 
 
 class MinimalCourseRunSerializer(TimestampModelSerializer):
-    image = ImageField(read_only=True, source='image_url')
+    image = ImageField(read_only=True, source='card_image_url')
     marketing_url = serializers.SerializerMethodField()
     seats = SeatSerializer(many=True)
 


### PR DESCRIPTION
Serializer was using not existent field causing us to not be able to get the course card image.