### PR TITLE
Add temp logging on multiple seat objects to RCM

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -178,7 +178,7 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         ProgramFactory(courses=[course_run.course], status=program_status)
         self.reindex_courses(active_program)
 
-        with self.assertNumQueries(expected_queries, threshold=4):
+        with self.assertNumQueries(expected_queries, threshold=3):
             response = self.get_response('software', path=path)
             assert response.status_code == 200
             response_data = response.json()

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -178,7 +178,7 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         ProgramFactory(courses=[course_run.course], status=program_status)
         self.reindex_courses(active_program)
 
-        with self.assertNumQueries(expected_queries, threshold=3):
+        with self.assertNumQueries(expected_queries, threshold=4):
             response = self.get_response('software', path=path)
             assert response.status_code == 200
             response_data = response.json()

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -550,6 +550,18 @@ class EcommerceApiDataLoader(AbstractDataLoader):
             'credit_hours': credit_hours,
         }
 
+        found_seats = Seat.objects.filter(type=seat_type, credit_provider=credit_provider, currency=currency)
+        if found_seats.count() > 1:
+            ids = [seat.id for seat in found_seats]
+            msg = 'Found [{ids}] with type {type}, credit provider {provider} and currency {currency} for {key}'.format(
+                ids=ids,
+                type=seat_type,
+                provider=credit_provider,
+                currency=currency,
+                key=course_run.key
+            )
+            logger.warning(msg)
+
         course_run.seats.update_or_create(
             type=seat_type,
             credit_provider=credit_provider,
@@ -711,6 +723,16 @@ class EcommerceApiDataLoader(AbstractDataLoader):
 
         seat_type = attributes.get('seat_type')
         try:
+            found_seats = Seat.objects.filter(type=seat_type, course_run=course_run)
+            if found_seats.count() > 1:
+                ids = [seat.id for seat in found_seats]
+                msg = 'Found [{ids}] with type {type}, for {key}'.format(
+                    ids=ids,
+                    type=seat_type,
+                    key=course_run.key
+                )
+                logger.warning(msg)
+
             Seat.objects.get(course_run=course_run, type=seat_type)
         except Seat.DoesNotExist:
             msg = 'Could not find seat type {type} while loading enrollment code {title} with sku {sku}'.format(
@@ -726,6 +748,15 @@ class EcommerceApiDataLoader(AbstractDataLoader):
             title=title, sku=sku, partner=self.partner
         )
         logger.info(msg)
+        found_seats = Seat.objects.filter(type=seat_type, course_run=course_run)
+        if found_seats.count() > 1:
+            ids = [seat.id for seat in found_seats]
+            msg = 'Found {ids} with type {type}, for {key}'.format(
+                ids=ids,
+                type=seat_type,
+                key=course_run.key
+            )
+            logger.warning(msg)
         course_run.seats.update_or_create(type=seat_type, defaults=defaults)
         return sku
 


### PR DESCRIPTION
Added for debugging issues with multiple seats returned from various
queries in the RCM data loaders. Should be removed once the issue is
resolved.