### PR TITLE
DISCO-923: Re-implements search without PkSearchableMixin for CourseRun

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -641,7 +641,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(44):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])

--- a/course_discovery/apps/api/v1/views/catalog_queries.py
+++ b/course_discovery/apps/api/v1/views/catalog_queries.py
@@ -33,7 +33,7 @@ class CatalogQueryContainsViewSet(GenericAPIView):
                 course_run_ids = course_run_ids.split(',')
                 specified_course_ids = course_run_ids
                 identified_course_ids.update(CourseRun.search(query).filter(
-                    course__partner=partner, key__in=course_run_ids).values_list('key', flat=True))
+                    partner=partner.short_code, key__in=course_run_ids).values_list('key', flat=True))
             if course_uuids:
                 course_uuids = [UUID(course_uuid) for course_uuid in course_uuids.split(',')]
                 specified_course_ids += course_uuids

--- a/course_discovery/apps/core/tests/test_utils.py
+++ b/course_discovery/apps/core/tests/test_utils.py
@@ -1,7 +1,10 @@
 from django.db import models
 from django.test import TestCase
+from haystack.query import SearchQuerySet
 
-from course_discovery.apps.core.utils import get_all_related_field_names
+from course_discovery.apps.core.utils import SearchQuerySetWrapper, get_all_related_field_names
+from course_discovery.apps.course_metadata.models import CourseRun
+from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory
 
 
 class UnrelatedModel(models.Model):
@@ -37,3 +40,24 @@ class ModelUtilTests(TestCase):
         """ Verify the method returns the names of all relational fields for a model. """
         self.assertEqual(get_all_related_field_names(UnrelatedModel), [])
         self.assertEqual(set(get_all_related_field_names(RelatedModel)), {'foreignrelatedmodel', 'm2mrelatedmodel'})
+
+
+class SearchQuerySetWrapperTests(TestCase):
+    def setUp(self):
+        super(SearchQuerySetWrapperTests, self).setUp()
+        title = 'Some random course'
+        query = 'title:' + title
+
+        CourseRunFactory.create_batch(3, title=title)
+        self.search_queryset = SearchQuerySet().models(CourseRun).raw_search(query).load_all()
+        self.course_runs = [e.object for e in self.search_queryset]
+        self.wrapper = SearchQuerySetWrapper(self.search_queryset)
+
+    def test_count(self):
+        self.assertEqual(self.search_queryset.count(), self.wrapper.count())
+
+    def test_iter(self):
+        self.assertEqual([e for e in self.course_runs], [e for e in self.wrapper])
+
+    def test_getitem(self):
+        self.assertEqual(self.course_runs[0], self.wrapper[0])

--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -100,3 +100,31 @@ def delete_orphans(model):
     field_names = get_all_related_field_names(model)
     kwargs = {'{0}__isnull'.format(field_name): True for field_name in field_names}
     model.objects.filter(**kwargs).delete()
+
+
+class SearchQuerySetWrapper(object):
+    """
+    Decorates a SearchQuerySet object using a generator for efficient iteration
+    """
+
+    def __init__(self, qs):
+        self.qs = qs
+
+    def __getattr__(self, item):
+        try:
+            super().__getattr__(item)
+        except AttributeError:
+            # If the attribute is not found on this class,
+            # proxy the request to the SearchQuerySet.
+            return getattr(self.qs, item)
+
+    def __iter__(self):
+        for result in self.qs:
+            yield result.object
+
+    def __getitem__(self, key):
+        if isinstance(key, int) and (key >= 0 or key < self.count()):
+            # return the object at the specified position
+            return self.qs[key].object
+        # Pass the slice/range on to the delegate
+        return SearchQuerySetWrapper(self.qs[key])

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -21,6 +21,7 @@ from taggit.models import Tag
 from course_discovery.apps.api.tests.mixins import SiteMixin
 from course_discovery.apps.core.models import Currency
 from course_discovery.apps.core.tests.helpers import make_image_file
+from course_discovery.apps.core.utils import SearchQuerySetWrapper
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import (
     FAQ, AbstractMediaModel, AbstractNamedModel, AbstractTitleDescriptionModel, AbstractValueModel,
@@ -224,14 +225,14 @@ class CourseRunTests(TestCase):
         title = 'Some random title'
         course_runs = factories.CourseRunFactory.create_batch(3, title=title)
         query = 'title:' + title
-        actual_sorted = sorted(CourseRun.search(query), key=lambda course_run: course_run.key)
+        actual_sorted = sorted(SearchQuerySetWrapper(CourseRun.search(query)), key=lambda course_run: course_run.key)
         expected_sorted = sorted(course_runs, key=lambda course_run: course_run.key)
         self.assertEqual(actual_sorted, expected_sorted)
 
     def test_wildcard_search(self):
         """ Verify the method returns an unfiltered queryset of course runs. """
         course_runs = factories.CourseRunFactory.create_batch(3)
-        actual_sorted = sorted(CourseRun.search('*'), key=lambda course_run: course_run.key)
+        actual_sorted = sorted(SearchQuerySetWrapper(CourseRun.search('*')), key=lambda course_run: course_run.key)
         expected_sorted = sorted(course_runs + [self.course_run], key=lambda course_run: course_run.key)
         self.assertEqual(actual_sorted, expected_sorted)
 


### PR DESCRIPTION
Re-implementing previous state before changes were made in https://github.com/edx/course-discovery/pull/1838 as it broke performance of the query_contains endpoint.

Additional followup work is scheduled at https://openedx.atlassian.net/browse/DISCO-954 for `.search` performance.