### PR TITLE
Add presave hooks to enforce external_key uniqueness

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -828,6 +828,7 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
     uuid = models.UUIDField(default=uuid4, editable=False, verbose_name=_('UUID'))
     course = models.ForeignKey(Course, models.CASCADE, related_name='course_runs')
     key = models.CharField(max_length=255)
+    # There is a post save function in signals.py that verifies that this is unique within a program
     external_key = models.CharField(max_length=225, blank=True, null=True)
     status = models.CharField(default=CourseRunStatus.Unpublished, max_length=255, null=False, blank=False,
                               db_index=True, choices=CourseRunStatus.choices, validators=[CourseRunStatus.validator])

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -162,12 +162,12 @@ def ensure_external_key_uniquness__course_run(sender, instance, **kwargs):  # py
     If the course is not associated with a program, we will still verify that the external_key
     is unique within course runs in the course
     """
-    if instance.id:
-        old_course_run = CourseRun.everything.get(pk=instance.id)
-        if instance.external_key == old_course_run.external_key and instance.course == old_course_run.course:
-            return
     if not instance.external_key:
         return
+    if instance.id:
+        old_course_run = CourseRun.everything.get(pk=instance.pk)
+        if instance.external_key == old_course_run.external_key and instance.course == old_course_run.course:
+            return
 
     course = instance.course
     curricula = course.degree_course_curricula.select_related('program').all()
@@ -196,7 +196,7 @@ def ensure_external_key_uniquness__curriculum(sender, instance, **kwargs):  # py
     if not instance.id:
         return  # If not instance.id, we can't access course_curriculum, so we can't do anything
     if instance.program:
-        old_curriculum = Curriculum.objects.get(pk=instance.id)
+        old_curriculum = Curriculum.objects.get(pk=instance.pk)
         if old_curriculum.program and instance.program.id == old_curriculum.program.id:
             return
 

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -163,7 +163,7 @@ def ensure_external_key_uniquness__course_run(sender, instance, **kwargs):  # py
     is unique within course runs in the course
     """
     if instance.id:
-        old_course_run = CourseRun.objects.get(pk=instance.id)
+        old_course_run = CourseRun.everything.get(pk=instance.id)
         if instance.external_key == old_course_run.external_key and instance.course == old_course_run.course:
             return
     if not instance.external_key:

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -366,6 +366,11 @@ class ProgramFactory(factory.django.DjangoModelFactory):
         if create:  # pragma: no cover
             add_m2m_data(self.instructor_ordering, extracted)
 
+    @factory.post_generation
+    def curricula(self, create, extracted, **kwargs):
+        if create:  # pragma: no cover
+            add_m2m_data(self.curricula, extracted)
+
 
 class DegreeFactory(ProgramFactory):
     class Meta(object):
@@ -404,6 +409,7 @@ class CurriculumFactory(factory.DjangoModelFactory):
     class Meta(object):
         model = Curriculum
 
+    name = FuzzyText()
     uuid = factory.LazyFunction(uuid4)
     marketing_text_brief = FuzzyText()
     marketing_text = FuzzyText()

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -1,8 +1,10 @@
 import uuid
 
+import ddt
 import mock
 import pytest
 from django.apps import apps
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from factory import DjangoModelFactory
 from testfixtures import LogCapture
@@ -10,10 +12,11 @@ from waffle.testutils import override_switch
 
 from course_discovery.apps.core.models import Currency
 from course_discovery.apps.course_metadata.models import (
-    Curriculum, CurriculumCourseMembership, DataLoaderConfig, DeletePersonDupsConfig, DrupalPublishUuidConfig,
-    MigratePublisherToCourseMetadataConfig, ProfileImageDownloadConfig, ProgramType, Seat, SubjectTranslation,
-    TagCourseUuidsConfig, TopicTranslation
+    CourseRun, Curriculum, CurriculumCourseMembership, DataLoaderConfig, DeletePersonDupsConfig,
+    DrupalPublishUuidConfig, MigratePublisherToCourseMetadataConfig, ProfileImageDownloadConfig, ProgramType, Seat,
+    SubjectTranslation, TagCourseUuidsConfig, TopicTranslation
 )
+from course_discovery.apps.course_metadata.signals import _duplicate_external_key_message
 from course_discovery.apps.course_metadata.tests import factories
 
 LOGGER_NAME = 'course_discovery.apps.course_metadata.signals'
@@ -271,3 +274,300 @@ class CurriculumCourseMembershipTests(TestCase):
         for course_run in self.course_runs:
             for seat in course_run.seats.all():
                 self.assertNotEqual(seat.type, Seat.MASTERS)
