### PR TITLE
Upgrade django to 1.11.15 for security update

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.5.1
 boto==2.42.0
 cryptography==1.7.1
-django==1.11.11
+django==1.11.15
 django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1


### PR DESCRIPTION
## [LEARNER-6035](https://openedx.atlassian.net/browse/LEARNER-6035)


### Description
There is a vulnerability of phishing in django 1.11.11 announced by django community.To avoid it,upgrade current django version to 1.11.15 to overcome that vulnerability.

https://docs.djangoproject.com/en/2.0/releases/1.11.15/#cve-2018-14574-open-redirect-possibility-in-commonmiddleware