### PR TITLE
Support CORS access

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -58,6 +58,7 @@ THIRD_PARTY_APPS = [
     'parler',
     # edx-drf-extensions
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens.
+    'corsheaders',
 ]
 
 PROJECT_APPS = [
@@ -80,6 +81,7 @@ INSTALLED_APPS += PROJECT_APPS
 INSTALLED_APPS += ['haystack']
 
 MIDDLEWARE_CLASSES = (
+    'corsheaders.middleware.CorsMiddleware',
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -1,5 +1,6 @@
 # noinspection PyUnresolvedReferences
 from course_discovery.settings._debug_toolbar import *  # isort:skip
+from corsheaders.defaults import default_headers as corsheaders_default_headers
 from course_discovery.settings.production import *
 
 DEBUG = True
@@ -11,6 +12,14 @@ LOGGING['handlers']['local'] = {
 
 # Determine which requests should render Django Debug Toolbar
 INTERNAL_IPS = ('127.0.0.1',)
+
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+    'use-jwt-cookie',
+)
+CORS_ORIGIN_WHITELIST = (
+    'localhost:18400',  # publisher-frontend
+)
 
 HAYSTACK_CONNECTIONS['default']['URL'] = 'http://edx.devstack.elasticsearch:9200/'
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1
 django-contrib-comments==1.8.0
+django-cors-headers==2.4.0
 django-extensions==1.7.8
 django-filter==1.0.4
 django-fsm==2.6.0


### PR DESCRIPTION
Using django-cors-headers. Only current devstack allowance is for the new publisher-frontend on localhost port 18400.