### PR TITLE
Add course_runs_staffed to people

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -45,6 +45,13 @@ class SerializationMixin:
     def serialize_course_run(self, run, many=False, format=None, extra_context=None):
         return self._serialize_object(serializers.CourseRunWithProgramsSerializer, run, many, format, extra_context)
 
+    def serialize_minimal_course_run(self, run, many=False, format=None, extra_context=None):
+        return self._serialize_object(serializers.MinimalCourseRunSerializer, run, many, format, extra_context)
+
+    def serialize_minimal_publisher_course_run(self, run, many=False, format=None, extra_context=None):
+        return self._serialize_object(serializers.MinimalPublisherCourseRunSerializer, run, many, format,
+                                      extra_context)
+
     def serialize_course_run_search(self, run, serializer=None):
         obj = self._get_search_result(CourseRun, key=run.key)
         return self._serialize_object(serializer or serializers.CourseRunSearchSerializer, obj)

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -203,7 +203,7 @@ class PersonFactory(factory.DjangoModelFactory):
     family_name = factory.Faker('last_name')
     bio = FuzzyText()
     profile_image_url = FuzzyURL()
-    profile_image = FuzzyText(prefix='https://example.com/person/profile_image')
+    profile_image = FuzzyText(prefix='person/profile_image')
 
     class Meta:
         model = Person


### PR DESCRIPTION
When serialized via the API, Person objects will now include two new opt-in fields: course_runs_staffed and publisher_course_runs_staffed.

(Publisher data is probably considered sensitive. But so is Person data in general. You can only hit the Person API if you are on a course team.) 

I also fixed the API to only return Persons for the current site (rather than across all sites). And to not expose email/courses_staffed for any endpoint but /people/

This is useful for a duplicate-finding script I'm writing that wants to know whether certain Person objects are linked elsewhere.

The new fields look like:

```
    "course_runs_staffed": [
        {
            "key": "course-v1:Org+Course+Number"
            "uuid": "a74cc1ff-fa7d-4ac9-bfca-b8d97a95b1ed",
            "title": "Course Name",
            "image": null,
            "short_description": null,
            "marketing_url": null,
            "seats": [
                {
                    "type": "audit",
                    "price": "0.00",
                    "currency": "USD",
                    "upgrade_deadline": null,
                    "credit_provider": null,
                    "credit_hours": null,
                    "sku": "E507FFD",
                    "bulk_sku": null
                },
                {
                    "type": "verified",
                    "price": "150.00",
                    "currency": "USD",
                    "upgrade_deadline": "2018-11-21T00:00:00Z",
                    "credit_provider": null,
                    "credit_hours": null,
                    "sku": "0FF5E5D",
                    "bulk_sku": null
                }
            ],
            "start": "2017-12-01T00:00:00Z",
            "end": "2019-04-01T00:00:00Z",
            "enrollment_start": null,
            "enrollment_end": null,
            "pacing_type": "self_paced",
            "type": "verified",
            "status": "published"
        }
    ],
    "publisher_course_runs_staffed": [
        {
            "lms_course_id": null,
            "course": "edX+Mike101",
            "title": "Mike's Course",
            "start": "2018-10-01T00:00:00Z",
            "end": "2019-01-31T00:00:00Z",
            "pacing_type": "self_paced"
        }
    ]
```