### PR TITLE
Adding enrollment count to metadata refresh.

### DIFF
--- a/course_discovery/apps/core/tests/factories.py
+++ b/course_discovery/apps/core/tests/factories.py
@@ -51,6 +51,8 @@ class PartnerFactory(factory.DjangoModelFactory):
     marketing_site_url_root = factory.Faker('url')
     marketing_site_api_username = factory.Faker('user_name')
     marketing_site_api_password = factory.Faker('password')
+    analytics_url = factory.Faker('url')
+    analytics_token = factory.Faker('sha256')
     oidc_url_root = factory.Faker('url')
     oidc_key = factory.Faker('sha256')
     oidc_secret = factory.Faker('sha256')

--- a/course_discovery/apps/course_metadata/data_loaders/analytics_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/analytics_api.py
@@ -1,0 +1,134 @@
+import datetime
+import logging
+
+import pytz
+
+from django.utils.functional import cached_property
+
+from analyticsclient.client import Client
+from course_discovery.apps.course_metadata.data_loaders import AbstractDataLoader
+from course_discovery.apps.course_metadata.models import CourseRun
+
+logger = logging.getLogger(__name__)
+
+
+class AnalyticsAPIDataLoader(AbstractDataLoader):
+
+    API_TIMEOUT = 5  # time in seconds
+
+    def __init__(self, partner, api_url, access_token=None, token_type=None, max_workers=None,
+                 is_threadsafe=False, **kwargs):
+        super(AnalyticsAPIDataLoader, self).__init__(
+            partner, api_url, access_token, token_type, max_workers, is_threadsafe, **kwargs
+        )
+
+        # uuid: {course, count, recent_count}
+        self.course_dictionary = {}
+        # uuid: {program, count, recent_count}
+        self.program_dictionary = {}
+
+        if not (self.partner.analytics_url and self.partner.analytics_token):
+            msg = 'Analytics API credentials are not properly configured for Partner [{partner}]!'.format(
+                partner=partner.short_code)
+            raise Exception(msg)
+
+    @cached_property
+    def api_client(self):
+
+        analytics_api_client = Client(base_url=self.partner.analytics_url,
+                                      auth_token=self.partner.analytics_token,
+                                      timeout=self.API_TIMEOUT)
+
+        return analytics_api_client
+
+    def ingest(self):
+        """ Load data for all course runs. """
+
+        now = datetime.datetime.now(pytz.UTC)
+        # We don't need a high level of precision - looking for ~6months of data
+        six_months_ago = now - datetime.timedelta(days=180)
+        course_summaries_response = self.api_client.course_summaries()
+        course_run_summaries = course_summaries_response.course_summaries(recent_date=six_months_ago,
+                                                                          fields=['course_id',
+                                                                                  'count',
+                                                                                  'recent_count_change'])
+
+        for course_run_summary in course_run_summaries:
+            self._process_course_run_summary(course_run_summary=course_run_summary)
+
+        for course_dict in self.course_dictionary.values():
+            self._process_course_enrollment_count(course_dict['course'],
+                                                  course_dict['count'],
+                                                  course_dict['recent_count'])
+
+        for program_dict in self.program_dictionary.values():
+            # Update program count
+            program = program_dict['program']
+            program.enrollment_count = program_dict['count']
+            program.recent_enrollment_count = program_dict['recent_count']
+            program.save()
+            logger.info('Updating program: {program_uuid}'.format(program_uuid=program.uuid))
+
+    def _process_course_run_summary(self, course_run_summary):
+        # Get course run object from course run key
+        course_run_key = course_run_summary['course_id']
+        course_run_count = int(course_run_summary['count'])
+        course_run_recent_count = int(course_run_summary['recent_count_change'])
+        try:
+            course_run = CourseRun.objects.get(key__iexact=course_run_key)
+        except CourseRun.DoesNotExist:
+            logger.info('Course run: [{course_run_key}] not found in DB.'.format(course_run_key=course_run_key))
+            return
+
+        course = course_run.course
+        # Update course run counts
+        course_run.enrollment_count = course_run_count
+        course_run.recent_enrollment_count = course_run_recent_count
+        course_run.save()
+        logger.info('Updating course run: {course_run_key}'.format(course_run_key=course_run_key))
+
+        logger.info('Updating course dictionary for course uuid: {course_uuid}'.format(course_uuid=course.uuid))
+        # Add course run total to course total in dictionary
+        if course.uuid in self.course_dictionary:
+            logger.info('incrementing count from {old_count} to {new_count}'.format(
+                old_count=self.course_dictionary[course.uuid]['count'],
+                new_count=self.course_dictionary[course.uuid]['count'] + course_run_count))
+            logger.info('incrementing recent count from {old_count} to {new_count}'.format(
+                old_count=self.course_dictionary[course.uuid]['recent_count'],
+                new_count=self.course_dictionary[course.uuid]['recent_count'] + course_run_recent_count
+            ))
+            self.course_dictionary[course.uuid]['count'] += course_run_count
+            self.course_dictionary[course.uuid]['recent_count'] += course_run_recent_count
+        else:
+            logger.info('setting course count to {count}'.format(count=course_run_count))
+            logger.info('setting recent count to {count}'.format(count=course_run_recent_count))
+            self.course_dictionary[course.uuid] = {'course': course,
+                                                   'count': course_run_count,
+                                                   'recent_count': course_run_recent_count}
+
+    def _process_course_enrollment_count(self, course, count, recent_count):
+        # update course count
+        course.enrollment_count = count
+        course.recent_enrollment_count = recent_count
+        course.save()
+        logger.info('Updating course: {course_uuid}'.format(course_uuid=course.uuid))
+
+        logger.info('Updating program dictionary for course uuid: {course_uuid}'.format(course_uuid=course.uuid))
+        # Add course count to program dictionary for all programs
+        for program in course.programs.all():
+            # add course total to program total in dictionary
+            if program.uuid in self.program_dictionary:
+                logger.info('incrementing from {old_count} to {new_count}'.format(
+                    old_count=self.program_dictionary[program.uuid]['count'],
+                    new_count=self.program_dictionary[program.uuid]['count'] + count))
+                logger.info('incrementing from {old_count} to {new_count}'.format(
+                    old_count=self.program_dictionary[program.uuid]['recent_count'],
+                    new_count=self.program_dictionary[program.uuid]['recent_count'] + recent_count))
+                self.program_dictionary[program.uuid]['count'] += count
+                self.program_dictionary[program.uuid]['recent_count'] += recent_count
+            else:
+                logger.info('setting count to {count}'.format(count=count))
+                logger.info('setting recent count to {count}'.format(count=recent_count))
+                self.program_dictionary[program.uuid] = {'program': program,
+                                                         'count': count,
+                                                         'recent_count': recent_count}

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -737,6 +737,39 @@ PROGRAMS_API_BODIES = [
     },
 ]
 
