### PR TITLE
Have editable=1 only deliver drafts

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -14,7 +14,7 @@ from rest_framework.exceptions import NotFound, PermissionDenied
 from course_discovery.apps.api.utils import cast2int
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import (
-    Course, CourseEditor, CourseRun, Organization, Person, Program, Subject, Topic
+    Course, CourseRun, Organization, Person, Program, Subject, Topic
 )
 
 logger = logging.getLogger(__name__)
@@ -131,17 +131,10 @@ class FilterSetMixin:
 class CourseFilter(filters.FilterSet):
     keys = CharListFilter(name='key', lookup_expr='in')
     uuids = UUIDListFilter()
-    editable = filters.BooleanFilter(method='filter_editable')
 
     class Meta:
         model = Course
         fields = ('keys', 'uuids',)
-
-    def filter_editable(self, queryset, name, value):
-        if self.request and cast2int(value, name):
-            return CourseEditor.editable_courses(self.request.user, queryset)
-        else:
-            return queryset
 
 
 class CourseRunFilter(FilterSetMixin, filters.FilterSet):

--- a/course_discovery/apps/api/tests/test_filters.py
+++ b/course_discovery/apps/api/tests/test_filters.py
@@ -1,13 +1,7 @@
-from django.test import TestCase
-from mock import MagicMock
 from rest_framework.test import APIRequestFactory
 from rest_framework.views import APIView
 
-from course_discovery.apps.api.filters import CourseFilter, HaystackRequestFilterMixin
-from course_discovery.apps.core.tests.factories import UserFactory
-from course_discovery.apps.course_metadata.models import Course
-from course_discovery.apps.course_metadata.tests.factories import CourseEditorFactory, CourseFactory
-from course_discovery.apps.publisher.tests.factories import OrganizationExtensionFactory
+from course_discovery.apps.api.filters import HaystackRequestFilterMixin
 
 
 class TestHaystackRequestFilterMixin:
@@ -33,81 +27,3 @@ class TestHaystackRequestFilterMixin:
         filters = HaystackRequestFilterMixin.get_request_filters(request)
         assert 'q' not in filters
         assert filters.get('test') == '0'
