### PR TITLE
Allow standard ol HTML tag attributes

### DIFF
--- a/course_discovery/apps/course_metadata/validators.py
+++ b/course_discovery/apps/course_metadata/validators.py
@@ -19,6 +19,7 @@ class HtmlValidator(HTMLParser):
     ALLOWED_TAG_ATTRS = {
         'a': {'href', 'rel', 'target', 'title'},
         'img': {'alt', 'height', 'src', 'width'},
+        'ol': {'reversed', 'start', 'type'},
     }
 
     def error(self, message=None):


### PR DESCRIPTION
Sometimes our stored HTML will use ol attributes like start or type.
Allow them, it's harmless.