### PR TITLE
add subject names to enterprise catalog metadata

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1387,6 +1387,7 @@ class CourseSearchSerializer(HaystackSerializer):
             'card_image_url',
             'course_runs',
             'uuid',
+            'subjects',
         )
 
 


### PR DESCRIPTION
[ENT-1341](https://openedx.atlassian.net/browse/ENT-1341)

**Description:**

This updates the`/enterprise/api/v1/enterprise_catalogs/<catalog_id>/` endpoint and adds the name of subjects associated with each course . Here is a [catalog metadata response](https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/067dfbf1-d3d8-48e0-8dfe-d37d73f1b3ab/) with subject names.

**Testing Instructions:**
- Create and link subjects with courses [here](https://discovery-business.sandbox.edx.org/admin/course_metadata/course/47/change/)
- Execute `./manage.py update_index` to update the search indexes
- Hit the `/enterprise/api/v1/enterprise_catalogs/<catalog_id>/` endpoint to get expected data.
- Here is an existing [catalog](https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/067dfbf1-d3d8-48e0-8dfe-d37d73f1b3ab/) with subject names.
- By default endpoint returns data in `XML` format, to get data in `JSON` add `.json` after the catalog uuid like https://business.sandbox.edx.org/enterprise/api/v1/enterprise_catalogs/067dfbf1-d3d8-48e0-8dfe-d37d73f1b3ab.json