### PR TITLE
Fix is_enrollable logic to handle archived runs

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1420,8 +1420,8 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
         null enrollment_start and enrollment_end.
         """
         now = datetime.datetime.now(pytz.UTC)
-        return (not self.enrollment_end or self.enrollment_end >= now) and
-                (not self.enrollment_start or self.enrollment_start <= now)
+        return ((not self.enrollment_end or self.enrollment_end >= now) and
+                (not self.enrollment_start or self.enrollment_start <= now))
 
     @property
     def is_marketable(self):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1418,7 +1418,7 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
         """
         now = datetime.datetime.now(pytz.UTC)
         return (not self.enrollment_end or self.enrollment_end >= now) and
-            (not self.enrollment_start or self.enrollment_start <= now)
+                (not self.enrollment_start or self.enrollment_start <= now)
 
     @property
     def is_marketable(self):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1417,8 +1417,8 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
         fields.
         """
         now = datetime.datetime.now(pytz.UTC)
-        return (not self.has_enrollment_ended(now) and
-                (not self.enrollment_start or self.enrollment_start <= now))
+        return (not self.enrollment_end or self.enrollment_end >= now) and
+            (not self.enrollment_start or self.enrollment_start <= now)
 
     @property
     def is_marketable(self):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1415,6 +1415,9 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
         Note that missing enrollment_end or enrollment_start are considered to
         mean that the course run does not have a restriction on the respective
         fields.
+        Additionally, we don't consider the end date because archived course
+        runs may have ended, but they are always enrollable since they have
+        null enrollment_start and enrollment_end.
         """
         now = datetime.datetime.now(pytz.UTC)
         return (not self.enrollment_end or self.enrollment_end >= now) and


### PR DESCRIPTION
We only consider enrollment_end and enrollment_start for the
enrollability check on course runs, since archived runs may have ended
but they can always be enrolled in (at least at the time of writing
this). This logic should also hold for all other types of runs,
assuming they are correctly setting enrollment end/start.