### PR TITLE
Allow staff access to Publisher APIs

### DIFF
--- a/course_discovery/apps/publisher/api/permissions.py
+++ b/course_discovery/apps/publisher/api/permissions.py
@@ -22,14 +22,14 @@ class InternalUserPermission(BasePermission):
     """ Permission class to check user is an internal user. """
 
     def has_object_permission(self, request, view, obj):
-        return is_internal_user(request.user)
+        return request.user.is_staff or is_internal_user(request.user)
 
 
 class PublisherUserPermission(BasePermission):
     """ Permission class to check user is a publisher user. """
 
     def has_object_permission(self, request, view, obj):
-        return is_publisher_user(request.user)
+        return request.user.is_staff or is_publisher_user(request.user)
 
     def has_permission(self, request, view):
-        return is_publisher_user(request.user)
+        return request.user.is_staff or is_publisher_user(request.user)


### PR DESCRIPTION
A few Publisher APIs were marked as only allowing publisher users. We should also let staff in.

https://openedx.atlassian.net/browse/DISCO-1365