### PR TITLE
Add log output to debug sporadic sanity check failures

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
+++ b/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from django.conf import settings
 from django.core.management import CommandError
@@ -39,12 +40,12 @@ class Command(HaystackCommand):
             backend = connection.get_backend()
             record_count = self.get_record_count(backend.conn, backend.index_name)
             alias, index_name = self.prepare_backend_index(backend)
-            alias_mappings.append((backend, index_name, alias))
+            alias_mappings.append((backend, index_name, alias, record_count))
 
         super(Command, self).handle(*items, **options)
 
         # Set the alias (from settings) to the timestamped catalog.
-        for backend, index, alias in alias_mappings:
+        for backend, index, alias, record_count in alias_mappings:
             # Run a sanity check to ensure we aren't drastically changing the
             # index, which could be indicative of a bug.
             if not options.get('disable_change_limit', False):
@@ -62,13 +63,51 @@ class Command(HaystackCommand):
             # This is done to fail the sanity check
             return 1
 
+    def get_per_model_record_count(self, conn, index, content_type):
+        return conn.search(index=index, q='content_type:{}'.format(content_type)).get('hits', {}).get('total', 0)
+
     def sanity_check_new_index(self, conn, index, previous_record_count):
         """ Ensure that we do not point to an index that looks like it has missing data. """
         current_record_count = conn.count(index).get('count')
         percentage_change = self.percentage_change(current_record_count, previous_record_count)
-
         # Verify there was not a big shift in record count
         record_count_is_sane = percentage_change < settings.INDEX_SIZE_CHANGE_THRESHOLD
+
+        if not record_count_is_sane:
+            attempts = 0
+            while attempts < 2:
+                attempts += 1
+                current_attempt_record_count = conn.count(index).get('count')
+                current_attempt_percentage_change = self.percentage_change(
+                    current_attempt_record_count, previous_record_count)
+                alternate_current_record_count = conn.search(index).get('hits', {}).get('total', 0)
+                course_search_record_count = self.get_per_model_record_count(conn, index, 'course')
+                courserun_search_record_count = self.get_per_model_record_count(conn, index, 'courserun')
+                program_search_record_count = self.get_per_model_record_count(conn, index, 'program')
+                person_search_record_count = self.get_per_model_record_count(conn, index, 'person')
+                message = '''
+    Sanity check failed for attempt #{0}.
+    Percentage change: {1}
+    Base record count: {2}
+    Search record count: {3}
+    Course count: {4}
+    CourseRun count: {5}
+    Program count: {6}
+    People count: {7}
+                '''.format(
+                    attempts,
+                    str(int(round(current_attempt_percentage_change * 100, 0))) + '%',
+                    current_attempt_record_count,
+                    alternate_current_record_count,
+                    course_search_record_count,
+                    courserun_search_record_count,
+                    program_search_record_count,
+                    person_search_record_count
+                )
+                logger.info(message)
+                logger.info('...sleeping for 5 seconds...')
+                time.sleep(5)
+
         index_info_string = (
             'The previous index contained [{}] records. '
             'The new index contains [{}] records, a [{:.2f}%] change.'.format(


### PR DESCRIPTION
The update_index job fails sporadically via the sanity check of the record count on the newly created index.  It's not clear why the record count in these cases is off, so this change adds some output as well as a second read of the counts after a 5 second pause.  The goal is to try to learn whether a race condition is causing the record count discrepancy, and/or whether the missing records are of one specific content type.