### PR TITLE
publish should remove existing organizations

### DIFF
--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -133,6 +133,7 @@ class CourseRunViewSet(viewsets.GenericViewSet):
         }
         discovery_course, created = Course.objects.update_or_create(partner=partner, key=course_key, defaults=defaults)
         discovery_course.image.save(publisher_course.image.name, publisher_course.image.file)
+        discovery_course.authoring_organizations.clear()
         discovery_course.authoring_organizations.add(*publisher_course.organizations.all())
 
         subjects = [subject for subject in [


### PR DESCRIPTION
## [EDUCATOR-2974](https://openedx.atlassian.net/browse/EDUCATOR-2974)

### Description
The publish to discovery method should remove all the existing organizations before adding new ones.
Currently it is only able to add organization and not able to delete the existing ones.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @attiyaIshaque
- [ ] @noraiz-anwar

### Post-review
- [ ] Rebase and squash commits
