### PR TITLE
Use proper serializer and limit result.

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1995,6 +1995,16 @@ class AggregateSearchSerializer(HaystackSerializer):
         }
 
 
+class LimitedAggregateSearchSerializer(HaystackSerializer):
+    class Meta:
+        fields = ['subject', 'uuid', 'key', 'aggregation_key', 'content_type']
+        index_classes = [
+            search_indexes.CourseRunIndex,
+            search_indexes.CourseIndex,
+            search_indexes.ProgramIndex,
+        ]
+
+
 class AggregateFacetSearchSerializer(BaseHaystackFacetSerializer):
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
@@ -2034,15 +2044,6 @@ class AggregateSearchModelSerializer(HaystackSerializer):
             search_indexes.CourseIndex: CourseSearchModelSerializer,
             search_indexes.ProgramIndex: ProgramSearchModelSerializer,
         }
-
-
-class LimitedAggregateSearchModelSerializer(HaystackSerializer):
-    class Meta:
-        index_classes = [
-            search_indexes.CourseRunIndex,
-            search_indexes.CourseIndex,
-            search_indexes.ProgramIndex,
-        ]
 
 
 class TypeaheadBaseSearchSerializer(serializers.Serializer):

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -371,11 +371,11 @@ class LimitedAggregateSearchViewSetTests(
 
     # pylint: disable=no-member
     def serialize_course_run_search(self, run):
-        return super().serialize_course_run_search(run, serializers.LimitedAggregateSearchModelSerializer)
+        return super().serialize_course_run_search(run, serializers.LimitedAggregateSearchSerializer)
 
     # pylint: disable=no-member
     def serialize_program_search(self, program):
-        return super().serialize_program_search(program, serializers.LimitedAggregateSearchModelSerializer)
+        return super().serialize_program_search(program, serializers.LimitedAggregateSearchSerializer)
 
     def test_results_only_include_published_objects(self):
         """ Verify the search results only include items with status set to 'Published'. """

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -180,7 +180,7 @@ class LimitedAggregateSearchView(FacetMixin, HaystackViewSet):
     lookup_field = 'key'
     permission_classes = (IsAuthenticated,)
     facet_serializer_class = serializers.AggregateFacetSearchSerializer
-    serializer_class = serializers.LimitedAggregateSearchModelSerializer
+    serializer_class = serializers.LimitedAggregateSearchSerializer
 
     def filter_facet_queryset(self, queryset):
         queryset = super().filter_facet_queryset(queryset)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/WEBSITE-64

Use the correct serializer in the correct places. Fixes page sizing and also `format=json`.