### PR TITLE
LEARNER-5665: Add credit pathway endpoint for the api.

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -21,9 +21,9 @@ from course_discovery.apps.core.api_client.lms import LMSAPIClient
 from course_discovery.apps.course_metadata import search_indexes
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import (
-    FAQ, CorporateEndorsement, Course, CourseEntitlement, CourseRun, Endorsement, Image, Organization, Person,
-    PersonSocialNetwork, PersonWork, Position, Prerequisite, Program, ProgramType, Seat, SeatType, Subject, Topic,
-    Video
+    FAQ, CorporateEndorsement, Course, CourseEntitlement, CourseRun, CreditPathway, Endorsement, Image,
+    Organization, Person, PersonSocialNetwork, PersonWork, Position, Prerequisite, Program, ProgramType,
+    Seat, SeatType, Subject, Topic, Video
 )
 
 User = get_user_model()
@@ -897,6 +897,18 @@ class ProgramSerializer(MinimalProgramSerializer):
             'individual_endorsements', 'languages', 'transcript_languages', 'subjects', 'price_ranges',
             'staff', 'credit_redemption_overview', 'applicable_seat_types', 'instructor_ordering'
         )
+
+
+class CreditPathwaySerializer(serializers.ModelSerializer):
+    """ Serializer for CreditPathway. """
+    name = serializers.CharField()
+    org_name = serializers.CharField()
+    email = serializers.EmailField()
+    programs = MinimalProgramSerializer(many=True)
+
+    class Meta:
+        model = CreditPathway
+        fields = ('id', 'name', 'org_name', 'email', 'programs')
 
 
 class ProgramTypeSerializer(serializers.ModelSerializer):

--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -85,6 +85,9 @@ class SerializationMixin:
     def serialize_topic(self, topic, many=False, format=None, extra_context=None):
         return self._serialize_object(serializers.TopicSerializer, topic, many, format, extra_context)
 
+    def serialize_credit_pathway(self, credit_pathway, many=False, format=None, extra_context=None):
+        return self._serialize_object(serializers.CreditPathwaySerializer, credit_pathway, many, format, extra_context)
+
 
 class TypeaheadSerializationMixin:
     def serialize_course_run_search(self, run):

--- a/course_discovery/apps/api/v1/tests/test_views/test_pathways.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_pathways.py
@@ -1,0 +1,50 @@
+import pytest
+from django.contrib.auth.models import Group
+from django.core.cache import cache
+from django.test import RequestFactory
+from django.urls import reverse
+
+from course_discovery.apps.api.v1.tests.test_views.mixins import SerializationMixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from course_discovery.apps.course_metadata.tests.factories import CreditPathwayFactory, ProgramFactory
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('django_cache')
+class TestCreditPathwayViewSet(SerializationMixin):
+    client = None
+    django_assert_num_queries = None
+    list_path = reverse('api:v1:credit_pathway-list')
+    partner = None
+    request = None
+    program = None
+
+    @pytest.fixture(autouse=True)
+    def setup(self, client, django_assert_num_queries, partner):
+        user = UserFactory(is_staff=True, is_superuser=True)
+        internal_test_group = Group.objects.create(name='internal-test')
+        user.groups.add(internal_test_group)
+
+        client.login(username=user.username, password=USER_PASSWORD)
+
+        site = partner.site
+        request = RequestFactory(SERVER_NAME=site.domain).get('')
+        request.site = site
+        request.user = user
+
+        self.client = client
+        self.django_assert_num_queries = django_assert_num_queries
+        self.partner = partner
+        self.request = request
+        cache.clear()
+
+    def test_pathway_list(self):
+        pathways = []
+        for _ in range(4):
+            pathway = CreditPathwayFactory()
+            program = ProgramFactory()
+            pathway.programs.add(program)
+            pathways.insert(0, pathway)
+        response = self.client.get(self.list_path)
+        assert response.status_code == 200
+        assert response.data['results'] == self.serialize_credit_pathway(pathways, many=True)

--- a/course_discovery/apps/api/v1/urls.py
+++ b/course_discovery/apps/api/v1/urls.py
@@ -10,6 +10,7 @@ from course_discovery.apps.api.v1.views.course_runs import CourseRunViewSet
 from course_discovery.apps.api.v1.views.courses import CourseViewSet
 from course_discovery.apps.api.v1.views.currency import CurrencyView
 from course_discovery.apps.api.v1.views.organizations import OrganizationViewSet
+from course_discovery.apps.api.v1.views.pathways import CreditPathwayViewSet
 from course_discovery.apps.api.v1.views.people import PersonViewSet
 from course_discovery.apps.api.v1.views.program_types import ProgramTypeViewSet
 from course_discovery.apps.api.v1.views.programs import ProgramViewSet
@@ -35,6 +36,7 @@ router.register(r'people', PersonViewSet, base_name='person')
 router.register(r'subjects', SubjectViewSet, base_name='subject')
 router.register(r'topics', TopicViewSet, base_name='topic')
 router.register(r'programs', ProgramViewSet, base_name='program')
+router.register(r'credit_pathways', CreditPathwayViewSet, base_name='credit_pathway')
 router.register(r'program_types', ProgramTypeViewSet, base_name='program_type')
 router.register(r'search/all', search_views.AggregateSearchViewSet, base_name='search-all')
 router.register(r'search/courses', search_views.CourseSearchViewSet, base_name='search-courses')

--- a/course_discovery/apps/api/v1/views/pathways.py
+++ b/course_discovery/apps/api/v1/views/pathways.py
@@ -1,0 +1,14 @@
+""" Views for accessing CreditPathway data """
+from rest_framework import viewsets
+from rest_framework_extensions.cache.mixins import CacheResponseMixin
+
+from course_discovery.apps.api import serializers
+from course_discovery.apps.api.permissions import ReadOnlyByPublisherUser
+
+from course_discovery.apps.course_metadata.models import CreditPathway
+
+
+class CreditPathwayViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+    permission_classes = (ReadOnlyByPublisherUser,)
+    serializer_class = serializers.CreditPathwaySerializer
+    queryset = CreditPathway.objects.all()


### PR DESCRIPTION
Adding in an endpoint for pulling in a list of `CreditPathway` objects. Currently, this is a very bare bones endpoint only meant to be used by the `credentials` repo.