### PR TITLE
Neem hackathon: faster course_metadata.test_models.py

### DIFF
--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -49,9 +49,8 @@ def timestamped_object_key_constructor(*args, **kwargs):  # pylint: disable=unus
     return TimestampedObjectKeyConstructor()(**kwargs)
 
 
-def set_api_timestamp(msg):
+def set_api_timestamp():
     timestamp = time.time()
-    logger.debug('{msg} Updating API timestamp to {timestamp}'.format(msg=msg, timestamp=timestamp))
     cache.set(API_TIMESTAMP_KEY, timestamp, None)
 
 
@@ -60,7 +59,7 @@ def api_change_receiver(sender, **kwargs):  # pylint: disable=unused-argument
     Receiver function for handling post_save and post_delete signals emitted by
     course_metadata models.
     """
-    set_api_timestamp('{model_name} model changed.'.format(model_name=sender.__name__))
+    set_api_timestamp()
 
 
 class CompressedCacheResponse(CacheResponse):

--- a/course_discovery/apps/core/urls.py
+++ b/course_discovery/apps/core/urls.py
@@ -5,6 +5,8 @@ from django.conf.urls import url
 
 from course_discovery.apps.core.lookups import UserAutocomplete
 
+app_name = 'core'
+
 urlpatterns = [
     url(r'^user-autocomplete/$', UserAutocomplete.as_view(), name='user-autocomplete',),
 ]

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -207,7 +207,7 @@ class Command(BaseCommand):
 
             # TODO Cleanup CourseRun overrides equivalent to the Course values.
 
-        set_api_timestamp('Data loading complete.')
+        set_api_timestamp()
 
         if not success:
             raise CommandError('One or more of the data loaders above failed.')

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1184,7 +1184,6 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
             if matching_seat_types & seat_types:
                 return course_run_type
 
-        logger.debug('Unable to determine type for course run [%s]. Seat types are [%s]', self.key, seat_types)
         return None
 
     @property

--- a/course_discovery/apps/course_metadata/urls.py
+++ b/course_discovery/apps/course_metadata/urls.py
@@ -8,6 +8,8 @@ from course_discovery.apps.course_metadata.lookups import (
 )
 from course_discovery.apps.course_metadata.views import CourseRunSelectionAdmin
 
+app_name = 'course_metadata'
+
 urlpatterns = [
     url(r'^update_course_runs/(?P<pk>\d+)/$', CourseRunSelectionAdmin.as_view(), name='update_course_runs',),
     url(r'^course-autocomplete/$', CourseAutocomplete.as_view(), name='course-autocomplete',),

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -49,7 +49,10 @@ DATABASES = {
 
 JWT_AUTH['JWT_SECRET_KEY'] = 'course-discovery-jwt-secret-key'
 
-LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
+LOGGING['handlers']['local'] = {
+    'class': 'logging.NullHandler',
+    'level': 'INFO',
+}
 
 PUBLISHER_FROM_EMAIL = 'test@example.com'
 

--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -34,7 +34,7 @@ admin.autodiscover()
 urlpatterns = oauth2_urlpatterns + [
     url(r'^admin/course_metadata/', include('course_discovery.apps.course_metadata.urls', namespace='admin_metadata')),
     url(r'^admin/core/', include('course_discovery.apps.core.urls', namespace='admin_core')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^api/', include('course_discovery.apps.api.urls', namespace='api')),
     # Use the same auth views for all logins, including those originating from the browseable API.
     url(r'^api-auth/', include(oauth2_urlpatterns, namespace='rest_framework')),


### PR DESCRIPTION
Trying to clean up warnings and hasten tests for a team hackathon.  This PR:
* Re-uses program test data in course_metadata test_models.py
* removes a few django url deprecation warnings
* removes a useless log.debug() call.