### PR TITLE
Updated MEDIA_URL to work for external access of static files in devs…

### DIFF
--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -26,6 +26,15 @@ JWT_AUTH.update({
     ),
 })
 
+# MEDIA CONFIGURATION
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#media-url
+MEDIA_ROOT = 'media'
+# LOCAL_MEDIA_URL was added to support external services like edx-mktg retrieving
+# static files in DEBUG and local Devstack
+LOCAL_MEDIA_URL = '/media/'
+MEDIA_URL = 'http://localhost:18381' + LOCAL_MEDIA_URL
+# END MEDIA CONFIGURATION
+
 DEFAULT_PARTNER_ID = 1
 
 # Allow live changes to JS and CSS

--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -64,8 +64,9 @@ if 'course_discovery.apps.edx_catalog_extensions' in settings.INSTALLED_APPS:
 
 if settings.DEBUG:  # pragma: no cover
     # We need this url pattern to serve user uploaded assets according to
-    # https://docs.djangoproject.com/en/1.10/howto/static-files/#serving-files-uploaded-by-a-user-during-development
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    # https://docs.djangoproject.com/en/1.11/howto/static-files/#serving-files-uploaded-by-a-user-during-development
+    # This was modified to use LOCAL_MEDIA_URL to be able to server static files to external services like edx-mktg
+    urlpatterns += static(settings.LOCAL_MEDIA_URL, document_root=settings.MEDIA_ROOT)
     if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         import debug_toolbar
 


### PR DESCRIPTION
…tack

This change will allow the retrieval of local static files in Devstack will still providing static external URLs to users of the Discovery API