### PR TITLE
EDUCATOR-3941 Remove field Curriculum.degree

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -912,7 +912,6 @@ class DegreeSerializer(serializers.ModelSerializer):
     campus_image = serializers.ImageField()
     title_background_image = serializers.ImageField()
     costs = DegreeCostSerializer(many=True)
-    curriculum = CurriculumSerializer()
     quick_facts = IconTextPairingSerializer(many=True)
     lead_capture_image = StdImageSerializerField()
     deadlines = DegreeDeadlineSerializer(many=True)
@@ -923,7 +922,7 @@ class DegreeSerializer(serializers.ModelSerializer):
         model = Degree
         fields = (
             'application_requirements', 'apply_url', 'banner_border_color', 'campus_image', 'title_background_image',
-            'costs', 'curriculum', 'deadlines', 'lead_capture_list_name', 'quick_facts',
+            'costs', 'deadlines', 'lead_capture_list_name', 'quick_facts',
             'overall_ranking', 'prerequisite_coursework', 'rankings',
             'lead_capture_image', 'micromasters_url', 'micromasters_long_title', 'micromasters_long_description',
             'micromasters_background_image', 'costs_fine_print', 'deadlines_fine_print', 'hubspot_lead_capture_form_id',

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -964,8 +964,8 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
 
         rankings = RankingFactory.create_batch(3)
         degree = DegreeFactory.create(rankings=rankings)
-        curriculum = CurriculumFactory.create(degree=degree, program=degree)
-        degree.curriculum = curriculum
+        curriculum = CurriculumFactory.create(program=degree)
+        degree.curricula = [curriculum]
         quick_facts = IconTextPairingFactory.create_batch(3, degree=degree)
         degree.deadline = DegreeDeadlineFactory.create_batch(size=3, degree=degree)
         degree.cost = DegreeCostFactory.create_batch(size=3, degree=degree)
@@ -987,7 +987,6 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
             'banner_border_color': degree.banner_border_color,
             'campus_image': degree.campus_image,
             'costs': expected_degree_costs,
-            'curriculum': expected_curriculum,
             'deadlines': expected_degree_deadlines,
             'quick_facts': expected_quick_facts,
             'prerequisite_coursework': degree.prerequisite_coursework,

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -23,7 +23,7 @@ from course_discovery.apps.api.serializers import (
     ContainedCoursesSerializer, ContentTypeSerializer, CorporateEndorsementSerializer, CourseEntitlementSerializer,
     CourseRunSearchModelSerializer, CourseRunSearchSerializer, CourseRunSerializer, CourseRunWithProgramsSerializer,
     CourseSearchModelSerializer, CourseSearchSerializer, CourseSerializer, CourseWithProgramsSerializer,
-    CurriculumSerializer, DegreeCostSerializer, DegreeDeadlineSerializer, EndorsementSerializer, FAQSerializer,
+    DegreeCostSerializer, DegreeDeadlineSerializer, EndorsementSerializer, FAQSerializer,
     FlattenedCourseRunWithCourseSerializer, IconTextPairingSerializer, ImageSerializer, MinimalCourseRunSerializer,
     MinimalCourseSerializer, MinimalOrganizationSerializer, MinimalPersonSerializer, MinimalProgramCourseSerializer,
     MinimalProgramSerializer, NestedProgramSerializer, OrganizationSerializer, PathwaySerializer,
@@ -41,7 +41,7 @@ from course_discovery.apps.core.tests.mixins import ElasticsearchTestMixin, LMSA
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import Course, CourseRun, Person, Program
 from course_discovery.apps.course_metadata.tests.factories import (
-    AdditionalPromoAreaFactory, CorporateEndorsementFactory, CourseFactory, CourseRunFactory, CurriculumFactory,
+    AdditionalPromoAreaFactory, CorporateEndorsementFactory, CourseFactory, CourseRunFactory,
     DegreeCostFactory, DegreeDeadlineFactory, DegreeFactory, EndorsementFactory, ExpectedLearningItemFactory,
     IconTextPairingFactory, ImageFactory, JobOutlookItemFactory, OrganizationFactory, PathwayFactory,
     PersonAreaOfExpertiseFactory, PersonFactory, PersonSocialNetworkFactory, PositionFactory, PrerequisiteFactory,
@@ -964,8 +964,6 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
 
         rankings = RankingFactory.create_batch(3)
         degree = DegreeFactory.create(rankings=rankings)
-        curriculum = CurriculumFactory.create(program=degree)
-        degree.curricula = [curriculum]
         quick_facts = IconTextPairingFactory.create_batch(3, degree=degree)
         degree.deadline = DegreeDeadlineFactory.create_batch(size=3, degree=degree)
         degree.cost = DegreeCostFactory.create_batch(size=3, degree=degree)
@@ -973,13 +971,12 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
         serializer = self.serializer_class(degree, context={'request': request})
         expected = self.get_expected_data(degree, request)
         expected_rankings = RankingSerializer(rankings, many=True).data
-        expected_curriculum = CurriculumSerializer(curriculum).data
         expected_quick_facts = IconTextPairingSerializer(quick_facts, many=True).data
         expected_degree_deadlines = DegreeDeadlineSerializer(degree.deadline, many=True).data
         expected_degree_costs = DegreeCostSerializer(degree.cost, many=True).data
 
         # Tack in degree data
-        expected['curricula'] = [expected_curriculum]
+        expected['curricula'] = []
         expected['degree'] = {
             'application_requirements': degree.application_requirements,
             'apply_url': degree.apply_url,

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -339,14 +339,13 @@ class DegreeCourseCurriculumAdmin(admin.ModelAdmin):
 
 @admin.register(Curriculum)
 class CurriculumAdmin(admin.ModelAdmin):
-    list_display = ('uuid', 'degree', 'program')
+    list_display = ('uuid', 'program')
     inlines = (DegreeProgramCurriculumInline, DegreeCourseCurriculumInline)
 
 
 class CurriculumAdminInline(admin.StackedInline):
     model = Curriculum
     extra = 1
-    fk_name = 'degree'
 
 
 class IconTextPairingInline(admin.StackedInline):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1647,11 +1647,10 @@ class DegreeCost(TimeStampedModel):
 
 class Curriculum(TimeStampedModel):
     """
-    This model links a degree to the curriculum associated with that degree, that is, the
-    courses and programs that compose the degree.
+    This model links a program to the curriculum associated with that program, that is, the
+    courses and programs that compose the program.
     """
     uuid = models.UUIDField(blank=True, default=uuid4, editable=False, unique=True, verbose_name=_('UUID'))
-    degree = models.OneToOneField(Degree, on_delete=models.CASCADE, related_name='curriculum')
     program = models.ForeignKey(
         Program,
         on_delete=models.CASCADE,

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -397,7 +397,7 @@ class CurriculumFactory(factory.DjangoModelFactory):
     uuid = factory.LazyFunction(uuid4)
     marketing_text_brief = FuzzyText()
     marketing_text = FuzzyText()
-    degree = factory.SubFactory(DegreeFactory)
+    program = factory.SubFactory(ProgramFactory)
 
     @factory.post_generation
     def program_curriculum(self, create, extracted, **kwargs):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -1551,13 +1551,8 @@ class DegreeTests(TestCase):
         self.course_run = factories.CourseRunFactory()
         self.courses = [self.course_run.course]
         self.degree = factories.DegreeFactory(courses=self.courses)
-        self.curriculum = factories.CurriculumFactory(program=self.degree)
 
     def test_basic_degree(self):
-        assert self.degree.curricula != []
-        assert self.curriculum.program_curriculum is not None
-        assert self.curriculum.course_curriculum is not None
-        assert self.curriculum.marketing_text is not None
         assert self.degree.lead_capture_list_name is not None
         assert self.degree.lead_capture_image is not None
         assert self.degree.campus_image is not None

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -1438,7 +1438,7 @@ class CurriculumTests(TestCase):
 
     def test_str(self):
         uuid_string = uuid.uuid4()
-        curriculum = Curriculum.objects.create(degree=self.degree, program=self.degree, uuid=uuid_string)
+        curriculum = Curriculum(program=self.degree, uuid=uuid_string)
         self.assertEqual(str(curriculum), str(uuid_string))
 
 
@@ -1551,10 +1551,10 @@ class DegreeTests(TestCase):
         self.course_run = factories.CourseRunFactory()
         self.courses = [self.course_run.course]
         self.degree = factories.DegreeFactory(courses=self.courses)
-        self.curriculum = factories.CurriculumFactory(degree=self.degree, program=self.degree)
+        self.curriculum = factories.CurriculumFactory(program=self.degree)
 
     def test_basic_degree(self):
-        assert self.degree.curriculum is not None
+        assert self.degree.curricula != []
         assert self.curriculum.program_curriculum is not None
         assert self.curriculum.course_curriculum is not None
         assert self.curriculum.marketing_text is not None

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -4,7 +4,9 @@ from django.apps import apps
 from factory import DjangoModelFactory
 
 from course_discovery.apps.course_metadata.models import (
-    DataLoaderConfig, DeletePersonDupsConfig, DrupalPublishUuidConfig, ProfileImageDownloadConfig, SubjectTranslation,
+    Curriculum, DataLoaderConfig, DegreeCourseCurriculum,
+    DegreeProgramCurriculum, DeletePersonDupsConfig,
+    DrupalPublishUuidConfig, ProfileImageDownloadConfig, SubjectTranslation,
     TopicTranslation
 )
 from course_discovery.apps.course_metadata.tests import factories
@@ -29,7 +31,9 @@ class TestCacheInvalidation:
         for model in apps.get_app_config('course_metadata').get_models():
             # Ignore models that aren't exposed by the API or are only used for testing.
             if model in [DataLoaderConfig, DeletePersonDupsConfig, DrupalPublishUuidConfig, SubjectTranslation,
-                         TopicTranslation, ProfileImageDownloadConfig] or 'abstract' in model.__name__.lower():
+                         TopicTranslation, ProfileImageDownloadConfig,
+                         Curriculum, DegreeProgramCurriculum, DegreeCourseCurriculum,  # Skip temporarily
+                         ] or 'abstract' in model.__name__.lower():
                 continue
 
             factory = factory_map.get(model)


### PR DESCRIPTION
**Ticket:** https://openedx.atlassian.net/browse/EDUCATOR-3941
**Team:** @edx/educator-neem 

This is the first PR in a series of two. It removes `Curriculum.degree`, and temporarily removes parts of tests that involve saving `Curriculum` objects to the database. 

The second, which does migrations for this PR and reinstates the old tests, is #1771