### PR TITLE
Always pull start date from Studio

### DIFF
--- a/course_discovery/apps/core/models.py
+++ b/course_discovery/apps/core/models.py
@@ -130,6 +130,10 @@ class Partner(TimeStampedModel):
         return bool(self.marketing_site_url_root)
 
     @property
+    def uses_publisher(self):
+        return settings.ENABLE_PUBLISHER and self.publisher_url
+
+    @property
     def access_token(self):
         """
         Returns the access token for this service.

--- a/course_discovery/apps/publisher/studio_api_utils.py
+++ b/course_discovery/apps/publisher/studio_api_utils.py
@@ -19,7 +19,10 @@ class StudioAPI(StudioAPIBase):
         return course_run.title_override or course_run.course.title
 
     @classmethod
-    def _run_times(cls, course_run):
+    def _run_times(cls, course_run, creating):
+        # We don't use the creating param - normal StudioAPI uses it to only send dates when creating.
+        # But for historical reasons, we always push them. (rest of system is moving to Studio as the
+        # only place these dates get edited, but we are from an older time and didn't want to change it)
         return course_run.start_date_temporary, course_run.end_date_temporary
 
     @classmethod

--- a/course_discovery/apps/publisher/tests/test_studio_api_utils.py
+++ b/course_discovery/apps/publisher/tests/test_studio_api_utils.py
@@ -84,7 +84,8 @@ def assert_data_generated_correctly(course_run, expected_team_data):
         'team': expected_team_data,
         'pacing_type': course_run.pacing_type_temporary,
     }
-    assert StudioAPI.generate_data_for_studio_api(course_run) == expected
+    # the publisher djangoapp doesn't care about the 'creating' flag passed below, so we just always set it False
+    assert StudioAPI.generate_data_for_studio_api(course_run, creating=False) == expected
 
 
 @pytest.mark.django_db

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -576,6 +576,7 @@ TAGGIT_CASE_INSENSITIVE = True
 SOLO_CACHE = 'default'
 SOLO_CACHE_TIMEOUT = 3600
 
+ENABLE_PUBLISHER = False  # either old (publisher djangoapp) or new (publisher-frontend)
 PUBLISHER_FROM_EMAIL = None
 
 USERNAME_REPLACEMENT_WORKER = "REPLACE WITH VALID USERNAME"

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -63,6 +63,8 @@ SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = "http://localhost:18000/logout"
 
 BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://edx.devstack.lms:18000/oauth2"
 
+ENABLE_PUBLISHER = True
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -54,6 +54,7 @@ LOGGING['handlers']['local'] = {
     'level': 'INFO',
 }
 
+ENABLE_PUBLISHER = True
 PUBLISHER_FROM_EMAIL = 'test@example.com'
 
 # Set to 0 to disable edx-django-sites-extensions to retrieve


### PR DESCRIPTION
We're switching to always editing the start date in Studio, not
Publisher. So always pull it in from Studio in RCM. And don't push
it to Studio from new Publisher unless we're creating the run.

Also use the new ENABLE_PUBLISHER feature flag - rather than whether
a marketing site is associated with a partner - to determine how
much data we pull from Studio.

https://openedx.atlassian.net/browse/DISCO-1313