### PR TITLE
Fixes salesforce login for Prod environments

### DIFF
--- a/course_discovery/apps/course_metadata/salesforce.py
+++ b/course_discovery/apps/course_metadata/salesforce.py
@@ -63,7 +63,7 @@ class SalesforceUtil:
                 'organizationId': salesforce_config.organization_id,
                 # security_token must be an empty string if organizationId is set
                 'security_token': '' if salesforce_config.organization_id else salesforce_config.token,
-                'domain': 'test' if salesforce_config.is_sandbox else ''
+                'domain': 'test' if salesforce_config.is_sandbox else None
             }
             return Salesforce(**sf_kwargs)
 


### PR DESCRIPTION
With an empty string for domain, you receive a ```requests.exceptions.InvalidURL: URL has an invalid label.``` on login. However security token needs to be an empty string still. This update fixes that.