### PR TITLE
Add username replacement API

### DIFF
--- a/course_discovery/apps/api/permissions.py
+++ b/course_discovery/apps/api/permissions.py
@@ -1,7 +1,10 @@
+from django.conf import settings
 from rest_framework.permissions import SAFE_METHODS, BasePermission, DjangoModelPermissions
 
 from course_discovery.apps.course_metadata.models import CourseEditor
 from course_discovery.apps.course_metadata.utils import parse_course_key_fragment
+
+USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
 
 
 class ReadOnlyByPublisherUser(BasePermission):
@@ -58,3 +61,11 @@ class IsCourseRunEditorOrDjangoOrReadOnly(BasePermission):
             return True
         else:
             return CourseEditor.is_course_editable(request.user, obj.course)
+
+
+class CanReplaceUsername(BasePermission):
+    """
+    Grants access to the Username Replacement API for the service user.
+    """
+    def has_permission(self, request, view):
+        return request.user.username == getattr(settings, "USERNAME_REPLACEMENT_WORKER")

--- a/course_discovery/apps/api/v1/tests/test_views/test_user_management.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_user_management.py
@@ -1,0 +1,94 @@
+import json
+
+import ddt
+import mock
+from django.urls import reverse
+
+from course_discovery.apps.api.tests.jwt_utils import generate_jwt_header_for_user
+from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase
+from course_discovery.apps.core.tests.factories import UserFactory
+
+
+JSON_CONTENT_TYPE = 'application/json'
+
+
+@ddt.ddt
+@mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
+class UsernameReplacementViewTests(APITestCase):
+    """ Tests UsernameReplacementView """
+    SERVICE_USERNAME = 'test_replace_username_service_worker'
+
+    def setUp(self):
+        super(UsernameReplacementViewTests, self).setUp()
+        self.service_user = UserFactory(username=self.SERVICE_USERNAME)
+        self.url = reverse("api:v1:replace_usernames")
+
+    def build_jwt_headers(self, user):
+        """
+        Helper function for creating headers for the JWT authentication.
+        """
+        token = generate_jwt_header_for_user(user)
+        headers = {'HTTP_AUTHORIZATION': token}
+        return headers
+
+    def call_api(self, user, data):
+        """ Helper function to call API with data """
+        data = json.dumps(data)
+        headers = self.build_jwt_headers(user)
+        return self.client.post(self.url, data, content_type=JSON_CONTENT_TYPE, **headers)
+
+    def test_auth(self):
+        """ Verify the endpoint only works with the service worker """
+        data = {
+            "username_mappings": [
+                {"test_username_1": "test_new_username_1"},
+                {"test_username_2": "test_new_username_2"}
+            ]
+        }
+
+        # Test unauthenticated
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 401)
+
+        # Test non-service worker
+        random_user = UserFactory()
+        response = self.call_api(random_user, data)
+        self.assertEqual(response.status_code, 403)
+
+        # Test service worker
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 200)
+
+    @ddt.data(
+        [{}, {}],
+        {},
+        [{"test_key": "test_value", "test_key_2": "test_value_2"}]
+    )
+    def test_bad_schema(self, mapping_data):
+        """ Verify the endpoint rejects bad data schema """
+        data = {
+            "username_mappings": mapping_data
+        }
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_existing_and_non_existing_users(self):
+        """
+        Tests a mix of existing and non existing users. Users that don't exist
+        in this service are also treated as a success because no work needs to
+        be done changing their username.
+        """
+        random_users = [UserFactory() for _ in range(5)]
+        fake_usernames = ["myname_" + str(x) for x in range(5)]
+        existing_users = [{user.username: user.username + '_new'} for user in random_users]
+        non_existing_users = [{username: username + '_new'} for username in fake_usernames]
+        data = {
+            "username_mappings": existing_users + non_existing_users
+        }
+        expected_response = {
+            'failed_replacements': [],
+            'successful_replacements': existing_users + non_existing_users
+        }
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected_response)

--- a/course_discovery/apps/api/v1/urls.py
+++ b/course_discovery/apps/api/v1/urls.py
@@ -16,6 +16,7 @@ from course_discovery.apps.api.v1.views.program_types import ProgramTypeViewSet
 from course_discovery.apps.api.v1.views.programs import ProgramViewSet
 from course_discovery.apps.api.v1.views.subjects import SubjectViewSet
 from course_discovery.apps.api.v1.views.topics import TopicViewSet
+from course_discovery.apps.api.v1.views.user_management import UsernameReplacementView
 
 partners_router = routers.SimpleRouter()
 partners_router.register(r'affiliate_window/catalogs', AffiliateWindowViewSet, base_name='affiliate_window')
@@ -24,7 +25,8 @@ urlpatterns = [
     url(r'^partners/', include(partners_router.urls, namespace='partners')),
     url(r'search/typeahead', search_views.TypeaheadSearchView.as_view(), name='search-typeahead'),
     url(r'currency', CurrencyView.as_view(), name='currency'),
-    url(r'^catalog/query_contains/?', CatalogQueryContainsViewSet.as_view(), name='catalog-query_contains')
+    url(r'^catalog/query_contains/?', CatalogQueryContainsViewSet.as_view(), name='catalog-query_contains'),
+    url(r'^replace_usernames/$', UsernameReplacementView.as_view(), name="replace_usernames"),
 ]
 
 router = routers.SimpleRouter()

