### PR TITLE
Avoid direct assignment for relations

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -815,13 +815,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         # Handle writing nested video data separately
         if 'get_video' in validated_data:
             self.update_video(instance, validated_data.pop('get_video'))
-
-        # Write all other attributes to the instance
-        for attr, value in validated_data.items():
-            setattr(instance, attr, value)
-
-        instance.save()
-        return instance
+        return super().update(instance, validated_data)
 
     def validate(self, attrs):
         course = attrs.get('course', None)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -199,7 +199,7 @@ class CourseSerializerTests(MinimalCourseSerializerTests):
         request = make_request()
         course = CourseFactory()
         course_runs = CourseRunFactory.create_batch(3, course=course)
-        course.course_runs = course_runs
+        course.course_runs.set(course_runs)
         course.canonical_course_run = course_runs[0]
         serializer = self.serializer_class(course, context={'request': request, 'exclude_utm': 1})
 
@@ -1061,7 +1061,7 @@ class ProgramSerializerTests(MinimalProgramSerializerTests):
         rankings = RankingFactory.create_batch(3)
         degree = DegreeFactory.create(rankings=rankings)
         curriculum = CurriculumFactory.create(program=degree)
-        degree.curricula = [curriculum]
+        degree.curricula.set([curriculum])
         quick_facts = IconTextPairingFactory.create_batch(3, degree=degree)
         degree.deadline = DegreeDeadlineFactory.create_batch(size=3, degree=degree)
         degree.cost = DegreeCostFactory.create_batch(size=3, degree=degree)

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -336,7 +336,7 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
                     format(float(entitlement_data['price']), '.2f') != str(course.entitlements.first().price)
                 )
         if entitlements:
-            course.entitlements = entitlements
+            course.entitlements.set(entitlements)
             # If entitlements were updated, we also want to update seats
             for course_run in course.active_course_runs:
                 course_run.update_or_create_seats()

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_analytics_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_analytics_api.py
@@ -46,8 +46,7 @@ class AnalyticsAPIDataLoaderTests(DataLoaderTestMixin, TestCase):
 
         # Create a program with all of the courses we created
         program = ProgramFactory()
-        program.courses = courses.values()
-        program.save()
+        program.courses.set(courses.values())  # pylint: disable=no-member
 
     @responses.activate
     def test_ingest(self):

--- a/course_discovery/apps/course_metadata/management/commands/delete_person_dups.py
+++ b/course_discovery/apps/course_metadata/management/commands/delete_person_dups.py
@@ -112,24 +112,21 @@ class Command(BaseCommand):
             if pinfo.target in program.instructor_ordering.all():
                 continue
             new_instructors = [filter_person(instructor) for instructor in program.instructor_ordering.all()]
-            program.instructor_ordering = new_instructors
-            program.save()
+            program.instructor_ordering.set(new_instructors)
 
         # Update metadata course runs
         for course_run in pinfo.person.courses_staffed.all():
             if pinfo.target in course_run.staff.all():
                 continue
             new_staff = [filter_person(staff) for staff in course_run.staff.all()]
-            course_run.staff = new_staff
-            course_run.save()
+            course_run.staff.set(new_staff)
 
         # Update publisher course runs
         for publisher_course_run in pinfo.person.publisher_course_runs_staffed.all():
             if pinfo.target in publisher_course_run.staff.all():
                 continue
             new_staff = [filter_person(staff) for staff in publisher_course_run.staff.all()]
-            publisher_course_run.staff = new_staff
-            publisher_course_run.save()
+            publisher_course_run.staff.set(new_staff)
 
         # And finally, actually delete the person
         pinfo.person.delete()

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_delete_person_dups.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_delete_person_dups.py
@@ -132,18 +132,14 @@ class DeletePersonDupsCommandTests(TestCase):
         ])
 
     def test_target_already_present(self):
+        # pylint: disable=no-member
         # Change everything to include target. We expect that target's place isn't altered.
-        self.courserun1.staff = list(self.courserun1.staff.all()) + [self.target]
-        self.courserun1.save()
-        self.courserun2.staff = list(self.courserun2.staff.all()) + [self.target]
-        self.courserun2.save()
-        self.publisher_courserun1.staff = list(self.publisher_courserun1.staff.all()) + [self.target]
-        self.publisher_courserun1.save()
+        self.courserun1.staff.set(list(self.courserun1.staff.all()) + [self.target])
+        self.courserun2.staff.set(list(self.courserun2.staff.all()) + [self.target])
+        self.publisher_courserun1.staff.set(list(self.publisher_courserun1.staff.all()) + [self.target])
         # This one is reversed, because target would normally be on end anyway. So put it first instead.
