### PR TITLE
Pull pacing_type from Studio

### DIFF
--- a/course_discovery/apps/api/tests/test_utils.py
+++ b/course_discovery/apps/api/tests/test_utils.py
@@ -51,7 +51,7 @@ class StudioAPITests(TestCase):
         self.client = mock.Mock()
         self.api = StudioAPI(self.client)
 
-    def make_studio_data(self, run, add_schedule=True):
+    def make_studio_data(self, run, add_pacing=True, add_schedule=True):
         key = CourseKey.from_string(run.key)
         data = {
             'title': run.title,
@@ -59,8 +59,9 @@ class StudioAPITests(TestCase):
             'number': key.course,
             'run': key.run,
             'team': [],
-            'pacing_type': run.pacing_type,
         }
+        if add_pacing:
+            data['pacing_type'] = run.pacing_type
         if add_schedule:
             data['schedule'] = {
                 'start': serialize_datetime(run.start),
@@ -88,6 +89,6 @@ class StudioAPITests(TestCase):
         run = CourseRunFactory()
         self.api.update_course_run_details_in_studio(run)
 
-        expected_data = self.make_studio_data(run, add_schedule=False)
+        expected_data = self.make_studio_data(run, add_pacing=False, add_schedule=False)
         self.assertEqual(self.client.course_runs.call_args_list, [mock.call(run.key)])
         self.assertEqual(self.client.course_runs.return_value.patch.call_args_list[0][0][0], expected_data)

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -154,6 +154,7 @@ class StudioAPI:
         editors = cls._run_editors(course_run)
         org, number, run = cls._run_key_parts(course_run)
         start, end = cls._run_times(course_run, creating)
+        pacing = cls._run_pacing(course_run, creating)
 
         if user:
             editors.append(user)
@@ -177,8 +178,10 @@ class StudioAPI:
             'number': number,
             'run': run,
             'team': team,
-            'pacing_type': cls._run_pacing(course_run),
         }
