### PR TITLE
Adds in revised CompressedCacheResponseMixin

### DIFF
--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -1,8 +1,11 @@
 import logging
 import time
+import zlib
 
+from django.conf import settings
 from django.core.cache import cache
-from rest_framework_extensions.key_constructor.bits import KeyBitBase, QueryParamsKeyBit
+from rest_framework_extensions.cache.decorators import CacheResponse
+from rest_framework_extensions.key_constructor.bits import KeyBitBase, QueryParamsKeyBit, UserKeyBit
 from rest_framework_extensions.key_constructor.constructors import (
     DefaultListKeyConstructor, DefaultObjectKeyConstructor
 )
@@ -25,6 +28,10 @@ class TimestampedListKeyConstructor(DefaultListKeyConstructor):
     # cache collisions when other query params are involved. For more, see:
     # https://github.com/chibisov/drf-extensions/blob/master/rest_framework_extensions/key_constructor/bits.py#L48-L49
     querystring = QueryParamsKeyBit()
+    # The UserKeyBit ensures that responses are only cached on a per-user basis,
+    # to avoid the issue where another user's username will appear in the api view
+    # rendered response, even though you are not actually the other user.
+    user = UserKeyBit()
 
 
 class TimestampedObjectKeyConstructor(DefaultObjectKeyConstructor):
@@ -32,6 +39,10 @@ class TimestampedObjectKeyConstructor(DefaultObjectKeyConstructor):
     # The DefaultObjectKeyConstructor doesn't include querystring parameters
     # in its cache key.
     querystring = QueryParamsKeyBit()
+    # The UserKeyBit ensures that responses are only cached on a per-user basis,
+    # to avoid the issue where another user's username will appear in the api view
+    # rendered response, even though you are not actually the other user.
+    user = UserKeyBit()
 
 
 def timestamped_list_key_constructor(*args, **kwargs):  # pylint: disable=unused-argument
@@ -61,3 +72,61 @@ def api_change_receiver(sender, **kwargs):  # pylint: disable=unused-argument
     )
 
     set_api_timestamp(timestamp)
+
+
+class CompressedCacheResponse(CacheResponse):
+    """
+    Subclasses CacheResponse to allow for compression of content going into the cache
+    See https://github.com/chibisov/drf-extensions/blob/0.3.1/rest_framework_extensions/cache/decorators.py#L52
+    for the implementation of process_cache_response without compression
+    """
+    def process_cache_response(self, view_instance, view_method, request, args, kwargs):
+        key = self.calculate_key(
+            view_instance=view_instance,
+            view_method=view_method,
+            request=request,
+            args=args,
+            kwargs=kwargs
+        )
+        response = self.cache.get(key)
+
+        if not response:
+            response = view_method(view_instance, request, *args, **kwargs)
+            response = view_instance.finalize_response(request, response, *args, **kwargs)
+            response.render()  # should be rendered, before pickling while storing to cache
+
+            if not response.status_code >= 400 or self.cache_errors:
+                self.cache.set(key, response, self.timeout)
+
+        if not hasattr(response, '_closable_objects'):
+            response._closable_objects = []  # pylint: disable=protected-access
+
+        try:
+            response.data = zlib.decompress(response.data)
+        except TypeError:
+            # If we get a type error, the response data was never compressed
+            pass
+
+        return response
+
+
+# Decorator for mixin
+compressed_cache_response = CompressedCacheResponse
+
+
+class CompressedCacheResponseMixin():
+    """
+    Acts like drf-extensions CacheResponseMixin, but with compression into the cache and decompression out of it
+    """
+    object_cache_key_func = timestamped_object_key_constructor
+    list_cache_key_func = timestamped_list_key_constructor
+    object_cache_timeout = settings.REST_FRAMEWORK_EXTENSIONS['DEFAULT_CACHE_RESPONSE_TIMEOUT']
+    list_cache_timeout = settings.REST_FRAMEWORK_EXTENSIONS['DEFAULT_CACHE_RESPONSE_TIMEOUT']
+
+    @compressed_cache_response(key_func=list_cache_key_func, timeout=list_cache_timeout)
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @compressed_cache_response(key_func=object_cache_key_func, timeout=object_cache_timeout)
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)

