### PR TITLE
filter customer catalogs by subjects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Clinton Blackburn <cblackburn@edx.org>
 Bill DeRusha <bill@edx.org>
 Rabia Iftikhar <rabiaiftikhar2392@gmail.com>
 Asad Azam <asadazam93@gmail.com>
+Muhammad Ammar <mammar@gmail.com>

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -149,6 +149,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
     enrollment_end = indexes.DateTimeField(model_attr='course_runs__enrollment_end', null=True)
     availability = indexes.CharField(model_attr='course_runs__availability')
     first_enrollable_paid_seat_price = indexes.IntegerField(null=True)
+    subject_uuids = indexes.MultiValueField()
 
     course_runs = indexes.MultiValueField()
     expected_learning_items = indexes.MultiValueField()
@@ -175,6 +176,9 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
 
     def prepare_first_enrollable_paid_seat_price(self, obj):
         return obj.first_enrollable_paid_seat_price
+
+    def prepare_subject_uuids(self, obj):
+        return [str(subject.uuid) for subject in obj.subjects.all()]
 
 
 class CourseRunIndex(BaseCourseIndex, indexes.Indexable):


### PR DESCRIPTION
[ENT-1160](https://openedx.atlassian.net/browse/ENT-1160)

This adds a `subject_uuids` filter field to filter courses by `subjects`. A sample catalog content filter query with `subject_uuids` field will look like below

```json
{
  "content_type":"course",
  "subject_uuids":[
    "5c2fd9a8-a7e8-4e87-af5d-1153e388d29c"
  ]
}
```

**Testing Instructions:**

1. Create [subjects](https://discovery-business.sandbox.edx.org/admin/course_metadata/subject/).
2. Link the newly created subjects with [courses](https://discovery-business.sandbox.edx.org/admin/course_metadata/course/).
3. Create [customer catalog](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomercatalog/) with `content_type` set to `course` and `subject_uuids`.
5. Execute `./manage.py rebuild_index` to rebuild the elastic search indexes.
4. Get `https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/<catalog-id>/` to see correct results are returned.