### PR TITLE
Added search option for course entitlements

### DIFF
--- a/course_discovery/apps/publisher/admin.py
+++ b/course_discovery/apps/publisher/admin.py
@@ -120,8 +120,14 @@ class SeatAdmin(SimpleHistoryAdmin):
 
 @admin.register(CourseEntitlement)
 class CourseEntitlementAdmin(SimpleHistoryAdmin):
-    list_display = ['course', 'mode']
+    list_display = ['course', 'get_course_number', 'mode']
+
+    def get_course_number(self, obj):
+        return obj.course.number
+    get_course_number.short_description = 'Course number'
+
     raw_id_fields = ['course']
+    search_fields = ['course__title', 'course__number']
 
 
 @admin.register(PublisherUser)


### PR DESCRIPTION
Added search option for course entitlements using course name and course number.
CourseEntitlementAdmin can not be used with out a search option as there are 706 entries and no way to find the one you are looking for.

all changes have been tested locally. 