### PR TITLE
Don't throttle publisher users

### DIFF
--- a/course_discovery/apps/core/tests/test_throttles.py
+++ b/course_discovery/apps/core/tests/test_throttles.py
@@ -7,6 +7,7 @@ from course_discovery.apps.api.tests.mixins import SiteMixin
 from course_discovery.apps.core.models import UserThrottleRate
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from course_discovery.apps.core.throttles import OverridableUserRateThrottle, throttling_cache
+from course_discovery.apps.publisher.tests.factories import GroupFactory
 
 
 class RateLimitingExceededTest(SiteMixin, APITestCase):
@@ -72,4 +73,9 @@ class RateLimitingExceededTest(SiteMixin, APITestCase):
         """ Verify staff users are not throttled. """
         self.user.is_staff = True
         self.user.save()
+        self.assert_rate_limit_successfully_exceeded()
+
+    def test_publisher_user_throttling(self):
+        """ Verify publisher users are not throttled. """
+        self.user.groups.add(GroupFactory())
         self.assert_rate_limit_successfully_exceeded()

--- a/course_discovery/apps/core/throttles.py
+++ b/course_discovery/apps/core/throttles.py
@@ -3,6 +3,7 @@ from django.core.cache import InvalidCacheBackendError, caches
 from rest_framework.throttling import UserRateThrottle
 
 from course_discovery.apps.core.models import UserThrottleRate
+from course_discovery.apps.publisher.utils import is_publisher_user
 
 
 def throttling_cache():
@@ -23,7 +24,7 @@ class OverridableUserRateThrottle(UserRateThrottle):
         user = request.user
 
         if user and user.is_authenticated:
-            if user.is_superuser or user.is_staff:
+            if user.is_superuser or user.is_staff or is_publisher_user(user):
                 return True
             try:
                 # Override this throttle's rate if applicable


### PR DESCRIPTION
They make a lot of requests - exempt them from our default very low throttle of 100 requests.