### PR TITLE
New Course Run must not be added to associated retired programs.

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -209,6 +209,20 @@ class CourseRunTests(TestCase):
         factories.ProgramFactory(courses=[self.course_run.course], status=ProgramStatus.Deleted)
         self.assertEqual(self.course_run.program_types, [active_program.type.name])
 
+    def test_new_course_run_excluded_in_retired_programs(self):
+        """ Verify the newly created course run must be excluded in associated retired programs"""
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(course=course)
+        program = factories.ProgramFactory(
+            courses=[course], status=ProgramStatus.Retired,
+        )
+        course_run.weeks_to_complete = 2
+        course_run.save()
+        new_course_run = factories.CourseRunFactory(course=course)
+        new_course_run.save()
+        self.assertEqual(program.excluded_course_runs.count(), 1)
+        self.assertEqual(len(list(program.course_runs)), 1)
+
     @ddt.data(
         # Case 1: Return False when there are no paid Seats.
         ([('audit', 0)], False),


### PR DESCRIPTION
## [LEARNER-1176](https://openedx.atlassian.net/browse/LEARNER-1176)

### Description
Project Coordinators need to be able to exclude all future runs of courses in a program, so that they can convert an XSeries program into a Professional Certificate (or into a MicroMasters), without all future course runs applying to both the XSeries program and the Professional Certificate.

- [x] Unit Tests