### PR TITLE
Clean up SiteMixin, other test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help: ## Display this help message
 static: ## Gather all static assets for production
 	$(NODE_BIN)/webpack --config webpack.config.js --display-error-details --progress --optimize-minimize
 	python manage.py collectstatic -v 0 --noinput
-	python manage.py compress -v3 --force
+	python manage.py compress -v0 --force
 
 static.dev:
 	$(NODE_BIN)/webpack --config webpack.config.js --display-error-details --progress

--- a/course_discovery/apps/api/tests/mixins.py
+++ b/course_discovery/apps/api/tests/mixins.py
@@ -2,17 +2,27 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.test import RequestFactory
 
+from conftest import TEST_DOMAIN
 from course_discovery.apps.core.tests.factories import PartnerFactory, SiteFactory
 
 
 class SiteMixin(object):
-    def setUp(self):
-        super(SiteMixin, self).setUp()
-        domain = 'testserver.fake'
-        self.client = self.client_class(SERVER_NAME=domain)
-        Site.objects.all().delete()
-        self.site = SiteFactory(id=settings.SITE_ID, domain=domain)
-        self.partner = PartnerFactory(site=self.site)
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.request = RequestFactory(SERVER_NAME=self.site.domain).get('')
-        self.request.site = self.site
+        Site.objects.all().delete()
+        cls.site = SiteFactory(id=settings.SITE_ID, domain=TEST_DOMAIN)
+        cls.partner = PartnerFactory(site=cls.site)
+
+        cls.request = RequestFactory(SERVER_NAME=cls.site.domain).get('')
+        cls.request.site = cls.site
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.partner.delete()
+
+    def setUp(self):
+        super().setUp()
+        self.client = self.client_class(SERVER_NAME=TEST_DOMAIN)

--- a/course_discovery/apps/api/v1/tests/test_views/test_people.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_people.py
@@ -24,6 +24,11 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
     """ Tests for the person resource. """
     people_list_url = reverse('api:v1:person-list')
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._original_partner_marketing_site_api_username = cls.partner.marketing_site_api_username
+
     def setUp(self):
         super(PersonViewSetTests, self).setUp()
         self.user = UserFactory()
@@ -45,6 +50,9 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
             'uuid': '18d5542f-fa80-418e-b416-455cfdeb4d4e',
             'uri': 'https://stage.edx.org/node/28691'
         }
+
+        self.partner.marketing_site_api_username = self._original_partner_marketing_site_api_username
+        self.partner.save()
 
     def person_exists(self, data):
         return Person.objects.filter(

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -35,8 +35,8 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         return self.client.get(url)
 
     def build_facet_url(self, params):
-        return 'http://testserver.fake{path}?{query}'.format(
-            path=self.faceted_path, query=urllib.parse.urlencode(params)
+        return 'http://{domain}{path}?{query}'.format(
+            domain=self.site.domain, path=self.faceted_path, query=urllib.parse.urlencode(params)
         )
 
     def assert_successful_search(self, path=None, serializer=None):

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -31,17 +31,23 @@ from course_discovery.apps.course_metadata.tests import factories
 class AdminTests(SiteMixin, TestCase):
     """ Tests Admin page."""
 
-    def setUp(self):
-        super(AdminTests, self).setUp()
-        self.user = UserFactory(is_staff=True, is_superuser=True)
-        self.client.login(username=self.user.username, password=USER_PASSWORD)
-        self.course_runs = factories.CourseRunFactory.create_batch(3)
-        self.courses = [course_run.course for course_run in self.course_runs]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = UserFactory(is_staff=True, is_superuser=True)
+        cls.course_runs = factories.CourseRunFactory.create_batch(3)
+        cls.courses = [course_run.course for course_run in cls.course_runs]
 
-        self.excluded_course_run = factories.CourseRunFactory(course=self.courses[0])
-        self.program = factories.ProgramFactory(
-            courses=self.courses, excluded_course_runs=[self.excluded_course_run]
+        cls.excluded_course_run = factories.CourseRunFactory(course=cls.courses[0])
+        cls.program = factories.ProgramFactory(
+            courses=cls.courses,
+            excluded_course_runs=[cls.excluded_course_run],
+            partner=cls.partner,  # cls.partner provided by SiteMixin.setUpClass()
         )
+
+    def setUp(self):
+        super().setUp()
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
 
     def _post_data(self, status=ProgramStatus.Unpublished, marketing_slug='/foo'):
         return {

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -230,14 +230,19 @@ class SeatSignalsTests(TestCase):
 
 class CurriculumCourseMembershipTests(TestCase):
     """ Tests of the CurriculumCourseMembership model """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.course_runs = factories.CourseRunFactory.create_batch(3)
+        cls.course = cls.course_runs[0].course
+        cls.program_type = ProgramType.objects.get(slug='masters')
+        cls.partner = factories.PartnerFactory()
+        cls.degree = factories.DegreeFactory(courses=[cls.course], type=cls.program_type, partner=cls.partner)
+        cls.curriculum = Curriculum.objects.create(program=cls.degree, uuid=uuid.uuid4())
+
     def setUp(self):
         super().setUp()
-        self.course_runs = factories.CourseRunFactory.create_batch(3)
-        self.course = self.course_runs[0].course
-        self.program_type = ProgramType.objects.get(slug='masters')
-        self.partner = factories.PartnerFactory()
-        self.degree = factories.DegreeFactory(courses=[self.course], type=self.program_type, partner=self.partner)
-        self.curriculum = Curriculum.objects.create(program=self.degree, uuid=uuid.uuid4())
+        self.program_type.refresh_from_db()
 
     @override_switch('masters_course_mode_enabled', active=False)
     def test_course_curriculum_membership_side_effect_flag_inactive(self):


### PR DESCRIPTION
* Modify SiteMixin (in tests) to create test site in setUpClass(), rename the domain to just "testserver" (there was a failing test somewhere due to the `.fake` getting trimmed in some URL serializer).
* trim more test setup from test_models.py
* Change `make static` target to run `./manage.py compress` with verbosity 0.