### PR TITLE
Try removing cacheresponsemixin from pathways

### DIFF
--- a/course_discovery/apps/api/v1/views/pathways.py
+++ b/course_discovery/apps/api/v1/views/pathways.py
@@ -1,12 +1,11 @@
 """ Views for accessing Pathway data """
 from rest_framework import viewsets
-from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import serializers
 from course_discovery.apps.api.permissions import ReadOnlyByPublisherUser
 
 
-class PathwayViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+class PathwayViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (ReadOnlyByPublisherUser,)
     serializer_class = serializers.PathwaySerializer
 


### PR DESCRIPTION
Because why not

This endpoint seems to rarely be used, and when it is used it doesn't get very high throughput, so it seems reasonable to test dropping this.