+
+
+class ExternalCourseKeyTestMixin(object):
+
+    @classmethod
+    def _add_courses_to_curriculum(cls, curriculum, *courses):
+        for course in courses:
+            factories.CurriculumCourseMembershipFactory(
+                course=course,
+                curriculum=curriculum
+            )
+
+    @classmethod
+    def _create_course_and_runs(cls, course_identifier=1):
+        course_name = 'course-{}'.format(course_identifier)
+        course = factories.CourseFactory(
+            key='course-id/' + course_name + '/test',
+            title=course_name,
+        )
+        for course_run_letter in ('a', 'b', 'c'):
+            course_run_name = course_name + course_run_letter
+            factories.CourseRunFactory(
+                course=course,
+                key='course-run-id/' + course_run_name + '/test',
+                external_key='ext-key-' + course_run_name,
+            )
+        return course
+    
+    def _create_single_course_curriculum(self, external_key, curriculum_name,):
+        course_run = factories.CourseRunFactory(
+            external_key=external_key
+        )
+        curriculum = factories.CurriculumFactory(
+            name=curriculum_name,
+            program=None,
+        )
+        factories.CurriculumCourseMembershipFactory(
+            course=course_run.course,
+            curriculum=curriculum,
+        )
+        return course_run, curriculum
+
+    @classmethod
+    def _create_error_message(self, course_run, curriculum=None, program=None):
+        message = "Duplicate external_key found: external_key={} course_run={} course={}".format(
+            course_run.external_key,
+            course_run,
+            course_run.course
+        )
+        if curriculum:
+            message = message + " curriculum={}".format(curriculum)
+            if program:
+                message = message + " program={}".format(curriculum.program)
+        return message
+
+
+@ddt.ddt
+class ExternalCourseKeyTests(TestCase, ExternalCourseKeyTestMixin):
+    """
+    There are currently three scenarios that can cause CourseRuns to have conflicting external_keys:
+        1) Two Course Runs in the same Course
+        2) Two Course Runs in different Courses but in the same Curriculum
+        3) Two Course Runs in differenct Courses and Curricula but the same Program
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """
+        Sets up the tree for testing external course keys
+
+        program          1         2
+                        / \\       |
+        curriculum    1    2      3
+                      |     \\   / \\
+        course        1        2     3
+        """
+        super().setUpTestData()
+        cls.program_1 = factories.ProgramFactory(title='program_1')
+        cls.program_2 = factories.ProgramFactory(title='program_2')
+        cls.programs = [None, cls.program_1, cls.program_2]
+        cls.course_1 = cls._create_course_and_runs(1)
+        cls.course_2 = cls._create_course_and_runs(2)
+        cls.course_3 = cls._create_course_and_runs(3)
+        cls.curriculum_1 = factories.CurriculumFactory(
+            name='curriculum_1',
+            program=cls.program_1,
+        )
+        cls.curriculum_2 = factories.CurriculumFactory(
+            name='curriculum_2',
+            program=cls.program_1,
+        )
+        cls.curriculum_3 = factories.CurriculumFactory(
+            name='curriculum_3',
+            program=cls.program_2,
+        )
+        cls.curriculums = [None, cls.curriculum_1, cls.curriculum_2, cls.curriculum_3]
+        cls._add_courses_to_curriculum(cls.curriculum_1, cls.course_1)
+        cls._add_courses_to_curriculum(cls.curriculum_2, cls.course_2)
+        cls._add_courses_to_curriculum(cls.curriculum_3, cls.course_2, cls.course_3)
+
+    @ddt.unpack
+    @ddt.data(
+        ('course-run-id/course-2a/test', 3, 2),  # Scenario 1, within the same Course
+        ('course-run-id/course-3a/test', 3, 2),  # Scenario 2, within the same Curriculum
+        ('course-run-id/course-1a/test', 1, 1),  # Scenario 3, within the same Program
+    )
+    def test_create_course_run(self, copy_key, curriculum_id, program_id):
+        program = self.programs[program_id]
+        curriculum = self.curriculums[curriculum_id]
+        copied_course_run = CourseRun.objects.get(key=copy_key)
+        message = self._create_error_message(copied_course_run, curriculum, program)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            factories.CourseRunFactory(
+                course=self.course_2,
+                external_key=copied_course_run.external_key,
+            )
+
+    @ddt.unpack
+    @ddt.data(
+        ('course-run-id/course-2b/test', 3, 2),  # Scenario 1, within the same Course
+        ('course-run-id/course-3a/test', 3, 2),  # Scenario 2, within the same Curriculum
+        ('course-run-id/course-1a/test', 1, 1),  # Scenario 3, within the same Program
+    )
+    def test_modify_course_run(self, copy_key, curriculum_id, program_id):
+        program = self.programs[program_id]
+        curriculum = self.curriculums[curriculum_id]
+        copied_course_run = CourseRun.objects.get(key=copy_key)
+        message = self._create_error_message(copied_course_run, curriculum, program)
+        course_run = CourseRun.objects.get(key='course-run-id/course-2a/test')
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            course_run.external_key = copied_course_run.external_key
+            course_run.save()
+
+    @ddt.data(
+        1,  # Scenario 2, within the same Curriculum
+        2,  # Scenaario 3, within the same Program
+    )
+    def test_create_curriculum_course_membership(self, curriculum_id):
+        new_course_run = factories.CourseRunFactory(
+            external_key='ext-key-course-1a'
+        )
+        new_course = new_course_run.course
+        course_run_1a = CourseRun.objects.get(key='course-run-id/course-1a/test')
+        message = self._create_error_message(course_run_1a, self.curriculum_1, self.program_1)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            factories.CurriculumCourseMembershipFactory(
+                course=new_course,
+                curriculum=self.curriculums[curriculum_id],
+            )
+
+    @ddt.data(
+        1,  # Scenario 2, within the same Curriculum
+        2,  # Scenaario 3, within the same Program
+    )
+    def test_modify_curriculum_course_membership(self, curriculum_id):
+        new_course_run = factories.CourseRunFactory(
+            external_key='ext-key-course-1a'
+        )
+        new_course = new_course_run.course
+        curriculum_course_membership = factories.CurriculumCourseMembershipFactory(
+            course=new_course,
+            curriculum=self.curriculum_3,
+        )
+        course_run_1a = CourseRun.objects.get(key='course-run-id/course-1a/test')
+        message = self._create_error_message(course_run_1a, self.curriculum_1, self.program_1)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            curriculum_course_membership.curriculum = self.curriculums[curriculum_id]
+            curriculum_course_membership.save()
+
+    # pylint: disable=pointless-string-statement
+    def test_create_curriculum(self):
+        """
+        I can't think of any case that would cause the exception on creating a curriculum
+        but I will keep this blank test here for enumeration's sake
+        """
+        pass
+
+    def test_modify_curriculum(self):
+        course_run_1a = CourseRun.objects.get(key='course-run-id/course-1a/test')
+        _, curriculum_4 = self._create_single_course_curriculum('ext-key-course-1a', 'curriculum_4')
+        new_program = factories.ProgramFactory(
+            curricula=[curriculum_4]
+        )
+        message = self._create_error_message(course_run_1a, self.curriculum_1, self.program_1)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            curriculum_4.program = self.program_1
+            curriculum_4.save()
+        curriculum_4.refresh_from_db()
+        self.assertEqual(curriculum_4.program, new_program)
+
+
+class ExternalCourseKeyIncompleteStructureTests(TestCase, ExternalCourseKeyTestMixin):
+    """
+    Tests that the external_key validation still works within an incomplete hierarchy
+    (Course alone or curriculum without a program)
+    """
+    
+    def test_create_course_run__course_run_only(self):
+        course = self._create_course_and_runs()
+        course_run = course.course_runs.first()
+        message = self._create_error_message(course_run)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            factories.CourseRunFactory(
+                course=course,
+                external_key=course_run.external_key
+            )
+
+    def test_modify_course_run__course_run_only(self):
+        course = self._create_course_and_runs(1)
+        course_run_1a = course.course_runs.get(external_key='ext-key-course-1a')
+        course_run_1b = course.course_runs.get(external_key='ext-key-course-1b')
+        message = self._create_error_message(course_run_1a)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            course_run_1b.external_key = 'ext-key-course-1a'
+            course_run_1b.save()
+
+    def test_create_course_run__curriculum_only(self):
+        course_run, curriculum_1 = self._create_single_course_curriculum('colliding-key', 'curriculum_1')
+        message = _duplicate_external_key_message(course_run, curriculum_1)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            factories.CourseRunFactory(
+                course=course_run.course,
+                external_key='colliding-key'
+            )
+
+    def test_modify_course_run__curriculum_only(self):
+        course_run_1a, curriculum_1 = self._create_single_course_curriculum('colliding-key', 'curriculum_1')
+        course_run_1b = factories.CourseRunFactory(
+            course=course_run_1a.course,
+            external_key='this-is-a-different-external-key'
+        )
+        message = _duplicate_external_key_message(course_run_1a, curriculum_1)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            course_run_1b.external_key = 'colliding-key'
+            course_run_1b.save()
+
+    def test_create_curriculum_course_membership__curriculum_only(self):
+        course_run_1, curriculum_1 = self._create_single_course_curriculum('colliding-key', 'curriculum_1')
+        course_run_2 = factories.CourseRunFactory(
+            external_key='colliding-key'
+        )
+        message = _duplicate_external_key_message(course_run_1, curriculum_1)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            factories.CurriculumCourseMembershipFactory(
+                course=course_run_2.course,
+                curriculum=curriculum_1,
+            )
+
+    def test_modify_curriculum_course_membership__curriculum_only(self):
+        course_run_1, curriculum_1 = self._create_single_course_curriculum('colliding-key', 'curriculum_1')
+        course_run_2, _ = self._create_single_course_curriculum('colliding-key', 'curriculum_2')
+        curriculum_course_membership_2 = course_run_2.course.curriculum_course_membership.first()
+        message = _duplicate_external_key_message(course_run_1, curriculum_1)
+        with self.assertRaisesRegex(ValidationError, message):  # pylint: disable=deprecated-method
+            curriculum_course_membership_2.curriculum = curriculum_1
+            curriculum_course_membership_2.save()
+
+class ExternalCourseKeyDBTest(TestCase, ExternalCourseKeyTestMixin):
+
+    def test_curriculum_repeats(self):
+        course_a = self._create_course_and_runs('a')
+        course_b = self._create_course_and_runs('b')
+        program = factories.ProgramFactory(title='program_1')
+
+        curriculum_2 = factories.CurriculumFactory(
+            program=program,
+        )
+        factories.CurriculumCourseMembershipFactory(
+            course=course_a,
+            curriculum=curriculum,
+        )
+        factories.CurriculumCourseMembershipFactory(
+            course=course_b,
+            curriculum=curriculum,
+        )
+
+        curriculum_2 = factories.CurriculumFactory(
+            program=program,
+        )
+        factories.CurriculumCourseMembershipFactory(
+            course=course_a,
+            curriculum=curriculum,
+        )
+        factories.CurriculumCourseMembershipFactory(
+            course=course_b,
+            curriculum=curriculum,
+        )
+
+        course_run = course_a.course_runs.first()
+        with self.assertNumQueries(0):
+            course_run.external_key = 'something-else'
+            course_run.save()
+            
+
+
+
+

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -632,7 +632,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
         )
 
     def test_draft_does_not_collide_with_draft(self):
-        with self.assertNumQueries(77):
+        with self.assertNumQueries(FuzzyInt(77, 2)):
             factories.CourseRunFactory(
                 course=self.course_1,
                 draft=True,
@@ -642,7 +642,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
     def test_draft_collides_with_nondraft(self):
         course_run_1a = self.course_1.course_runs.get(external_key='ext-key-course-1a')
         message = _duplicate_external_key_message([course_run_1a])
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(FuzzyInt(8, 2)):
             with self.assertRaisesRegex(ValidationError, escape(message)):  # pylint: disable=deprecated-method
                 factories.CourseRunFactory(
                     course=self.course_1,
@@ -651,7 +651,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
                 )
 
     def test_nondraft_does_not_collide_with_draft(self):
-        with self.assertNumQueries(77):
+        with self.assertNumQueries(FuzzyInt(77, 2)):
             factories.CourseRunFactory(
                 course=self.course_1,
                 draft=False,
@@ -659,14 +659,14 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
             )
 
     def test_collision_does_not_include_drafts(self):
-        with self.assertNumQueries(77):
+        with self.assertNumQueries(FuzzyInt(77, 2)):
             course_run = factories.CourseRunFactory(
                 course=self.course_1,
                 draft=False,
                 external_key='external-key-drafttest'
             )
         message = _duplicate_external_key_message([course_run])  # Not draft_course_run_1
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(FuzzyInt(7, 2)):
             with self.assertRaisesRegex(ValidationError, escape(message)):  # pylint: disable=deprecated-method
                 factories.CourseRunFactory(
                     course=self.course_1,


### PR DESCRIPTION
Add pre_save hooks to CourseRun, CurriculumCourseMembership, and Curriculum
to make sure that no two CourseRuns that have been 'linked' together within
a Course, Curriculum, or Program have the same external course key