### PR TITLE
Add endpoint for program data fixture

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -56,7 +56,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         """ Verify the endpoint returns the details for a single course with UUID. """
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.uuid})
 
-        with self.assertNumQueries(FuzzyInt(46, 2)):
+        with self.assertNumQueries(FuzzyInt(45, 3)):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data, self.serialize_course(self.course))

--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -128,3 +128,10 @@ class SearchQuerySetWrapper(object):
             return self.qs[key].object
         # Pass the slice/range on to the delegate
         return SearchQuerySetWrapper(self.qs[key])
+
+
+def use_read_replica_if_available(queryset):
+    """
+    If there is a database called 'read_replica', use that database for the queryset.
+    """
+    return queryset.using("read_replica") if "read_replica" in settings.DATABASES else queryset

--- a/course_discovery/apps/edx_catalog_extensions/api/v1/tests/test_views.py
+++ b/course_discovery/apps/edx_catalog_extensions/api/v1/tests/test_views.py
@@ -1,6 +1,10 @@
 import datetime
+import json
 import urllib.parse
+from collections import defaultdict
 
+import ddt
+import mock
 import pytz
 from django.urls import reverse
 
@@ -8,9 +12,19 @@ from course_discovery.apps.api.v1.tests.test_views.mixins import (
     APITestCase, LoginMixin, SerializationMixin, SynonymTestMixin
 )
 from course_discovery.apps.api.v1.tests.test_views.test_search import ElasticsearchTestMixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
-from course_discovery.apps.course_metadata.tests.factories import CourseFactory, CourseRunFactory, ProgramFactory
+from course_discovery.apps.course_metadata.models import (
+    AdditionalPromoArea, Course, CourseRun, Curriculum, CurriculumCourseMembership, CurriculumCourseRunExclusion, Image,
+    LevelType, Organization, Program, ProgramType, SeatType, Video
+)
+from course_discovery.apps.course_metadata.tests.factories import (
+    CourseFactory, CourseRunFactory, CurriculumCourseMembershipFactory, CurriculumCourseRunExclusionFactory,
+    CurriculumFactory, OrganizationFactory, ProgramFactory, ProgramTypeFactory, SeatTypeFactory
+)
 from course_discovery.apps.edx_catalog_extensions.api.serializers import DistinctCountsAggregateFacetSearchSerializer
