### PR TITLE
Undo change to Degree admin page

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -346,7 +346,7 @@ class CurriculumAdmin(admin.ModelAdmin):
 class CurriculumAdminInline(admin.StackedInline):
     model = Curriculum
     extra = 1
-    fk_name = 'program'
+    fk_name = 'degree'
 
 
 class IconTextPairingInline(admin.StackedInline):


### PR DESCRIPTION
**Team:** @edx/educator-neem 

In #1763, I updated the Degree admin page to display curricula based on the new `Curriculum.program` field. Because this field has not yet been backfilled, we want to go back to displaying a curriculum based on the old `Curriculum.degree` field.
