### PR TITLE
WL-1575: Update partner if already exists

### DIFF
--- a/course_discovery/apps/core/management/commands/create_sites_and_partners.py
+++ b/course_discovery/apps/core/management/commands/create_sites_and_partners.py
@@ -103,8 +103,8 @@ class Command(BaseCommand):
             logger.info("Successfully created {site} site".format(site=site_partner))
             partner_data['site'] = site
 
-            logger.info("Creating '{partner}' Partner".format(partner=site_partner))
-            Partner.objects.get_or_create(
+            logger.info("Creating or Updating '{partner}' Partner".format(partner=site_partner))
+            Partner.objects.update_or_create(
                 short_code=site_partner,
                 defaults=partner_data
             )

--- a/course_discovery/apps/core/management/commands/tests/test_create_sites_and_partners.py
+++ b/course_discovery/apps/core/management/commands/tests/test_create_sites_and_partners.py
@@ -23,11 +23,11 @@ class CreateSitesAndPartnersTests(TestCase):
         """
         checks that all the sites and partners are valid.
         """
-        sites = Site.objects.all()
+        sites = Site.objects.filter(domain__contains=self.dns_name)
         partners = Partner.objects.all()
 
         # there is an extra default site.
-        self.assertEqual(len(sites), len(SITES) + 1)
+        self.assertEqual(len(sites), len(SITES))
         self.assertEqual(len(partners), len(SITES))
 
         for site in sites:
@@ -107,4 +107,13 @@ class CreateSitesAndPartnersTests(TestCase):
             "--theme-path", self.theme_path
         )
         # if we run command with same dns then it will not duplicates the sites and partners.
+        self._assert_site_and_partner_are_valid()
+
+        self.dns_name = "new-dns"
+        call_command(
+            "create_sites_and_partners",
+            "--dns-name", self.dns_name,
+            "--theme-path", self.theme_path
+        )
+        # if we run command with new dns then it should still create sites and partners without breaking.
         self._assert_site_and_partner_are_valid()


### PR DESCRIPTION
This PR has changes to update partner data if partner already exists when we run `create_sites_and_partners` command.
@hasnain-naveed could you please review?