### PR TITLE
ENT-1163 Add course_runs list to course object search results

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1265,6 +1265,19 @@ class BaseHaystackFacetSerializer(HaystackFacetSerializer):
 
 
 class CourseSearchSerializer(HaystackSerializer):
+    course_runs = serializers.SerializerMethodField()
+
+    def get_course_runs(self, result):
+        return [
+            {
+                'key': course_run.key,
+                'enrollment_start': course_run.enrollment_start,
+                'enrollment_end': course_run.enrollment_end,
+                'start': course_run.start,
+                'end': course_run.end,
+            }
+            for course_run in result.object.course_runs.all()
+        ]
 
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
@@ -1276,6 +1289,7 @@ class CourseSearchSerializer(HaystackSerializer):
             'short_description',
             'title',
             'card_image_url',
+            'course_runs',
         )
 
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1331,8 +1331,11 @@ class CourseSearchSerializerTests(TestCase):
     def test_data(self):
         request = make_request()
         course = CourseFactory()
+        course_run = CourseRunFactory(course=course)
+        course.course_runs.add(course_run)
+        course.save()
         serializer = self.serialize_course(course, request)
-        assert serializer.data == self.get_expected_data(course, request)
+        assert serializer.data == self.get_expected_data(course, course_run, request)
 
     def serialize_course(self, course, request):
         """ Serializes the given `Course` as a search result. """
@@ -1341,7 +1344,7 @@ class CourseSearchSerializerTests(TestCase):
         return serializer
 
     @classmethod
-    def get_expected_data(cls, course, request):  # pylint: disable=unused-argument
+    def get_expected_data(cls, course, course_run, request):  # pylint: disable=unused-argument
         return {
             'key': course.key,
             'title': course.title,
@@ -1350,6 +1353,13 @@ class CourseSearchSerializerTests(TestCase):
             'content_type': 'course',
             'aggregation_key': 'course:{}'.format(course.key),
             'card_image_url': course.card_image_url,
+            'course_runs': [{
+                'key': course_run.key,
+                'enrollment_start': course_run.enrollment_start,
+                'enrollment_end': course_run.enrollment_end,
+                'start': course_run.start,
+                'end': course_run.end,
+            }],
         }
 
 
@@ -1357,7 +1367,7 @@ class CourseSearchModelSerializerTests(CourseSearchSerializerTests):
     serializer_class = CourseSearchModelSerializer
 
     @classmethod
-    def get_expected_data(cls, course, request):
+    def get_expected_data(cls, course, course_run, request):  # pylint: disable=unused-argument
         expected_data = CourseWithProgramsSerializerTests.get_expected_data(course, request)
         expected_data.update({'content_type': 'course'})
         return expected_data


### PR DESCRIPTION
I tested this on devstack by hitting the search/all endpoint for courses, and saw that the course run keys were getting returned now: http://localhost:18381/api/v1/search/all/?partner=edx&level_type=Introductory&level_type=Intermediate&level_type=Advanced&content_type=course

However, there seem to be some dependency issues that I am having trouble getting through to run unit tests locally... but hopefully we can get them passing in travis on the PR.