### PR TITLE
Show length of a program on the courses endpoint

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -520,14 +520,19 @@ class CatalogSerializer(serializers.ModelSerializer):
 class NestedProgramSerializer(serializers.ModelSerializer):
     """
     Serializer used when nesting a Program inside another entity (e.g. a Course). The resulting data includes only
-    the basic details of the Program and none of the details about its related entities (e.g. courses).
+    the basic details of the Program and none of the details about its related entities, aside from the number
+    of courses in the program.
     """
     type = serializers.SlugRelatedField(slug_field='name', queryset=ProgramType.objects.all())
+    number_of_courses = serializers.SerializerMethodField()
 
     class Meta:
         model = Program
-        fields = ('uuid', 'title', 'type', 'marketing_slug', 'marketing_url',)
-        read_only_fields = ('uuid', 'marketing_url',)
+        fields = ('uuid', 'title', 'type', 'marketing_slug', 'marketing_url', 'number_of_courses',)
+        read_only_fields = ('uuid', 'marketing_url', 'number_of_courses',)
+
+    def get_number_of_courses(self, obj):
+        return obj.courses.count()
 
 
 class MinimalPublisherCourseRunSerializer(TimestampModelSerializer):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1173,7 +1173,8 @@ class CorporateEndorsementSerializerTests(TestCase):
 
 class NestedProgramSerializerTests(TestCase):
     def test_data(self):
-        program = ProgramFactory()
+        course_run = CourseRunFactory()
+        program = ProgramFactory(courses=[course_run.course])
         serializer = NestedProgramSerializer(program)
 
         expected = {
@@ -1182,6 +1183,7 @@ class NestedProgramSerializerTests(TestCase):
             'marketing_url': program.marketing_url,  # pylint: disable=no-member
             'type': program.type.name,
             'title': program.title,
+            'number_of_courses': program.courses.count(),
         }
 
         self.assertDictEqual(serializer.data, expected)

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -161,9 +161,9 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         (list_path, serializers.CourseRunSearchSerializer,
          ['results', 0, 'program_types', 0], ProgramStatus.Unpublished, 8),
         (detailed_path, serializers.CourseRunSearchModelSerializer,
-         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 37),
+         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 40),
         (detailed_path, serializers.CourseRunSearchModelSerializer,
-         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 38),
+         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 42),
     )
     @ddt.unpack
     def test_exclude_unavailable_program_types(self, path, serializer, result_location_keys, program_status,


### PR DESCRIPTION
DISCO-502

Example result for programs on a specific course:
<img width="408" alt="screen shot 2019-01-09 at 11 34 56 am" src="https://user-images.githubusercontent.com/14864970/50913650-cc349900-1402-11e9-9595-035cc3e91dea.png">
