### PR TITLE
Add a test_local.py settings file to speed up local test setup.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,20 @@ Is the build failing because translations are out of date?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Run ``make check_translations_up_to_date`` and check in the generated *.mo & *.po files to your PR.
 
+Running Tests Locally, Fast
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There is a test settings file ``course_discovery.settings.test_local`` that allows you to persist the test
+database between runs of the unittests (as long as you don't restart your container).  It stores the SQLite
+database file at ``/dev/shm``, which is a filesystem backed by RAM.  Using this test file in conjunction with
+pytest's ``--reuse-db`` option can significantly cut down on local testing iteration time.  You can use this
+as follows: ``pytest course_discovery/apps/course_metadata/tests/test_utils.py --ds=course_discovery.settings.test_local --reuse-db``
+
+The first run will incur the normal cost of database creation (typically around 30 seconds), but the second run
+will completely skip that startup cost, since the ``--reuse-db`` option causes pytest to use the already persisted
+database in the ``/dev/shm`` directory.  If you need to change models or create databases between runs, you can tell
+pytest to recreate the database with ``-recreate-db``.
+
 
 Reporting Security Issues
 -------------------------

--- a/course_discovery/settings/test_local.py
+++ b/course_discovery/settings/test_local.py
@@ -1,0 +1,11 @@
+import sys
+
+from course_discovery.settings.test import *
+
+
+# This allows you to use the --reuse-db option, even with in-memory SQLite databases,
+# since /dev/shm is a filesystem on the machine's RAM, and should persist between
+# processes until you reboot.  Don't use this in travis.
+# Source: http://www.obeythetestinggoat.com/speeding-up-django-unit-tests-with-sqlite-keepdb-and-devshm.html
+DATABASES['default']['NAME'] = '/dev/shm/course_discovery.test.db.sqlite3'
+DATABASES['default']['TEST'] = {'NAME': DATABASES['default']['NAME']}


### PR DESCRIPTION
Before this change, the first and every subsequent run of 
```
pytest course_discovery/apps/course_metadata/tests/test_utils.py
```
runs in `13 passed in 41.72 seconds` time.  Most of that time is database setup.

With this PR you can now run:
```
pytest course_discovery/apps/course_metadata/tests/test_utils.py --reuse-db --ds=course_discovery.settings.test_local
```
and the first run will still take about 40 seconds, but the second run finishes much faster: `13 passed in 7.27 seconds`

FYI: @edx/educator-neem 