### PR TITLE
Performance tweaks to analytics refresh

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/analytics_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/analytics_api.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class AnalyticsAPIDataLoader(AbstractDataLoader):
 
-    API_TIMEOUT = 5  # time in seconds
+    API_TIMEOUT = 10  # time in seconds
 
     def __init__(self, partner, api_url, access_token=None, token_type=None, max_workers=None,
                  is_threadsafe=False, **kwargs):

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -149,7 +149,9 @@ class Command(BaseCommand):
                 ),
                 (
                     (CoursesApiDataLoader, partner.courses_api_url, max_workers),
-                    (AnalyticsAPIDataLoader, partner.analytics_url, max_workers),
+                ),
+                (
+                    (AnalyticsAPIDataLoader, partner.analytics_url, 1),
                 ),
                 (
                     (EcommerceApiDataLoader, partner.ecommerce_api_url, 1),

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_refresh_course_metadata.py
@@ -39,7 +39,7 @@ class RefreshCourseMetadataCommandTests(TransactionTestCase):
             (CourseMarketingSiteDataLoader, partner.marketing_site_url_root, None),
             (OrganizationsApiDataLoader, partner.organizations_api_url, None),
             (CoursesApiDataLoader, partner.courses_api_url, None),
-            (AnalyticsAPIDataLoader, partner.analytics_url, None),
+            (AnalyticsAPIDataLoader, partner.analytics_url, 1),
             (EcommerceApiDataLoader, partner.ecommerce_api_url, 1),
             (ProgramsApiDataLoader, partner.programs_api_url, None),
         ]


### PR DESCRIPTION
DISCO-472

Separate the process to a separate thread, in stage interleaving this process with course api ingestion made both processes much slower.  Increase timeout to 10s - 5s was sufficient for stage data, but insufficient for prod data.