### PR TITLE
Document why autocomplete is pinned

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 beautifulsoup4
 django
 django-admin-sortable2
-django-autocomplete-light==3.1.8
+django-autocomplete-light
 django-choices
 django-compressor
 django-contrib-comments

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,3 +26,6 @@ transifex-client<0.13
 
 # FIXME: 3+ require schemes in CORS_ORIGIN_WHITELIST URLs - remember to update configuration when you remove this
 django-cors-headers<3
+
+# FIXME: 3.2 changed the 'id' field in responses from a number to a string - need to validate if that's a safe change
+django-autocomplete-light<3.2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -37,7 +37,7 @@ django-fsm==2.6.1
 django-guardian==1.5.1
 django-haystack==2.8.1
 django-libsass==0.7
-django-parler==1.9.2
+django-parler==2.0
 django-rest-swagger==2.2.0
 django-simple-history==2.7.3
 django-solo==1.1.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -26,7 +26,7 @@ django-fsm==2.6.1
 django-guardian==1.5.1
 django-haystack==2.8.1
 django-libsass==0.7
-django-parler==1.9.2
+django-parler==2.0
 django-rest-swagger==2.2.0
 django-ses==0.8.10
 django-simple-history==2.7.3


### PR DESCRIPTION
Move the autocomplete pin to constraints.txt with a note about why
we pin it - they changed the serialization a bit, and I'm not sure
whether it's safe to update, so I'm just leaving it pinned.