### PR TITLE
Add wait time to courses api for refresh_course_metadata

### DIFF
--- a/course_discovery/apps/core/views.py
+++ b/course_discovery/apps/core/views.py
@@ -8,7 +8,9 @@ from django.db import DatabaseError, connection, transaction
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.views.generic import View
+
 from course_discovery.apps.core.constants import Status
+
 try:
     import newrelic.agent
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
This is the quickest "handling" of 429s I can think/code up today.

https://openedx.atlassian.net/browse/LEARNER-5560