### PR TITLE
Unpublish drafts along with old runs

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -661,6 +661,8 @@ class Course(DraftModelMixin, PkSearchableMixin, TimeStampedModel):
         Find old course runs that are no longer active but still published.
         These will be unpublished and linked to an active course run.
 
+        Designed to work on official runs.
+
         Arguments:
             published_runs (iterable): optional optimization; pass published CourseRuns to avoid a lookup
 
@@ -690,6 +692,9 @@ class Course(DraftModelMixin, PkSearchableMixin, TimeStampedModel):
             publisher.add_url_redirect(earliest_active_run, run)
             run.status = CourseRunStatus.Unpublished
             run.save()
+            if run.draft_version:
+                run.draft_version.status = CourseRunStatus.Unpublished
+                run.draft_version.save()
 
         return True
 


### PR DESCRIPTION
When the update_marketing_redirects command runs, it was only
unpublishing official rows of old inactive runs. This changes it
to also unpublish the draft rows, just to keep those in sync.