### PR TITLE
Update for refresh course metadata to continue if an exception is

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -94,9 +94,12 @@ class Command(BaseCommand):
                     partner.oidc_secret,
                     token_type=token_type
                 )
-            except Exception:
-                logger.exception('No access token acquired through client_credential flow.')
-                raise
+            except Exception:  # pylint: disable=broad-except
+                message = '[{name}] Failed to retrieve access token through client_credential flow.'.format(
+                    name=partner.name
+                )
+                logger.exception(message)
+                continue
             username = jwt.decode(access_token, verify=False)['preferred_username']
             kwargs = {'username': username} if username else {}
 

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
                     token_type=token_type
                 )
             except Exception:  # pylint: disable=broad-except
-                message = '[{name}] Failed to retrieve access token through client_credential flow.'.format(
+                message = 'Failed to retrieve access token through client_credential flow for Partner [{name}]'.format(
                     name=partner.name
                 )
                 logger.exception(message)

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
@@ -189,7 +189,9 @@ class RefreshCourseMetadataCommandTests(TransactionTestCase):
             logger = 'course_discovery.apps.course_metadata.management.commands.refresh_course_metadata.logger'
             with mock.patch(logger) as mock_logger:
                 call_command('refresh_course_metadata')
-            expected_calls = [mock.call('Failed to retrieve access token through client_credential flow.')]
+            expected_calls = [mock.call(
+                '[{name}] Failed to retrieve access token through client_credential flow.'.format(self.partner.name)
+            )]
             mock_logger.exception.assert_has_calls(expected_calls)
 
     def test_refresh_course_metadata_with_loader_exception(self):

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
@@ -188,9 +188,8 @@ class RefreshCourseMetadataCommandTests(TransactionTestCase):
         with mock.patch('edx_rest_api_client.client.EdxRestApiClient.get_oauth_access_token', side_effect=Exception):
             logger = 'course_discovery.apps.course_metadata.management.commands.refresh_course_metadata.logger'
             with mock.patch(logger) as mock_logger:
-                with self.assertRaises(Exception):
-                    call_command('refresh_course_metadata')
-            expected_calls = [mock.call('No access token acquired through client_credential flow.')]
+                call_command('refresh_course_metadata')
+            expected_calls = [mock.call('Failed to retrieve access token through client_credential flow.')]
             mock_logger.exception.assert_has_calls(expected_calls)
 
     def test_refresh_course_metadata_with_loader_exception(self):

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
@@ -190,7 +190,9 @@ class RefreshCourseMetadataCommandTests(TransactionTestCase):
             with mock.patch(logger) as mock_logger:
                 call_command('refresh_course_metadata')
             expected_calls = [mock.call(
-                '[{name}] Failed to retrieve access token through client_credential flow.'.format(self.partner.name)
+                'Failed to retrieve access token through client_credential flow for Partner [{name}]'.format(
+                    self.partner.name
+                )
             )]
             mock_logger.exception.assert_has_calls(expected_calls)
 


### PR DESCRIPTION
reached on Connection errors.

[LEARNER-6211]

Continue trying the other partners when the connection to one partner fails.