+ANALYTICS_API_COURSE_SUMMARIES_BODIES = [
+    {
+        'course_id': '00test/00test/00test',
+        'count': '5',
+        'recent_count_change': '2'
+    },
+    {
+        'course_id': '00test/00test/01test',
+        'count': '6',
+        'recent_count_change': '1'
+    },
+    {
+        'course_id': '00test/01test/00test',
+        'count': '6',
+        'recent_count_change': '1'
+    },
+    {
+        'course_id': '00test/01test/01test',
+        'count': '6',
+        'recent_count_change': '1'
+    },
+    {
+        'course_id': '00test/01test/02test',
+        'count': '11',
+        'recent_count_change': '4'
+    },
+    {
+        'course_id': '00test/02test/00test',
+        'count': '111111',
+        'recent_count_change': '111'
+    }
+]
+
 MARKETING_SITE_API_XSERIES_BODIES = [
     {
         'body': {

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_analytics_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_analytics_api.py
@@ -1,0 +1,96 @@
+import json
+
+import responses
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.data_loaders.analytics_api import AnalyticsAPIDataLoader
+from course_discovery.apps.course_metadata.data_loaders.tests import JSON, mock_data
+from course_discovery.apps.course_metadata.data_loaders.tests.mixins import DataLoaderTestMixin
+from course_discovery.apps.course_metadata.models import Course, CourseRun, Program
+from course_discovery.apps.course_metadata.tests.factories import CourseFactory, CourseRunFactory, ProgramFactory
+
+
+class AnalyticsAPIDataLoaderTests(DataLoaderTestMixin, TestCase):
+    @property
+    def api_url(self):
+        return self.partner.analytics_url
+
+    loader_class = AnalyticsAPIDataLoader
+    mocked_data = mock_data.ANALYTICS_API_COURSE_SUMMARIES_BODIES
+
+    def _define_course_metadata(self):
+        # Add course runs, courses, and programs to DB to copy data into
+        courses = {}
+        # Course runs map to courses in the way opaque keys would (without actually using opaque keys code)
+        course_to_run_mapping = {
+            '00test/00test/00test': '00test/00test',
+            '00test/00test/01test': '00test/00test',
+            '00test/01test/00test': '00test/01test',
+            '00test/01test/01test': '00test/01test',
+            '00test/01test/02test': '00test/01test',
+            '00test/02test/00test': '00test/02test'
+        }
+        for course_summary in self.mocked_data:
+            course_run_key = course_summary['course_id']
+            course_key = course_to_run_mapping[course_run_key]
+            if course_key in courses:
+                course = courses[course_key]
+                course_run = CourseRunFactory(key=course_summary['course_id'], course=course)
+                course_run.save()
+            else:
+                course = CourseFactory(key=course_key)
+                course.save()
+                course_run = CourseRunFactory(key=course_summary['course_id'], course=course)
+                course_run.save()
+                courses[course_key] = course_run.course
+
+        # Create a program with all of the courses we created
+        program = ProgramFactory()
+        program.courses = courses.values()
+        program.save()
+
+    @responses.activate
+    def test_ingest(self):
+        self._define_course_metadata()
+
+        url = '{root_url}course_summaries/'.format(root_url=self.api_url)
+
+        responses.add(
+            method=responses.GET,
+            url=url,
+            body=json.dumps(self.mocked_data),
+            match_querystring=False,
+            content_type=JSON
+        )
+        self.loader.ingest()
+
+        # For runs, let's just confirm that enrollment counts were recorded and add up counts for courses
+        expected_course_enrollment_counts = {}
+        course_runs = CourseRun.objects.all()
+        for course_run in course_runs:
+            self.assertTrue(course_run.enrollment_count > 0)
+            self.assertTrue(course_run.recent_enrollment_count > 0)
+            course = course_run.course
+            if course.key in expected_course_enrollment_counts.keys():
+                expected_course_enrollment_counts[course.key]['count'] += course_run.enrollment_count
+                expected_course_enrollment_counts[course.key]['recent_count'] += course_run.recent_enrollment_count
+            else:
+                expected_course_enrollment_counts[course.key] = {'count': course_run.enrollment_count,
+                                                                 'recent_count': course_run.recent_enrollment_count}
+
+        # For courses, let's confirm that the course math is right in the ingest method and add courses for programs
+        expected_program_enrollment_count = 0
+        expected_program_recent_enrollment_count = 0
+        courses = Course.objects.all()
+        for course in courses:
+            expected_counts = expected_course_enrollment_counts[course.key]
+            expected_program_enrollment_count += expected_counts['count']
+            expected_program_recent_enrollment_count += expected_counts['recent_count']
+            self.assertEqual(course.enrollment_count, expected_counts['count'])
+            self.assertEqual(course.recent_enrollment_count, expected_counts['recent_count'])
+        courses = Course.objects.all()
+
+        # For programs, let's confirm that the program math is right in the ingest method
+        programs = Program.objects.all()
+        self.assertEqual(programs[0].enrollment_count, expected_program_enrollment_count)
+        self.assertEqual(programs[0].recent_enrollment_count, expected_program_recent_enrollment_count)

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -13,6 +13,7 @@ from edx_rest_api_client.client import EdxRestApiClient
 
 from course_discovery.apps.api.cache import api_change_receiver, set_api_timestamp
 from course_discovery.apps.core.models import Partner
+from course_discovery.apps.course_metadata.data_loaders.analytics_api import AnalyticsAPIDataLoader
 from course_discovery.apps.course_metadata.data_loaders.api import (
     CoursesApiDataLoader, EcommerceApiDataLoader, OrganizationsApiDataLoader, ProgramsApiDataLoader
 )
@@ -148,6 +149,7 @@ class Command(BaseCommand):
                 ),
                 (
                     (CoursesApiDataLoader, partner.courses_api_url, max_workers),
+                    (AnalyticsAPIDataLoader, partner.analytics_url, max_workers),
                 ),
                 (
                     (EcommerceApiDataLoader, partner.ecommerce_api_url, 1),
@@ -160,6 +162,7 @@ class Command(BaseCommand):
                     with concurrent.futures.ProcessPoolExecutor() as executor:
                         for loader_class, api_url, max_workers in stage:
                             if api_url:
+                                logger.info('Executing Loader [{}]'.format(api_url))
                                 executor.submit(
                                     execute_parallel_loader,
                                     loader_class,
@@ -175,6 +178,7 @@ class Command(BaseCommand):
                 # Flatten pipeline and run serially.
                 for loader_class, api_url, max_workers in itertools.chain(*(stage for stage in pipeline)):
                     if api_url:
+                        logger.info('Executing Loader [{}]'.format(api_url))
                         execute_loader(
                             loader_class,
                             partner,

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
@@ -9,6 +9,7 @@ from django.test import TransactionTestCase
 
 from course_discovery.apps.core.tests.factories import PartnerFactory
 from course_discovery.apps.core.tests.utils import mock_api_callback
+from course_discovery.apps.course_metadata.data_loaders.analytics_api import AnalyticsAPIDataLoader
 from course_discovery.apps.course_metadata.data_loaders.api import (
     CoursesApiDataLoader, EcommerceApiDataLoader, OrganizationsApiDataLoader, ProgramsApiDataLoader
 )
@@ -38,6 +39,7 @@ class RefreshCourseMetadataCommandTests(TransactionTestCase):
             (CourseMarketingSiteDataLoader, partner.marketing_site_url_root, None),
             (OrganizationsApiDataLoader, partner.organizations_api_url, None),
             (CoursesApiDataLoader, partner.courses_api_url, None),
+            (AnalyticsAPIDataLoader, partner.analytics_url, None),
             (EcommerceApiDataLoader, partner.ecommerce_api_url, 1),
             (ProgramsApiDataLoader, partner.programs_api_url, None),
         ]
@@ -208,6 +210,7 @@ class RefreshCourseMetadataCommandTests(TransactionTestCase):
                     CourseMarketingSiteDataLoader,
                     OrganizationsApiDataLoader,
                     CoursesApiDataLoader,
+                    AnalyticsAPIDataLoader,
                     EcommerceApiDataLoader,
                     ProgramsApiDataLoader,
                 )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/edx/edx-analytics-data-api-client.git@0.15.2#egg=edx-analytics-data-api-client==0.15.2  # edX
 beautifulsoup4==4.5.1
 boto==2.42.0
 cryptography==1.7.1


### PR DESCRIPTION
DISCO-396

Adding analytics API to metadata refresh data loaders.  Updates enrollment count and recent enrollment count fields on course run, course, and program.