### PR TITLE
Allow looking up org users by UUID

### DIFF
--- a/course_discovery/apps/publisher/api/urls.py
+++ b/course_discovery/apps/publisher/api/urls.py
@@ -9,7 +9,7 @@ from course_discovery.apps.publisher.api.views import (
 
 urlpatterns = [
     url(r'^course_role_assignments/(?P<pk>\d+)/$', CourseRoleAssignmentView.as_view(), name='course_role_assignments'),
-    url(r'^admins/organizations/(?P<pk>\d+)/users/$', OrganizationGroupUserView.as_view(),
+    url(r'^admins/organizations/(?P<pk>[0-9a-f-]+)/users/$', OrganizationGroupUserView.as_view(),
         name='organization_group_users'),
     url(r'^course_state/(?P<pk>\d+)/$', ChangeCourseStateView.as_view(), name='change_course_state'),
     url(r'^course_runs/(?P<pk>\d+)/$', UpdateCourseRunView.as_view(), name='update_course_run'),

--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -6,13 +6,12 @@ import mock
 import responses
 from django.test import override_settings
 from django.urls import reverse
-from rest_framework.test import APITestCase
 from testfixtures import LogCapture
 from waffle.testutils import override_switch
 
-from course_discovery.apps.api.v1.tests.test_views.mixins import OAuth2Mixin
+from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
 from course_discovery.apps.core.models import Currency
-from course_discovery.apps.core.tests.factories import PartnerFactory, StaffUserFactory, UserFactory
+from course_discovery.apps.core.tests.factories import StaffUserFactory, UserFactory
 from course_discovery.apps.core.tests.helpers import make_image_file
 from course_discovery.apps.core.utils import serialize_datetime
 from course_discovery.apps.course_metadata.models import CourseEntitlement as DiscoveryCourseEntitlement
@@ -38,8 +37,6 @@ class CourseRunViewSetTests(OAuth2Mixin, APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.partner = PartnerFactory()
-        self.client = self.client_class(SERVER_NAME=self.partner.site.domain)
         self.user = StaffUserFactory()
         self.client.force_login(self.user)
 


### PR DESCRIPTION
Allow both UUID and the old database ID too.

The course serialization gives UUIDs for orgs, not IDs. Which seems appropriate. So when getting a list of org users, I figured it made sense to open up the API to UUIDs too.