--- a/course_discovery/apps/api/v1/tests/test_cache.py
+++ b/course_discovery/apps/api/v1/tests/test_cache.py
@@ -1,0 +1,68 @@
+import zlib
+
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework import permissions, views
+from rest_framework.response import Response
+from rest_framework_extensions.test import APIRequestFactory
+
+from course_discovery.apps.api.cache import compressed_cache_response
+
+factory = APIRequestFactory()
+
+
+class CompressedCacheResponseTest(TestCase):
+    def setUp(self):
+        super(CompressedCacheResponseTest, self).setUp()
+        self.request = factory.get('')
+        self.cache_response_key = 'cache_response_key'
+
+    def test_should_handle_getting_uncompressed_response_from_cache(self):
+        """ Verify that the decorator correctly returns uncompressed responses """
+        def key_func(**kwargs):  # pylint: disable=unused-argument
+            return self.cache_response_key
+
+        class TestView(views.APIView):
+            permission_classes = [permissions.AllowAny]
+
+            @compressed_cache_response(key_func=key_func)
+            def get(self, request, *args, **kwargs):
+                return Response('test response')
+
+        view_instance = TestView()
+        view_instance.headers = {}  # pylint: disable=attribute-defined-outside-init
+        uncompressed_cached_response = Response('cached test response')
+        view_instance.finalize_response(request=self.request, response=uncompressed_cached_response)
+        uncompressed_cached_response.render()
+        cache.set(self.cache_response_key, uncompressed_cached_response)
+
+        response = view_instance.dispatch(request=self.request)
+        self.assertEqual(response.content.decode('utf-8'), '"cached test response"')
+
+    def test_should_handle_getting_compressed_response_from_cache(self):
+        """ Verify that the decorator correctly returns compressed responses """
+        def key_func(**kwargs):  # pylint: disable=unused-argument
+            return self.cache_response_key
+
+        class TestView(views.APIView):
+            permission_classes = [permissions.AllowAny]
+
+            @compressed_cache_response(key_func=key_func)
+            def get(self, request, *args, **kwargs):
+                return Response('test response')
+
+        view_instance = TestView()
+        view_instance.headers = {}  # pylint: disable=attribute-defined-outside-init
+        compressed_cached_response = Response('compressed cached test response')
+        view_instance.finalize_response(request=self.request, response=compressed_cached_response)
+        compressed_cached_response.render()
+
+        # Data is encoded and compressed before response goes into the cache
+        compressed_cached_response.data = zlib.compress(compressed_cached_response.data.encode('utf-8'))
+        cache.set(
+            self.cache_response_key,
+            compressed_cached_response,
+        )
+
+        response = view_instance.dispatch(request=self.request)
+        self.assertEqual(response.content.decode('utf-8'), '"compressed cached test response"')

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -16,9 +16,9 @@ from rest_framework import status, viewsets
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import SAFE_METHODS, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import filters, serializers
+from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.permissions import IsCourseEditorOrReadOnly
 from course_discovery.apps.api.serializers import CourseEntitlementSerializer, MetadataWithRelatedChoices
@@ -53,7 +53,7 @@ def writable_request_wrapper(method):
 
 
 # pylint: disable=no-member
-class CourseViewSet(CacheResponseMixin, viewsets.ModelViewSet):
+class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
     """ Course resource. """
 
     filter_backends = (DjangoFilterBackend, rest_framework_filters.OrderingFilter)

--- a/course_discovery/apps/api/v1/views/pathways.py
+++ b/course_discovery/apps/api/v1/views/pathways.py
@@ -1,12 +1,12 @@
 """ Views for accessing Pathway data """
 from rest_framework import viewsets
-from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import serializers
+from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.permissions import ReadOnlyByPublisherUser
 
 
-class PathwayViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+class PathwayViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = (ReadOnlyByPublisherUser,)
     serializer_class = serializers.PathwaySerializer
 

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -3,16 +3,16 @@ from rest_framework import filters as rest_framework_filters
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_extensions.cache.mixins import CacheResponseMixin
 
 from course_discovery.apps.api import filters, serializers
+from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.utils import get_query_param
 from course_discovery.apps.course_metadata.models import Program
 
 
 # pylint: disable=no-member
-class ProgramViewSet(CacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+class ProgramViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
     """ Program resource. """
     lookup_field = 'uuid'
     lookup_value_regex = '[0-9a-f-]+'

--- a/course_discovery/settings/local.py
+++ b/course_discovery/settings/local.py
@@ -8,7 +8,8 @@ ALLOWED_HOSTS = ['*']
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
     }
 }
 # END CACHE CONFIGURATION


### PR DESCRIPTION
The mixin will eventually compress response date before going into the
cache, in an effort to try and fix the memcached issues we are seeing
with large items. This first commit does not have compression, but
only attempts to safely decompress items from the cache, to avoid
issues with blue/green deployments. A follow up will be to actually add
compression once the safe decompression is deployed.

Also, only caches JSON responses to prevent users from seeing other
usernames in the cached browsable api responses