### PR TITLE
DISCO-1364: fix bug about always setting verified deadline

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -745,6 +745,20 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, expected_error_message)
 
+    def test_create_fails_if_run_creation_fails(self):
+        '''
+        For clarity, this only applies for when the course run endpoint receives an error response
+        from Studio. Other errors (PermissionDenied, ValidationError, Http404) are all caught and
+        raised to the course endpoint, but some errors just create a response.
+        '''
+        studio_url = '{root}/api/v1/course_runs/'.format(root=self.partner.studio_url.strip('/'))
+        responses.add(responses.POST, studio_url, status=400)
+        response = self.create_course_and_course_run()
+        self.assertEqual(response.status_code, 400)
+        expected_error_message = ('Failed to set data: Failed to set course run data: '
+                                  'Client Error 400: {studio_url}'.format(studio_url=studio_url))
+        self.assertEqual(response.data, expected_error_message)
+
     def test_create_with_api_exception(self):
         with mock.patch(
             # We are using get_course_key because it is called prior to tryig to contact the

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -234,7 +234,9 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
                 'price': price,
                 'mode': course_creation_fields['mode'],
             })
-            CourseRunViewSet().create_run_helper(course_run_creation_fields, request)
+            run_response = CourseRunViewSet().create_run_helper(course_run_creation_fields, request)
+            if run_response.status_code != 201:
+                raise Exception(str(run_response.data))
 
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)


### PR DESCRIPTION
Also found a different bug where on course creation, if there is
an error with the course run creation that is not caught and
raised and instead caught through our general exception catch,
it creates a response which the course endpoint then drops.