### PR TITLE
Fixed filtering by course number on dashboard

### DIFF
--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -2211,6 +2211,26 @@ class CourseListViewPaginationTests(PaginationMixin, TestCase):
                                     reverse=self.sort_directions[direction]),
                              internal_users_statuses)
 
+    @ddt.data(
+        {'direction': 'asc'},
+        {'direction': 'desc'},
+    )
+    @ddt.unpack
+    def test_ordering_with_course_number_column(self, direction):
+        """
+        Verify that ordering by course number column is working as expected.
+        """
+
+        for page in (1, 2, 3):
+            courses = self.get_courses(
+                query_params={'sortColumn': 1, 'sortDirection': direction, 'pageSize': 4, 'page': page}
+            )
+            course_numbers = [course['number'] for course in courses]
+            self.assertEqual(sorted(course_numbers,
+                                    key=lambda number: number.lower(),
+                                    reverse=self.sort_directions[direction]),
+                             course_numbers)
+
 
 class CourseDetailViewTests(TestCase):
     """ Tests for the course detail view. """

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -1138,7 +1138,7 @@ class CourseListView(mixins.LoginRequiredMixin, ListView):
         # record can be returned multiple times. We are not doing ordering for these fields
         ordering_fields = {
             0: 'title',
-            # 1: 'organizations__key',
+            1: 'number',
             # 2: 'course_user_roles__user__full_name',
             3: 'course_runs_count',
             4: 'course_state__owner_role_modified',


### PR DESCRIPTION
## [EDUCATOR-2912](https://openedx.atlassian.net/browse/EDUCATOR-2912)

### Description
Fixed courses filtering by course number on publisher courses dashboard

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [ ] @noraiz-anwar

### Post-review
- [ ] Rebase and squash commits
