### PR TITLE
Enterprise Customer Catalogs: Filter courses by subject

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Clinton Blackburn <cblackburn@edx.org>
 Bill DeRusha <bill@edx.org>
 Rabia Iftikhar <rabiaiftikhar2392@gmail.com>
 Asad Azam <asadazam93@gmail.com>
+Mushtaq Ali <mushtaak@gmail.com>

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -148,6 +148,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
     enrollment_start = indexes.DateTimeField(model_attr='course_runs__enrollment_start', null=True)
     enrollment_end = indexes.DateTimeField(model_attr='course_runs__enrollment_end', null=True)
     availability = indexes.CharField(model_attr='course_runs__availability')
+    subjects = indexes.CharField(model_attr='subjects__uuid')
 
     course_runs = indexes.MultiValueField()
     expected_learning_items = indexes.MultiValueField()


### PR DESCRIPTION
The purpose of this PR is to add the capability to filter enterprise customer catalogs by subject uuids.

[ENT-1160](https://openedx.atlassian.net/browse/ENT-1160)

**Testing Instructions:**
1. Add subject_uuids filter to `content_filter` in Enterprise Customer Catalogs admin. For example: 
```
{
  "content_type":"courserun",
  "subjects":[
    "7041563a-269f-4e5c-b7a8-83356923d50f"
  ]
}
```
2.  View `enterprise_catalogs` api endpoint of that particular catalog.
https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/68953429-1848-4f03-a733-682f6944dfa3/

4. Observe that correct records are filtered out based on `subject_uuids`