### PR TITLE
ENT-1106 Filter courses by price in search endpoint

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -517,6 +517,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
             'course', 'full_description', 'announcement', 'video', 'seats', 'content_language', 'license', 'outcome',
             'transcript_languages', 'instructors', 'staff', 'min_effort', 'max_effort', 'weeks_to_complete', 'modified',
             'level_type', 'availability', 'mobile_available', 'hidden', 'reporting_type', 'eligible_for_financial_aid',
+            'first_enrollable_paid_seat_price',
         )
 
     def get_instructors(self, obj):  # pylint: disable=unused-argument
@@ -1281,9 +1282,13 @@ class CourseFacetSerializer(BaseHaystackFacetSerializer):
 
 class CourseRunSearchSerializer(HaystackSerializer):
     availability = serializers.SerializerMethodField()
+    first_enrollable_paid_seat_price = serializers.SerializerMethodField()
 
     def get_availability(self, result):
         return result.object.availability
+
+    def get_first_enrollable_paid_seat_price(self, result):
+        return result.object.first_enrollable_paid_seat_price
 
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
@@ -1296,6 +1301,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
             'enrollment_end',
             'enrollment_start',
             'first_enrollable_paid_seat_sku',
+            'first_enrollable_paid_seat_price',
             'full_description',
             'has_enrollable_seats',
             'image_url',
@@ -1337,6 +1343,7 @@ class CourseRunFacetSerializer(BaseHaystackFacetSerializer):
             'mobile_available': {},
             'organizations': {'size': settings.SEARCH_FACET_LIMIT},
             'pacing_type': {},
+            'first_enrollable_paid_seat_price': {},
             'prerequisites': {},
             'seat_types': {},
             'subjects': {},

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -229,7 +229,7 @@ class CourseWithProgramsSerializerTests(CourseSerializerTests):
         self.assertEqual(serializer.data, self.get_expected_data(self.course, self.request))
 
 
-class MinimalCourseRunSerializerTests(TestCase):
+class MinimalCourseRunBaseTestSerializer(TestCase):
     serializer_class = MinimalCourseRunSerializer
 
     @classmethod
@@ -257,12 +257,15 @@ class MinimalCourseRunSerializerTests(TestCase):
             'status': course_run.status,
         }
 
+
+class MinimalCourseRunSerializerTests(MinimalCourseRunBaseTestSerializer):
+
     def test_data(self):
         request = make_request()
         course_run = CourseRunFactory()
         serializer = self.serializer_class(course_run, context={'request': request})
         expected = self.get_expected_data(course_run, request)
-        self.assertDictEqual(serializer.data, expected)
+        assert serializer.data == expected
 
     def test_get_lms_course_url(self):
         partner = PartnerFactory()
@@ -275,7 +278,7 @@ class MinimalCourseRunSerializerTests(TestCase):
         self.assertEqual(lms_course_url, expected_url)
 
 
-class CourseRunSerializerTests(MinimalCourseRunSerializerTests):
+class CourseRunSerializerTests(MinimalCourseRunBaseTestSerializer):
     serializer_class = CourseRunSerializer
 
     @classmethod
@@ -1419,6 +1422,7 @@ class CourseRunSearchSerializerTests(ElasticsearchTestMixin, TestCase):
             'aggregation_key': 'courserun:{}'.format(course_run.course.key),
             'has_enrollable_seats': course_run.has_enrollable_seats,
             'first_enrollable_paid_seat_sku': course_run.first_enrollable_paid_seat_sku(),
+            'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price,
         }
 
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -181,7 +181,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
             # to be included.
             filtered_course_run = CourseRunFactory(course=course)
 
