### PR TITLE
Don't send double emails on publish

### DIFF
--- a/course_discovery/apps/publisher/models.py
+++ b/course_discovery/apps/publisher/models.py
@@ -956,7 +956,7 @@ class CourseRunState(TimeStampedModel, ChangedByMixin):
         if not discovery_run:
             return
 
-        discovery_run.publish()
+        discovery_run.publish(send_emails=False)  # disable new-style emails, we'll send our own below
 
         # Notify course team
         if waffle.switch_is_active('enable_publisher_email_notifications'):


### PR DESCRIPTION
We were accidentally sending two publish emails when publishing
from old publisher. This is because we now make drafts of rows
even when working in old publisher and the new email flow was
only checking if drafts existed.

https://openedx.atlassian.net/browse/DISCO-1357