### PR TITLE
ARCH-233: Add JWT Auth Middleware.

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -93,6 +93,8 @@ MIDDLEWARE_CLASSES = (
     'simple_history.middleware.HistoryRequestMiddleware',
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 )
 
 ROOT_URLCONF = 'course_discovery.urls'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,7 +36,7 @@ edx-ccx-keys==0.2.0
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.0
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.1
+edx-drf-extensions==1.10.0
 edx-opaque-keys==0.3.1
 edx-rest-api-client==1.8.2
 elasticsearch>=1.0.0,<2.0.0


### PR DESCRIPTION
From edx-drf-extensions:
1. EnsureJWTAuthSettingsMiddleware: Ensures proper JWT auth settings
   for endpoints.
2. JwtAuthCookieMiddleware: Combines the JWT auth cookie parts into a
   JWT auth cookie.

ARCH-233