### PR TITLE
ENT-2223: Updated Field for Image URL

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1822,6 +1822,7 @@ class CourseSearchSerializer(HaystackSerializer):
             'short_description',
             'title',
             'card_image_url',
+            'image_url',
             'course_runs',
             'uuid',
             'seat_types',


### PR DESCRIPTION
Description: This PR updates the CourseSearchSerializer to return the image_url field.

JIRA: https://openedx.atlassian.net/browse/ENT-2223