### PR TITLE
Try to fix null uuid on stage course search view

### DIFF
--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -121,6 +121,8 @@ class CatalogDataViewSet(viewsets.GenericViewSet):
 
 
 class CourseSearchViewSet(BaseHaystackViewSet):
+    document_uid_field = 'uuid'
+    lookup_field = 'uuid'
     index_models = (Course,)
     detail_serializer_class = serializers.CourseSearchModelSerializer
     facet_serializer_class = serializers.CourseFacetSerializer


### PR DESCRIPTION
Follows the pattern of program search here: https://github.com/edx/course-discovery/blob/cef4537d1cbd8a6c5d5337972130d4d4549ee44d/course_discovery/apps/api/v1/views/search.py#L139-L141


Doesn't do anything for me locally, but maybe it works on stage