### PR TITLE
Use cache_response decorator for courses list

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -5,6 +5,7 @@ import ddt
 import pytest
 import pytz
 import responses
+from django.core.cache import cache
 from django.db import IntegrityError
 from django.db.models.functions import Lower
 from mock import mock
@@ -48,6 +49,7 @@ class CourseViewSetTests(SerializationMixin, APITestCase):
         self.course = CourseFactory(partner=self.partner, title='Fake Test', key='edX+Fake101')
         self.org = OrganizationFactory(key='edX', partner=self.partner)
         self.course.authoring_organizations.add(self.org)  # pylint: disable=no-member
+        cache.clear()
 
     def test_get(self):
         """ Verify the endpoint returns the details for a single course. """

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -15,6 +15,7 @@ from rest_framework import status, viewsets
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import SAFE_METHODS, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework_extensions.cache.decorators import cache_response
 
 from course_discovery.apps.api import filters, serializers
 from course_discovery.apps.api.pagination import ProxiedPagination
@@ -304,6 +305,7 @@ class CourseViewSet(viewsets.ModelViewSet):
         # Not supported
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
+    @cache_response()
     def list(self, request, *args, **kwargs):
         """ List all courses.
          ---


### PR DESCRIPTION
Supposedly the cacheresponsemixin does not work for list if you define
your own list for an API view. Let's try this instead.