### PR TITLE
ENT-1469 - Exposing course and course_run api fields in api

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1702,6 +1702,9 @@ class CourseSearchSerializer(HaystackSerializer):
                 'go_live_date': course_run.go_live_date,
                 'start': course_run.start,
                 'end': course_run.end,
+                'availability': course_run.availability,
+                'pacing_type': course_run.pacing_type,
+                'enrollment_mode': course_run.type,
             }
             for course_run in result.object.course_runs.all()
         ]
@@ -1720,6 +1723,7 @@ class CourseSearchSerializer(HaystackSerializer):
             'uuid',
             'subjects',
             'languages',
+            'organizations',
         )
 
 

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -123,7 +123,7 @@ class BaseCourseIndex(OrganizationsMixin, BaseIndex):
         return [subject.name for subject in obj.subjects.all()]
 
     def prepare_organizations(self, obj):
-        return self.prepare_authoring_organizations(obj) + self.prepare_sponsoring_organizations(obj)
+        return set(self.prepare_authoring_organizations(obj) + self.prepare_sponsoring_organizations(obj))
 
     def prepare_authoring_organizations(self, obj):
         return self._prepare_organizations(obj.authoring_organizations.all())
@@ -182,9 +182,9 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
         return [str(subject.uuid) for subject in obj.subjects.all()]
 
     def prepare_languages(self, obj):
-        return [
+        return {
             self._prepare_language(course_run.language) for course_run in obj.course_runs.all() if course_run.language
-        ]
+        }
 
 
 class CourseRunIndex(BaseCourseIndex, indexes.Indexable):


### PR DESCRIPTION
Exposing a few fields for course and course_run. Includes the following:

Course
- organizations

Course_run
- availability
- pacing type
- type (aka, seat type)