### PR TITLE
Allow filtering courses by editable

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -14,7 +14,7 @@ from rest_framework.exceptions import NotFound, PermissionDenied
 from course_discovery.apps.api.utils import cast2int
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import (
-    Course, CourseRun, Organization, Person, Program, Subject, Topic
+    Course, CourseEditor, CourseRun, Organization, Person, Program, Subject, Topic
 )
 
 logger = logging.getLogger(__name__)
@@ -131,10 +131,17 @@ class FilterSetMixin:
 class CourseFilter(filters.FilterSet):
     keys = CharListFilter(name='key', lookup_expr='in')
     uuids = UUIDListFilter()
+    editable = filters.BooleanFilter(method='filter_editable')
 
     class Meta:
         model = Course
         fields = ('keys', 'uuids',)
+
+    def filter_editable(self, queryset, name, value):
+        if self.request and cast2int(value, name):
+            return CourseEditor.editable_courses(self.request.user, queryset)
+        else:
+            return queryset
 
 
 class CourseRunFilter(FilterSetMixin, filters.FilterSet):

--- a/course_discovery/apps/api/permissions.py
+++ b/course_discovery/apps/api/permissions.py
@@ -1,5 +1,7 @@
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
+from course_discovery.apps.course_metadata.models import CourseEditor
+
 
 class ReadOnlyByPublisherUser(BasePermission):
     """
@@ -17,30 +19,13 @@ class IsCourseEditorOrReadOnly(BasePermission):
     """
     def has_permission(self, request, view):
         if request.method == 'POST':
-            # You must be a member of the organization within which you are creating a course
             org = request.data.get('org')
-            return org and (
-                request.user.is_staff or
-                request.user.groups.filter(organization_extension__organization__key=org).exists()
-            )
+            return org and CourseEditor.can_create_course(request.user, org)
         else:
             return True  # other write access attempts will be caught by object permissions below
 
     def has_object_permission(self, request, view, obj):
         if request.method in SAFE_METHODS:
             return True
-        elif request.user.is_staff:  # staff users are always editors
-            return True
-
-        authoring_orgs = obj.authoring_organizations.all()
-
-        # No matter what, if an editor or their organization has been removed from the course, they can't be an editor
-        # for it. This handles cases of being dropped from an org... But might be too restrictive in case we want
-        # to allow outside guest editors on a course? Let's try this for now and see how it goes.
-        valid_editors = obj.editors.filter(user__groups__organization_extension__organization__in=authoring_orgs)
-
-        if not valid_editors.exists():
-            # No valid editors - this is an edge case where we just grant anyone in an authoring org access
-            return request.user.groups.filter(organization_extension__organization__in=authoring_orgs).exists()
         else:
-            return request.user in {x.user for x in valid_editors}
+            return CourseEditor.is_course_editable(request.user, obj)

--- a/course_discovery/apps/api/tests/test_filters.py
+++ b/course_discovery/apps/api/tests/test_filters.py
@@ -1,7 +1,13 @@
+from django.test import TestCase
+from mock import MagicMock
 from rest_framework.test import APIRequestFactory
 from rest_framework.views import APIView
 
-from course_discovery.apps.api.filters import HaystackRequestFilterMixin
+from course_discovery.apps.api.filters import CourseFilter, HaystackRequestFilterMixin
+from course_discovery.apps.core.tests.factories import UserFactory
+from course_discovery.apps.course_metadata.models import Course
+from course_discovery.apps.course_metadata.tests.factories import CourseEditorFactory, CourseFactory
+from course_discovery.apps.publisher.tests.factories import OrganizationExtensionFactory
 
 
 class TestHaystackRequestFilterMixin:
@@ -27,3 +33,81 @@ class TestHaystackRequestFilterMixin:
         filters = HaystackRequestFilterMixin.get_request_filters(request)
         assert 'q' not in filters
         assert filters.get('test') == '0'
+
+
+class TestCourseFilter(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.qs = Course.objects.all()
+
+        self.org_ext = OrganizationExtensionFactory()
+        self.user.groups.add(self.org_ext.group)
+
+        # *** Add a bunch of courses ***
+
+        # Course with no editors
+        self.course_no_editors = CourseFactory(title="no editors")
+
+        # Course with an invalid editor (no group membership)
+        bad_editor = UserFactory()
+        self.course_bad_editor = CourseFactory(title="bad editor")
+        CourseEditorFactory(user=bad_editor, course=self.course_bad_editor)
+
+        # Course with an invalid editor (but course is in our group)
+        self.course_bad_editor_in_group = CourseFactory(title="bad editor in group")
+        self.course_bad_editor_in_group.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
+        CourseEditorFactory(user=bad_editor, course=self.course_bad_editor_in_group)
+
+        # Course with a valid other editor
+        good_editor = UserFactory()
+        good_editor.groups.add(self.org_ext.group)
+        self.course_good_editor = CourseFactory(title="good editor")
+        self.course_good_editor.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
+        CourseEditorFactory(user=good_editor, course=self.course_good_editor)
+
+        # Course with user as an invalid editor (no group membership)
+        self.course_no_group = CourseFactory(title="no group")
+        CourseEditorFactory(user=self.user, course=self.course_no_group)
+
+        # Course with user as an valid editor
+        self.course_editor = CourseFactory(title="editor")
+        self.course_editor.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
+        CourseEditorFactory(user=self.user, course=self.course_editor)
+
+        # *** End course definitions ***
+
+        request = MagicMock()
+        request.user = self.user
+        self.filter = CourseFilter(request=request)
+
+    def filter_editable(self, value='1'):
+        return self.filter.filter_editable(self.qs, 'editable', value)
+
+    def test_editable_no_request(self):
+        """ Verify the we don't touch the queryset if no request is passed. """
+        self.filter = CourseFilter()
+        with self.assertNumQueries(0):
+            self.assertEqual(self.filter_editable(), self.qs)
+
+    def test_editable_disabled(self):
+        """ Verify the we don't touch the queryset if editable is off. """
+        with self.assertNumQueries(0):
+            self.assertEqual(self.filter_editable('0'), self.qs)
+
+    def test_editable_is_staff(self):
+        """ Verify staff users can see all courses. """
+        self.user.is_staff = True
+        self.user.save()
+        with self.assertNumQueries(0):
+            self.assertEqual(self.filter_editable(), self.qs)
+
+    def test_editable_no_access(self):
+        """ Verify users without any editor status see nothing. """
+        self.user.groups.clear()
+        self.assertEqual(list(self.filter_editable()), [])
+
+    def test_editable(self):
+        """ Verify users can see courses they can edit. """
+        with self.assertNumQueries(1):
+            self.assertEqual(list(self.filter_editable()), [self.course_bad_editor_in_group, self.course_editor])


### PR DESCRIPTION
If you pass editable=1 to the courses list endpoint, you'll now only see courses that you will be able to edit.

I refactored the logic into classmethods on CourseEditor. I felt it made sense to have it all in a row.

The ticket mentions also allowing all internal users to "see the course" but I believe that item was mostly about not messing up the current list view for internal users. Bots (internal users) don't need to list editable courses and see everything, to my knowledge, eh? 

https://openedx.atlassian.net/browse/DISCO-539