-            with self.assertNumQueries(21):
+            with self.assertNumQueries(22):
                 response = self.client.get(url)
 
             assert response.status_code == 200

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -32,7 +32,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns the details for a single course. """
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -44,7 +44,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data.get('programs') == []
@@ -59,7 +59,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
         url += '?include_deleted_programs=1'
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(14):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data == \
@@ -71,7 +71,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get(url)
             assert response.status_code == 200
             assert response.data.get('programs') == []
@@ -86,7 +86,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
         url += '?include_unpublished_programs=1'
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(14):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data == \
@@ -126,7 +126,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns a list of all course runs. """
         url = reverse('api:v1:course_run-list')
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(13):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -139,7 +139,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         """ Verify the endpoint returns a list of all course runs sorted by start date. """
         url = '{root}?ordering=start'.format(root=reverse('api:v1:course_run-list'))
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(13):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -155,7 +155,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, APITestC
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(36):
+        with self.assertNumQueries(39):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -157,13 +157,13 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
 
     @ddt.data(
         (list_path, serializers.CourseRunSearchSerializer,
-         ['results', 0, 'program_types', 0], ProgramStatus.Deleted, 6),
+         ['results', 0, 'program_types', 0], ProgramStatus.Deleted, 8),
         (list_path, serializers.CourseRunSearchSerializer,
-         ['results', 0, 'program_types', 0], ProgramStatus.Unpublished, 6),
+         ['results', 0, 'program_types', 0], ProgramStatus.Unpublished, 8),
         (detailed_path, serializers.CourseRunSearchModelSerializer,
-         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 35),
+         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 37),
         (detailed_path, serializers.CourseRunSearchModelSerializer,
-         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 36),
+         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 38),
     )
     @ddt.unpack
     def test_exclude_unavailable_program_types(self, path, serializer, result_location_keys, program_status,
@@ -195,13 +195,14 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
             assert response_data == active_program.type.name
 
     @ddt.data(
-        [{'title': 'Software Testing', 'excluded': True}],
-        [{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True}],
-        [{'title': 'Software Testing', 'excluded': False}, {'title': 'Software Testing 2', 'excluded': False}],
-        [{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True},
-         {'title': 'Software Testing 3', 'excluded': False}],
+        ([{'title': 'Software Testing', 'excluded': True}], 6),
+        ([{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True}], 7),
+        ([{'title': 'Software Testing', 'excluded': False}, {'title': 'Software Testing 2', 'excluded': False}], 7),
+        ([{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True},
+         {'title': 'Software Testing 3', 'excluded': False}], 8),
     )
-    def test_excluded_course_run(self, course_runs):
+    @ddt.unpack
+    def test_excluded_course_run(self, course_runs, expected_queries):
         course_list = []
         course_run_list = []
         excluded_course_run_list = []
@@ -223,7 +224,7 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         )
         self.reindex_courses(program)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(expected_queries):
             response = self.get_response('software', path=self.list_path)
 
         assert response.status_code == 200

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -529,6 +529,16 @@ class CourseRun(TimeStampedModel):
         """
         return self.seats.exclude(type__in=Seat.SEATS_WITH_PREREQUISITES).filter(price__gt=0.0)
 
+    @property
+    def first_enrollable_paid_seat_price(self):
+        seats = list(self._enrollable_paid_seats().order_by('upgrade_deadline'))
+        if not seats:
+            # Enrollable paid seats are not available for this CourseRun.
+            return None
+
+        price = int(seats[0].price) if seats[0].price else None
+        return price
+
     def first_enrollable_paid_seat_sku(self):
         seats = list(self._enrollable_paid_seats().order_by('upgrade_deadline'))
         if not seats:

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -206,6 +206,7 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     subject_uuids = indexes.MultiValueField()
     has_enrollable_paid_seats = indexes.BooleanField(null=False)
     first_enrollable_paid_seat_sku = indexes.CharField(null=True)
+    first_enrollable_paid_seat_price = indexes.IntegerField(null=True)
     paid_seat_enrollment_end = indexes.DateTimeField(null=True)
     license = indexes.MultiValueField(model_attr='license', faceted=True)
     has_enrollable_seats = indexes.BooleanField(model_attr='has_enrollable_seats', null=False)
@@ -220,6 +221,9 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
 
     def prepare_first_enrollable_paid_seat_sku(self, obj):
         return obj.first_enrollable_paid_seat_sku()
+
+    def prepare_first_enrollable_paid_seat_price(self, obj):
+        return obj.first_enrollable_paid_seat_price
 
     def prepare_is_current_and_still_upgradeable(self, obj):
         return obj.is_current_and_still_upgradeable()

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -255,6 +255,14 @@ class CourseRunTests(TestCase):
         factories.SeatFactory.create(course_run=course_run, type='verified', price=10, sku='ABCDEF')
         self.assertEqual(course_run.first_enrollable_paid_seat_sku(), 'ABCDEF')
 
+    def test_first_enrollable_paid_seat_price(self):
+        """
+        Verify that first_enrollable_paid_seat_price returns price of first paid seat.
+        """
+        course_run = factories.CourseRunFactory.create()
+        factories.SeatFactory.create(course_run=course_run, type='verified', price=10, sku='ABCDEF')
+        self.assertEqual(course_run.first_enrollable_paid_seat_price, 10)
+
     @ddt.data(
         # Case 1: Return None when there are no enrollable paid Seats.
         ([('audit', 0, None)], '2016-12-31 00:00:00Z', '2016-08-31 00:00:00Z', None),


### PR DESCRIPTION
Add price filtering for course runs with filter `first_enrollable_paid_seat_price`.

**Remaining Tasks:**

1. Unittests

**Testing Instructions:**

1. Install `course-discovery` service with the branch `zub/1106-catalog-filter-on-price`.
2. Add multiple courses in LMS and add related course modes with different prices in Ecommerce.
3. In discovery service run `refresh_course_metadata` command to populate the new courses in discovery service and then run `rebuild_index` command to update the elasticsearch.
```
zubair-arbi@business i-022cc502e9151c314:~$ sudo -H -u discovery bash
discovery@business:~/discovery$ source /edx/app/discovery/discovery_env
discovery@business:~/discovery$ cd /edx/app/discovery/discovery/
discovery@business:~/discovery$ ./manage.py refresh_course_metadata
discovery@business:~/discovery$ ./manage.py rebuild_index
```
4. Now access the API https://discovery-business.sandbox.edx.org/api/v1/course_runs/ and verify that now course runs have a new field `first_enrollable_paid_seat_price` which have price same as the first enrollable seat for that course.
```json
{
    "key": "course-v1:edX+TCE101+2018_T1",
    "uuid": "d8284752-03cf-4a8b-8d48-3ce7af489237",
    "title": "Test Course for enrollment codes",
    "image": null,
    "short_description": null,
    "marketing_url": null,
    "seats": [
        {
            "type": "professional",
            "price": "10.00",
            "currency": "USD",
            "upgrade_deadline": null,
            "credit_provider": null,
            "credit_hours": null,
            "sku": "B76DF8D",
            "bulk_sku": "F157816"
        }
    ],
    "start": "2018-03-30T00:00:00Z",
    "end": "2019-03-31T00:00:00Z",
    "enrollment_start": null,
    "enrollment_end": null,
    "pacing_type": "instructor_paced",
    "type": "professional",
    "status": "published",
    "course": "edX+TCE101",
    "full_description": null,
    "announcement": null,
    "video": null,
    "content_language": null,
    "license": "",
    "outcome": null,
    "transcript_languages": [],
    "instructors": [],
    "staff": [],
    "min_effort": null,
    "max_effort": null,
    "weeks_to_complete": null,
    "modified": "2018-08-06T08:33:31.851692Z",
    "level_type": null,
    "availability": "Current",
    "mobile_available": true,
    "hidden": false,
    "reporting_type": "mooc",
    "eligible_for_financial_aid": true,
    "first_enrollable_paid_seat_price": 10,
    "programs": []
}
```
5. Now go to Ecommerce coupons page https://ecommerce-business.sandbox.edx.org/coupons/new/ and select `Multiple courses` option. Then verify that you can filter the course runs on the basis of field `first_enrollable_paid_seat_price`.
For exact match of courses with 300 paid seats: `first_enrollable_paid_seat_price:300`
For range of courses with paid seats of prices 0 to 70: `first_enrollable_paid_seat_price:[0 TO 70]`
<img width="988" alt="screen shot 2018-08-06 at 5 52 18 pm" src="https://user-images.githubusercontent.com/5072991/43718436-168637a4-99a4-11e8-921d-1e02833ee879.png">

___Note:___
_During the indexing we convert the price of course run seat to integer from decimal because:_
1. _In Ecom we do the same when we publish the course seat to LMS https://github.com/edx/ecommerce/blob/master/ecommerce/courses/publishers.py#L41_
```
'price': int(stock_record.price_excl_tax),
```
2. _The price field `min_price` in course_modes models in LMS is also integer field https://github.com/edx/edx-platform/blob/master/common/djangoapps/course_modes/models.py#L76_
```
min_price = models.IntegerField(default=0, verbose_name=_("Price"))
```
3. _I was getting error on DecimalField during serialization, a know issue with `drf-haystack` https://github.com/inonit/drf-haystack/issues/116_