### PR TITLE
Change CompressedCacheMixin strategy

### DIFF
--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -18,7 +18,6 @@ from rest_framework.permissions import SAFE_METHODS, IsAuthenticated
 from rest_framework.response import Response
 
 from course_discovery.apps.api import filters, serializers
-from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.permissions import IsCourseEditorOrReadOnly
 from course_discovery.apps.api.serializers import CourseEntitlementSerializer, MetadataWithRelatedChoices
@@ -53,7 +52,7 @@ def writable_request_wrapper(method):
 
 
 # pylint: disable=no-member
-class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
+class CourseViewSet(viewsets.ModelViewSet):
     """ Course resource. """
 
     filter_backends = (DjangoFilterBackend, rest_framework_filters.OrderingFilter)

--- a/course_discovery/apps/api/v1/views/pathways.py
+++ b/course_discovery/apps/api/v1/views/pathways.py
@@ -2,11 +2,10 @@
 from rest_framework import viewsets
 
 from course_discovery.apps.api import serializers
-from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.permissions import ReadOnlyByPublisherUser
 
 
-class PathwayViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+class PathwayViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (ReadOnlyByPublisherUser,)
     serializer_class = serializers.PathwaySerializer
 

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -5,14 +5,13 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from course_discovery.apps.api import filters, serializers
-from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.utils import get_query_param
 from course_discovery.apps.course_metadata.models import Program
 
 
 # pylint: disable=no-member
-class ProgramViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
     """ Program resource. """
     lookup_field = 'uuid'
     lookup_value_regex = '[0-9a-f-]+'


### PR DESCRIPTION
Changes the compression/caching strategy to separate the response into
a tuple, and compress the rendered content, before reassembling the
response when it comes out of the cache. This is done because rendered
content can't actually be set.

The CompressedCacheResponseMixin is removed from all endpoints where
it is used so that we can remove all keys from the cache, then add the
mixin back in, hopefully preventing any issues with different data
formats in the cache.