### PR TITLE
ENT-1639: Enable language filter in enterprise catalogs of content type 'course'

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1609,6 +1609,7 @@ class CourseSearchSerializer(HaystackSerializer):
             'course_runs',
             'uuid',
             'subjects',
+            'languages',
         )
 
 
@@ -1781,7 +1782,8 @@ class AggregateSearchSerializer(HaystackSerializer):
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
         ignore_fields = COMMON_IGNORED_FIELDS
-        fields = CourseRunSearchSerializer.Meta.fields + ProgramSearchSerializer.Meta.fields
+        fields = CourseRunSearchSerializer.Meta.fields + ProgramSearchSerializer.Meta.fields + \
+            CourseSearchSerializer.Meta.fields
         serializers = {
             search_indexes.CourseRunIndex: CourseRunSearchSerializer,
             search_indexes.CourseIndex: CourseSearchSerializer,

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1495,7 +1495,11 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
                 'end': course_run.end,
             }],
             'uuid': str(course.uuid),
-            'subjects': [subject.name for subject in course.subjects.all()]
+            'subjects': [subject.name for subject in course.subjects.all()],
+            'languages': [
+                serialize_language(course_run.language) for course_run in course.course_runs.all()
+                if course_run.language
+            ]
         }
 
 

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -155,6 +155,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
     expected_learning_items = indexes.MultiValueField()
 
     prerequisites = indexes.MultiValueField(faceted=True)
+    languages = indexes.MultiValueField()
 
     def prepare_aggregation_key(self, obj):
         return 'course:{}'.format(obj.key)
@@ -179,6 +180,11 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
 
     def prepare_subject_uuids(self, obj):
         return [str(subject.uuid) for subject in obj.subjects.all()]
+
+    def prepare_languages(self, obj):
+        return [
+            self._prepare_language(course_run.language) for course_run in obj.course_runs.all() if course_run.language
+        ]
 
 
 class CourseRunIndex(BaseCourseIndex, indexes.Indexable):


### PR DESCRIPTION
**JIRA Ticket:** [ENT-1639](https://openedx.atlassian.net/browse/ENT-1639)

**Description:**
This PR adds a filter field `languages` to search API endpoint for `content_type` course.

**Testing Instructions:**

- Make sure adding languages filter to the search all API endpint has the the desired result. I have deployed the code on business sandbox and [here](https://discovery-business.sandbox.edx.org/api/v1/search/all/?content_type=course&languages=French,English) is a sample url for testing.