--- a/course_discovery/apps/api/v1/views/user_management.py
+++ b/course_discovery/apps/api/v1/views/user_management.py
@@ -1,0 +1,147 @@
+import logging
+
+from django.apps import apps
+from django.db import transaction
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from rest_framework import permissions, status
+from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
+from rest_framework.views import APIView
+
+from course_discovery.apps.api.permissions import CanReplaceUsername
+
+log = logging.getLogger(__name__)
+
+
+class UsernameReplacementView(APIView):
+    """
+    WARNING: This API is only meant to be used as part of a larger job that
+    updates usernames across all services. DO NOT run this alone or users will
+    not match across the system and things will be broken. This API should be
+    called from the LMS endpoint which verifies uniqueness of the username
+    first.
+
+    API will recieve a list of current usernames and their new username.
+    """
+
+    authentication_classes = (JwtAuthentication, )
+    permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
+
+    def post(self, request):
+        """
+        **POST Parameters**
+
+        A POST request must include the following parameter.
+
+        * username_mappings: Required. A list of objects that map the current username (key)
+          to the new username (value)
+            {
+                "username_mappings": [
+                    {"current_username_1": "new_username_1"},
+                    {"current_username_2": "new_username_2"}
+                ]
+            }
+
+        **POST Response Values**
+
+        As long as data validation passes, the request will return a 200 with a new mapping
+        of old usernames (key) to new username (value)
+
+        {
+            "successful_replacements": [
+                {"old_username_1": "new_username_1"}
+            ],
+            "failed_replacements": [
+                {"old_username_2": "new_username_2"}
+            ]
+        }
+        """
+
+        # (model_name, column_name)
+        MODELS_WITH_USERNAME = (
+            ('core.user', 'username'),
+        )
+
+        username_mappings = request.data.get("username_mappings")
+        replacement_locations = self._load_models(MODELS_WITH_USERNAME)
+
+        if not self._has_valid_schema(username_mappings):
+            raise ValidationError("Request data does not match schema")
+
+        successful_replacements, failed_replacements = [], []
+
+        for username_pair in username_mappings:
+            current_username = list(username_pair.keys())[0]
+            new_username = list(username_pair.values())[0]
+            successfully_replaced = self._replace_username_for_all_models(
+                current_username,
+                new_username,
+                replacement_locations
+            )
+            if successfully_replaced:
+                successful_replacements.append({current_username: new_username})
+            else:
+                failed_replacements.append({current_username: new_username})
+        return Response(
+            status=status.HTTP_200_OK,
+            data={
+                "successful_replacements": successful_replacements,
+                "failed_replacements": failed_replacements
+            }
+        )
+
+    def _load_models(self, models_with_fields):
+        """ Takes tuples that contain a model path and returns the list with a loaded version of the model """
+        try:
+            replacement_locations = [(apps.get_model(model), column) for (model, column) in models_with_fields]
+        except LookupError:  # pragma: no cover
+            log.exception("Unable to load models for username replacement")
+            raise
+        return replacement_locations
+
+    def _has_valid_schema(self, post_data):
+        """ Verifies the data is a list of objects with a single key:value pair """
+        if not isinstance(post_data, list):
+            return False
+        for obj in post_data:
+            if not (isinstance(obj, dict) and len(obj) == 1):
+                return False
+        return True
+
+    def _replace_username_for_all_models(self, current_username, new_username, replacement_locations):
+        """
+        Replaces current_username with new_username for all (model, column) pairs in replacement locations.
+        Returns if it was successful or not. Will return successful even if no matching
+        """
+        try:
+            with transaction.atomic():
+                num_rows_changed = 0
+                for (model, column) in replacement_locations:
+                    num_rows_changed += model.objects.filter(
+                        **{column: current_username}
+                    ).update(
+                        **{column: new_username}
+                    )
+        except Exception as exc:  # pragma: no cover pylint: disable=broad-except
+            log.exception(
+                "Unable to change username from %s to %s. Failed on table %s because %s",
+                current_username,
+                new_username,
+                model.__class__.__name__,
+                exc
+            )
+            return False
+        if num_rows_changed == 0:
+            log.info(
+                "Unable to change username from %s to %s because %s doesn't exist.",
+                current_username,
+                new_username,
+                current_username
+            )
+        else:
+            log.info(
+                "Successfully changed username from %s to %s.",
+                current_username,
+                new_username
+            )
+        return True

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -534,6 +534,8 @@ SOLO_CACHE_TIMEOUT = 3600
 
 PUBLISHER_FROM_EMAIL = None
 
+USERNAME_REPLACEMENT_WORKER = "REPLACE WITH VALID USERNAME"
+
 # If no upgrade deadline is specified for a course run seat, when the course is published the deadline will default to
 # the course run end date minus the specified number of days.
 PUBLISHER_UPGRADE_DEADLINE_DAYS = 10


### PR DESCRIPTION
New API replaces all copies of username in this service with a new
username. Requires user be in a username_replacement_admin group. Should
only be ran as a larger job to update usernames across all services,
otherwise the system will be left in a broken state for those users.