### PR TITLE
Fix course staff/instructor ordering.

### DIFF
--- a/course_discovery/apps/publisher/templates/publisher/course_run/edit_run_form.html
+++ b/course_discovery/apps/publisher/templates/publisher/course_run/edit_run_form.html
@@ -220,7 +220,7 @@
                         <label class="field-label ">
                             {% trans "Search for Instructor:" %}
                         </label>
-                        <select name="staff" data-autocomplete-light-function="select2"
+                        <select name="instructor" data-autocomplete-light-function="select2"
                                 multiple="multiple" data-minimum-input-length="2"
                                 data-autocomplete-light-url="/admin/course_metadata/person-autocomplete/"
                                 id="id_staff" data-html="true" class="field-input">

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -1020,7 +1020,7 @@ class CourseRunEditView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMix
 
     def post(self, request, *args, **kwargs):
         user = request.user
-
+        staff = request.POST.getlist('staff')
         context = self.get_context_data()
         course_run = context.get('course_run')
         lms_course_id = course_run.lms_course_id
@@ -1044,7 +1044,8 @@ class CourseRunEditView(mixins.LoginRequiredMixin, mixins.PublisherPermissionMix
             try:
                 with transaction.atomic():
                     course_run = run_form.save(changed_by=user)
-                    run_form.save_m2m()
+                    course_run.staff.clear()
+                    course_run.staff.add(*staff)
 
                     # If price-type comes with request then save the seat object.
                     if seat_form and request.POST.get('type'):


### PR DESCRIPTION
## [Course Staff(Instructor) order not editable EDUCATOR-3013](https://openedx.atlassian.net/browse/EDUCATOR-3013)

### Description
This PR fixes the course staff ordering while adding and updating.


### Before Fix
On edit page:
<img width="531" alt="screen shot 2018-06-07 at 9 42 37 pm" src="https://user-images.githubusercontent.com/7627421/41115038-b0997740-6a9f-11e8-96cc-df065a7cbda5.png">
On preview page order disturb:
<img width="570" alt="screen shot 2018-06-07 at 9 43 09 pm" src="https://user-images.githubusercontent.com/7627421/41115039-b0cd194c-6a9f-11e8-8ed5-398fb6c717d1.png">

### After Fix
On edit page:
<img width="535" alt="screen shot 2018-06-07 at 10 10 46 pm" src="https://user-images.githubusercontent.com/7627421/41115096-e431b202-6a9f-11e8-8031-595fc8fb723f.png">
On preview page order correct:
<img width="592" alt="screen shot 2018-06-07 at 10 10 59 pm" src="https://user-images.githubusercontent.com/7627421/41115097-e4650652-6a9f-11e8-8791-498237224d36.png">





### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @Rabia23 
### Post-review
- [x] Rebase and squash commits
