### PR TITLE
Added endpoint to return data fixture for easy transfer

### DIFF
--- a/course_discovery/apps/edx_catalog_extensions/api/v1/urls.py
+++ b/course_discovery/apps/edx_catalog_extensions/api/v1/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import url
 
-from course_discovery.apps.edx_catalog_extensions.api.v1.views import DistinctCountsAggregateSearchViewSet
+from course_discovery.apps.edx_catalog_extensions.api.v1.views import DistinctCountsAggregateSearchViewSet, get_fixture
 
 # Only expose the facets action of this view
 distinct_facets_action = DistinctCountsAggregateSearchViewSet.as_view({'get': 'facets'})
 
 urlpatterns = [
-    url(r'^search/all/facets', distinct_facets_action, name='search-all-facets')
+    url(r'^search/all/facets', distinct_facets_action, name='search-all-facets'),
+    url(r'^fixture/', get_fixture, name='get-fixture')
 ]

--- a/course_discovery/apps/edx_catalog_extensions/api/v1/views.py
+++ b/course_discovery/apps/edx_catalog_extensions/api/v1/views.py
@@ -1,3 +1,8 @@
+from django.apps import apps
+from django.core.exceptions import FieldError
+from django.core.serializers import json
+from django.http.response import Http404, HttpResponse, HttpResponseForbidden
+
 from course_discovery.apps.api.v1.views.search import AggregateSearchViewSet
 from course_discovery.apps.edx_catalog_extensions.api.serializers import DistinctCountsAggregateFacetSearchSerializer
 from course_discovery.apps.edx_haystack_extensions.distinct_counts.query import DistinctCountsSearchQuerySet
@@ -13,3 +18,52 @@ class DistinctCountsAggregateSearchViewSet(AggregateSearchViewSet):
         """ Return the base Queryset to use to build up the search query."""
         queryset = super(DistinctCountsAggregateSearchViewSet, self).get_queryset(*args, **kwargs)
         return DistinctCountsSearchQuerySet.from_queryset(queryset).with_distinct_counts('aggregation_key')
+
+
+class Walker:
+    def __init__(self, exclude=None):
+        self.seen = set()
+        self.exclude = set(exclude or [])
+
+    def walk(self, *objs):
+        for obj in objs:
+            name = '{}.{}'.format(obj._meta.app_label, obj._meta.model_name)
+            if name in self.exclude:
+                continue
+            key = (name, obj.pk)
+            if key in self.seen:
+                continue
+            self.seen.add(key)
+            for field in obj._meta.many_to_many:
+                for oo in self.walk(*getattr(obj, field.name).all()):
+                    yield oo
+            for field in obj._meta.fields:
+                if field.is_relation:
+                    related_obj = getattr(obj, field.name, None)
+                    if related_obj:
+                        for oo in self.walk(related_obj):
+                            yield oo
+            yield obj
+
+
+def get_fixture(request):
+    """
+    Returns a json fixture suitable for use with Django's loaddata command.
+
+    For instance:
+    /extensions/api/v1/fixture/?model=course_metadata.program&authoring_organizations__key=MITx
+    will return all MITx programs and related objects (courses, courseruns, tags, etc.)
+    """
+    if not request.user.is_staff:
+        return HttpResponseForbidden()
+    try:
+        query_args = {}
+        for key, value in request.GET.items():
+            query_args[key] = value
+        model_name = query_args.pop('model')
+        model_object = apps.get_model(model_name).objects.filter(**query_args)
+    except (KeyError, FieldError):
+        raise Http404()
+    serializer = json.Serializer()
+    response = serializer.serialize(Walker(['sites.site', 'core.user', 'core.partner']).walk(*model_object))
+    return HttpResponse(response, content_type='text/json')


### PR DESCRIPTION
The fixture can be saved to a json file and loaded with `manage.py loaddata`.

