### PR TITLE
Added search option in CourseEntitlementAdmin view

### DIFF
--- a/course_discovery/apps/publisher/admin.py
+++ b/course_discovery/apps/publisher/admin.py
@@ -120,8 +120,9 @@ class SeatAdmin(SimpleHistoryAdmin):
 
 @admin.register(CourseEntitlement)
 class CourseEntitlementAdmin(SimpleHistoryAdmin):
-    list_display = ['course', 'mode']
+    list_display = ['course', 'course__number', 'mode']
     raw_id_fields = ['course']
+    search_fields = ['course__title', 'course__number']
 
 
 @admin.register(PublisherUser)


### PR DESCRIPTION
Added search option in CourseEntitlementAdmin view.
CourseEntitlementAdmin can not be used with out a search option as there are 706 entries and no way to find the one you are looking for. 