### PR TITLE
Fix elasticsearch endpoint for Persons

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1405,24 +1405,29 @@ class CourseRunFacetSerializer(BaseHaystackFacetSerializer):
 
 
 class PersonSearchSerializer(HaystackSerializer):
+    profile_image_url = serializers.SerializerMethodField()
+
+    def get_profile_image_url(self, result):
+        return result.object.get_profile_image_url
+
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
         ignore_fields = COMMON_IGNORED_FIELDS
         index_classes = [search_indexes.PersonIndex]
-        fields = (
+        fields = search_indexes.BASE_SEARCH_INDEX_FIELDS + (
             'uuid',
             'salutation',
             'full_name',
             'bio',
             'bio_language',
-            'get_profile_image_url',
+            'profile_image_url',
             'position',
         )
 
 
-class PersonSearchModelSerializer(HaystackSerializerMixin, PersonSerializer):
+class PersonSearchModelSerializer(HaystackSerializerMixin, ContentTypeSerializer, PersonSerializer):
     class Meta(PersonSerializer.Meta):
-        fields = PersonSerializer.Meta.fields
+        fields = ContentTypeSerializer.Meta.fields + PersonSerializer.Meta.fields
 
 
 class PersonFacetSerializer(BaseHaystackFacetSerializer):
@@ -1483,6 +1488,7 @@ class AggregateSearchSerializer(HaystackSerializer):
             search_indexes.CourseRunIndex: CourseRunSearchSerializer,
             search_indexes.CourseIndex: CourseSearchSerializer,
             search_indexes.ProgramIndex: ProgramSearchSerializer,
+            search_indexes.PersonIndex: PersonSearchSerializer,
         }
 
 
@@ -1498,7 +1504,8 @@ class AggregateFacetSearchSerializer(BaseHaystackFacetSerializer):
         serializers = {
             search_indexes.CourseRunIndex: CourseRunFacetSerializer,
             search_indexes.CourseIndex: CourseFacetSerializer,
-            search_indexes.ProgramIndex: ProgramFacetSerializer
+            search_indexes.ProgramIndex: ProgramFacetSerializer,
+            search_indexes.PersonIndex: PersonFacetSerializer,
         }
 
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1498,7 +1498,9 @@ class PersonSearchSerializerTest(ElasticsearchTestMixin, TestCase):
             'uuid': str(person.uuid),
             'bio': person.bio,
             'bio_language': person.bio_language,
-            'get_profile_image_url': person.get_profile_image_url,
+            'content_type': 'person',
+            'aggregation_key': 'person:' + str(person.uuid),
+            'profile_image_url': person.get_profile_image_url,
             'full_name': person.full_name
         }
 
@@ -1540,6 +1542,7 @@ class PersonSearchModelSerializerTests(PersonSearchSerializerTest):
             },
             'slug': person.slug,
             'email': person.email,
+            'content_type': 'person',
         }
 
 

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -350,6 +350,9 @@ class PersonIndex(BaseIndex, indexes.Indexable):
     get_profile_image_url = indexes.CharField(model_attr='get_profile_image_url', null=True)
     position = indexes.MultiValueField()
 
+    def prepare_aggregation_key(self, obj):
+        return 'person:{}'.format(obj.uuid)
+
     def prepare_position(self, obj):
         try:
             position = Position.objects.get(person=obj)


### PR DESCRIPTION
The new "people" elasticsearch query endpoint doesn't work.
 
1. All people are returned for any query: https://prod-edx-discovery.edx.org/api/v1/search/people/?q=complicatedquery
1. 500 errors for an "all" query that hits a person: https://prod-edx-discovery.edx.org/api/v1/search/all/?q=Arcia
1. The profile image field is serialized as "get_profile_image_url" instead of just "profile_image_url"
1. When people are included in an "all" query, there is no way to tell what sort of object it is (wasn't setting the aggregation_key or content_type fields).

This PR should fix all of those. The endpoint still requires exact matches on a field. But that's not new with our elasticsearch endpoints.