### PR TITLE
Fix AWIN data feed missing image url.

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1606,7 +1606,7 @@ class AffiliateWindowSerializer(serializers.ModelSerializer):
         return ''
 
     def get_imgurl(self, obj):
-        return obj.course_run.card_image_url or obj.course_run.course.card_image_url
+        return obj.course_run.image_url or obj.course_run.card_image_url
 
 
 class FlattenedCourseRunWithCourseSerializer(CourseRunSerializer):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1579,7 +1579,7 @@ class AffiliateWindowSerializerTests(TestCase):
                 'actualp': seat.price
             },
             'currency': seat.currency.code,
-            'imgurl': course_run.course.card_image_url,
+            'imgurl': course_run.image_url,
             'category': 'Other Experiences',
             'validfrom': course_run.start.strftime('%Y-%m-%d'),
             'validto': course_run.end.strftime('%Y-%m-%d'),

--- a/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
@@ -103,7 +103,7 @@ class AffiliateWindowViewSetTests(ElasticsearchTestMixin, SerializationMixin, AP
         assert content.find('name').text == self.course_run.title
         assert content.find('desc').text == self.course_run.full_description
         assert content.find('purl').text == self.course_run.marketing_url
-        assert content.find('imgurl').text == self.course_run.card_image_url
+        assert content.find('imgurl').text == self.course_run.image_url
         assert content.find('price/actualp').text == str(seat.price)
         assert content.find('currency').text == seat.currency.code
         assert content.find('category').text == AffiliateWindowSerializer.CATEGORY


### PR DESCRIPTION
If course has a stored image in image field use that otherwise fallback to card image url.

PROD-700