### PR TITLE
Loosened version pin for elasticsearch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ edx-django-utils==1.0.1
 edx-drf-extensions==2.0.1
 edx-opaque-keys==0.3.1
 edx-rest-api-client==1.8.2
-elasticsearch>=1.0.0,<2.0.0
+elasticsearch>=1.0.0,<6.0
 html2text==2016.9.19
 jsonfield==1.0.3
 markdown==2.6.6


### PR DESCRIPTION
Updated the version restrictions to support through the 5.x release of elasticsearch as that is what is supported for Django Haystack