### PR TITLE
Avoid assuming runs have end dates

### DIFF
--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -372,6 +372,9 @@ def calculated_seat_upgrade_deadline(seat):
         if seat.upgrade_deadline:
             return seat.upgrade_deadline
 
+        if not seat.course_run.end:
+            return None
+
         deadline = seat.course_run.end - datetime.timedelta(days=settings.PUBLISHER_UPGRADE_DEADLINE_DAYS)
         deadline = deadline.replace(hour=23, minute=59, second=59, microsecond=99999)
         return deadline


### PR DESCRIPTION
When migrating from old publisher to course metadata, we were
trying to migrate some pre-publisher runs that didn't have end
dates, like all modern runs do. Handle those gracefully.