### PR TITLE
Improving catalog typeahead search results

### DIFF
--- a/course_discovery/settings/synonyms.py
+++ b/course_discovery/settings/synonyms.py
@@ -63,4 +63,5 @@ SYNONYMS = [
     ['vba', 'excel'],
     ['usa', 'united states of america', 'america', 'murika'],
     ['virtual reality', 'VR'],
+    ['chemistri', 'chemistry']
 ]


### PR DESCRIPTION
This patch would enable search results to
work for complete string too. Now it
would show same results for search string
'chemistry' as 'chemistr'

LEARNER-3051