### PR TITLE
Utility function to create just in time draft world for Courses or Course runs.

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_utils.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_utils.py
@@ -1,0 +1,161 @@
+import ddt
+from django.test import TestCase
+
+from course_discovery.apps.api.tests.mixins import SiteMixin
+from course_discovery.apps.api.v1.views import utils
+from course_discovery.apps.course_metadata.models import Course, CourseEntitlement, CourseRun, Seat
+from course_discovery.apps.course_metadata.tests.factories import (
+    CourseEntitlementFactory, CourseFactory, CourseRunFactory, SeatFactory
+)
+
+
+@ddt.ddt
+class TestEnsureDraftWorld(SiteMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @ddt.data(
+        None,
+        {'weeks_to_complete': 7},
+        {'weeks_to_complete': 7, 'title_override': 'New Title'},
+    )
+    def test_set_draft_state(self, attrs):
+        course_run = CourseRunFactory()
+        draft_course_run, original_course_run = utils.set_draft_state(course_run, CourseRun, attrs)
+
+        self.assertEqual(1, len(CourseRun.objects.all()))
+        self.assertEqual(2, len(CourseRun.everything.all()))
+
+        self.assertTrue(draft_course_run.draft)
+        self.assertFalse(original_course_run.draft)
+
+        if attrs:
+            model_fields = [field.name for field in CourseRun._meta.get_fields()]
+            diff_of_fields = [field for field in filter(
+                lambda f: getattr(original_course_run, f, None) != getattr(draft_course_run, f, None),
+                model_fields
+            )]
+            for key, value in attrs.items():
+                # Make sure that any attributes we changed are different in the draft course run from the original
+                self.assertIn(key, diff_of_fields)
+                self.assertEqual(getattr(draft_course_run, key), value)
+
+    def test_set_draft_state_with_foreign_key(self):
+        course = CourseFactory()
+        course_run = CourseRunFactory(course=course)
+        draft_course, original_course = utils.set_draft_state(course, Course)
+        draft_course_run, original_course_run = utils.set_draft_state(course_run, CourseRun, {'course': draft_course})
+
+        self.assertEqual(1, len(CourseRun.objects.all()))
+        self.assertEqual(2, len(CourseRun.everything.all()))
+        self.assertEqual(1, len(Course.objects.all()))
+        self.assertEqual(2, len(Course.everything.all()))
+
+        self.assertTrue(draft_course_run.draft)
+        self.assertFalse(original_course_run.draft)
+
+        self.assertTrue(draft_course.draft)
+        self.assertFalse(original_course.draft)
+
+        self.assertNotEqual(draft_course_run.course, original_course_run.course)
+        self.assertEqual(draft_course_run.course, draft_course)
+        self.assertEqual(original_course_run.course, original_course)
+
+    def test_ensure_draft_world_draft_obj_given(self):
+        course_run = CourseRunFactory(draft=True)
+        ensured_draft_course_run = utils.ensure_draft_world(course_run)
+
+        self.assertEqual(ensured_draft_course_run, course_run)
+        self.assertEqual(ensured_draft_course_run.id, course_run.id)
+        self.assertEqual(ensured_draft_course_run.uuid, course_run.uuid)
+        self.assertEqual(ensured_draft_course_run.draft, course_run.draft)
+
+    def test_ensure_draft_world_not_draft_course_run_given(self):
+        course = CourseFactory()
+        course_run = CourseRunFactory(course=course)
+        verified_seat = SeatFactory(type='verified', course_run=course_run)
+        audit_seat = SeatFactory(type='audit', course_run=course_run)
+        course_run.seats.add(verified_seat, audit_seat)
+
+        ensured_draft_course_run = utils.ensure_draft_world(course_run)
+        not_draft_course_run = CourseRun.objects.get(uuid=course_run.uuid)
+
+        self.assertNotEqual(ensured_draft_course_run, not_draft_course_run)
+        self.assertEqual(ensured_draft_course_run.uuid, not_draft_course_run.uuid)
+        self.assertTrue(ensured_draft_course_run.draft)
+        self.assertNotEqual(ensured_draft_course_run.course, not_draft_course_run.course)
+        self.assertEqual(ensured_draft_course_run.course.uuid, not_draft_course_run.course.uuid)
+
+        # Check slugs are equal
+        self.assertEqual(ensured_draft_course_run.slug, not_draft_course_run.slug)
+
+        # Seat checks
+        draft_seats = ensured_draft_course_run.seats.all()
+        not_draft_seats = Seat.objects.filter(course_run=not_draft_course_run)
+        self.assertNotEqual(draft_seats, not_draft_seats)
+        for i, __ in enumerate(draft_seats):
+            self.assertEqual(draft_seats[i].price, not_draft_seats[i].price)
+            self.assertEqual(draft_seats[i].sku, not_draft_seats[i].sku)
+            self.assertNotEqual(draft_seats[i].course_run, not_draft_seats[i].course_run)
+            self.assertEqual(draft_seats[i].course_run.uuid, not_draft_seats[i].course_run.uuid)
+            self.assertEqual(draft_seats[i].official_version, not_draft_seats[i])
+            self.assertEqual(not_draft_seats[i].draft_version, draft_seats[i])
+
+        # Check draft course is also created
+        not_draft_course = Course.objects.get(uuid=course.uuid)
+        draft_course = ensured_draft_course_run.course
+        self.assertNotEqual(draft_course, not_draft_course)
+        self.assertEqual(draft_course.uuid, not_draft_course.uuid)
+        self.assertTrue(draft_course.draft)
+
+        # Check official and draft versions match up
+        self.assertEqual(ensured_draft_course_run.official_version, not_draft_course_run)
+        self.assertEqual(not_draft_course_run.draft_version, ensured_draft_course_run)
+
+    def test_ensure_draft_world_not_draft_course_given(self):
+        course = CourseFactory()
+        entitlement = CourseEntitlementFactory(course=course)
+        course.entitlements.add(entitlement)
+        course_runs = CourseRunFactory.create_batch(3, course=course)
+        for run in course_runs:
+            course.course_runs.add(run)
+        course.canonical_course_run = course_runs[0]
+        course.save()
+
+        ensured_draft_course = utils.ensure_draft_world(course)
+        not_draft_course = Course.objects.get(uuid=course.uuid)
+
+        self.assertNotEqual(ensured_draft_course, not_draft_course)
+        self.assertEqual(ensured_draft_course.uuid, not_draft_course.uuid)
+        self.assertTrue(ensured_draft_course.draft)
+
+        # Check slugs are equal
+        self.assertEqual(ensured_draft_course.slug, not_draft_course.slug)
+
+        # Check canonical course run was updated
+        self.assertNotEqual(ensured_draft_course.canonical_course_run, not_draft_course.canonical_course_run)
+        self.assertTrue(ensured_draft_course.canonical_course_run.draft)
+        self.assertEqual(ensured_draft_course.canonical_course_run.uuid, not_draft_course.canonical_course_run.uuid)
+
+        # Check course runs all share the same UUIDs, but are now all drafts
+        not_draft_course_runs_uuids = [run.uuid for run in course_runs]
+        draft_course_runs_uuids = [
+            run.uuid for run in ensured_draft_course.course_runs.all()
+        ]
+        self.assertListEqual(draft_course_runs_uuids, not_draft_course_runs_uuids)
+
+        # Entitlement checks
+        draft_entitlement = ensured_draft_course.entitlements.first()
+        not_draft_entitlement = CourseEntitlement.objects.get(course=not_draft_course)
+        self.assertNotEqual(draft_entitlement, not_draft_entitlement)
+        self.assertEqual(draft_entitlement.price, not_draft_entitlement.price)
+        self.assertEqual(draft_entitlement.sku, not_draft_entitlement.sku)
+        self.assertNotEqual(draft_entitlement.course, not_draft_entitlement.course)
+        self.assertEqual(draft_entitlement.course.uuid, not_draft_entitlement.course.uuid)
+
+        # Check official and draft versions match up
+        self.assertEqual(ensured_draft_course.official_version, not_draft_course)
+        self.assertEqual(not_draft_course.draft_version, ensured_draft_course)
+
+        self.assertEqual(draft_entitlement.official_version, not_draft_entitlement)
+        self.assertEqual(not_draft_entitlement.draft_version, draft_entitlement)

--- a/course_discovery/apps/api/v1/views/utils.py
+++ b/course_discovery/apps/api/v1/views/utils.py
@@ -1,0 +1,81 @@
+from course_discovery.apps.course_metadata.models import Course, CourseEntitlement, CourseRun, Seat
+
+
+def set_draft_state(obj, model, attrs=None):
+    """
+    Sets the draft state for an object by giving it a new primary key. Also sets any given
+    attributes (primarily used for setting foreign keys that also point to draft rows). This will
+    make any additional operations on the object to be done to the new draft state object.
+
+    Parameters:
+        obj (Model object): The object to create a draft state for. *Must have draft and draft_version as attributes.*
+        model (Model class): the model class so it can be used to get the original object
+        attrs ({str: value}): Dictionary of attributes to set on the draft model. The key should be the
+            attribute name as a string and the value should be the value to set.
+
+    Returns:
+        (Model obj, Model obj): Tuple of Model objects where the first is the draft object
+            and the second is the original
+    """
+    original_obj = model.objects.get(pk=obj.pk)
+    obj.pk = None
+    obj.draft = True
+    if attrs:
+        for key, value in attrs.items():
+            setattr(obj, key, value)
+    # Will throw an integrity error if the draft row already exists, but this
+    # should be caught as part of a try catch in the API calling ensure_draft_world
+    obj.save()
+    original_obj.draft_version = obj
+    original_obj.save()
+    return obj, original_obj
+
+
+def ensure_draft_world(obj):
+    """
+    Ensures the draft world exists for an object. The draft world is defined as all draft objects related to
+    the incoming draft object. For now, this will create the draft Course, all draft Course Runs associated
+    with that course, all draft Seats associated with all of the course runs, and all draft Entitlements
+    associated with the course.
+
+    Assumes that if the given object is already a draft, the draft world for that object already exists.
+
+    Will throw an integrity error if the draft row already exists, but this
+    should be caught as part of a try catch in the API calling ensure_draft_world
+
+    Parameters:
+        obj (Model object): The object to create a draft state for. *Must have draft as an attribute.*
+
+    Returns:
+        obj (Model object): The returned object will be the draft version on the input object.
+    """
+    if obj.draft:
+        return obj
+
+    if isinstance(obj, CourseRun):
+        ensure_draft_world(obj.course)
+        return CourseRun.everything.get(key=obj.key, draft=True)
+
+    elif isinstance(obj, Course):
+        # We need to null this out because it will fail with a OneToOne uniqueness error when saving the draft
+        obj.canonical_course_run = None
+        draft_course, original_course = set_draft_state(obj, Course)
+        draft_course.slug = original_course.slug
+
+        # Create draft course runs, the corresponding draft seats, and the draft entitlement
+        for run in original_course.course_runs.all():
+            draft_run, original_run = set_draft_state(run, CourseRun, {'course': draft_course})
+            draft_run.slug = original_run.slug
+            draft_run.save()
+
+            for seat in original_run.seats.all():
+                set_draft_state(seat, Seat, {'course_run': draft_run})
+            if original_course.canonical_course_run and draft_run.uuid == original_course.canonical_course_run.uuid:
+                draft_course.canonical_course_run = draft_run
+        for entitlement in original_course.entitlements.all():
+            set_draft_state(entitlement, CourseEntitlement, {'course': draft_course})
+
+        draft_course.save()
+        return draft_course
+    else:
+        raise Exception('Ensure draft world only accepts Courses and Course Runs.')

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
@@ -481,7 +481,7 @@ class CourseMarketingSiteDataLoaderTests(AbstractMarketingSiteDataLoaderTestMixi
     def assert_topics_loaded(self, data):
         # Verify the topics were loaded from course tags
         course = self._get_course(data)
-        self.assertEqual(sorted(list(course.topics.names())), [u'communications', u'professional-programs'])
+        self.assertEqual(sorted(course.topics.names()), [u'communications', u'professional-programs'])
 
     def assert_no_override_unpublished_course_fields(self, data):
         course = self._get_course(data)

--- a/course_discovery/apps/course_metadata/managers.py
+++ b/course_discovery/apps/course_metadata/managers.py
@@ -8,7 +8,7 @@ class DraftManager(models.Manager):
     def get_queryset(self):
         return super().get_queryset().filter(draft=False)
 
-    def with_drafts(self):
+    def _with_drafts(self):
         return super().get_queryset()
 
     def filter_drafts(self, **kwargs):
@@ -16,7 +16,7 @@ class DraftManager(models.Manager):
         Acts like filter(), but prefers draft versions.
         If a draft is not available, we give back the non-draft version.
         """
-        return self.with_drafts().filter(Q(draft=True) | Q(draft_version=None)).filter(**kwargs)
+        return self._with_drafts().filter(Q(draft=True) | Q(draft_version=None)).filter(**kwargs)
 
     def get_draft(self, **kwargs):
         """

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -46,9 +46,8 @@ class DraftModelMixin(models.Model):
     """
     Defines a draft boolean field and an object manager to make supporting drafts more transparent.
 
-    This defines an 'objects' manager, so be aware that your default manager will exclude draft versions by default
-    unless you also define the 'objects' manager. You can still get all rows through self._base_manager or
-    self.objects.with_drafts().
+    This defines two managers. The 'everything' manager will return all rows. The 'objects' manager will exclude
+    draft versions by default unless you also define the 'objects' manager.
 
     Remember to add 'draft' to your unique_together clauses.
 
@@ -61,6 +60,7 @@ class DraftModelMixin(models.Model):
     draft_version = models.OneToOneField('self', models.CASCADE, null=True, blank=True,
                                          related_name='official_version', limit_choices_to={'draft': True})
 
+    everything = models.Manager()
     objects = DraftManager()
 
     class Meta(object):
@@ -474,6 +474,7 @@ class Course(DraftModelMixin, PkSearchableMixin, TimeStampedModel):
         default=None, null=True, blank=True, verbose_name=_('Additional Information')
     )
 
+    everything = CourseQuerySet.as_manager()
     objects = DraftManager.from_queryset(CourseQuerySet)()
 
     class Meta:
@@ -686,6 +687,7 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
         verbose_name=_('Add OFAC restriction text to the FAQ section of the Marketing site')
     )
 
+    everything = CourseRunQuerySet.as_manager()
     objects = DraftManager.from_queryset(CourseRunQuerySet)()
 
     class Meta:

--- a/course_discovery/apps/course_metadata/tests/test_managers.py
+++ b/course_discovery/apps/course_metadata/tests/test_managers.py
@@ -25,7 +25,7 @@ class DraftManagerTests(TestCase):
         Verify the query set allows access to draft rows too.
         """
         self.assertEqual(CourseRun._base_manager.count(), 2)  # pylint: disable=protected-access
-        self.assertEqual(CourseRun.objects.with_drafts().count(), 2)
+        self.assertEqual(CourseRun.objects._with_drafts().count(), 2)  # pylint: disable=protected-access
         self.assertEqual(CourseRun.objects.count(), 1)  # sanity check
 
     def test_filter_drafts(self):


### PR DESCRIPTION
It can take a Course or Course run as input and will create the entire draft world surrounding that object. It handles creation of a draft course, all draft course runs associated with that course, all draft seats associated with all course runs, and all draft entitlements associated with the course.