### PR TITLE
Optimize catalogs endpoint a bit

### DIFF
--- a/course_discovery/apps/api/v1/views/catalogs.py
+++ b/course_discovery/apps/api/v1/views/catalogs.py
@@ -90,11 +90,12 @@ class CatalogViewSet(viewsets.ModelViewSet):
         serializer: serializers.CatalogCourseSerializer
         """
         catalog = self.get_object()
-        queryset = catalog.courses().available()
-        course_runs = CourseRun.objects.active().enrollable().marketable()
-        if catalog.include_archived:
-            queryset = catalog.courses()
-            course_runs = CourseRun.objects.all()
+
+        queryset = catalog.courses()
+        course_runs = CourseRun.objects.all()
+        if not catalog.include_archived:
+            queryset = queryset.available()
+            course_runs = course_runs.active().enrollable().marketable()
 
         queryset = serializers.CatalogCourseSerializer.prefetch_queryset(
             self.request.site.partner,

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -46,6 +46,10 @@ class TestCourse:
         query = 'title:' + title
         assert set(Course.search(query)) == expected
 
+    def test_wildcard_search(self):
+        expected = set(factories.CourseFactory.create_batch(3))
+        assert set(Course.search('*')) == expected
+
     def test_image_url(self):
         course = factories.CourseFactory()
         assert course.image_url == course.image.small.url
@@ -156,6 +160,13 @@ class CourseRunTests(TestCase):
         query = 'title:' + title
         actual_sorted = sorted(SearchQuerySetWrapper(CourseRun.search(query)), key=lambda course_run: course_run.key)
         expected_sorted = sorted(course_runs, key=lambda course_run: course_run.key)
+        self.assertEqual(actual_sorted, expected_sorted)
+
+    def test_wildcard_search(self):
+        """ Verify the method returns an unfiltered queryset of course runs. """
+        course_runs = factories.CourseRunFactory.create_batch(3)
+        actual_sorted = sorted(SearchQuerySetWrapper(CourseRun.search('*')), key=lambda course_run: course_run.key)
+        expected_sorted = sorted(course_runs + [self.course_run], key=lambda course_run: course_run.key)
         self.assertEqual(actual_sorted, expected_sorted)
 
     def test_seat_types(self):


### PR DESCRIPTION
If the catalog query is simply '*', which is very common, don't bother with an elasticsearch query at all.

About 2/3rds of the catalogs are just '*'. On my devstack, it changes the query time from 3-4s to under 1s.

I also optimized a separate place where we were sometimes doing the elasticsearch query twice for no reason.