### PR TITLE
Add new publisher roles API

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/tests/test_boosting.py
+++ b/course_discovery/apps/edx_haystack_extensions/tests/test_boosting.py
@@ -55,7 +55,6 @@ class TestSearchBoosting:
         search_results = SearchQuerySet().models(CourseRun).all()
         assert len(search_results) == 2
         assert search_results[0].score > search_results[1].score
-        # pylint: disable=no-member
         assert int(test_record.start.timestamp()) == int(search_results[0].start.timestamp())
 
     @pytest.mark.parametrize(

--- a/course_discovery/apps/publisher/api/filters.py
+++ b/course_discovery/apps/publisher/api/filters.py
@@ -1,0 +1,12 @@
+from django_filters import rest_framework as filters
+
+from course_discovery.apps.api.filters import CharListFilter
+from course_discovery.apps.publisher.models import OrganizationUserRole
+
+
+class OrganizationUserRoleFilterSet(filters.FilterSet):
+    role = CharListFilter(field_name='role', lookup_expr='in')
+
+    class Meta:
+        model = OrganizationUserRole
+        fields = ('role',)

--- a/course_discovery/apps/publisher/api/serializers.py
+++ b/course_discovery/apps/publisher/api/serializers.py
@@ -18,7 +18,9 @@ from course_discovery.apps.publisher.emails import (
     send_change_role_assignment_email, send_email_for_studio_instance_created, send_email_preview_accepted,
     send_email_preview_page_is_available
 )
-from course_discovery.apps.publisher.models import CourseRun, CourseRunState, CourseState, CourseUserRole
+from course_discovery.apps.publisher.models import (
+    CourseRun, CourseRunState, CourseState, CourseUserRole, OrganizationUserRole
+)
 
 
 class UnvalidatedField(serializers.Field):
@@ -75,6 +77,15 @@ class GroupUserSerializer(serializers.ModelSerializer):
         Return full_name if exist otherwise username, to fix empty values in dropdown.
         """
         return obj.get_full_name() or obj.username
+
+
+class OrganizationUserRoleSerializer(serializers.ModelSerializer):
+    """Serializer for the `OrganizationUserRole` model to show role assignment. """
+    user = GroupUserSerializer()
+
+    class Meta:
+        model = OrganizationUserRole
+        fields = ('id', 'user', 'role',)
 
 
 class CourseRunSerializer(serializers.ModelSerializer):

--- a/course_discovery/apps/publisher/api/tests/test_serializers.py
+++ b/course_discovery/apps/publisher/api/tests/test_serializers.py
@@ -14,13 +14,13 @@ from course_discovery.apps.course_metadata.tests.factories import OrganizationFa
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.api.serializers import (
     CourseRevisionSerializer, CourseRunSerializer, CourseRunStateSerializer, CourseStateSerializer,
-    CourseUserRoleSerializer, GroupUserSerializer
+    CourseUserRoleSerializer, GroupUserSerializer, OrganizationUserRoleSerializer
 )
 from course_discovery.apps.publisher.choices import CourseRunStateChoices, CourseStateChoices, PublisherUserRole
 from course_discovery.apps.publisher.models import CourseRun, CourseState, Seat
 from course_discovery.apps.publisher.tests.factories import (
     CourseFactory, CourseRunFactory, CourseRunStateFactory, CourseStateFactory, CourseUserRoleFactory,
-    OrganizationExtensionFactory, SeatFactory
+    OrganizationExtensionFactory, OrganizationUserRoleFactory, SeatFactory
 )
 
 
@@ -93,6 +93,15 @@ class GroupUserSerializerTests(TestCase):
         serializer = GroupUserSerializer(user)
 
         expected = {'id': user.id, 'full_name': user.username, 'email': user.email}
+        self.assertDictEqual(serializer.data, expected)
+
+
+class OrganizationUserRoleSerializerTests(TestCase):
+    def test_basic_serialization(self):
+        role = OrganizationUserRoleFactory()
+        serializer = OrganizationUserRoleSerializer(role)
+
+        expected = {'id': role.id, 'role': role.role, 'user': GroupUserSerializer(role.user).data}
         self.assertDictEqual(serializer.data, expected)
 
 

--- a/course_discovery/apps/publisher/api/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/tests/test_views.py
@@ -21,7 +21,9 @@ from course_discovery.apps.course_metadata.tests.factories import CourseRunFacto
 from course_discovery.apps.course_metadata.tests.factories import OrganizationFactory, PersonFactory
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.api import views
-from course_discovery.apps.publisher.choices import CourseRunStateChoices, CourseStateChoices, PublisherUserRole
+from course_discovery.apps.publisher.choices import (
+    CourseRunStateChoices, CourseStateChoices, InternalUserRole, PublisherUserRole
+)
 from course_discovery.apps.publisher.constants import ADMIN_GROUP_NAME, INTERNAL_USER_GROUP_NAME
 from course_discovery.apps.publisher.models import (
     Course, CourseRun, CourseRunState, CourseState, OrganizationExtension, Seat
@@ -212,6 +214,84 @@ class OrganizationGroupUserViewTests(APITestCase):
         """ Verify that endpoint accepts a UUID. """
         response = self.query(org_id=self.organization.uuid)
         self.assertExpectedUsers(response)
+
+
+class OrganizationUserRoleViewTests(APITestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.user = UserFactory.create(username="test_user", password=USER_PASSWORD)
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+        self.internal_user_group = Group.objects.get(name=INTERNAL_USER_GROUP_NAME)
+        self.user.groups.add(self.internal_user_group)
+        self.pc_slug = InternalUserRole.ProjectCoordinator
+        self.pm_slug = InternalUserRole.PartnerManager
+        self.pub_slug = InternalUserRole.Publisher
+        self.role = factories.OrganizationUserRoleFactory(user=self.user, role=self.pc_slug)
+        self.organization = self.role.organization
+
+    def query(self, org_id=None, param=None):
+        if org_id is None:
+            org_id = self.organization.id
+        url = reverse('publisher:api:organization_user_roles', kwargs={'pk': org_id})
+        if param:
+            url += '?' + param
+        return self.client.get(path=url, content_type=JSON_CONTENT_TYPE)
+
+    def assertExpectedRoles(self, response, roles=None):
+        self.assertEqual(response.status_code, 200)
+        roles = roles or [self.role.role]
+        self.assertListEqual(sorted(roles), sorted(role['role'] for role in response.json()['results']))
+
+    def test_happy_path(self):
+        """
+        Verify that view returns list of roles associated with the given organization id.
+        """
+        response = self.query()
+        self.assertExpectedRoles(response)
+
+    def test_num_queries(self):
+        view = views.OrganizationUserRoleView(kwargs={'pk': str(self.organization.id)})
+        with self.assertNumQueries(1, threshold=0):
+            list(view.get_queryset())
+
+    def test_role_param(self):
+        """
+        Verify that view accepts a role query param.
+        """
+        factories.OrganizationUserRoleFactory(organization=self.organization, role=self.pub_slug)
+        factories.OrganizationUserRoleFactory(organization=self.organization, role=self.pub_slug)
+        factories.OrganizationUserRoleFactory(organization=self.organization, role=self.pm_slug)
+
+        # Single role
+        response = self.query(param='role=%s' % self.pm_slug)
+        self.assertExpectedRoles(response, [self.pm_slug])
+
+        # Two roles
+        response = self.query(param='role=%s,%s' % (self.pm_slug, self.pub_slug))
+        self.assertExpectedRoles(response, [self.pm_slug, self.pub_slug, self.pub_slug])
+
+    def test_only_org_roles(self):
+        """
+        Verify that view only returns results for the given org.
+        """
+        factories.OrganizationUserRoleFactory(role=self.pub_slug)
+        response = self.query()
+        self.assertExpectedRoles(response)  # new role above won't be included
+
+    def test_get_without_publisher_user_permissions(self):
+        """
+        Verify that endpoint returns a permission error with login users not associated
+        with any publisher group.
+        """
+        self.user.groups.remove(self.internal_user_group)
+        response = self.query()
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_organization_by_uuid(self):
+        """ Verify that endpoint accepts a UUID. """
+        response = self.query(org_id=self.role.organization.uuid)
+        self.assertExpectedRoles(response)
 
 
 @override_switch('enable_publisher_email_notifications', True)

--- a/course_discovery/apps/publisher/api/urls.py
+++ b/course_discovery/apps/publisher/api/urls.py
@@ -3,14 +3,16 @@ from django.conf.urls import include, url
 
 from course_discovery.apps.publisher.api.views import (
     AcceptAllRevisionView, ChangeCourseRunStateView, ChangeCourseStateView, CourseRevisionDetailView,
-    CourseRoleAssignmentView, CoursesAutoComplete, OrganizationGroupUserView, RevertCourseRevisionView,
-    UpdateCourseRunView
+    CourseRoleAssignmentView, CoursesAutoComplete, OrganizationGroupUserView, OrganizationUserRoleView,
+    RevertCourseRevisionView, UpdateCourseRunView
 )
 
 urlpatterns = [
     url(r'^course_role_assignments/(?P<pk>\d+)/$', CourseRoleAssignmentView.as_view(), name='course_role_assignments'),
     url(r'^admins/organizations/(?P<pk>[0-9a-f-]+)/users/$', OrganizationGroupUserView.as_view(),
         name='organization_group_users'),
+    url(r'^admins/organizations/(?P<pk>[0-9a-f-]+)/roles/$', OrganizationUserRoleView.as_view(),
+        name='organization_user_roles'),
     url(r'^course_state/(?P<pk>\d+)/$', ChangeCourseStateView.as_view(), name='change_course_state'),
     url(r'^course_runs/(?P<pk>\d+)/$', UpdateCourseRunView.as_view(), name='update_course_run'),
     url(r'^course_revisions/(?P<history_id>\d+)/$', CourseRevisionDetailView.as_view(), name='course_revisions'),


### PR DESCRIPTION
Specifically, an endpoint that lists OrganizationUserRole entries.

This lives in the old publisher djangoapp and under the old
publisher URL scheme - just for parity with similar APIs that we
already use.

https://openedx.atlassian.net/browse/DISCO-1269