### PR TITLE
Refactor how we call delete_orphans

### DIFF
--- a/course_discovery/apps/core/tests/test_utils.py
+++ b/course_discovery/apps/core/tests/test_utils.py
@@ -2,9 +2,9 @@ from django.db import models
 from django.test import TestCase
 from haystack.query import SearchQuerySet
 
-from course_discovery.apps.core.utils import SearchQuerySetWrapper, get_all_related_field_names
-from course_discovery.apps.course_metadata.models import CourseRun
-from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory
+from course_discovery.apps.core.utils import SearchQuerySetWrapper, delete_orphans, get_all_related_field_names
+from course_discovery.apps.course_metadata.models import CourseRun, Video
+from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, VideoFactory
 
 
 class UnrelatedModel(models.Model):
@@ -40,6 +40,16 @@ class ModelUtilTests(TestCase):
         """ Verify the method returns the names of all relational fields for a model. """
         self.assertEqual(get_all_related_field_names(UnrelatedModel), [])
         self.assertEqual(set(get_all_related_field_names(RelatedModel)), {'foreignrelatedmodel', 'm2mrelatedmodel'})
+
+    def test_delete_orphans(self):
+        """ Verify the delete_orphans method deletes orphaned instances. """
+        orphan = VideoFactory()
+        used = CourseRunFactory().video
+
+        delete_orphans(Video)
+
+        self.assertTrue(used.__class__.objects.filter(pk=used.pk).exists())
+        self.assertFalse(orphan.__class__.objects.filter(pk=orphan.pk).exists())
 
 
 class SearchQuerySetWrapperTests(TestCase):

--- a/course_discovery/apps/course_metadata/data_loaders/__init__.py
+++ b/course_discovery/apps/course_metadata/data_loaders/__init__.py
@@ -8,7 +8,6 @@ from django.utils.functional import cached_property
 from edx_rest_api_client.client import EdxRestApiClient
 from opaque_keys.edx.keys import CourseKey
 
-from course_discovery.apps.core.utils import delete_orphans
 from course_discovery.apps.course_metadata.models import Image, Video
 
 
@@ -134,12 +133,6 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
             str
         """
         return '{org}+{course}'.format(org=course_run_key.org, course=course_run_key.course)
-
-    @classmethod
-    def delete_orphans(cls):
-        """ Remove orphaned objects from the database. """
-        for model in (Image, Video):
-            delete_orphans(model)
 
     @classmethod
     def _get_or_create_media(cls, media_type, url):

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -49,8 +49,6 @@ class OrganizationsApiDataLoader(AbstractDataLoader):
 
         logger.info('Retrieved %d organizations from %s.', count, api_url)
 
-        self.delete_orphans()
-
     def update_organization(self, body):
         key = body['short_name']
         logo = body['logo']
@@ -108,8 +106,6 @@ class CoursesApiDataLoader(AbstractDataLoader):
                     self._process_response(response)
 
         logger.info('Retrieved %d course runs from %s.', count, self.partner.courses_api_url)
-
-        self.delete_orphans()
 
     def _load_data(self, page):  # pragma: no cover
         """Make a request for the given page and process the response."""
@@ -328,8 +324,6 @@ class EcommerceApiDataLoader(AbstractDataLoader):
                 if attempt_count >= EcommerceApiDataLoader.LOADER_MAX_RETRY:
                     raise CommandError('Max retries exceeded and Ecommerce Data Loader failed to successfully load')
             else:
-                # If no errors were detected clean up Orphans
-                self.delete_orphans()
                 self._delete_entitlements()
 
     def _load_ecommerce_data(self):

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -20,8 +20,7 @@ from course_discovery.apps.course_metadata.models import (
     Course, CourseEntitlement, CourseRun, Organization, Program, ProgramType, Seat, SeatType
 )
 from course_discovery.apps.course_metadata.tests.factories import (
-    CourseEntitlementFactory, CourseFactory, CourseRunFactory, ImageFactory, OrganizationFactory, SeatFactory,
-    VideoFactory
+    CourseEntitlementFactory, CourseFactory, CourseRunFactory, OrganizationFactory, SeatFactory
 )
 from course_discovery.apps.publisher.constants import PUBLISHER_ENABLE_READ_ONLY_FIELDS
 
@@ -53,14 +52,6 @@ class AbstractDataLoaderTest(TestCase):
         # Parse datetime strings
         dt = datetime.datetime.utcnow()
         self.assertEqual(AbstractDataLoader.parse_date(dt.isoformat()), dt)
-
-    def test_delete_orphans(self):
-        """ Verify the delete_orphans method deletes orphaned instances. """
-        instances = (ImageFactory(), VideoFactory(),)
-        AbstractDataLoader.delete_orphans()
-
-        for instance in instances:
-            self.assertFalse(instance.__class__.objects.filter(pk=instance.pk).exists())
 
     def test_clean_html(self):
         """ Verify the method removes unnecessary HTML attributes. """

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -12,6 +12,7 @@ from edx_rest_api_client.client import EdxRestApiClient
 
 from course_discovery.apps.api.cache import api_change_receiver, set_api_timestamp
 from course_discovery.apps.core.models import Partner
+from course_discovery.apps.core.utils import delete_orphans
 from course_discovery.apps.course_metadata.data_loaders.analytics_api import AnalyticsAPIDataLoader
 from course_discovery.apps.course_metadata.data_loaders.api import (
     CoursesApiDataLoader, EcommerceApiDataLoader, OrganizationsApiDataLoader, ProgramsApiDataLoader
@@ -19,7 +20,7 @@ from course_discovery.apps.course_metadata.data_loaders.api import (
 from course_discovery.apps.course_metadata.data_loaders.marketing_site import (
     SchoolMarketingSiteDataLoader, SponsorMarketingSiteDataLoader, SubjectMarketingSiteDataLoader
 )
-from course_discovery.apps.course_metadata.models import Course, DataLoaderConfig
+from course_discovery.apps.course_metadata.models import Course, DataLoaderConfig, Image, Video
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +207,10 @@ class Command(BaseCommand):
                         ) and success
 
             # TODO Cleanup CourseRun overrides equivalent to the Course values.
+
+        # Clean up any media orphans that we might have created
+        delete_orphans(Image)
+        delete_orphans(Video)
 
         set_api_timestamp()
 


### PR DESCRIPTION
Call it just once per RCM run, rather than once per loader.

https://openedx.atlassian.net/browse/DISCO-1223