### PR TITLE
Expose CreditPathway model in Django admin

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -176,6 +176,11 @@ class ProgramAdmin(admin.ModelAdmin):
               'js/sortable_select.js')
 
 
+@admin.register(CreditPathway)
+class CreditPathwayAdmin(admin.ModelAdmin):
+    list_display = ('name', 'org_name', 'email')
+
+
 @admin.register(ProgramType)
 class ProgramTypeAdmin(admin.ModelAdmin):
     list_display = ('name', 'slug',)


### PR DESCRIPTION
Allows ability to add credit pathways in Django admin 