-
-
-class TestCourseFilter(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.user = UserFactory()
-        self.qs = Course.objects.all()
-
-        self.org_ext = OrganizationExtensionFactory()
-        self.user.groups.add(self.org_ext.group)
-
-        # *** Add a bunch of courses ***
-
-        # Course with no editors
-        self.course_no_editors = CourseFactory(title="no editors")
-
-        # Course with an invalid editor (no group membership)
-        bad_editor = UserFactory()
-        self.course_bad_editor = CourseFactory(title="bad editor")
-        CourseEditorFactory(user=bad_editor, course=self.course_bad_editor)
-
-        # Course with an invalid editor (but course is in our group)
-        self.course_bad_editor_in_group = CourseFactory(title="bad editor in group")
-        self.course_bad_editor_in_group.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
-        CourseEditorFactory(user=bad_editor, course=self.course_bad_editor_in_group)
-
-        # Course with a valid other editor
-        good_editor = UserFactory()
-        good_editor.groups.add(self.org_ext.group)
-        self.course_good_editor = CourseFactory(title="good editor")
-        self.course_good_editor.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
-        CourseEditorFactory(user=good_editor, course=self.course_good_editor)
-
-        # Course with user as an invalid editor (no group membership)
-        self.course_no_group = CourseFactory(title="no group")
-        CourseEditorFactory(user=self.user, course=self.course_no_group)
-
-        # Course with user as an valid editor
-        self.course_editor = CourseFactory(title="editor")
-        self.course_editor.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
-        CourseEditorFactory(user=self.user, course=self.course_editor)
-
-        # *** End course definitions ***
-
-        request = MagicMock()
-        request.user = self.user
-        self.filter = CourseFilter(request=request)
-
-    def filter_editable(self, value='1'):
-        return self.filter.filter_editable(self.qs, 'editable', value)
-
-    def test_editable_no_request(self):
-        """ Verify the we don't touch the queryset if no request is passed. """
-        self.filter = CourseFilter()
-        with self.assertNumQueries(0):
-            self.assertEqual(self.filter_editable(), self.qs)
-
-    def test_editable_disabled(self):
-        """ Verify the we don't touch the queryset if editable is off. """
-        with self.assertNumQueries(0):
-            self.assertEqual(self.filter_editable('0'), self.qs)
-
-    def test_editable_is_staff(self):
-        """ Verify staff users can see all courses. """
-        self.user.is_staff = True
-        self.user.save()
-        with self.assertNumQueries(0):
-            self.assertEqual(self.filter_editable(), self.qs)
-
-    def test_editable_no_access(self):
-        """ Verify users without any editor status see nothing. """
-        self.user.groups.clear()
-        self.assertEqual(list(self.filter_editable()), [])
-
-    def test_editable(self):
-        """ Verify users can see courses they can edit. """
-        with self.assertNumQueries(1):
-            self.assertEqual(list(self.filter_editable()), [self.course_bad_editor_in_group, self.course_editor])

--- a/course_discovery/apps/course_metadata/managers.py
+++ b/course_discovery/apps/course_metadata/managers.py
@@ -9,3 +9,52 @@ class DraftManager(models.Manager):
 
     def with_drafts(self):
         return super().get_queryset()
+
+    def find_drafts(self, **kwargs):
+        """
+        Acts like filter(), but prefers draft versions.
+        If a draft is not available, we give back the non-draft version.
+
+        This returns a list, not a queryset!
+        """
+        kwargs.pop('draft', None)  # Guard against accidental extra draft filtering here
+        rows = self.with_drafts().filter(**kwargs)
+
+        # We need to find matching rows (minus draft column), so grab the first unique together
+        meta = self.model._meta  # pylint
+        assert len(meta.unique_together) > 0, 'DraftManager requires unique_together for model ' + meta.object_name
+        unique = list(meta.unique_together[0])
+        unique.remove('draft')
+
+        # Now group rows by that uniqueness constraint, preferring a draft result
+        answers = {}
+        for row in rows:
+            key = tuple(getattr(row, field) for field in unique)
+            if row.draft:
+                answers[key] = row
+            else:
+                answers.setdefault(key, row)
+
+        return list(answers.values())
+
+    def filter_drafts(self, **kwargs):
+        """
+        Acts like filter(), but prefers draft versions.
+        If a draft is not available, we give back the non-draft version.
+        """
+        drafts = self.find_drafts(**kwargs)
+        ids = (x.id for x in drafts)
+        return self.with_drafts().filter(id__in=ids)
+
+    def get_draft(self, **kwargs):
+        """
+        Acts like get(), but prefers draft versions. (including raising exceptions like get does)
+        If a draft is not available, we give back the non-draft version.
+        """
+        drafts = self.find_drafts(**kwargs)
+        if not drafts:
+            raise self.model.DoesNotExist()
+        elif len(drafts) > 1:
+            raise self.model.MultipleObjectsReturned()
+        else:
+            return drafts[0]

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -381,26 +381,30 @@ class PkSearchableMixin:
     """
 
     @classmethod
-    def search(cls, query):
+    def search(cls, query, queryset=None):
         """ Queries the search index.
 
         Args:
             query (str) -- Elasticsearch querystring (e.g. `title:intro*`)
+            queryset (models.QuerySet) -- base queryset to search, defaults to objects.all()
 
         Returns:
             QuerySet
         """
         query = clean_query(query)
 
+        if queryset is None:
+            queryset = cls.objects.all()
+
         if query == '(*)':
             # Early-exit optimization. Wildcard searching is very expensive in elasticsearch. And since we just
             # want everything, we don't need to actually query elasticsearch at all.
-            return cls.objects.all()
+            return queryset
 
         results = SearchQuerySet().models(cls).raw_search(query)
         ids = {result.pk for result in results}
 
-        return cls.objects.filter(pk__in=ids)
+        return queryset.filter(pk__in=ids)
 
 
 class Course(DraftModelMixin, PkSearchableMixin, TimeStampedModel):

--- a/course_discovery/apps/course_metadata/tests/test_managers.py
+++ b/course_discovery/apps/course_metadata/tests/test_managers.py
@@ -1,3 +1,4 @@
+from django.db import models
 from django.test import TestCase
 
 from course_discovery.apps.course_metadata.models import CourseRun
@@ -5,25 +6,69 @@ from course_discovery.apps.course_metadata.tests.factories import CourseRunFacto
 
 
 class DraftManagerTests(TestCase):
+    def setUp(self):
+        self.draft = CourseRunFactory(draft=True)
+        self.nondraft = CourseRunFactory(draft=False, uuid=self.draft.uuid, key=self.draft.key,
+                                         course=self.draft.course)
+
     def test_base_filter(self):
         """
         Verify the query set filters draft states out at a base level, not just by overriding all().
         """
-        CourseRunFactory(draft=True)
-        nondraft = CourseRunFactory(draft=False)
-
         self.assertEqual(CourseRun.objects.count(), 1)
-        self.assertEqual(CourseRun.objects.first(), nondraft)
-        self.assertEqual(CourseRun.objects.last(), nondraft)
-        self.assertEqual(list(CourseRun.objects.all()), [nondraft])
+        self.assertEqual(CourseRun.objects.first(), self.nondraft)
+        self.assertEqual(CourseRun.objects.last(), self.nondraft)
+        self.assertEqual(list(CourseRun.objects.all()), [self.nondraft])
 
     def test_with_drafts(self):
         """
         Verify the query set allows access to draft rows too.
         """
-        CourseRunFactory(draft=True)
-        CourseRunFactory(draft=False)
-
         self.assertEqual(CourseRun._base_manager.count(), 2)  # pylint: disable=protected-access
         self.assertEqual(CourseRun.objects.with_drafts().count(), 2)
         self.assertEqual(CourseRun.objects.count(), 1)  # sanity check
+
+    def test_find_drafts(self):
+        extra_draft = CourseRunFactory(draft=True)
+        extra_nondraft = CourseRunFactory(draft=False)
+
+        result = CourseRun.objects.find_drafts()
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(set(result), {extra_draft, extra_nondraft, self.draft})
+
+    def test_find_drafts_with_kwargs(self):
+        extra = CourseRunFactory()
+
+        result = CourseRun.objects.find_drafts(course=extra.course)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], extra)
+
+    def test_find_drafts_ignores_draft_arg(self):
+        result = CourseRun.objects.find_drafts(draft=False)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0].draft)
+
+    def test_filter_drafts(self):
+        extra = CourseRunFactory()
+
+        result = CourseRun.objects.filter_drafts()
+        self.assertIsInstance(result, models.QuerySet)
+        self.assertEqual(result.count(), 2)
+        self.assertEqual(set(result), {extra, self.draft})
+
+    def test_filter_drafts_with_kwargs(self):
+        extra = CourseRunFactory()
+
+        result = CourseRun.objects.filter_drafts(course=extra.course)
+        self.assertEqual(result.count(), 1)
+        self.assertEqual(result.first(), extra)
+
+    def test_get_draft(self):
+        extra = CourseRunFactory(course=self.draft.course)
+
+        with self.assertRaises(CourseRun.DoesNotExist):
+            CourseRun.objects.get_draft(hidden=True)
+        with self.assertRaises(CourseRun.MultipleObjectsReturned):
+            CourseRun.objects.get_draft(course=extra.course)
+        self.assertEqual(CourseRun.objects.get_draft(uuid=self.draft.uuid), self.draft)

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -25,8 +25,9 @@ from course_discovery.apps.core.utils import SearchQuerySetWrapper
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import (
     FAQ, AbstractMediaModel, AbstractNamedModel, AbstractTitleDescriptionModel, AbstractValueModel,
-    CorporateEndorsement, Course, CourseRun, Curriculum, CurriculumCourseMembership, CurriculumCourseRunExclusion,
-    DegreeCost, DegreeDeadline, Endorsement, Program, Ranking, Seat, SeatType, Subject, Topic
+    CorporateEndorsement, Course, CourseEditor, CourseRun, Curriculum, CurriculumCourseMembership,
+    CurriculumCourseRunExclusion, DegreeCost, DegreeDeadline, Endorsement, Program, Ranking, Seat, SeatType, Subject,
+    Topic
 )
 from course_discovery.apps.course_metadata.publishers import (
     CourseRunMarketingSitePublisher, ProgramMarketingSitePublisher
@@ -34,6 +35,7 @@ from course_discovery.apps.course_metadata.publishers import (
 from course_discovery.apps.course_metadata.tests import factories, toggle_switch
 from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, ImageFactory
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
+from course_discovery.apps.publisher.tests.factories import OrganizationExtensionFactory
 
 
 # pylint: disable=no-member
@@ -96,6 +98,67 @@ class TestCourse:
         factories.SeatFactory.create(course_run=course_run, type='verified', price=100, sku='ABCDEF')
         assert course_run.first_enrollable_paid_seat_price == 100
         assert course.first_enrollable_paid_seat_price == 100
+
+
+class TestCourseEditor(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = factories.UserFactory()
+        self.qs = Course.objects.all()
+
+        self.org_ext = OrganizationExtensionFactory()
+        self.user.groups.add(self.org_ext.group)
+
+        # *** Add a bunch of courses ***
+
+        # Course with no editors
+        self.course_no_editors = factories.CourseFactory(title="no editors")
+
+        # Course with an invalid editor (no group membership)
+        bad_editor = factories.UserFactory()
+        self.course_bad_editor = factories.CourseFactory(title="bad editor")
+        factories.CourseEditorFactory(user=bad_editor, course=self.course_bad_editor)
+
+        # Course with an invalid editor (but course is in our group)
+        self.course_bad_editor_in_group = factories.CourseFactory(title="bad editor in group")
+        self.course_bad_editor_in_group.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
+        factories.CourseEditorFactory(user=bad_editor, course=self.course_bad_editor_in_group)
+
+        # Course with a valid other editor
+        good_editor = factories.UserFactory()
+        good_editor.groups.add(self.org_ext.group)
+        self.course_good_editor = factories.CourseFactory(title="good editor")
+        self.course_good_editor.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
+        factories.CourseEditorFactory(user=good_editor, course=self.course_good_editor)
+
+        # Course with user as an invalid editor (no group membership)
+        self.course_no_group = factories.CourseFactory(title="no group")
+        factories.CourseEditorFactory(user=self.user, course=self.course_no_group)
+
+        # Course with user as an valid editor
+        self.course_editor = factories.CourseFactory(title="editor")
+        self.course_editor.authoring_organizations.add(self.org_ext.organization)  # pylint: disable=no-member
+        factories.CourseEditorFactory(user=self.user, course=self.course_editor)
+
+    def filter_editable(self):
+        return CourseEditor.editable_courses(self.user, self.qs)
+
+    def test_editable_is_staff(self):
+        """ Verify staff users can see all courses. """
+        self.user.is_staff = True
+        self.user.save()
+        with self.assertNumQueries(0):
+            self.assertEqual(self.filter_editable(), self.qs)
+
+    def test_editable_no_access(self):
+        """ Verify users without any editor status see nothing. """
+        self.user.groups.clear()
+        self.assertEqual(list(self.filter_editable()), [])
+
+    def test_editable(self):
+        """ Verify users can see courses they can edit. """
+        with self.assertNumQueries(1):
+            self.assertEqual(list(self.filter_editable()), [self.course_bad_editor_in_group, self.course_editor])
 
 
 @ddt.ddt


### PR DESCRIPTION
For the course endpoint, move editable=1 handling into the endpoint itself and have it surface draft versions, if available.

https://openedx.atlassian.net/browse/DISCO-715

There's a bit of test-noise because I moved tests from the filter file to the model file.