### PR TITLE
Add a read_replica DB definition to settings.

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -121,7 +121,16 @@ DATABASES = {
         'HOST': 'localhost',  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
         'PORT': '',  # Set to empty string for default.
         'ATOMIC_REQUESTS': False,
-    }
+    },
+    'read_replica': {
+        'ENGINE': 'django.db.backends.',
+        'NAME': 'discovery',
+        'USER': 'discov001',
+        'PASSWORD': 'password',
+        'HOST': 'localhost',
+        'PORT': '',
+        'ATOMIC_REQUESTS': False,
+    },
 }
 
 # Internationalization

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -1,4 +1,5 @@
 import warnings
+from copy import deepcopy
 from os import environ
 
 import certifi
@@ -68,6 +69,19 @@ HAYSTACK_CONNECTIONS['default'].update({
 
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
+
+if environ.get('DISCOVERY_MYSQL_REPLICA_HOST'):
+    DATABASES['read_replica'] = {
+        'PASSWORD': environ.get('DISCOVERY_MYSQL_REPLICA_PASSWORD', DATABASES['default']['PASSWORD']),
+        'ENGINE': environ.get('DISCOVERY_MYSQL_REPLICA_ENGINE', DATABASES['default']['ENGINE']),
+        'USER': environ.get('DISCOVERY_MYSQL_REPLICA_USER', DATABASES['default']['USER']),
+        'NAME': environ.get('DISCOVERY_MYSQL_REPLICA_NAME', DATABASES['default']['NAME']),
+        'HOST': environ.get('DISCOVERY_MYSQL_REPLICA_HOST', DATABASES['default']['HOST']),
+        'PORT': environ.get('DISCOVERY_MYSQL_REPLICA_PORT', DATABASES['default']['PORT']),
+        'ATOMIC_REQUESTS': DATABASES['default']['ATOMIC_REQUESTS'],
+    }
+else:
+    DATABASES['read_replica'] = deepcopy(DATABASES['default'])
 
 # NOTE (CCB): Treat all MySQL warnings as exceptions. This is especially
 # desired for truncation warnings, which hide potential data integrity issues.


### PR DESCRIPTION
We'd like to be able to use the read-replica from production for a somewhat experimental endpoint we're exposing.  This PR defines a `read_replica` django database.