### PR TITLE
Prep for new-style middleware

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -94,5 +94,6 @@ def client():
     return Client(SERVER_NAME=TEST_DOMAIN)
 
 
-def pytest_sessionstart(session):  # pylint: disable=unused-argument
+@pytest.fixture(autouse=True)
+def clear_cache(request):  # pylint: disable=unused-argument
     cache.clear()

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -8,7 +8,6 @@ import pytest
 import pytz
 import responses
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from rest_framework.reverse import reverse
 
 from course_discovery.apps.api.tests.jwt_utils import generate_jwt_header_for_user
@@ -47,7 +46,6 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
         )
         self.course = self.course_run.course
         self.refresh_index()
-        cache.clear()
 
     def assert_catalog_created(self, **headers):
         name = 'The Kitchen Sink'

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -164,7 +164,7 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         (list_path, serializers.CourseRunSearchSerializer,
          ['results', 0, 'program_types', 0], ProgramStatus.Unpublished, 8),
         (detailed_path, serializers.CourseRunSearchModelSerializer,
-         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 40),
+         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 43),
         (detailed_path, serializers.CourseRunSearchModelSerializer,
          ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 42),
     )

--- a/course_discovery/apps/core/tests/test_api_clients.py
+++ b/course_discovery/apps/core/tests/test_api_clients.py
@@ -2,7 +2,6 @@ import logging
 
 import mock
 import responses
-from django.core.cache import cache
 from django.test import TestCase
 
 from course_discovery.apps.core.api_client import lms
@@ -43,7 +42,6 @@ class TestLMSAPIClient(LMSAPIClientMixin, TestCase):
             'site': 1,
             'contacted': True
         }
-        cache.clear()
 
     @responses.activate
     @mock.patch.object(Partner, 'access_token', return_value='JWT fake')

--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -4,7 +4,6 @@ from datetime import date
 
 import mock
 import responses
-from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
 from rest_framework.test import APITestCase
@@ -48,7 +47,6 @@ class CourseRunViewSetTests(OAuth2Mixin, APITestCase):
         # so their cache of the access token is not shared yet.
         self.mock_access_token()
         self.mock_access_token()
-        cache.clear()  # clear our saved Partner.access_token so that we expect do the same mock requests
 
     def test_without_authentication(self):
         self.client.logout()

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,7 +7,7 @@ django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1
 django-contrib-comments
-django-cors-headers==2.4.0
+django-cors-headers
 django-extensions==1.7.8
 django-filter==1.0.4
 django-fsm==2.6.0
@@ -15,7 +15,7 @@ django-guardian==1.4.8
 django-haystack==2.8.1
 django-libsass==0.7
 django-parler
-django-simple-history==2.7.0
+django-simple-history
 django-solo==1.1.2
 django-sortedm2m==1.4.0
 django-stdimage

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,8 +18,11 @@ docker-compose<1.24  # newer versions require a newer requests
 # FIXME: 0.13+ requires python-slugify, which conflicts with unicode-slugify
 transifex-client<0.13
 
-# FIXME: 2.x dropped support for the deprecated MIDDLEWARE_CLASSES variable that we still use
+# FIXME: 2.x needs Django 2
 django-debug-toolbar<2
 
 # FIXME: 5+ made using the deprecated funcargnames attribute an error, still used by pytest-django-ordering
 pytest<5
+
+# FIXME: 3+ require schemes in CORS_ORIGIN_WHITELIST URLs - remember to update configuration when you remove this
+django-cors-headers<3

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -26,7 +26,7 @@ django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1
 django-contrib-comments==1.9.1
-django-cors-headers==2.4.0
+django-cors-headers==2.5.3
 django-debug-toolbar==1.11
 django-elasticsearch-debug-toolbar==1.2.0
 django-extensions==1.7.8
@@ -37,7 +37,7 @@ django-haystack==2.8.1
 django-libsass==0.7
 django-parler==1.9.2
 django-rest-swagger==2.1.2
-django-simple-history==2.7.0
+django-simple-history==2.7.2
 django-solo==1.1.2
 django-sortedm2m==1.4.0
 django-stdimage==3.2.0
@@ -137,7 +137,7 @@ selenium==3.141.0
 semantic-version==2.6.0   # via edx-drf-extensions
 simple-salesforce==0.74.3
 simplejson==3.16.0        # via django-rest-swagger
-six==1.12.0               # via astroid, cryptography, django-appconf, django-choices, django-extensions, django-guardian, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, libsass, mock, packaging, pyjwkest, pylint, pyopenssl, pytest-xdist, python-dateutil, responses, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
+six==1.12.0               # via astroid, cryptography, django-appconf, django-choices, django-extensions, django-guardian, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, libsass, mock, packaging, pyjwkest, pylint, pyopenssl, pytest-xdist, python-dateutil, responses, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==1.9.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -19,7 +19,7 @@ django-autocomplete-light==3.1.8
 django-choices==1.4.3
 django-compressor==2.1.1
 django-contrib-comments==1.9.1
-django-cors-headers==2.4.0
+django-cors-headers==2.5.3
 django-extensions==1.7.8
 django-filter==1.0.4
 django-fsm==2.6.0
@@ -29,7 +29,7 @@ django-libsass==0.7
 django-parler==1.9.2
 django-rest-swagger==2.1.2
 django-ses==0.8.1
-django-simple-history==2.7.0
+django-simple-history==2.7.2
 django-solo==1.1.2
 django-sortedm2m==1.4.0
 django-stdimage==3.2.0
@@ -98,7 +98,7 @@ rjsmin==1.0.12            # via django-compressor
 semantic-version==2.6.0   # via edx-drf-extensions
 simple-salesforce==0.74.3
 simplejson==3.16.0        # via django-rest-swagger
-six==1.12.0               # via cryptography, django-appconf, django-choices, django-extensions, django-guardian, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, libsass, pyjwkest, pyopenssl, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
+six==1.12.0               # via cryptography, django-appconf, django-choices, django-extensions, django-guardian, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, libsass, pyjwkest, pyopenssl, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django


### PR DESCRIPTION
    Update middleware dependencies to versions that can handle
    new-style MIDDLEWARE setting.
    
    Except for django-waffle. I could not get it to avoid being
    flaky once upgraded. Need to take a pass at that later.
    
    Also, we now clear the cache in-between every test. (Was part
    of debugging waffle, but seems like a good idea anyway.)