### PR TITLE
Fixing issue where RCM will create an official version of a course ru…

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -138,6 +138,12 @@ class CoursesApiDataLoader(AbstractDataLoader):
                         # Therefore, we don't need to do the statements below
                         course = self.update_course(course, body)
                 else:
+                    # We need to add in this check as part of the Publisher Frontend work. This is caused by
+                    # the creation of a draft version pushing out to Studio and then this function creating the
+                    # official version from the course run in Studio. Instead, we want to prevent the creation of
+                    # official versions if the draft version of the course run already exists.
+                    if CourseRun.everything.filter(key=course_run_id, draft=True).first():
+                        continue
                     course, created = self.get_or_create_course(body)
                     course_run = self.create_course_run(course, body)
                     if created:

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -110,8 +110,8 @@ COURSES_API_BODIES = [
 COURSES_API_BODY_ORIGINAL = {
     'effort': None,
     'end': None,
-    'enrollment_start': None,
-    'enrollment_end': None,
+    'enrollment_start': '2015-05-15T13:00:00Z',
+    'enrollment_end': '2015-06-29T13:00:00Z',
     'id': 'course-v1:KyotoUx+000x+3T2016',
     'media': {
         'course_image': {


### PR DESCRIPTION
…n (and potentially course) since it exists in Studio, but not in discovery. It exists in Studio because we add it there in PublisherFE when we create the draft version of a course run.