### PR TITLE
Expose is_enrollable,is_marketable on runs in API

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -650,7 +650,7 @@ class MinimalCourseRunSerializer(DynamicFieldsMixin, TimestampModelSerializer):
         model = CourseRun
         fields = ('key', 'uuid', 'title', 'external_key', 'image', 'short_description', 'marketing_url',
                   'seats', 'start', 'end', 'go_live_date', 'enrollment_start', 'enrollment_end',
-                  'pacing_type', 'type', 'status',)
+                  'pacing_type', 'type', 'status', 'is_enrollable', 'is_marketable',)
 
     def get_marketing_url(self, obj):
         include_archived = self.context.get('include_archived')

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -369,6 +369,8 @@ class MinimalCourseRunBaseTestSerializer(TestCase):
             'seats': SeatSerializer(course_run.seats, many=True).data,
             'status': course_run.status,
             'external_key': course_run.external_key,
+            'is_enrollable': course_run.is_enrollable,
+            'is_marketable': course_run.is_marketable,
         }
 
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -701,7 +701,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(44):
+        with self.assertNumQueries(44, threshold=3):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -166,7 +166,7 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         (detailed_path, serializers.CourseRunSearchModelSerializer,
          ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 43),
         (detailed_path, serializers.CourseRunSearchModelSerializer,
-         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 42),
+         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 43),
     )
     @ddt.unpack
     def test_exclude_unavailable_program_types(self, path, serializer, result_location_keys, program_status,


### PR DESCRIPTION
[DISCO-1242](https://openedx.atlassian.net/browse/DISCO-1242)