### PR TITLE
Instead of error on index count limit surprise, just log about it

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
+++ b/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
@@ -50,7 +50,7 @@ class Command(HaystackCommand):
             if not options.get('disable_change_limit', False):
                 record_count_is_sane, index_info_string = self.sanity_check_new_index(backend.conn, index, record_count)
                 if not record_count_is_sane:
-                    raise CommandError('Sanity check failed for new index. ' + index_info_string)
+                    logger.info('Sanity check warning for new index. ' + index_info_string)
 
             self.set_alias(backend, alias, index)
 


### PR DESCRIPTION
Remove the command error when the index limit check was tripped.  Turn that into an info
@mikedikan @MatthewPiatetsky @fysheets  Please review