### PR TITLE
Move CORS config to base.py from devstack.py

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -4,6 +4,8 @@ from logging.handlers import SysLogHandler
 from os.path import abspath, dirname, join
 from sys import path
 
+from corsheaders.defaults import default_headers as corsheaders_default_headers
+
 here = lambda *x: join(abspath(dirname(__file__)), *x)
 PROJECT_ROOT = here('..')
 root = lambda *x: abspath(join(abspath(PROJECT_ROOT), *x))
@@ -243,6 +245,12 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
     'guardian.backends.ObjectPermissionBackend',
 )
+
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+    'use-jwt-cookie',
+)
+# CORS_ORIGIN_WHITELIST is empty by default so above is not used unless the whitelist is set elsewhere
 
 # Guardian settings
 ANONYMOUS_USER_NAME = None  # Do not allow anonymous user access

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -1,6 +1,5 @@
 # noinspection PyUnresolvedReferences
 from course_discovery.settings._debug_toolbar import *  # isort:skip
-from corsheaders.defaults import default_headers as corsheaders_default_headers
 from course_discovery.settings.production import *
 
 DEBUG = True
@@ -13,10 +12,6 @@ LOGGING['handlers']['local'] = {
 # Determine which requests should render Django Debug Toolbar
 INTERNAL_IPS = ('127.0.0.1',)
 
-CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_HEADERS = corsheaders_default_headers + (
-    'use-jwt-cookie',
-)
 CORS_ORIGIN_WHITELIST = (
     'localhost:18400',  # publisher-frontend
 )


### PR DESCRIPTION
Production will use same basic settings, with a different whitelist.