### PR TITLE
Reconnect to Django in RCM

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -208,6 +208,8 @@ class Command(BaseCommand):
 
             # TODO Cleanup CourseRun overrides equivalent to the Course values.
 
+        connection.connect()  # reconnect to django outside of loop (see connect comment above)
+
         # Clean up any media orphans that we might have created
         delete_orphans(Image)
         delete_orphans(Video)


### PR DESCRIPTION
Right at the end of the RCM main loop, when we are performing cleanup, try to reconnect to Django.

This will hopefully fix the recent consistent RCM failure.