### PR TITLE
Add publisher user permission on discovery people API.

### DIFF
--- a/course_discovery/apps/api/permissions.py
+++ b/course_discovery/apps/api/permissions.py
@@ -1,0 +1,11 @@
+from rest_framework.permissions import BasePermission
+
+
+class ReadOnlyByPublisherUser(BasePermission):
+    """
+    Custom Permission class to check user is a publisher user.
+    """
+    def has_permission(self, request, view):
+        if request.method == 'GET':
+                return request.user.groups.exists()
+        return True

--- a/course_discovery/apps/api/v1/tests/test_views/test_people.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_people.py
@@ -6,6 +6,7 @@ from mock import mock
 from rest_framework.reverse import reverse
 from testfixtures import LogCapture
 
+from course_discovery.apps.api.permissions import ReadOnlyByPublisherUser
 from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, SerializationMixin
 from course_discovery.apps.api.v1.views.people import logger as people_logger
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
@@ -27,9 +28,10 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
         self.target_permissions = Permission.objects.filter(
             codename__in=['add_person', 'change_person', 'delete_person']
         )
-        internal_test_group = Group.objects.create(name='internal-test')
-        internal_test_group.permissions.add(*self.target_permissions)
-        self.user.groups.add(internal_test_group)
+        self.permisson_class = ReadOnlyByPublisherUser()
+        self.internal_test_group = Group.objects.create(name='internal-test')
+        self.internal_test_group.permissions.add(*self.target_permissions)
+        self.user.groups.add(self.internal_test_group)
         self.client.login(username=self.user.username, password=USER_PASSWORD)
         self.person = PersonFactory(partner=self.partner)
         self.organization = OrganizationFactory(partner=self.partner)
@@ -125,10 +127,16 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
         assert response.status_code == 403
         assert Person.objects.count() == current_people_count
 
-    def test_get(self):
+    def test_get_single_person_without_publisher_user(self):
+        """ Verify the endpoint shows permission error for the details for a single person. """
+        self.user.groups.remove(self.internal_test_group)
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_single_person_with_publisher_user(self):
         """ Verify the endpoint returns the details for a single person. """
         url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
-
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.serialize_person(self.person))
@@ -140,11 +148,17 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
-    def test_list(self):
-        """ Verify the endpoint returns a list of all people. """
+    def test_list_with_publihser_user(self):
+        """ Verify the endpoint returns a list of all people with the publisher user """
         response = self.client.get(self.people_list_url)
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(response.data['results'], self.serialize_person(Person.objects.all(), many=True))
+
+    def test_list_without_publisher_user(self):
+        """ Verify the endpoint shows permission error when non-publisher user acccessed """
+        self.user.groups.remove(self.internal_test_group)
+        response = self.client.get(self.people_list_url)
+        self.assertEqual(response.status_code, 403)
 
     def test_list_filter_by_slug(self):
         """ Verify the endpoint allows people to be filtered by slug. """

--- a/course_discovery/apps/api/v1/views/people.py
+++ b/course_discovery/apps/api/v1/views/people.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from course_discovery.apps.api import filters, serializers
 from course_discovery.apps.api.pagination import PageNumberPagination
+from course_discovery.apps.api.permissions import ReadOnlyByPublisherUser
 from course_discovery.apps.course_metadata.exceptions import MarketingSiteAPIClientException, PersonToMarketingException
 from course_discovery.apps.course_metadata.people import MarketingSitePeople
 
@@ -22,7 +23,7 @@ class PersonViewSet(viewsets.ModelViewSet):
     filter_class = filters.PersonFilter
     lookup_field = 'uuid'
     lookup_value_regex = '[0-9a-f-]+'
-    permission_classes = (DjangoModelPermissions,)
+    permission_classes = (DjangoModelPermissions, ReadOnlyByPublisherUser,)
     queryset = serializers.PersonSerializer.prefetch_queryset()
     serializer_class = serializers.PersonSerializer
     pagination_class = PageNumberPagination


### PR DESCRIPTION
## [Unprotected Discovery API reveals a list of "People"  EDUCATOR-3070](https://openedx.atlassian.net/browse/EDUCATOR-3070)

### Description
This PR fixes that add publisher user permissions on the discovery people API. The list of all people only accessible by publisher members.

### After Fix
<img width="1222" alt="screen shot 2018-06-27 at 2 57 56 pm" src="https://user-images.githubusercontent.com/7627421/41967237-97cd4c84-7a1a-11e8-8389-98b521a885fd.png">

### Test
- [x] unit tests



### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @awaisdar001   
- [x] @asadazam93 

CC: @schenedx 

### Post-review
- [x] Rebase and squash commits
