### PR TITLE
Remove a no longer needed function from refresh_course_metadata

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/marketing_site.py
@@ -389,7 +389,6 @@ class CourseMarketingSiteDataLoader(AbstractMarketingSiteDataLoader):
                         course = self.update_course(course_run.course, data)
                         self.set_subjects(course, data)
                         self.set_authoring_organizations(course, data)
-                        self.set_extra_descriptions(course, data)
                         logger.info(
                             'Processed course with key [%s] based on the data from courserun [%s]',
                             course.key,


### PR DESCRIPTION
I believe `self.set_extra_descriptions()` function is no longer needed. Actually, the function had no definitions. Removing

@staubina Thank you for finding this bug