### PR TITLE
Add missing devstack settings for SSO/OAUTH2

### DIFF
--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -56,6 +56,11 @@ PARLER_LANGUAGES = {
      }
 }
 
+SOCIAL_AUTH_EDX_OAUTH2_ISSUER = "http://localhost:18000"
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = "http://edx.devstack.lms:18000"
+SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = "http://localhost:18000"
+SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = "http://localhost:18000/logout"
+
 BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://edx.devstack.lms:18000/oauth2"
 
 #####################################################################


### PR DESCRIPTION
This fixes the logout flow (when logout is initiated from discovery),
and other possible SSO login issues in devstack.

This is part of the DOP->DOT migration.

---

Previously, values were inherited from https://github.com/edx/course-discovery/blob/master/course_discovery/settings/base.py#L292-L294 which are incorrect for devstack, and do not contain any *_PUBLIC_URL_ROOT which devstack requires.