### PR TITLE
ENT-970: Include course image reference in serialized response

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -600,7 +600,7 @@ class CourseSerializer(MinimalCourseSerializer):
         fields = MinimalCourseSerializer.Meta.fields + (
             'short_description', 'full_description', 'level_type', 'subjects', 'prerequisites', 'prerequisites_raw',
             'expected_learning_items', 'video', 'sponsors', 'modified', 'marketing_url', 'syllabus_raw', 'outcome',
-            'original_image',
+            'original_image', 'card_image_url',
         )
 
     def get_marketing_url(self, obj):
@@ -1148,6 +1148,7 @@ class BaseHaystackFacetSerializer(HaystackFacetSerializer):
 
 
 class CourseSearchSerializer(HaystackSerializer):
+
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
         ignore_fields = COMMON_IGNORED_FIELDS
@@ -1157,6 +1158,7 @@ class CourseSearchSerializer(HaystackSerializer):
             'key',
             'short_description',
             'title',
+            'card_image_url'
         )
 
 

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1158,7 +1158,7 @@ class CourseSearchSerializer(HaystackSerializer):
             'key',
             'short_description',
             'title',
-            'card_image_url'
+            'card_image_url',
         )
 
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -165,6 +165,7 @@ class CourseSerializerTests(MinimalCourseSerializerTests):
             'syllabus_raw': course.syllabus_raw,
             'outcome': course.outcome,
             'original_image': ImageField().to_representation(course.original_image_url),
+            'card_image_url': course.card_image_url,
         })
 
         return expected
@@ -1266,6 +1267,7 @@ class CourseSearchSerializerTests(TestCase):
             'full_description': course.full_description,
             'content_type': 'course',
             'aggregation_key': 'course:{}'.format(course.key),
+            'card_image_url': course.card_image_url,
         }
 
 

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -139,6 +139,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
     model = Course
 
     uuid = indexes.CharField(model_attr='uuid')
+    card_image_url = indexes.CharField(model_attr='card_image_url', null=True)
     org = indexes.CharField()
     course_runs = indexes.MultiValueField()
     expected_learning_items = indexes.MultiValueField()


### PR DESCRIPTION
@schenedx I'd like to include the course image reference in the serialized response for this endpoint when "course" items are returned -- I noticed the "image" field in the course_metadata_course table looks like this:  `media/course/image/eaa0a24b-a6f1-42af-bd3e-9e53bcbed272-0c32c6d3fcc7.jpg`  Do you have a recommendation on how to transform this value into a fully-qualified URL?

cc: @UmanShahzad since he appears to have recently been in this area of the code

---

*Testing instructions*:

1. Get course-discovery started on the docker devstack on this branch.
1. Login to the LMS with an admin user, then go to `localhost:18381/login`, then modify the edX demo course to have a Card Image URL (it's a text field) that's any URL you want.
1. Do `make discovery-shell` and then `./manage.py update_index --disable-change-limit`.
1. Go to `localhost:18381/api-docs` and look for `/api/v1/search/courses` and try that endpoint to see if the `card_image_url` is present with the URL you entered above for the edX demo course, but null for the e2e course that also comes by default on the docker devstack.