### PR TITLE
Retry update index job upon sanity check failure

### DIFF
--- a/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
+++ b/course_discovery/apps/edx_haystack_extensions/management/commands/update_index.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 
@@ -53,9 +52,10 @@ class Command(HaystackCommand):
             for backend, index, alias, record_count in alias_mappings:
                 # Run a sanity check to ensure we aren't drastically changing the
                 # index, which could be indicative of a bug.
-                if not options.get('disable_change_limit', False):
-                    record_count_is_sane, index_info_string = \
-                        self.sanity_check_new_index(backend.conn, index, record_count)
+                if index in indexes_pending and not options.get('disable_change_limit', False):
+                    record_count_is_sane, index_info_string = self.sanity_check_new_index(
+                        backend.conn, index, record_count
+                    )
                     if record_count_is_sane:
                         self.set_alias(backend, alias, index)
                         indexes_pending.pop(index, None)
@@ -66,7 +66,7 @@ class Command(HaystackCommand):
                     indexes_pending.pop(index, None)
 
         if indexes_pending:
-            raise CommandError('Sanity check failed for new index(es). ' + json.dumps(indexes_pending))
+            raise CommandError('Sanity check failed for new index(es): {}'.format(indexes_pending))
 
     def percentage_change(self, current, previous):
         try:


### PR DESCRIPTION
We continue to see somewhat frequent failures of the job to update the ES search index due to the record count sanity check failing.  The common action taken when the alert is received is to manually re-run the jenkins job which usually results in job success.

After discussing with DevOps the complexities of adding a retry at the jenkins job config level, the approach in this PR of simply forcing a retry of the index build seems like the simplest approach to avoiding the noisy alerts.  This is an interim workaround until we put effort into upgrading our search backend, ES version, etc.

LEARNER-6364