### PR TITLE
DISCO-1317: Always write to draft when publishing

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/migrate_publisher_to_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/migrate_publisher_to_course_metadata.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
             for publisher_course in PublisherCourse.objects.filter(organizations__in=[org]).order_by('modified'):
                 for course_run in publisher_course.course_runs.all():
                     try:
-                        publish_to_course_metadata(partner, course_run, draft=True)
+                        publish_to_course_metadata(partner, course_run, create_official=False)
                     except IntegrityError as e:
                         logger.exception(
                             _('Error publishing course run [{course_run_key}] to Course Metadata: {error}. '

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1295,7 +1295,7 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
             Seat.everything.filter(draft=True, course_run=self).exclude(type=mode).delete()  # pylint: disable=no-member
         self.seats.set(seats)
 
-    def update_or_create_official_version(self):
+    def update_or_create_official_version(self, create_ecom_products=True):
         draft_version = CourseRun.everything.get(pk=self.pk)
         official_version = set_official_state(draft_version, CourseRun)
 
@@ -1309,7 +1309,8 @@ class CourseRun(DraftModelMixin, TimeStampedModel):
         official_version.save()
 
         # Push any product (seat, entitlement) changes to ecommerce as well
-        push_to_ecommerce_for_course_run(official_version)
+        if create_ecom_products:
+            push_to_ecommerce_for_course_run(official_version)
 
         return official_version
 


### PR DESCRIPTION
We want to always write to the draft row and if the publish is coming from
old publisher, we want to also write to the official row. This will help
with data issues we were running into where the draft and official rows
were not in sync.