### PR TITLE
Set authoring_organizations on Course create

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -317,6 +317,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         expected_course_key = '{org}+{number}'.format(org=course_data['org'], number=course_data['number'])
         self.assertEqual(course.key, expected_course_key)
         self.assertEqual(course.title, course_data['title'])
+        self.assertListEqual(list(course.authoring_organizations.all()), [self.org])
         self.assertEqual(1, CourseEntitlement.objects.count())
 
     def test_create_fails_with_missing_field(self):

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -187,6 +187,10 @@ class CourseViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
 
         course = serializer.save()
+
+        organization = Organization.objects.get(key=course_creation_fields['org'])
+        course.authoring_organizations.add(organization)
+
         price = request.data.get('price', 0.00)
         mode = SeatType.objects.get(slug=course_creation_fields['mode'])
         entitlement = CourseEntitlement.objects.create(


### PR DESCRIPTION
In the new course creation API endpoint, make sure to set authoring_organizations (much like the old publisher endpoint did).

https://openedx.atlassian.net/browse/DISCO-616

In old publisher:
```
                    organization_extension = get_object_or_404(
                        OrganizationExtension, organization=course_form.data['organization']
                    )
                    course.organizations.add(organization_extension.organization)
```

I chose not to manually check OrganizationExtension, since we wouldn't use it for anything in that same method. It might be worth enforcing that it exists? But even then, it might not exist by the time we do want to do something with it. Felt like it makes more sense to only complain about it missing when we try to use it.