### PR TITLE
Add staff permission on discovery people API.

### DIFF
--- a/course_discovery/apps/api/permissions.py
+++ b/course_discovery/apps/api/permissions.py
@@ -1,0 +1,11 @@
+from rest_framework.permissions import BasePermission
+
+
+class ReadByStaffOnly(BasePermission):
+    """
+    Custom permission to only allow owners of the object.
+    """
+    def has_permission(self, request, view):
+        if request.method == 'GET':
+                return request.user.is_staff
+        return True

--- a/course_discovery/apps/api/v1/views/people.py
+++ b/course_discovery/apps/api/v1/views/people.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from course_discovery.apps.api import filters, serializers
 from course_discovery.apps.api.pagination import PageNumberPagination
+from course_discovery.apps.api.permissions import ReadByStaffOnly
 from course_discovery.apps.course_metadata.exceptions import MarketingSiteAPIClientException, PersonToMarketingException
 from course_discovery.apps.course_metadata.people import MarketingSitePeople
 
@@ -22,7 +23,7 @@ class PersonViewSet(viewsets.ModelViewSet):
     filter_class = filters.PersonFilter
     lookup_field = 'uuid'
     lookup_value_regex = '[0-9a-f-]+'
-    permission_classes = (DjangoModelPermissions,)
+    permission_classes = (DjangoModelPermissions, ReadByStaffOnly,)
     queryset = serializers.PersonSerializer.prefetch_queryset()
     serializer_class = serializers.PersonSerializer
     pagination_class = PageNumberPagination


### PR DESCRIPTION
## [Unprotected Discovery API reveals a list of "People"  EDUCATOR-3070](https://openedx.atlassian.net/browse/EDUCATOR-3070)

### Description
This PR fixes that add staff permission on the discovery people API. The list of all people only accessible by staff members.

### After Fix
<img width="1222" alt="screen shot 2018-06-27 at 2 57 56 pm" src="https://user-images.githubusercontent.com/7627421/41967237-97cd4c84-7a1a-11e8-8389-98b521a885fd.png">

### Test
- [x] unit tests



### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @schenedx  
- [x] @asadazam93 

### Post-review
- [x] Rebase and squash commits
