### PR TITLE
Allow read-only access to courses

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -28,7 +28,7 @@ from course_discovery.apps.core.api_client.lms import LMSAPIClient
 from course_discovery.apps.course_metadata import search_indexes
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import (
-    FAQ, AdditionalPromoArea, CorporateEndorsement, Course, CourseEntitlement, CourseRun, Curriculum,
+    FAQ, AdditionalPromoArea, CorporateEndorsement, Course, CourseEditor, CourseEntitlement, CourseRun, Curriculum,
     CurriculumCourseMembership, CurriculumProgramMembership, Degree, DegreeCost, DegreeDeadline, Endorsement,
     IconTextPairing, Image, LevelType, Organization, Pathway, Person, PersonAreaOfExpertise, PersonSocialNetwork,
     Position, Prerequisite, Program, ProgramType, Ranking, Seat, SeatType, Subject, Topic, Video
@@ -964,6 +964,7 @@ class CourseWithProgramsSerializer(CourseSerializer):
     marketing_course_runs = serializers.SerializerMethodField()
     course_runs = serializers.SerializerMethodField()
     programs = NestedProgramSerializer(read_only=True, many=True)
+    editable = serializers.SerializerMethodField()
 
     @classmethod
     def prefetch_queryset(cls, partner, queryset=None, course_runs=None, programs=None):  # pylint: disable=arguments-differ
@@ -1014,12 +1015,16 @@ class CourseWithProgramsSerializer(CourseSerializer):
             }
         ).data
 
+    def get_editable(self, course):
+        return CourseEditor.is_course_editable(self.context['request'].user, course)
+
     class Meta(CourseSerializer.Meta):
         model = Course
         fields = CourseSerializer.Meta.fields + (
             'programs',
             'marketing_course_runs',
             'course_run_keys',
+            'editable',
         )
 
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -244,7 +244,8 @@ class CourseWithProgramsSerializerTests(CourseSerializerTests):
                 many=True,
                 context={'request': request},
             ).data,
-            'course_run_keys': [course_run.key for course_run in course.course_runs.all()]
+            'course_run_keys': [course_run.key for course_run in course.course_runs.all()],
+            'editable': False,
         })
 
         return expected

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -98,15 +98,16 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         # We don't want to create an additional elasticsearch index right now for draft courses, so we
         # try to implement a basic search behavior with this pubq parameter here against key and name.
         pub_q = self.request.query_params.get('pubq')
-        edit_mode = get_query_param(self.request, 'editable') or self.request.method not in SAFE_METHODS
+        edit_method = self.request.method not in SAFE_METHODS
+        edit_mode = get_query_param(self.request, 'editable') or edit_method
 
         if edit_mode and q:
             raise EditableAndQUnsupported()
 
-        # Start with either draft versions or real versions of the courses
         if edit_mode:
+            # Start with either draft versions or real versions of the courses
             queryset = Course.objects.filter_drafts()
-            queryset = CourseEditor.editable_courses(self.request.user, queryset)
+            queryset = CourseEditor.editable_courses(self.request.user, queryset, check_editors=edit_method)
         else:
             queryset = self.queryset
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -431,6 +431,14 @@ class TestCourseEditor(TestCase):
         self.assertResultsEqual(self.filter_editable_course_runs, {self.run_bad_editor_in_group, self.run_editor},
                                 queries=1)
 
+    def test_editable_without_checking_editors(self):
+        """ Verify the that we can get a list of *potentially editable* courses (courses in org). """
+        self.assertResultsEqual(
+            partial(CourseEditor.editable_courses, self.user, self.courses_qs, check_editors=False),
+            {self.course_bad_editor_in_group, self.course_good_editor, self.course_editor},
+            queries=1,
+        )
+
     def test_course_editors_when_valid_editors(self):
         self.assertResultsEqual(partial(CourseEditor.course_editors, self.course_editor), {self.user}, queries=1)
 


### PR DESCRIPTION
If a user is not an editor, but is still in an authoring organization for that course, let them view the course.

Also add an 'editable' field to the serialization for a course, so a frontend will know whether to allow edits in the UI.

This means we have some overloading of `editable` - but I'm not sure how much a problem it is:
* GET with editable=0 -> can read, `editable=true/false` in serialization
* GET with editable=1 and not in org -> 403
* GET with editable=1 and in org but not editor -> read, `editable=false` in serialization
* GET with editable=1 and in org and editor -> read, `editable=true` in serialization

https://openedx.atlassian.net/browse/DISCO-1143