### PR TITLE
Fix publishing to drupal by suppressing publication on initial save

### DIFF
--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -191,9 +191,7 @@ class CourseRunViewSet(viewsets.ModelViewSet):
         old_course_run = course.canonical_course_run
 
         # And finally, save to database and push to studio
-        course_run = serializer.save()
-        course_run.draft = True
-        course_run.save()
+        course_run = serializer.save(draft=True)
         self.push_to_studio(request, course_run, create=True, old_course_run=old_course_run)
 
         headers = self.get_success_headers(serializer.data)

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -177,9 +177,7 @@ class CourseViewSet(viewsets.ModelViewSet):
         if Course.objects.filter(partner=partner, key=course_creation_fields['key']).exists():
             raise Exception(_('A course with key {key} already exists.').format(key=course_creation_fields['key']))
 
-        course = serializer.save()
-        course.draft = True
-        course.save()
+        course = serializer.save(draft=True)
 
         organization = Organization.objects.get(key=course_creation_fields['org'])
         course.authoring_organizations.add(organization)

--- a/course_discovery/apps/course_metadata/publishers.py
+++ b/course_discovery/apps/course_metadata/publishers.py
@@ -382,7 +382,6 @@ class CourseRunMarketingSitePublisher(BaseMarketingSitePublisher):
             logger.info('Created new marketing site node [%s] for course run [%s].', node_id, obj.key)
 
         if node_id and (not previous_obj or obj.slug != previous_obj.slug):
-
             logger.info('Setting marketing alias of [%s] for course [%s].', obj.slug, obj.key)
             # Don't pass previous_obj to update_node_alias, because we don't want to delete the old alias.
             # Not deleting it means that Drupal will automatically have old alias point to new alias.
@@ -399,10 +398,14 @@ class CourseRunMarketingSitePublisher(BaseMarketingSitePublisher):
             dict: Data to PUT to the Drupal API.
         """
         data = super().serialize_obj(obj)
+        if obj.status == CourseRunStatus.Reviewed or obj.status == CourseRunStatus.Published:
+            status = 1
+        else:
+            status = 0
 
         return {
             **data,
-            'status': 1 if obj.status == CourseRunStatus.Published else 0,
+            'status': status,
             'title': obj.title,
             'field_course_id': obj.key,
             'type': 'course',


### PR DESCRIPTION
since that creates a new slug which we then copy over. Also switching
the marketing published condition to status=Reviewed or
status=Published so course teams are able to see the marketing page as
soon as the course is reviewed.