### PR TITLE
Add CompressedCacheResponseMixin

### DIFF
--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -1,11 +1,16 @@
 import logging
 import time
+import zlib
 
+from django.conf import settings
 from django.core.cache import cache
+from django.http.response import HttpResponse
+from rest_framework_extensions.cache.decorators import CacheResponse
 from rest_framework_extensions.key_constructor.bits import KeyBitBase, QueryParamsKeyBit
 from rest_framework_extensions.key_constructor.constructors import (
     DefaultListKeyConstructor, DefaultObjectKeyConstructor
 )
+
 
 logger = logging.getLogger(__name__)
 API_TIMESTAMP_KEY = 'api_timestamp'
@@ -61,3 +66,73 @@ def api_change_receiver(sender, **kwargs):  # pylint: disable=unused-argument
     )
 
     set_api_timestamp(timestamp)
+
+
+class CompressedCacheResponse(CacheResponse):
+    """
+    Subclasses CacheResponse to allow for compression of content going into the cache
+
+    See https://github.com/chibisov/drf-extensions/blob/master/rest_framework_extensions/cache/decorators.py#L64
+    for the implementation of process_cache_response without compression
+    """
+    def process_cache_response(self, view_instance, view_method, request, args, kwargs):
+        key = self.calculate_key(
+            view_instance=view_instance,
+            view_method=view_method,
+            request=request,
+            args=args,
+            kwargs=kwargs
+        )
+
+        response_triple = self.cache.get(key)
+        if not response_triple:
+            # render response to create and cache the content byte string
+            response = view_method(view_instance, request, *args, **kwargs)
+            response = view_instance.finalize_response(request, response, *args, **kwargs)
+            response.render()
+
+            if not response.status_code >= 400 or self.cache_errors:
+                compressed_content = zlib.compress(response.rendered_content)
+                response_triple = (
+                    compressed_content,
+                    response.status_code,
+                    response._headers.copy()  # pylint: disable=protected-access
+                )
+                self.cache.set(key, response_triple, self.timeout)
+        else:
+            # build smaller Django HttpResponse
+            content, status, headers = response_triple
+            try:
+                decompressed_content = zlib.decompress(content)
+            except TypeError:
+                # If we get a type error, the cache contents were never compressed
+                decompressed_content = content
+            response = HttpResponse(content=decompressed_content, status=status)
+            response._headers = headers  # pylint: disable=protected-access
+
+        if not hasattr(response, '_closable_objects'):
+            response._closable_objects = []  # pylint: disable=protected-access
+
+        return response
+
+
+# Decorator for mixin
+compressed_cache_response = CompressedCacheResponse
+
+
+class CompressedCacheResponseMixin():
+    """
+    Acts like drf-extensions CacheResponseMixin, but compresses values before caching
+    """
+    object_cache_key_func = timestamped_object_key_constructor
+    list_cache_key_func = timestamped_list_key_constructor
+    object_cache_timeout = settings.REST_FRAMEWORK_EXTENSIONS['DEFAULT_CACHE_RESPONSE_TIMEOUT']
+    list_cache_timeout = settings.REST_FRAMEWORK_EXTENSIONS['DEFAULT_CACHE_RESPONSE_TIMEOUT']
+
+    @compressed_cache_response(key_func=list_cache_key_func, timeout=list_cache_timeout)
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @compressed_cache_response(key_func=object_cache_key_func, timeout=object_cache_timeout)
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -16,9 +16,9 @@ from rest_framework import status, viewsets
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import SAFE_METHODS, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import filters, serializers
+from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.permissions import IsCourseEditorOrReadOnly
 from course_discovery.apps.api.serializers import CourseEntitlementSerializer, MetadataWithRelatedChoices
@@ -31,6 +31,7 @@ from course_discovery.apps.course_metadata.models import (
     Course, CourseEditor, CourseEntitlement, CourseRun, Organization, Program, Seat, SeatType, Video
 )
 from course_discovery.apps.course_metadata.utils import ensure_draft_world, validate_course_number
+
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ def writable_request_wrapper(method):
 
 
 # pylint: disable=no-member
-class CourseViewSet(CacheResponseMixin, viewsets.ModelViewSet):
+class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
     """ Course resource. """
 
     filter_backends = (DjangoFilterBackend, rest_framework_filters.OrderingFilter)

--- a/course_discovery/apps/api/v1/views/pathways.py
+++ b/course_discovery/apps/api/v1/views/pathways.py
@@ -1,12 +1,12 @@
 """ Views for accessing Pathway data """
 from rest_framework import viewsets
-from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import serializers
+from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.permissions import ReadOnlyByPublisherUser
 
 
-class PathwayViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+class PathwayViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = (ReadOnlyByPublisherUser,)
     serializer_class = serializers.PathwaySerializer
 

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -3,16 +3,16 @@ from rest_framework import filters as rest_framework_filters
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import filters, serializers
+from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.utils import get_query_param
 from course_discovery.apps.course_metadata.models import Program
 
 
 # pylint: disable=no-member
-class ProgramViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+class ProgramViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
     """ Program resource. """
     lookup_field = 'uuid'
     lookup_value_regex = '[0-9a-f-]+'

--- a/course_discovery/settings/local.py
+++ b/course_discovery/settings/local.py
@@ -8,7 +8,8 @@ ALLOWED_HOSTS = ['*']
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
     }
 }
 # END CACHE CONFIGURATION


### PR DESCRIPTION
Mixin compresses response content going into the cache in order to
reduce the size of the objects that we're caching, which will hopefully
fix the memcached performance issues.