### PR TITLE
WL-1929: Added modified field to CourseSearchSerializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1703,6 +1703,7 @@ class CourseSearchSerializer(HaystackSerializer):
                 'go_live_date': course_run.go_live_date,
                 'start': course_run.start,
                 'end': course_run.end,
+                'modified': course_run.modified,
                 'availability': course_run.availability,
                 'pacing_type': course_run.pacing_type,
                 'enrollment_mode': course_run.type,

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1571,6 +1571,7 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
                 'go_live_date': course_run.go_live_date,
                 'start': course_run.start,
                 'end': course_run.end,
+                'modified': course_run.modified,
                 'availability': course_run.availability,
                 'pacing_type': course_run.pacing_type,
                 'enrollment_mode': course_run.type,


### PR DESCRIPTION
Added `modified` field to CourseSearchSerializer so it would available in course_runs of course data returned by `/api/v1/search/all` endpoint.