### PR TITLE
Added logs in case discovery run is not found

### DIFF
--- a/course_discovery/apps/publisher/signals.py
+++ b/course_discovery/apps/publisher/signals.py
@@ -18,6 +18,11 @@ def get_related_discovery_course_run(publisher_course_run):
         discovery_course = publisher_course_run.course.discovery_counterpart
         return discovery_course.course_runs.latest('start')
     except ObjectDoesNotExist:
+        logger.info(
+            'Related discovery course run not found for [%s] with partner [%s] ',
+            publisher_course_run.course.key,
+            publisher_course_run.course.partner
+        )
         return
 
 


### PR DESCRIPTION
## [EDUCATOR-3426](https://openedx.atlassian.net/browse/EDUCATOR-3426)

### Description
Added logs in case the related discovery course run is not found

**Sandbox**
N/A
### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @attiyaIshaque 
- [ ] @awaisdar001 

### Post-review
- [ ] Rebase and squash commits
