### PR TITLE
Disable caching for parler

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -140,6 +140,10 @@ PARLER_LANGUAGES = {
      }
  }
 
+# Parler seems to be a bit overeager with its caching of translated models,
+# and so we get a large number of sets, but rarely any gets
+PARLER_ENABLE_CACHING = False
+
 TIME_ZONE = 'UTC'
 
 USE_I18N = True


### PR DESCRIPTION
Before:
<img width="44" alt="Screen Shot 2019-05-28 at 11 24 50 AM" src="https://user-images.githubusercontent.com/14864970/58491276-b3701a00-813c-11e9-87e2-86b656d2d45d.png">
After:
<img width="43" alt="Screen Shot 2019-05-28 at 11 26 36 AM" src="https://user-images.githubusercontent.com/14864970/58491285-b8cd6480-813c-11e9-9b2d-68d612436934.png">

All the sets look like:
<img width="1211" alt="Screen Shot 2019-05-28 at 11 24 37 AM" src="https://user-images.githubusercontent.com/14864970/58491308-c1259f80-813c-11e9-9836-c67d2e85834b.png">

Lots of sets, we never actually seem to get the data, so let's try killing it