### PR TITLE
Tag AWIN feed with lowercase language code

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1555,7 +1555,7 @@ class AffiliateWindowSerializer(serializers.ModelSerializer):
     def get_lang(self, obj):
         language = obj.course_run.language
 
-        return language.code.split('-')[0].upper() if language else 'EN'
+        return language.code.split('-')[0].lower() if language else 'en'
 
     def get_custom3(self, obj):
         return ','.join(subject.name for subject in obj.course_run.subjects.all())

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1519,7 +1519,7 @@ class AffiliateWindowSerializerTests(TestCase):
             'category': 'Other Experiences',
             'validfrom': course_run.start.strftime('%Y-%m-%d'),
             'validto': course_run.end.strftime('%Y-%m-%d'),
-            'lang': course_run.language.code.split('-')[0].upper(),
+            'lang': course_run.language.code.split('-')[0].lower(),
             'custom1': course_run.pacing_type,
             'custom2': course_run.level_type.name,
             'custom3': ','.join(subject.name for subject in course_run.subjects.all()),


### PR DESCRIPTION
#### Problem
In the Awin feed, courses with language other than English i.e Spanish, are incorrectly tagged as a course in English. ```<language>en</language>```

Our data feed endpoint sends capitalized language code
<img width="623" alt="Screen Shot 2019-05-22 at 12 50 25 PM" src="https://user-images.githubusercontent.com/40633976/59746023-6d1b6000-928f-11e9-91c0-16977be6bc86.png">
 
#### Notes
It appears that because the ```<lang>``` value is capitalized, AWIN system is defaulting to the value ‘en’. The value ‘es’, however, would appear as ‘es’ in the Awin feed.

Converting language code to lowercase will solve the issue

[PROD-316](https://openedx.atlassian.net/browse/PROD-316)