+from course_discovery.apps.edx_catalog_extensions.api.v1.views import ProgramFixtureView
+from course_discovery.apps.ietf_language_tags.models import LanguageTag
 
 
 class DistinctCountsAggregateSearchViewSetTests(SerializationMixin, LoginMixin,
@@ -254,3 +268,144 @@ class DistinctCountsAggregateSearchViewSetTests(SerializationMixin, LoginMixin,
             'selected_facets': ['pacing_type_exact:self_paced'],
         }
         self.assert_url_path_and_query(pacing_types['self_paced']['narrow_url'], self.path, expected_query_params)
+
+
+@ddt.ddt
+class TestProgramFixtureView(APITestCase):
+
+    def setUp(self):
+        self.user = UserFactory()
+        self.staff = UserFactory(username='staff', is_staff=True)
+        seat_type = SeatTypeFactory(name="TestSeatType")
+        self.program_type = ProgramTypeFactory(
+            name="TestProgramType",
+            slug="test-program-type",
+            applicable_seat_types=[seat_type],
+        )
+
+    def login_user(self):
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+
+    def login_staff(self):
+        self.client.login(username=self.staff.username, password=USER_PASSWORD)
+
+    @staticmethod
+    def queries(n):
+        """ Adjust query count for boilerplate queries (user log in, etc.) """
+        return n + 3
+
+    def get(self, uuids):
+        path = reverse('extensions:api:v1:get-program-fixture')
+        if uuids:
+            uuids_str = ",".join(str(uuid) for uuid in uuids)
+            url = "{}?programs={}".format(path, uuids_str)
+        else:
+            url = path
+        return self.client.get(url)
+
+    def create_program(self, orgs):
+        program = ProgramFactory(
+            authoring_organizations=orgs, type=self.program_type
+        )
+        curr = CurriculumFactory(program=program)
+        course1 = CourseFactory()
+        _run1a = CourseRunFactory(course=course1)
+        _run1b = CourseRunFactory(course=course1)
+        course2 = CourseFactory()
+        _run2a = CourseRunFactory(course=course2)
+        run2b = CourseRunFactory(course=course2)
+        _mem1 = CurriculumCourseMembershipFactory(curriculum=curr, course=course1)
+        mem2 = CurriculumCourseMembershipFactory(curriculum=curr, course=course2)
+        _ex = CurriculumCourseRunExclusionFactory(course_membership=mem2, course_run=run2b)
+        return program
+
+    def test_200(self):
+        self.login_staff()
+        org1 = OrganizationFactory()
+        org2 = OrganizationFactory()
+        program1 = self.create_program([org1])
+        program2 = self.create_program([org2])
+        program12 = self.create_program([org1, org2])
+        programs = [program1, program2, program12]
+        uuids = [program.uuid for program in programs]
+
+        response = self.get(uuids)
+        self.assertEqual(response.status_code, 200)
+        fixture = json.loads(response.content.decode('utf-8'))
+
+        expected_counts_by_model = {
+            Organization: 2,
+            Program: 3,
+            Curriculum: 3,
+            Course: 6,
+            CourseRun: 12,
+            CurriculumCourseMembership: 6,
+            CurriculumCourseRunExclusion: 3,
+            ProgramType: 1,
+            SeatType: 1,
+            AdditionalPromoArea: 6,
+            Image: 21,
+            LevelType: 6,
+            Video: 21,
+            LanguageTag: 12,
+        }
+        expected_counts_by_model_label = {
+            model._meta.label.lower(): n
+            for model, n in expected_counts_by_model.items()
+        }
+
+        actual_appearances_by_model_label = defaultdict(set)
+        for record in fixture:
+            pk = record['pk']
+            model_label = record['model']
+            self.assertNotIn(pk, actual_appearances_by_model_label[model_label])
+            actual_appearances_by_model_label[model_label].add(pk)
+        actual_counts_by_model_label = {
+            model_label: len(appearances)
+            for model_label, appearances
+            in actual_appearances_by_model_label.items()
+        }
+
+        self.maxDiff = None
+        self.assertDictEqual(
+            actual_counts_by_model_label, expected_counts_by_model_label
+        )
+
+    def test_401(self):
+        response = self.get(None)
+        self.assertEqual(response.status_code, 401)
+
+    def test_403(self):
+        self.login_user()
+        response = self.get(None)
+        self.assertEqual(response.status_code, 403)
+
+    def test_404_no_programs(self):
+        self.login_staff()
+        with self.assertNumQueries(self.queries(0)):
+            response = self.get(None)
+        self.assertEqual(response.status_code, 404)
+
+    def test_422_too_many_programs(self):
+        self.login_staff()
+        org1 = OrganizationFactory()
+        program_1 = self.create_program([org1])
+        program_2 = self.create_program([org1])
+        with mock.patch.object(ProgramFixtureView, 'MAX_REQUESTED_PROGRAMS', 1):
+            with self.assertNumQueries(self.queries(2)):
+                response = self.get([program_1.uuid, program_2.uuid])
+        self.assertEqual(response.status_code, 422)
+
+    def test_404_bad_input(self):
+        self.login_staff()
+        with self.assertNumQueries(self.queries(0)):
+            response = self.get(['this-is-not-a-uuid'])
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_nonexistent(self):
+        self.login_staff()
+        program = self.create_program([OrganizationFactory()])
+        bad_uuid = 'e9222eb7-7218-4a8b-9dff-b42bafbf6ed7'
+        with self.assertNumQueries(self.queries(1)):
+            response = self.get([program.uuid, bad_uuid])
+        self.assertEqual(response.status_code, 404)

--- a/course_discovery/apps/edx_catalog_extensions/api/v1/urls.py
+++ b/course_discovery/apps/edx_catalog_extensions/api/v1/urls.py
@@ -1,10 +1,13 @@
 from django.conf.urls import url
 
-from course_discovery.apps.edx_catalog_extensions.api.v1.views import DistinctCountsAggregateSearchViewSet
+from course_discovery.apps.edx_catalog_extensions.api.v1.views import (
+    DistinctCountsAggregateSearchViewSet, ProgramFixtureView
+)
 
 # Only expose the facets action of this view
 distinct_facets_action = DistinctCountsAggregateSearchViewSet.as_view({'get': 'facets'})
 
 urlpatterns = [
-    url(r'^search/all/facets', distinct_facets_action, name='search-all-facets')
+    url(r'^search/all/facets', distinct_facets_action, name='search-all-facets'),
+    url(r'^program-fixture/$', ProgramFixtureView.as_view(), name='get-program-fixture'),
 ]

--- a/course_discovery/apps/edx_catalog_extensions/api/v1/views.py
+++ b/course_discovery/apps/edx_catalog_extensions/api/v1/views.py
@@ -1,6 +1,24 @@
+import logging
+from collections import defaultdict
+from uuid import UUID
+
+from django.contrib.sites.models import Site
+from django.core.serializers import json
+from django.http.response import HttpResponse
+from rest_framework.permissions import IsAdminUser
+from rest_framework.views import APIView
+
 from course_discovery.apps.api.v1.views.search import AggregateSearchViewSet
+from course_discovery.apps.core.models import Partner, User
+from course_discovery.apps.core.utils import use_read_replica_if_available
+from course_discovery.apps.course_metadata.models import (
+    CourseRun, Curriculum, CurriculumCourseMembership, CurriculumCourseRunExclusion, CurriculumProgramMembership,
+    Program
+)
 from course_discovery.apps.edx_catalog_extensions.api.serializers import DistinctCountsAggregateFacetSearchSerializer
 from course_discovery.apps.edx_haystack_extensions.distinct_counts.query import DistinctCountsSearchQuerySet
+
+logger = logging.getLogger(__name__)
 
 
 class DistinctCountsAggregateSearchViewSet(AggregateSearchViewSet):
@@ -13,3 +31,185 @@ class DistinctCountsAggregateSearchViewSet(AggregateSearchViewSet):
         """ Return the base Queryset to use to build up the search query."""
         queryset = super(DistinctCountsAggregateSearchViewSet, self).get_queryset(*args, **kwargs)
         return DistinctCountsSearchQuerySet.from_queryset(queryset).with_distinct_counts('aggregation_key')
+
+
+class ProgramFixtureView(APIView):
+    """
+    Returns a JSON fixture of program data suitable for use with Django's
+    loaddata command.
+
+    Query parameters:
+        * programs: comma-separated list of program UUIDs
+
+    Allowed methods:
+        * GET
+
+    Response codes:
+        * 200: Program fixture successfully fetched.
+        * 403: User not staff.
+        * 404: One or more program UUIDs invalid.
+        * 422: Too many programs requested.
+
+    Example:
+        Request:
+            GET /extensions/api/v1/program-fixture?programs=<uuid1>,<uuid2>
+        Response: 200 OK
+            <list of JSON fixture objects>
+    """
+    permission_classes = (IsAdminUser,)
+    QUERY_PARAM = 'programs'
+    HELP_STRING = 'Must provide comma-separated list of valid UUIDs in "program" query parameter.'
+    MAX_REQUESTED_PROGRAMS = 10
+
+    def get(self, request):
+        uuids_string = self.request.GET.get(self.QUERY_PARAM)
+        if not uuids_string:
+            return HttpResponse(self.HELP_STRING, status=404)
+        uuids_split = uuids_string.split(',')
+        try:
+            uuids = {UUID(uuid_str) for uuid_str in uuids_split}
+        except ValueError:
+            return HttpResponse(self.HELP_STRING, status=404)
+        if len(uuids) > self.MAX_REQUESTED_PROGRAMS:
+            return HttpResponse(
+                'Too many programs requested, only {} allowed.'.format(self.MAX_REQUESTED_PROGRAMS),
+                status=422,
+            )
+        programs = use_read_replica_if_available(
+            Program.objects.filter(uuid__in=list(uuids))
+        )
+        loaded_uuids = {program.uuid for program in programs}
+        bad_uuids = uuids - loaded_uuids
+        if bad_uuids:
+            return HttpResponse(
+                "Could not load programs from UUIDs: [{}]".format(
+                    ",".join(str(uuid) for uuid in bad_uuids)
+                ),
+                status=404,
+            )
+        objects = load_program_fixture(programs)
+        json_text = json.Serializer().serialize(objects)
+        return HttpResponse(json_text, content_type='text/json')
+
+
+def load_program_fixture(programs):
+    """
+    Given a list of of programs, load:
+    * Each program
+    * All associated curricula
+    * All associated curriciulum program/course memberships and course-run
+      exclusions
+    * All models that the above reference, either by foreign key or
+      or explicit many-to-many relationship.
+
+    Arguments:
+        programs (iterable[Program])
+
+    Returns: list[Model]
+    """
+    curricula_pks = use_read_replica_if_available(
+        Curriculum.objects.filter(
+            program__in=programs
+        ).values_list('pk', flat=True)
+    )
+    course_memberships = use_read_replica_if_available(
+        CurriculumCourseMembership.objects.filter(
+            curriculum__in=curricula_pks
+        ).values_list('pk', 'course_id')
+    )
+    course_membership_pks = [pk for pk, _ in course_memberships]
+    course_pks = [course_pk for _, course_pk in course_memberships]
+    course_run_pks = use_read_replica_if_available(
+        CourseRun.objects.filter(
+            course__in=course_pks
+        ).values_list('pk', flat=True)
+    )
+    program_membership_pks = use_read_replica_if_available(
+        CurriculumProgramMembership.objects.filter(
+            curriculum__in=curricula_pks
+        ).values_list('pk', flat=True)
+    )
+    exclusion_pks = use_read_replica_if_available(
+        CurriculumCourseRunExclusion.objects.filter(
+            course_membership__in=course_membership_pks
+        ).values_list('pk', flat=True)
+    )
+    pks_to_load = {
+        Program: {program.pk for program in programs},
+        Curriculum: set(curricula_pks),
+        CurriculumCourseMembership: set(course_membership_pks),
+        CurriculumProgramMembership: set(program_membership_pks),
+        CourseRun: set(course_run_pks),
+        CurriculumCourseRunExclusion: set(exclusion_pks),
+    }
+    excluded_models = {Site, Partner, User}
+    return load_related(pks_to_load, excluded_models)
+
+
+def load_related(pks_to_load, excluded_models):
+    """
+    Given a set of root models and primary keys, load all objects
+    related either by foreign key or explicit many-to-many relationship.
+
+    Arguments:
+        pks_to_load (dict[type, set[int]]):
+            Mapping from root model classes to primary keys of
+                the instances of them to load first.
+        excluded_models (frozenset[type]):
+            Model classes that we are not to load or traverse.
+
+    Returns: list[Model]
+    """
+
+    # Mapping from each model to a PK->instance dict.
+    # Is used as input and output for this function; is mutated.
+    # A PK that maps to a model instance is part of the result set.
+    # A PK that maps to None means that the PK is referenced by some
+    #     model instance, but we haven't loaded it yet.
+    # The result set is complete when all the PKs map to loaded instances.
+    results_by_model = defaultdict(dict, {
+        model: {pk: None for pk in pks}
+        for model, pks in pks_to_load.items()
+    })
+
+    while True:
+
+        # Choose a model that has instances that we still need to load.
+        model = None
+        pks_to_load = None
+        for model, results in results_by_model.items():
+            pks_to_load = {
+                pk for pk, instance in results.items()
+                if not instance
+            }
+            if pks_to_load:
+                break
+        else:
+            # All models fully loaded; return results flattened into a list.
+            return [
+                instance
+                for results in results_by_model.values()
+                for instance in results.values()
+            ]
+
+        # Load new instances and add them to `results_by_model`.
+        objects = use_read_replica_if_available(
+            model.objects.filter(pk__in=pks_to_load)
+        )
+        results_by_model[model].update({obj.pk: obj for obj in objects})
+
+        # For all relational fields on the model, update
+        # `results_by_model` with holes for referenced instances that we
+        # have not yet loaded.
+        for field in model._meta.fields + model._meta.many_to_many:
+            rel_model = field.related_model
+            if not rel_model:
+                continue
+            if rel_model in excluded_models:
+                continue
+            rel_pks_name = "{}__pk".format(field.name)
+            rel_pks = objects.values_list(rel_pks_name, flat=True)
+            results_by_model[rel_model].update({
+                pk: results_by_model[rel_model].get(pk)
+                for pk in rel_pks if pk
+            })


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4472

This is a staff-only endpoint that allows fetching of a fixture for up to 10 programs and all their related model instances. For use by Master's integration sandboxes to load production catalog data.