### PR TITLE
DISCO-1293 restrict access for new pub fe orgs

### DIFF
--- a/course_discovery/apps/publisher/context_processors.py
+++ b/course_discovery/apps/publisher/context_processors.py
@@ -1,9 +1,11 @@
 """ Publisher context processors. """
 
-from course_discovery.apps.publisher.utils import is_email_notification_enabled
+from course_discovery.apps.publisher.utils import is_email_notification_enabled, is_on_new_pub_fe, publisher_url
 
 
 def publisher(request):
     return {
-        'is_email_notification_enabled': is_email_notification_enabled(request.user)
+        'is_email_notification_enabled': is_email_notification_enabled(request.user),
+        'is_on_new_pub_fe': is_on_new_pub_fe(request.user),
+        'publisher_url': publisher_url(request.user),
     }

--- a/course_discovery/apps/publisher/templates/publisher/base.html
+++ b/course_discovery/apps/publisher/templates/publisher/base.html
@@ -17,6 +17,7 @@
     <div class="container">
         {% include 'publisher/_header.html' %}
         <div class="layout-1q3q layout-flush border-top">
+        {% if not is_on_new_pub_fe %}
             <nav class="layout-col layout-col-a layout-col-menu">
                 <ul class="list-divided menu-list">
                     <li class="item">
@@ -50,7 +51,14 @@
             </main>
 
         </div>
-
+        {% else %}
+            <div class="new-pub-banner-container">
+                <div>Your organization has been moved over to new publisher.</div>
+                {% if publisher_url %}
+                    <div>Please visit <a href="{{publisher_url}}">here</a>.</div>
+                {% endif %}
+            </div>
+        {% endif %}
         {% include 'publisher/_footer.html' %}
     </div>
 {% endblock %}

--- a/course_discovery/apps/publisher/tests/test_context_processors.py
+++ b/course_discovery/apps/publisher/tests/test_context_processors.py
@@ -14,6 +14,9 @@ class PublisherContextProcessorTests(TestCase):
         """ Validate that publisher context processor returns expected result. """
         request = RequestFactory().get('/')
         request.user = UserFactory()
-        self.assertDictEqual(
-            publisher(request), {'is_email_notification_enabled': is_email_notification_enabled(request.user)}
-        )
+        expected = {
+            'is_email_notification_enabled': is_email_notification_enabled(request.user),
+            'is_on_new_pub_fe': False,
+            'publisher_url': None
+        }
+        self.assertDictEqual(publisher(request), expected)

--- a/course_discovery/apps/publisher/tests/test_utils.py
+++ b/course_discovery/apps/publisher/tests/test_utils.py
@@ -20,7 +20,8 @@ from course_discovery.apps.publisher.models import OrganizationExtension
 from course_discovery.apps.publisher.tests import factories
 from course_discovery.apps.publisher.utils import (
     find_discovery_course, get_internal_users, has_role_for_course, is_email_notification_enabled, is_internal_user,
-    is_project_coordinator_user, is_publisher_admin, is_publisher_user, make_bread_crumbs, parse_datetime_field
+    is_on_new_pub_fe, is_project_coordinator_user, is_publisher_admin, is_publisher_user, make_bread_crumbs,
+    parse_datetime_field
 )
 
 
@@ -244,3 +245,12 @@ class PublisherUtilsTests(TestCase):
         assert find_discovery_course(pub_run2) == cm_run2.course
         assert find_discovery_course(pub_run_no_id) == cm_run2.course  # Most recent sibling run's course
         assert find_discovery_course(pub_run_no_siblings) is None
+
+    def test_is_on_new_pub_fe(self):
+        self.user.groups.add(self.organization_extension.group)
+
+        with self.settings(ORGS_ON_NEW_PUB_FE=self.organization_extension.organization.key):
+            self.assertTrue(is_on_new_pub_fe(self.user))
+
+        with self.settings(ORGS_ON_NEW_PUB_FE='example-key'):
+            self.assertFalse(is_on_new_pub_fe(self.user))

--- a/course_discovery/static/sass/_base.scss
+++ b/course_discovery/static/sass/_base.scss
@@ -17,6 +17,17 @@ html, body {
     background: $white;
 }
 
+.new-pub-banner-container {
+    background-color: #FFFFFF;
+    height: calc(100vh - 283px);
+    width: 100%;
+
+    div {
+        width: 100%;
+        margin-top: 20px;
+        text-align: center;
+    }
+}
 // ------------------------------
 // #TYPOGRAPHY
 // ------------------------------


### PR DESCRIPTION
if a user has all of their orgs listed in the new ORGS_ON_NEW_PUB_FE setting variable, then don't allow them to access old publisher