### PR TITLE
Fix the course runs filters on the dashboard.

### DIFF
--- a/course_discovery/apps/publisher/templates/publisher/dashboard/_in_progress.html
+++ b/course_discovery/apps/publisher/templates/publisher/dashboard/_in_progress.html
@@ -8,10 +8,10 @@
             <button type="button" class="btn-neutral btn-small btn-filter active" data-filter-column="-1">{% trans "All" %}
                 <span class="filter-count">{{ in_progress_count }}</span>
             </button>
-            <button type="button" class="btn-neutral btn-small btn-filter" data-search-value="{{ course_team_status }}" data-filter-column="5">{% trans "With Course Team" %}
+            <button type="button" class="btn-neutral btn-small btn-filter" data-search-value="{{ course_team_status }}" data-filter-column="4">{% trans "With Course Team" %}
                 <span class="filter-count">{{ course_team_count }}</span>
             </button>
-            <button type="button" class="btn-neutral btn-small btn-filter" data-search-value="{{ internal_user_status }}" data-filter-column="6">{% trans "With" %} {{ site_name }}
+            <button type="button" class="btn-neutral btn-small btn-filter" data-search-value="{{ internal_user_status }}" data-filter-column="5">{% trans "With" %} {{ site_name }}
                 <span class="filter-count">{{ internal_user_count }}</span>
             </button>
         </div>


### PR DESCRIPTION
## [11 courses in my ownership do not appear on my dashboard EDUCATOR-3075](https://openedx.atlassian.net/browse/EDUCATOR-3075)

### Description
This PR fixes that filters of course run in **In development** tab not only showing the count also shows the data.


### Before Fix
<img width="1093" alt="screen shot 2018-06-20 at 3 25 21 pm" src="https://user-images.githubusercontent.com/7627421/41657135-cc9371a6-74ab-11e8-8b06-38a671702a6f.png">

### After Fix


<img width="1100" alt="screen shot 2018-06-20 at 3 25 33 pm" src="https://user-images.githubusercontent.com/7627421/41657157-e4bf268a-74ab-11e8-8528-867342b7a5fb.png">




### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @Rabia23 
### Post-review
- [x] Rebase and squash commits
