### PR TITLE
Fix reference to null related name

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -88,15 +88,15 @@ class CourseEditorAdmin(admin.ModelAdmin):
 
 @admin.register(CourseEntitlement)
 class CourseEntitlementAdmin(admin.ModelAdmin):
-    list_display = ['course', 'get_course_number', 'mode', 'draft']
+    list_display = ['course', 'get_course_key', 'mode', 'draft']
 
-    def get_course_number(self, obj):
-        return obj.course.number
+    def get_course_key(self, obj):
+        return obj.course.key
 
-    get_course_number.short_description = 'Course number'
+    get_course_key.short_description = 'Course key'
 
     raw_id_fields = ('course', 'draft_version',)
-    search_fields = ['course__title', 'course__number']
+    search_fields = ['course__title', 'course__key']
 
 
 @admin.register(CourseRun)

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1336,11 +1336,11 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
             emails.send_email_for_internal_review(self)
 
         elif self.status == CourseRunStatus.Reviewed:
-            self.update_or_create_official_version()
+            official_version = self.update_or_create_official_version()
 
             # If we're due to go live already and we just now got reviewed, immediately go live
             if self.go_live_date and self.go_live_date <= datetime.datetime.now(pytz.UTC):
-                self.official_version.publish()  # will edit/save us too
+                official_version.publish()  # will edit/save us too
             else:  # The publish status check will send an email for go-live
                 emails.send_email_for_reviewed(self)
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -847,11 +847,15 @@ class CourseRunTests(OAuth2Mixin, TestCase):
     def test_reviewed_with_go_live_date(self, when, published, mock_email):
         draft = factories.CourseRunFactory(draft=True, go_live_date=when, announcement=None)
 
+        # force this prop to be cached, to catch any errors if we assume .official_version is valid after creation
+        self.assertIsNone(draft.official_version)
+
         draft.status = CourseRunStatus.Reviewed
         draft.save()
         draft.refresh_from_db()
+        official_version = CourseRun.objects.get(key=draft.key)
 
-        for run in [draft, draft.official_version]:
+        for run in [draft, official_version]:
             if published:
                 self.assertEqual(run.status, CourseRunStatus.Published)
                 self.assertIsNotNone(run.announcement)


### PR DESCRIPTION
This will avoid returning a 500 when trying to mark certain course runs as reviewed in Publisher.

Context from ticket comment:

> OK, here’s the story. Related names like official_version are cached. (well it’s actually an `@property` that hides the related name _official_version, but close enough for our purposes)
> Add oddly enough, those cached related names are not updated on a call to refresh_from_db (see Django bug https://code.djangoproject.com/ticket/30281).
> So what was happening was that the one test we had for this code path did not start with a cached official_version, so the code didn’t crash because when it referenced it after creating the official version, it found it and then cached it.
> But the production code path had already cached that property by referencing it before. So it crashed.
> The fix is to not assume the property is valid inside the save and simply use the return value of update_or_create_official_version instead.

https://openedx.atlassian.net/browse/DISCO-1310

I also threw in some unrelated creature comforts in the CourseEntitlement admin page.