### PR TITLE
DISCO-1366: Adds in max_retry logic for Salesforce login

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_salesforce.py
+++ b/course_discovery/apps/course_metadata/tests/test_salesforce.py
@@ -33,14 +33,18 @@ class TestSalesforce(TestCase):
         self.salesforce_config.save()
 
         with mock.patch(self.salesforce_path) as mock_salesforce:
-            SalesforceUtil(self.salesforce_config.partner)
-            mock_salesforce.assert_called_with(**{
-                'username': self.salesforce_config.username,
-                'password': self.salesforce_config.password,
-                'organizationId': self.salesforce_config.organization_id,
-                'security_token': '',
-                'domain': 'test',
-            })
+            with mock.patch('course_discovery.apps.course_metadata.salesforce.requests') as mock_requests:
+                SalesforceUtil(self.salesforce_config.partner)
+                mock_salesforce.assert_called_with(
+                    session=mock_requests.Session(),
+                    **{
+                        'username': self.salesforce_config.username,
+                        'password': self.salesforce_config.password,
+                        'organizationId': self.salesforce_config.organization_id,
+                        'security_token': '',
+                        'domain': 'test',
+                    }
+                )
 
     @factory.django.mute_signals(post_save)
     def test_wrapper_salesforce_expired_session_calls_login(self):


### PR DESCRIPTION
Enable retries for the 
```
requests.exceptions.ConnectionError: ('Connection aborted.', OSError("(104, 'ECONNRESET')",))
``` 
error.  (based on https://github.com/psf/requests/issues/4506)

For testing purposes I updated a Course Run on both my local and Stage which would send a request to Salesforce. After ~10 minutes of waiting, attempting to save and trigger a Salesforce write on Stage fails with the above error, while locally the request succeeds.

Alternatively, I could catch the OSError as part of the `salesforce_request_wrapper`, but that felt more harmful than enabling the max_retries.