### PR TITLE
Add curriculum details to program endpoint

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
@@ -481,7 +481,7 @@ class CourseMarketingSiteDataLoaderTests(AbstractMarketingSiteDataLoaderTestMixi
     def assert_topics_loaded(self, data):
         # Verify the topics were loaded from course tags
         course = self._get_course(data)
-        self.assertEqual(list(course.topics.names()), [u'professional-programs', u'communications'])
+        self.assertEqual(sorted(list(course.topics.names())), [u'communications', u'professional-programs'])
 
     def assert_no_override_unpublished_course_fields(self, data):
         course = self._get_course(data)

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -50,7 +50,7 @@ PARLER_LANGUAGES = {
          'fallbacks': [PARLER_DEFAULT_LANGUAGE_CODE],
          'hide_untranslated': False,
      }
- }
+}
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.


### PR DESCRIPTION
### [EDUCATOR-4163](https://openedx.atlassian.net/browse/EDUCATOR-4163)
This will allow master's degree programs setup under the new curriculum structure to return detailed course information.
### [EDUCATOR-4214](https://openedx.atlassian.net/browse/EDUCATOR-4214)
Expose curriculum uuid
