### PR TITLE
ENT-1156 Add price filter for course search endpoint

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -9,6 +9,7 @@ import pytz
 import waffle
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
+from django.db.models.functions import Lower
 from django.db.models.query_utils import Q
 from django.utils.functional import cached_property
 from django.utils.text import slugify
@@ -428,6 +429,14 @@ class Course(TimeStampedModel):
                 Q(enrollment_end__isnull=True)
             )
         )
+
+    @property
+    def first_enrollable_paid_seat_price(self):
+        for course_run in self.active_course_runs.order_by(Lower('key')):
+            if course_run.has_enrollable_paid_seats():
+                return course_run.first_enrollable_paid_seat_price
+
+        return None
 
     @classmethod
     def search(cls, query):

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -148,6 +148,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
     enrollment_start = indexes.DateTimeField(model_attr='course_runs__enrollment_start', null=True)
     enrollment_end = indexes.DateTimeField(model_attr='course_runs__enrollment_end', null=True)
     availability = indexes.CharField(model_attr='course_runs__availability')
+    first_enrollable_paid_seat_price = indexes.IntegerField(null=True)
 
     course_runs = indexes.MultiValueField()
     expected_learning_items = indexes.MultiValueField()
@@ -171,6 +172,9 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
         if course_run:
             return CourseKey.from_string(course_run.key).org
         return None
+
+    def prepare_first_enrollable_paid_seat_price(self, obj):
+        return obj.first_enrollable_paid_seat_price
 
 
 class CourseRunIndex(BaseCourseIndex, indexes.Indexable):


### PR DESCRIPTION
Add price filtering for courses with filter `first_enrollable_paid_seat_price`.

**Remaining Tasks:**

1. Unittests

**Related PR:** https://github.com/edx/course-discovery/pull/1491

**Testing Instructions:**

1. Install `course-discovery` service with the branch `zub/ENT-1156-price-filter-for-course-search`.
2. Add multiple courses in LMS and add related course modes with different prices in Ecommerce.
3. In discovery service run `refresh_course_metadata` command to populate the new courses in discovery service and then run `rebuild_index` command to update the elasticsearch.
```
zubair-arbi@business i-022cc502e9151c314:~$ sudo -H -u discovery bash
discovery@business:~/discovery$ source /edx/app/discovery/discovery_env
discovery@business:~/discovery$ cd /edx/app/discovery/discovery/
discovery@business:~/discovery$ ./manage.py refresh_course_metadata
discovery@business:~/discovery$ ./manage.py rebuild_index
```
4. Now access the API https://discovery-business.sandbox.edx.org/api/v1/search/ ~~and verify that now courses have a new field `first_enrollable_paid_seat_price` which have price same as the first paid seat of the first active course_run found, which has enrollable  paid seats (`has_enrollable_paid_seats`) for that course.~~
```json
{
    "key": "edX+TCE101",
    "full_description": null,
    "aggregation_key": "course:edX+TCE101",
    "title": "Test Course for enrollment codes",
    "content_type": "course",
    "short_description": null,
    "card_image_url": null
},
```

**_Get all courses which have a course run with paid enrollable seat with price `100`:_**
https://discovery-business.sandbox.edx.org/api/v1/search/all/?content_type=course&first_enrollable_paid_seat_price=100

**_Get all courses which have a course run with paid enrollable seat with price `100`:_**
https://discovery-business.sandbox.edx.org/api/v1/search/all/?first_enrollable_paid_seat_price=100

**_Get all courses which have a course run with paid enrollable seat with price less than or equal to `100`:_**
https://discovery-business.sandbox.edx.org/api/v1/search/all/?content_type=course&first_enrollable_paid_seat_price__lte=100

**_Get all courses which have a course run with paid enrollable seat with price greater than or equal to `100`:_**
https://discovery-business.sandbox.edx.org/api/v1/search/all/?content_type=course&first_enrollable_paid_seat_price__gte=100

**_Get all courses which have a course run with paid enrollable seat with price greater than`100`:_**
https://discovery-business.sandbox.edx.org/api/v1/search/all/?content_type=course&first_enrollable_paid_seat_price__gt=100