### PR TITLE
 WL-1688  make journals list view filterable with organization.

### DIFF
--- a/course_discovery/apps/core/tests/factories.py
+++ b/course_discovery/apps/core/tests/factories.py
@@ -63,7 +63,7 @@ class PartnerFactory(factory.DjangoModelFactory):
 
 
 class CurrencyFactory(factory.DjangoModelFactory):
-    code = factory.fuzzy.FuzzyText()
+    code = factory.fuzzy.FuzzyText(length=6)
     name = factory.fuzzy.FuzzyText()
 
     class Meta(object):

--- a/course_discovery/apps/journal/api/v1/tests/test_views.py
+++ b/course_discovery/apps/journal/api/v1/tests/test_views.py
@@ -1,8 +1,11 @@
+import uuid
+
 from pytest import mark
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from course_discovery.apps.journal.models import Journal
 from course_discovery.apps.journal.tests.factories import JournalBundleFactory, JournalFactory
 
 
@@ -13,7 +16,7 @@ class JournalViewSetTests(APITestCase):
     def setUp(self):
         super(JournalViewSetTests, self).setUp()
         self.user = UserFactory(is_staff=True)
-        self.journal = JournalFactory()
+        self.journal = JournalFactory(uuid=uuid.uuid4())
         self.client.login(username=self.user.username, password=USER_PASSWORD)
         self.journal_url = reverse('journal:api:v1:journal-list')
 
@@ -29,6 +32,32 @@ class JournalViewSetTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         self.assertTrue('partner' in response.data['results'][0])
+
+    def test_list_with_organization_filter(self):
+        """ Verify response on list view with organization filter"""
+
+        # creating another journal
+        journal = JournalFactory()
+
+        self.assertEqual(Journal.objects.count(), 2)
+
+        url_with_filter = '{url}?organization={org}'.format(url=self.journal_url, org=journal.organization.key)
+        response = self.client.get(url_with_filter)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_list_with_uuid_filter(self):
+        """ Verify response on list view with uuid's filter"""
+
+        journal_1 = JournalFactory()
+        journal_2 = JournalFactory()
+        self.assertEqual(Journal.objects.count(), 3)
+
+        uuid_list = ','.join([str(journal_1.uuid), str(journal_2.uuid)])
+        url_with_filter = '{url}?uuid={uuid}'.format(url=self.journal_url, uuid=uuid_list)
+        response = self.client.get(url_with_filter)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 2)
 
 
 @mark.django_db

--- a/course_discovery/apps/journal/api/v1/views.py
+++ b/course_discovery/apps/journal/api/v1/views.py
@@ -24,6 +24,16 @@ class JournalViewSet(viewsets.ModelViewSet):
     permission_classes = (IsAdminUser,)
     pagination_class = LargeResultsSetPagination
 
+    def list(self, request, *args, **kwargs):
+        organization = request.GET.get('organization')
+        if organization:
+            self.queryset = self.get_queryset().filter(organization__key=organization)
+        uuid = request.GET.get('uuid')  # uuid can be one or many separated by commas
+        if uuid:
+            self.queryset = self.get_queryset().filter(uuid__in=uuid.split(','))
+
+        return super(JournalViewSet, self).list(request, *args, **kwargs)
+
 
 class JournalBundleViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
     """ Journal Bundle"""


### PR DESCRIPTION
=> To support **WL-1688 create UI for publish_journals mgmt command** 

Added filter to get all Journals corresponding to an organization.
User have to send organization name using query params.
For Example 
`GET localhost:18381/journal/api/v1/journals?organization=edX` 

Added Journals list filter for UUIDs.
User have to send comma separated UUIDs using query params.
For Example 
`GET localhost:18381/journal/api/v1/journals?uuid=cade8e95-56c3-4979-aece-768af2d6781f,409bf8f2-222d-485f-a095-0fa5bd8b842f` 