### PR TITLE
Add publisher user permission on publisher Organization API.

### DIFF
--- a/course_discovery/apps/publisher/api/permissions.py
+++ b/course_discovery/apps/publisher/api/permissions.py
@@ -30,3 +30,6 @@ class PublisherUserPermission(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return is_publisher_user(request.user)
+
+    def has_permission(self, request, view):
+        return is_publisher_user(request.user)

--- a/course_discovery/apps/publisher/api/views.py
+++ b/course_discovery/apps/publisher/api/views.py
@@ -38,7 +38,7 @@ class CourseRoleAssignmentView(UpdateAPIView):
 class OrganizationGroupUserView(ListAPIView):
     """ List view for Users filtered by group """
     serializer_class = GroupUserSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, PublisherUserPermission)
     pagination_class = LargeResultsSetPagination
 
     def get_queryset(self):


### PR DESCRIPTION
## [Unprotected Publisher API reveals list of Course Admins, per Organization  EDUCATOR-3069](https://openedx.atlassian.net/browse/EDUCATOR-3069)

### Description
This PR fixes that add publisher user permissions on the publisher organization API. 

### After Fix
<img width="1055" alt="screen shot 2018-07-03 at 3 46 42 pm" src="https://user-images.githubusercontent.com/7627421/42215746-e5591ac4-7ed8-11e8-8b5a-a21a2684469a.png">

### Test
- [x] unit tests



### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @awaisdar001   
- [x] @asadazam93 

CC: @schenedx 

### Post-review
- [x] Rebase and squash commits
