### PR TITLE
fix 500 error when course related to a course run is changed manually

### DIFF
--- a/course_discovery/apps/publisher/api/v1/views.py
+++ b/course_discovery/apps/publisher/api/v1/views.py
@@ -154,6 +154,13 @@ class CourseRunViewSet(viewsets.GenericViewSet):
             'weeks_to_complete': course_run.length,
             'has_ofac_restrictions': course_run.has_ofac_restrictions
         }
+
+        # Give priority to Discovery course run's parent course rather than
+        # Publisher course run's parent course.
+        discovery_course_run = course_run.discovery_course_run
+        if discovery_course_run and course_run.discovery_course:
+            discovery_course = course_run.discovery_course
+
         discovery_course_run, __ = DiscoveryCourseRun.objects.update_or_create(
             course=discovery_course,
             key=course_run.lms_course_id,

--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -403,6 +403,19 @@ class CourseRun(TimeStampedModel, ChangedByMixin):
             return None
 
     @property
+    def discovery_course(self):
+        """
+        To retrieve the Discovery course run's parent course.
+
+        This property can be helpful in cases where we want to check if
+        Discovery run's parent course and Publisher run's parent course are
+        same.
+        """
+        discovery_run = self.discovery_course_run
+        if discovery_run:
+            return discovery_run.course
+
+    @property
     def studio_url(self):
         if self.lms_course_id and self.course.partner and self.course.partner.studio_url:
             path = 'course/{lms_course_id}'.format(lms_course_id=self.lms_course_id)


### PR DESCRIPTION
### PROD-137

### Description
Whenever a course run is published from Publisher, its equivalent is created in the course metadata(and other locations). The course metadata, along with other places, is supposed to be in sync with the publisher. It is possible to cause the data inconsistency in the course metadata from the discovery Django admin. One such case is the changing of the parent course of a course run in the metadata. This inconsistency leads to the inability of the user to publish the course run again as the unexpected behavior is not what is to be expected. Course teams do come across a situation where they have to change the parent course for a course run in Discovery.

This PR creates a patch to allow for publish to work even after causing the data inconsistency. This PR assumes that Discovery course has precedence over publisher course and if a discover course run already has an associated course, use it instead of publisher course run's course