### PR TITLE
Unpin django-extensions

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1365,13 +1365,6 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
         return True
 
     def push_to_marketing_site(self, previous_obj):
-        if not self.slug:
-            # If we are pushing this object to marketing site, let's make sure slug is defined.
-            # Nowadays slugs will be defined at creation time by AutoSlugField for us, so we only need this code
-            # path for database rows that were empty before we started using AutoSlugField.
-            self.slug = CourseRun._meta.get_field('slug').create_slug(self, True)
-            self.save()
-
         publisher = CourseRunMarketingSitePublisher(self.course.partner)
         publisher.publish_obj(self, previous_obj=previous_obj)
 

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -362,7 +362,7 @@ class ProgramEligibilityFilterTests(SiteMixin, TestCase):
 
     def test_queryset_method_returns_all_programs(self):
         """ Verify that all programs pass the filter. """
-        verified_seat_type, __ = SeatType.objects.get_or_create(name=Seat.VERIFIED)
+        verified_seat_type, __ = SeatType.objects.get_or_create(slug=Seat.VERIFIED)
         program_type = factories.ProgramTypeFactory(applicable_seat_types=[verified_seat_type])
         program_filter = ProgramEligibilityFilter(None, {}, None, None)
         course_run = factories.CourseRunFactory()
@@ -381,7 +381,7 @@ class ProgramEligibilityFilterTests(SiteMixin, TestCase):
 
     def test_queryset_method_returns_eligible_programs(self):
         """ Verify that one click purchase eligible programs pass the filter. """
-        verified_seat_type, __ = SeatType.objects.get_or_create(name=Seat.VERIFIED)
+        verified_seat_type, __ = SeatType.objects.get_or_create(slug=Seat.VERIFIED)
         program_type = factories.ProgramTypeFactory(applicable_seat_types=[verified_seat_type])
         program_filter = ProgramEligibilityFilter(None, {self.parameter_name: 1}, None, None)
         course_run = factories.CourseRunFactory(end=None, enrollment_end=None,)

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -544,14 +544,12 @@ class CourseRunTests(OAuth2Mixin, TestCase):
         course_run = CourseRunFactory(title='Test Title')
         self.assertEqual(course_run.slug, 'test-title')
 
-    @override_switch('publish_course_runs_to_marketing_site', active=True)
     def test_empty_slug_defined_on_save(self):
-        """ Verify the slug is defined on publication if it wasn't set already. """
-        with mock.patch.object(CourseRunMarketingSitePublisher, 'publish_obj', return_value=None):
-            self.course_run.slug = ''
-            self.course_run.title = 'Test Title'
-            self.course_run.save()
-            self.assertEqual(self.course_run.slug, 'test-title')
+        """ Verify the slug is defined on save if it wasn't set already. """
+        self.course_run.slug = ''
+        self.course_run.title = 'Test Title'
+        self.course_run.save()
+        self.assertEqual(self.course_run.slug, 'test-title')
 
     def test_program_types(self):
         """ Verify the property retrieves program types correctly based on programs. """

--- a/course_discovery/apps/course_metadata/tests/test_query.py
+++ b/course_discovery/apps/course_metadata/tests/test_query.py
@@ -105,16 +105,6 @@ class CourseRunQuerySetTests(TestCase):
 
         self.assertEqual(list(CourseRun.objects.marketable()), [course_run])
 
-    def test_marketable_exclusions(self):
-        """ Verify the method excludes CourseRuns without a slug. """
-        course_run = CourseRunFactory()
-        SeatFactory(course_run=course_run)
-
-        course_run.slug = ''  # blank out auto-generated slug
-        course_run.save()
-
-        self.assertEqual(CourseRun.objects.marketable().exists(), False)
-
     @ddt.data(True, False)
     def test_marketable_seats_exclusions(self, has_seats):
         """ Verify that the method excludes CourseRuns without seats. """

--- a/course_discovery/conftest.py
+++ b/course_discovery/conftest.py
@@ -54,12 +54,6 @@ def get_course_run_states():
     def end_future(course_run):
         course_run.end = future
 
-    def slug_blank(course_run):
-        course_run.slug = ''
-
-    def slug_valid(course_run):
-        course_run.slug = 'foo'
-
     def seats_null(course_run):  # pylint: disable=unused-argument
         pass
 
@@ -91,10 +85,6 @@ def get_course_run_states():
             end_future
         ],
         [
-            slug_blank,
-            slug_valid
-        ],
-        [
             seats_null,
             seats_exist
         ],
@@ -118,9 +108,6 @@ def get_course_run_states():
         [
             end_null,
             end_future
-        ],
-        [
-            slug_valid
         ],
         [
             seats_exist

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@ django-choices
 django-compressor
 django-contrib-comments
 django-cors-headers
-django-extensions==1.7.8
+django-extensions
 django-filter
 django-fsm
 django-guardian

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -31,7 +31,7 @@ django-contrib-comments==1.9.1
 django-cors-headers==2.5.3
 django-debug-toolbar==1.11
 django-elasticsearch-debug-toolbar==1.2.0
-django-extensions==1.7.8
+django-extensions==2.2.1
 django-filter==2.2.0
 django-fsm==2.6.1
 django-guardian==1.5.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,7 +20,7 @@ django-choices==1.7.0
 django-compressor==2.3
 django-contrib-comments==1.9.1
 django-cors-headers==2.5.3
-django-extensions==1.7.8
+django-extensions==2.2.1
 django-filter==2.2.0
 django-fsm==2.6.1
 django-guardian==1.5.1


### PR DESCRIPTION
This involves removing some code that assumed slugs could be blank.
AutoSlugField is now much more aggressive about recreating the slug
as needed.