### PR TITLE
Make it so staff users can read pathways

### DIFF
--- a/course_discovery/apps/api/permissions.py
+++ b/course_discovery/apps/api/permissions.py
@@ -9,11 +9,11 @@ USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
 
 class ReadOnlyByPublisherUser(BasePermission):
     """
-    Custom Permission class to check user is a publisher user.
+    Custom Permission class to check user is a publisher user or a staff user.
     """
     def has_permission(self, request, view):
         if request.method == 'GET':
-            return request.user.groups.exists()
+            return request.user.is_staff or request.user.groups.exists()
         return True
 
 


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4473

Fixes issue where `./manage.py lms cache_programs` was failing on sandboxes with a 403 from Discovery.

For context, the `pathways` endpoint (which was causing the 403) requires the `ReadOnlyByPublisherUser` permission, which very stringently requires that you _are part of a group_.

No other view in Discovery uses `ReadOnlyByPublisherUser`, and being "staff" is kinda like being in a group, so I figured that this fix would be reasonable.

