### PR TITLE
Use a unicode-capable slugify

### DIFF
--- a/course_discovery/apps/course_metadata/publishers.py
+++ b/course_discovery/apps/course_metadata/publishers.py
@@ -4,14 +4,13 @@ from urllib.parse import urljoin
 
 import waffle
 from bs4 import BeautifulSoup
-from django.utils.text import slugify
 
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.exceptions import (
     AliasCreateError, AliasDeleteError, FormRetrievalError, NodeCreateError, NodeDeleteError, NodeEditError,
     NodeLookupError
 )
-from course_discovery.apps.course_metadata.utils import MarketingSiteAPIClient
+from course_discovery.apps.course_metadata.utils import MarketingSiteAPIClient, uslugify
 
 logger = logging.getLogger(__name__)
 
@@ -426,7 +425,7 @@ class ProgramMarketingSitePublisher(BaseMarketingSitePublisher):
                     self.edit_node(node_id, node_data)
 
             if node_id:
-                self.get_and_delete_alias(slugify(obj.title))
+                self.get_and_delete_alias(uslugify(obj.title))
                 self.update_node_alias(obj, node_id, previous_obj)
 
     def serialize_obj(self, obj):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import datetime
 import itertools
 import uuid
@@ -508,6 +510,11 @@ class PersonTests(TestCase):
         self.person.family_name = None
         expected = self.person.given_name
         self.assertEqual(self.person.full_name, expected)
+
+    def test_unicode_slug(self):
+        """ Verify the slug is reasonable with a unicode name. """
+        self.person = factories.PersonFactory(given_name='商汤科', family_name='')
+        self.assertEqual(self.person.slug, 'shang-tang-ke')
 
     def test_get_profile_image_url(self):
         """

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import re
 
 import ddt
@@ -32,6 +34,22 @@ class UploadToFieldNamePathTests(TestCase):
         upload_path = upload_to(self.program, 'name' + ext)
         regex = re.compile(path + str(getattr(self.program, field)) + '-[a-f0-9]{12}' + ext)
         self.assertTrue(regex.match(upload_path))
+
+
+@ddt.ddt
+class UslugifyTests(TestCase):
+    """
+    Test the utiltity function uslugify
+    """
+    @ddt.data(
+        ('技研究', 'ji-yan-jiu'),
+        ('عائشة', 'ysh'),
+        ('TWO WORDS', 'two-words'),
+    )
+    @ddt.unpack
+    def test_uslugify(self, string, expected):
+        output = utils.uslugify(string)
+        self.assertEqual(output, expected)
 
 
 class MarketingSiteAPIClientTests(MarketingSiteAPIClientTestMixin):

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -4,6 +4,7 @@ import uuid
 
 import requests
 from django.utils.functional import cached_property
+from slugify import slugify
 from stdimage.models import StdImageFieldFile
 from stdimage.utils import UploadTo
 
@@ -72,6 +73,20 @@ def custom_render_variations(file_name, variations, storage, replace=True):
 
     # to prevent default behaviour
     return False
+
+
+def uslugify(string):
+    """Slugifies a string, while handling unicode"""
+    # only_ascii=True asks slugify to convert unicode to ascii
+    slug = slugify(string, only_ascii=True)
+
+    # Version 0.1.3 of unicode-slugify does not do the following for us.
+    # But 0.1.4 does! So once it's available and we upgrade, we can drop this extra logic.
+    slug = slug.strip().replace(' ', '-').lower()
+    slug = ''.join(filter(lambda c: c.isalnum() or c in '-_~', slug))
+    # End code that can be dropped with 0.1.4
+
+    return slug
 
 
 class MarketingSiteAPIClient(object):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,3 +49,4 @@ python-dateutil==2.5.3
 pytz==2016.6.1
 # Pinning `requests` at 2.9.1 because the latest version of the package causes test failures with mocked requests
 requests==2.9.1
+unicode-slugify==0.1.3


### PR DESCRIPTION
商汤科技研究 -> shang-tang-ke-ji-yan-jiu

This adds a new dependency on [unicode-slugify](https://pypi.org/project/unicode-slugify/). This is a project of Mozilla's (so it seems like a safe dependency) which further depends on [unidecode](https://pypi.org/project/Unidecode/) for the bulk of its work.