### PR TITLE
When PC approves a course run, move direct to course team

### DIFF
--- a/course_discovery/apps/publisher/api/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/tests/test_views.py
@@ -716,9 +716,9 @@ class ChangeCourseRunStateViewTests(SiteMixin, TestCase):
         self.run_state = CourseRunState.objects.get(course_run=self.course_run)
 
         self.assertEqual(self.run_state.name, CourseRunStateChoices.Approved)
-        self.assertEqual(self.run_state.owner_role, PublisherUserRole.Publisher)
+        self.assertEqual(self.run_state.owner_role, PublisherUserRole.CourseTeam)
 
-        self.assertEqual(len(mail.outbox), 2)
+        self.assertEqual(len(mail.outbox), 3)
 
     def test_mark_as_reviewed_by_pc(self):
         """
@@ -744,10 +744,9 @@ class ChangeCourseRunStateViewTests(SiteMixin, TestCase):
         self.run_state = CourseRunState.objects.get(course_run=self.course_run)
 
         self.assertEqual(self.run_state.name, CourseRunStateChoices.Approved)
-        self.assertEqual(self.run_state.owner_role, PublisherUserRole.Publisher)
+        self.assertEqual(self.run_state.owner_role, PublisherUserRole.CourseTeam)
 
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertNotIn(self.course_run.course.course_team_admin.email, mail.outbox[0].to)
+        self.assertEqual(len(mail.outbox), 2)
 
     def test_preview_accepted(self):
         """

--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -1016,12 +1016,13 @@ class CourseRunState(TimeStampedModel, ChangedByMixin):
         elif state == CourseRunStateChoices.Approved:
             user_role = self.course_run.course.course_user_roles.get(user=user)
             self.approved_by_role = user_role.role
-            self.change_owner_role(PublisherUserRole.Publisher)
+            self.change_owner_role(PublisherUserRole.CourseTeam)
             self.approved()
 
             if waffle.switch_is_active('enable_publisher_email_notifications'):
                 emails.send_email_for_mark_as_reviewed_course_run(self.course_run, user, site)
                 emails.send_email_to_publisher(self.course_run, user, site)
+                emails.send_email_preview_page_is_available(self.course_run, site)
 
         elif state == CourseRunStateChoices.Published:
             self.published(site)


### PR DESCRIPTION
This cuts out one of the publisher-owned (marketing-owned) steps where they craft the preview URL. Now that it's done automatically, we don't need to block on the course publisher.

I left in the bit where when a publisher *does* change the URL, it goes back to CourseTeam and sends email again. That should keep doing that. But I just also made the "send for review" button that the PC presses also do it.