### PR TITLE
Publish should not override existing organizations

### DIFF
--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -133,7 +133,6 @@ class CourseRunViewSet(viewsets.GenericViewSet):
         }
         discovery_course, created = Course.objects.update_or_create(partner=partner, key=course_key, defaults=defaults)
         discovery_course.image.save(publisher_course.image.name, publisher_course.image.file)
-        discovery_course.authoring_organizations.clear()
         discovery_course.authoring_organizations.add(*publisher_course.organizations.all())
 
         subjects = [subject for subject in [


### PR DESCRIPTION
## [EDUCATOR-3294](https://openedx.atlassian.net/browse/EDUCATOR-3294)

### Description
The publish to discovery method should not remove all the existing organizations before adding new ones.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @attiyaIshaque
- [ ] @awaisdar001 

### Post-review
- [ ] Rebase and squash commits