-        self.publisher_courserun2.staff = [self.target] + list(self.publisher_courserun2.staff.all())
-        self.publisher_courserun2.save()
-        self.program.instructor_ordering = list(self.program.instructor_ordering.all()) + [self.target]
-        self.program.save()
+        self.publisher_courserun2.staff.set([self.target] + list(self.publisher_courserun2.staff.all()))
+        self.program.instructor_ordering.set(list(self.program.instructor_ordering.all()) + [self.target])
 
         expected = [self.instructor1, self.instructor2, self.instructor3, self.target]
         expected_first = [self.target, self.instructor1, self.instructor2, self.instructor3]

--- a/course_discovery/apps/publisher/api/v1/tests/test_views.py
+++ b/course_discovery/apps/publisher/api/v1/tests/test_views.py
@@ -321,8 +321,7 @@ class CourseRunViewSetTests(OAuth2Mixin, APITestCase):
         discovery_course_run = CourseRun.objects.get(key=publisher_course_run.lms_course_id)
         assert discovery_course_run.staff.all().count() == 2
 
-        publisher_course_run.staff.clear()
-        publisher_course_run.staff = PersonFactory.create_batch(1)
+        publisher_course_run.staff.set(PersonFactory.create_batch(1))  # pylint: disable=no-member
         response = self.client.post(publish_url, {})
         assert response.status_code == 200
         discovery_course_run = CourseRun.objects.get(key=publisher_course_run.lms_course_id)

--- a/course_discovery/apps/publisher/tests/test_models.py
+++ b/course_discovery/apps/publisher/tests/test_models.py
@@ -994,8 +994,7 @@ class CourseRunStateTests(MarketingSitePublisherTestMixin):
         """
         Verify that method return False if data is missing.
         """
-        self.course_run.transcript_languages = []
-        self.course_run.save()
+        self.course_run.transcript_languages.clear()
         self.assertFalse(self.course_run_state.can_send_for_review())
 
     def test_preview_accepted(self):

--- a/course_discovery/apps/publisher/tests/test_views.py
+++ b/course_discovery/apps/publisher/tests/test_views.py
@@ -4079,8 +4079,7 @@ class CreateRunFromDashboardViewTests(SiteMixin, TestCase):
     def test_create_course_run_without_access_to_course(self):
         """ Verify that user cannot create course run for a course they don't have access to.
         """
-        self.course.organizations = []  # user will no longer be associated with course
-        self.course.save()
+        self.course.organizations.clear()  # user will no longer be associated with course
         post_data = self._post_data()
         response = self.client.post(self.create_course_run_url, post_data)
         self.assertContains(response, 'The page could not be updated. Make', status_code=400)

--- a/course_discovery/apps/publisher/tests/test_wrapper.py
+++ b/course_discovery/apps/publisher/tests/test_wrapper.py
@@ -170,8 +170,7 @@ class CourseRunWrapperTests(TestCase):
         staff_2 = PersonFactory()
         position = PositionFactory(person=staff_2)
 
-        self.course_run.staff = [staff, staff_2]
-        self.course_run.save()
+        self.course_run.staff.set([staff, staff_2])  # pylint: disable=no-member
 
         facebook = PersonSocialNetworkFactory(person=staff_2, type='facebook')
         twitter = PersonSocialNetworkFactory(person=staff_2, type='twitter', title='@MrTerry')

--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -37,7 +37,7 @@ urlpatterns = oauth2_urlpatterns + [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include('course_discovery.apps.api.urls', namespace='api')),
     # Use the same auth views for all logins, including those originating from the browseable API.
-    url(r'^api-auth/', include(oauth2_urlpatterns, namespace='rest_framework')),
+    url(r'^api-auth/', include((oauth2_urlpatterns, 'rest_framework'))),
     url(r'^api-docs/', SwaggerSchemaView.as_view(), name='api_docs'),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^health/$', core_views.health, name='health'),


### PR DESCRIPTION
In Django 2, we can't assign directly to either the reverse or forward side of a many-to-many relationship. You have to use set() or add() or clear().

So let's get ahead of that change.