### PR TITLE
Drop uses of CourseEntitlement.expires

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -558,7 +558,7 @@ class CourseEntitlementSerializer(serializers.ModelSerializer):
     currency = serializers.SlugRelatedField(read_only=True, slug_field='code')
     sku = serializers.CharField(allow_blank=True, allow_null=True)
     mode = serializers.SlugRelatedField(slug_field='slug', queryset=SeatType.objects.all().order_by('name'))
-    expires = serializers.DateTimeField()
+    expires = serializers.SerializerMethodField()
 
     @classmethod
     def prefetch_queryset(cls):
@@ -567,6 +567,10 @@ class CourseEntitlementSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = CourseEntitlement
         fields = ('mode', 'price', 'currency', 'sku', 'expires')
+
+    def get_expires(self, _obj):
+        # This was a never-used, deprecated field. Just keep returning None to avoid breaking our API.
+        return None
 
 
 class CatalogSerializer(serializers.ModelSerializer):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1361,7 +1361,7 @@ class CourseEntitlementSerializerTests(TestCase):
             'currency': self.entitlement.currency.code,
             'sku': self.entitlement.sku,
             'mode': str(self.entitlement.mode).lower(),
-            'expires': json_date_format(self.entitlement.expires)
+            'expires': None,
         }
 
         self.assertDictEqual(serializer.data, expected)

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -748,7 +748,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
                     'mode': entitlement.mode.slug,
                     'price': 1000,
                     'sku': entitlement.sku,
-                    'expires': entitlement.expires,
+                    'expires': None,
                 },
             ],
             # The API is expecting the image to be base64 encoded. We are simulating that here.

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -674,7 +674,6 @@ class EcommerceApiDataLoader(AbstractDataLoader):
             'price': price,
             'currency': currency,
             'sku': sku,
-            'expires': self.parse_date(body['expires'])
         }
         msg = 'Creating entitlement {title} with sku {sku} for partner {partner}'.format(
             title=title, sku=sku, partner=self.partner

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -616,7 +616,6 @@ class EcommerceApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestC
         body = [d for d in body if d['product_class'] == 'Course Entitlement']
         self.assertEqual(CourseEntitlement.objects.count(), len(body))
         for datum in body:
-            expires = datum['expires']
             attributes = {attribute['name']: attribute['value'] for attribute in datum['attribute_values']}
             course = Course.objects.get(uuid=attributes['UUID'])
             stock_record = datum['stockrecords'][0]
@@ -629,7 +628,6 @@ class EcommerceApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestC
 
             entitlement = course.entitlements.get(mode=mode)
 
-            self.assertEqual(entitlement.expires, expires)
             self.assertEqual(entitlement.course, course)
             self.assertEqual(entitlement.price, price)
             self.assertEqual(entitlement.currency.code, price_currency)

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1529,6 +1529,8 @@ class CourseEntitlement(DraftModelMixin, TimeStampedModel):
     price = models.DecimalField(**PRICE_FIELD_CONFIG)
     currency = models.ForeignKey(Currency, models.CASCADE, default='USD')
     sku = models.CharField(max_length=128, null=True, blank=True)
+
+    # TODO: this field is deprecated and scheduled for removal
     expires = models.DateTimeField(null=True, blank=True)
 
     history = HistoricalRecords()

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -524,7 +524,6 @@ class CourseEntitlementFactory(factory.DjangoModelFactory):
     price = FuzzyDecimal(0.0, 650.0)
     currency = factory.Iterator(Currency.objects.all())
     sku = FuzzyText(length=8)
-    expires = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC))
     course = factory.SubFactory(CourseFactory)
 
     class Meta:

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -1215,7 +1215,7 @@ class ProgramTests(TestCase):
         program_type = factories.ProgramTypeFactory(applicable_seat_types=[verified_seat_type])
         courses = []
         for __ in range(3):
-            entitlement = factories.CourseEntitlementFactory(mode=verified_seat_type, expires=None)
+            entitlement = factories.CourseEntitlementFactory(mode=verified_seat_type)
             for __ in range(3):
                 factories.SeatFactory(
                     course_run=factories.CourseRunFactory(
@@ -1374,7 +1374,7 @@ class ProgramTests(TestCase):
         # We are limiting each course to a single entitlement so this should raise an IntegrityError
         with transaction.atomic():
             with self.assertRaises(IntegrityError):
-                factories.CourseEntitlementFactory(mode=credit_seat_type, expires=None, course=courses[0])
+                factories.CourseEntitlementFactory(mode=credit_seat_type, course=courses[0])
 
     def test_one_click_purchase_eligible_with_unpublished_runs(self):
         """ Verify that program with unpublished course runs is one click purchase eligible. """


### PR DESCRIPTION
This is a never-used deprecated field. Step 1 of dropping the column
is to drop references. So that's what's happening here.

We keep serializing the field in our API as None though.

https://openedx.atlassian.net/browse/DISCO-820