### PR TITLE
Fix duplicate queries on courses endpoint

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -258,24 +258,10 @@ class CourseWithProgramsSerializerTests(CourseSerializerTests):
             status=ProgramStatus.Deleted
         )
 
-    def test_exclude_deleted_programs(self):
-        """
-        If the associated program is deleted,
-        CourseWithProgramsSerializer should not return any serialized programs
-        """
+    def test_data(self):
+        expected = self.get_expected_data(self.course, self.request)
         serializer = self.serializer_class(self.course, context={'request': self.request})
-        self.assertEqual(serializer.data['programs'], [])
-
-    def test_include_deleted_programs(self):
-        """
-        If the associated program is deleted, but we are sending in the 'include_deleted_programs' flag
-        CourseWithProgramsSerializer should return deleted programs
-        """
-        serializer = self.serializer_class(
-            self.course,
-            context={'request': self.request, 'include_deleted_programs': 1}
-        )
-        self.assertEqual(serializer.data, self.get_expected_data(self.course, self.request))
+        self.assertDictEqual(serializer.data, expected)
 
 
 class CurriculumSerializerTests(TestCase):
@@ -471,28 +457,6 @@ class CourseRunWithProgramsSerializerTests(TestCase):
         expected = CourseRunSerializer(self.course_run, context=self.serializer_context).data
         expected.update({'programs': []})
         assert serializer.data == expected
-
-    def test_exclude_deleted_programs(self):
-        """
-        If the associated program is deleted,
-        CourseRunWithProgramsSerializer should not return any serialized programs
-        """
-        ProgramFactory(courses=[self.course_run.course], status=ProgramStatus.Deleted)
-        serializer = CourseRunWithProgramsSerializer(self.course_run, context=self.serializer_context)
-        self.assertEqual(serializer.data['programs'], [])
-
-    def test_include_deleted_programs(self):
-        """
-        If the associated program is deleted, but we are sending in the 'include_deleted_programs' flag
-        CourseRunWithProgramsSerializer should return deleted programs
-        """
-        deleted_program = ProgramFactory(courses=[self.course_run.course], status=ProgramStatus.Deleted)
-        self.serializer_context['include_deleted_programs'] = 1
-        serializer = CourseRunWithProgramsSerializer(self.course_run, context=self.serializer_context)
-        self.assertEqual(
-            serializer.data['programs'],
-            NestedProgramSerializer([deleted_program], many=True, context=self.serializer_context).data
-        )
 
     def test_exclude_unpublished_program(self):
         """

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -236,7 +236,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         query = 'title:' + title
         url = '{root}?q={query}'.format(root=reverse('api:v1:course-list'), query=query)
 
-        with self.assertNumQueries(57):
+        with self.assertNumQueries(51):
             response = self.client.get(url)
             self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -247,7 +247,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         keys = ','.join([course.key for course in courses])
         url = '{root}?keys={keys}'.format(root=reverse('api:v1:course-list'), keys=keys)
 
-        with self.assertNumQueries(57):
+        with self.assertNumQueries(50):
             response = self.client.get(url)
             self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -258,7 +258,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         uuids = ','.join([str(course.uuid) for course in courses])
         url = '{root}?uuids={uuids}'.format(root=reverse('api:v1:course-list'), uuids=uuids)
 
-        with self.assertNumQueries(57):
+        with self.assertNumQueries(50):
             response = self.client.get(url)
             self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 


### PR DESCRIPTION
I'll probably have to change some tests, just want to put this up to get feedback that it makes sense.

Changes for 1 page  of results on the courses endpoint
Before:
<img width="207" alt="Screen Shot 2019-05-15 at 3 52 07 PM" src="https://user-images.githubusercontent.com/14864970/57805035-123f9780-772a-11e9-8dd5-b317c71675f3.png">
After:
<img width="191" alt="Screen Shot 2019-05-16 at 11 28 58 AM" src="https://user-images.githubusercontent.com/14864970/57867817-cf37ff80-77cf-11e9-9263-ca25b3c8bb11.png">



