### PR TITLE
Typeahead search for ordered_instructor

### DIFF
--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -54,6 +54,13 @@ class ProgramAdminForm(forms.ModelForm):
                     'class': 'sortable-select',
                 }
             ),
+            'instructor_ordering': autocomplete.ModelSelect2Multiple(
+                url='admin_metadata:person-autocomplete',
+                attrs={
+                    'data-minimum-input-length': 3,
+                    'class': 'sortable-select',
+                }
+            ),
         }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Adding typeahead search for this field because the number of instructors being rendered in the DOM brings the page to a grinding halt using the default widget