+
+        if pacing:
+            data['pacing_type'] = pacing
 
         if start or end:
             data['schedule'] = {
@@ -251,7 +254,9 @@ class StudioAPI:
         return course_run.start, course_run.end
 
     @classmethod
-    def _run_pacing(cls, course_run):
+    def _run_pacing(cls, course_run, creating):
+        if not creating:
+            return None  # not sent by default on update - studio is where pacing is edited by users
         return course_run.pacing_type
 
     @classmethod

--- a/course_discovery/apps/publisher/studio_api_utils.py
+++ b/course_discovery/apps/publisher/studio_api_utils.py
@@ -26,7 +26,10 @@ class StudioAPI(StudioAPIBase):
         return course_run.start_date_temporary, course_run.end_date_temporary
 
     @classmethod
-    def _run_pacing(cls, course_run):
+    def _run_pacing(cls, course_run, creating):
+        # We don't use the creating param - normal StudioAPI uses it to only send pacing when creating.
+        # But for historical reasons, we always push them. (rest of system is moving to Studio as the
+        # only place that pacing get edited, but we are from an older time and didn't want to change it)
         return course_run.pacing_type_temporary
 
     @classmethod

--- a/course_discovery/apps/publisher/tests/test_utils.py
+++ b/course_discovery/apps/publisher/tests/test_utils.py
@@ -19,9 +19,9 @@ from course_discovery.apps.publisher.mixins import (
 from course_discovery.apps.publisher.models import OrganizationExtension
 from course_discovery.apps.publisher.tests import factories
 from course_discovery.apps.publisher.utils import (
-    find_discovery_course, get_internal_users, has_role_for_course, is_email_notification_enabled, is_internal_user,
-    is_on_new_pub_fe, is_project_coordinator_user, is_publisher_admin, is_publisher_user, make_bread_crumbs,
-    parse_datetime_field
+    find_discovery_course, get_internal_users, has_role_for_course, is_course_on_new_pub_fe,
+    is_email_notification_enabled, is_internal_user, is_on_new_pub_fe, is_project_coordinator_user, is_publisher_admin,
+    is_publisher_user, make_bread_crumbs, parse_datetime_field
 )
 
 
@@ -252,9 +252,11 @@ class PublisherUtilsTests(TestCase):
 
         with self.settings(ORGS_ON_NEW_PUB_FE=self.organization_extension.organization.key):
             # When ORGS_ON_NEW_PUB_FE list present and user has no orgs
-            self.assertFalse(is_on_new_pub_fe(self.user))
+            self.assertTrue(is_on_new_pub_fe(self.user))
 
-            self.user.groups.add(self.organization_extension.group)
+        self.user.groups.add(self.organization_extension.group)
+
+        with self.settings(ORGS_ON_NEW_PUB_FE=self.organization_extension.organization.key):
             # When ORGS_ON_NEW_PUB_FE list present and user belongs to an org in the list
             self.assertTrue(is_on_new_pub_fe(self.user))
 
@@ -268,3 +270,30 @@ class PublisherUtilsTests(TestCase):
             self.user.groups.add(org_ext.group)
             # When ORGS_ON_NEW_PUB_FE list present and user belongs to orgs both on and off the list
             self.assertFalse(is_on_new_pub_fe(self.user))
+
+    def test_course_is_on_new_pub_fe(self):
+        org = self.organization_extension.organization
+        course = cm_factories.CourseFactory()
+
+        # When no ORGS_ON_NEW_PUB_FE list present
+        self.assertFalse(is_course_on_new_pub_fe(course))
+
+        with self.settings(ORGS_ON_NEW_PUB_FE=org.key):
+            # When ORGS_ON_NEW_PUB_FE list present and course has no orgs
+            self.assertTrue(is_course_on_new_pub_fe(course))
+
+        course.authoring_organizations.add(org)
+
+        with self.settings(ORGS_ON_NEW_PUB_FE=org.key):
+            # When ORGS_ON_NEW_PUB_FE list present and course is authored by an org in the list
+            self.assertTrue(is_course_on_new_pub_fe(course))
+
+        with self.settings(ORGS_ON_NEW_PUB_FE='example-key'):
+            # When ORGS_ON_NEW_PUB_FE list present and course is authored by an org not in the list
+            self.assertFalse(is_course_on_new_pub_fe(course))
+
+        with self.settings(ORGS_ON_NEW_PUB_FE=org.key):
+            org2 = cm_factories.OrganizationFactory()
+            course.authoring_organizations.add(org2)
+            # When ORGS_ON_NEW_PUB_FE list present and course is authored by orgs both on and off the list
+            self.assertFalse(is_course_on_new_pub_fe(course))

--- a/course_discovery/apps/publisher/utils.py
+++ b/course_discovery/apps/publisher/utils.py
@@ -165,19 +165,35 @@ def user_orgs(user):
 
 def is_on_new_pub_fe(user):
     """Returns if all the user's organizations have been moved to new publisher frontend"""
-    try:
-        orgs_on_new_pub_fe = settings.ORGS_ON_NEW_PUB_FE.split(',')
-        orgs = user_orgs(user)
-        if not orgs:
+    orgs_on_new_pub_fe = frozenset(filter(None, getattr(settings, 'ORGS_ON_NEW_PUB_FE', '').split(',')))
+    if not orgs_on_new_pub_fe:
+        return False
+
+    orgs = user_orgs(user)
+    for org in orgs:
+        if org.key not in orgs_on_new_pub_fe:
             return False
 
-        for org in orgs:
-            if org.key not in orgs_on_new_pub_fe:
-                return False
+    return True
 
-        return True
-    except AttributeError:
+
+def is_course_on_new_pub_fe(course):
+    """
+    Returns True if all the course's organizations have been moved to new publisher frontend
+
+    Args:
+        course: A course_metadata Course object (not a Publisher one)
+    """
+    orgs_on_new_pub_fe = frozenset(filter(None, getattr(settings, 'ORGS_ON_NEW_PUB_FE', '').split(',')))
+    if not orgs_on_new_pub_fe:
         return False
+
+    orgs = course.authoring_organizations.all()
+    for org in orgs:
+        if org.key not in orgs_on_new_pub_fe:
+            return False
+
+    return True
 
 
 def publisher_url(user):


### PR DESCRIPTION
When an org is on the new publisher, pull it in from Studio
and stop pushing it on updates. (i.e. move source-of-edit to
Studio for users of frontend-app-publisher)

https://openedx.atlassian.net/browse/DISCO-1341

This is related to https://github.com/edx/frontend-app-publisher/pull/258