### PR TITLE
ARCH-262: Reverts addition of JwtAuthCookieMiddleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
 
       install:
         - docker exec -t discovery bash -c 'apt update && apt install -y xvfb firefox gettext wget'
+        # Remove firefox but leave its dependencies, and then download and install a working version of firefox.
+        - docker exec -t discovery bash -c 'sudo dpkg -r --force-all firefox && TEMP_DEB="$(mktemp)" && wget -O "$TEMP_DEB" https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_61.0.1%2Bbuild1-0ubuntu0.16.04.1_amd64.deb && dpkg -i "$TEMP_DEB"'
         - docker exec -t discovery bash -c 'sed -i "s/course_discovery.settings.devstack/course_discovery.settings.test/" /edx/app/discovery/discovery_env'
         - docker exec -t discovery bash -c 'source /edx/app/discovery/discovery_env && cd /edx/app/discovery/discovery/ && make requirements'
 

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -94,7 +94,6 @@ MIDDLEWARE_CLASSES = (
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
-    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 )
 
 ROOT_URLCONF = 'course_discovery.urls'


### PR DESCRIPTION
When JWT cookies are required, there will be some work needed to make this work.  
See "[ARCH-266: Backend: Enable JWT Cookies in remaining IDAs.](https://openedx.atlassian.net/browse/ARCH-266)"