### PR TITLE
Disable editing number if course has a run

### DIFF
--- a/course_discovery/apps/publisher/templates/publisher/course_edit_form.html
+++ b/course_discovery/apps/publisher/templates/publisher/course_edit_form.html
@@ -144,11 +144,16 @@
                                     </div>
                                     <div class="col col-6">
                                         <label class="field-label ">{{ form.number.label_tag }} <span class="required">*</span></label>
+                                        {% if has_course_run %}
+                                            <span class="read-only-field">{{ course.number }}</span>
+                                            <input name="number" type="hidden" value="{{ course.number }}">
+                                        {% else %}
                                         {{ form.number }}
-                                        {% if form.number.errors %}
-                                            <div class="field-message-content">
-                                                {{ form.number.errors|escape }}
-                                            </div>
+                                            {% if form.number.errors %}
+                                                <div class="field-message-content">
+                                                    {{ form.number.errors|escape }}
+                                                </div>
+                                            {% endif %}
                                         {% endif %}
                                     </div>
                                 </div>

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -2699,6 +2699,27 @@ class CourseEditViewTests(SiteMixin, TestCase):
         response = self.client.get(self.edit_page_url)
         self.assertEqual(response.status_code, 403)
 
+    def test_edit_page_number_with_course_run(self):
+        """
+        Verify that the course team cannot edit course number if course has atleast one course run
+        """
+        self.user.groups.add(self.organization_extension.group)
+        assign_perm(OrganizationExtension.EDIT_COURSE, self.organization_extension.group, self.organization_extension)
+        factories.CourseRunFactory.create(
+            course=self.course, lms_course_id='course-v1:edxTest+Test342+2016Q1', end=datetime.now() + timedelta(days=1)
+        )
+        response = self.client.get(self.edit_page_url)
+        self.assertEqual(response.context['has_course_run'], True)
+
+    def test_edit_page_number_without_course_run(self):
+        """
+        Verify that the course team can edit course number if course has no run
+        """
+        self.user.groups.add(self.organization_extension.group)
+        assign_perm(OrganizationExtension.EDIT_COURSE, self.organization_extension.group, self.organization_extension)
+        response = self.client.get(self.edit_page_url)
+        self.assertEqual(response.context['has_course_run'], False)
+
     def test_edit_page_with_edit_permission(self):
         """
         Verify that user can access course edit page with edit permission.

--- a/course_discovery/apps/publisher/views.py
+++ b/course_discovery/apps/publisher/views.py
@@ -379,7 +379,8 @@ class CourseEditView(mixins.PublisherPermissionMixin, UpdateView):
             {
                 'course': self.get_object(),
                 'is_internal_user': is_internal_user(self.request.user),
-                'history_object': history_object
+                'history_object': history_object,
+                'has_course_run': self.object.course_runs.exists()
             }
         )
 


### PR DESCRIPTION
## [EDUCATOR-1846](https://openedx.atlassian.net/browse/EDUCATOR-1846)

### Description
Course teams should not be allowed to edit course number field after a course run has been created.

**Sandbox**
In progress

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @attiyaIshaque 
- [ ] @awaisdar001 

### Post-review
- [ ] Rebase and squash commits
