### PR TITLE
Exclude Ended course runs from endpoint api/v1/search/all/

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1806,7 +1806,7 @@ class CourseSearchSerializer(HaystackSerializer):
                 'estimated_hours': get_course_run_estimated_hours(course_run),
                 'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0
             }
-            for course_run in result.object.course_runs.exclude(end__lt=datetime.datetime.now(pytz.UTC))
+            for course_run in result.object.course_runs.exclude(end__lte=datetime.datetime.now(pytz.UTC))
         ]
 
     def get_seat_types(self, result):

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1806,7 +1806,7 @@ class CourseSearchSerializer(HaystackSerializer):
                 'estimated_hours': get_course_run_estimated_hours(course_run),
                 'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0
             }
-            for course_run in result.object.course_runs.all()
+            for course_run in result.object.course_runs.exclude(end__lt=datetime.datetime.now(pytz.UTC))
         ]
 
     def get_seat_types(self, result):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1619,7 +1619,7 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
             authoring_organizations=[organization],
             sponsoring_organizations=[organization],
         )
-        course_run = CourseRunFactory(course=course)
+        course_run = CourseRunFactory(course=course, end=datetime.datetime.now(UTC) + datetime.timedelta(days=10))
         course.course_runs.add(course_run)
         course.save()
         seat = SeatFactory(course_run=course_run)
@@ -1634,7 +1634,7 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
             authoring_organizations=[organization],
             sponsoring_organizations=[organization],
         )
-        course_run = CourseRunFactory(course=course, end=datetime.datetime(2016, 2, 1, tzinfo=UTC),)
+        course_run = CourseRunFactory(course=course)
         course.course_runs.add(course_run)
         course.save()
         seat = SeatFactory(course_run=course_run)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1626,6 +1626,44 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
         serializer = self.serialize_course(course, request)
         assert serializer.data == self.get_expected_data(course, course_run, seat)
 
+    def test_exclude_expired_course_run(self):
+        request = make_request()
+        organization = OrganizationFactory()
+        course = CourseFactory(
+            subjects=SubjectFactory.create_batch(3),
+            authoring_organizations=[organization],
+            sponsoring_organizations=[organization],
+        )
+        course_run = CourseRunFactory(course=course, end=datetime.datetime(2016, 2, 1, tzinfo=UTC),)
+        course.course_runs.add(course_run)
+        course.save()
+        seat = SeatFactory(course_run=course_run)
+        expected = {
+            'key': course.key,
+            'title': course.title,
+            'short_description': course.short_description,
+            'full_description': course.full_description,
+            'content_type': 'course',
+            'aggregation_key': 'course:{}'.format(course.key),
+            'card_image_url': course.card_image_url,
+            'course_runs': [],
+            'uuid': str(course.uuid),
+            'subjects': [subject.name for subject in course.subjects.all()],
+            'languages': [
+                serialize_language(course_run.language) for course_run in course.course_runs.all()
+                if course_run.language
+            ],
+            'seat_types': [seat.type],
+            'organizations': [
+                '{key}: {name}'.format(
+                    key=course.sponsoring_organizations.first().key,
+                    name=course.sponsoring_organizations.first().name,
+                )
+            ]
+        }
+        serializer = self.serialize_course(course, request)
+        self.assertDictEqual(serializer.data, expected)
+
     @classmethod
     def get_expected_data(cls, course, course_run, seat):
         return {

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -158,7 +158,8 @@ class CourseRunFactory(SalesforceRecordFactory):
     full_description_override = None
     language = factory.Iterator(LanguageTag.objects.all())
     start = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC))
-    end = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC)).end_dt
+    end = FuzzyDateTime(start_dt=datetime.datetime(2008, 1, 1, tzinfo=UTC),
+                        end_dt=datetime.datetime(2022, 1, 1, tzinfo=UTC)).end_dt
     go_live_date = None
     enrollment_start = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC))
     enrollment_end = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC)).end_dt

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -158,8 +158,7 @@ class CourseRunFactory(SalesforceRecordFactory):
     full_description_override = None
     language = factory.Iterator(LanguageTag.objects.all())
     start = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC))
-    end = FuzzyDateTime(start_dt=datetime.datetime(2008, 1, 1, tzinfo=UTC),
-                        end_dt=datetime.datetime(2022, 1, 1, tzinfo=UTC)).end_dt
+    end = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC)).end_dt
     go_live_date = None
     enrollment_start = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC))
     enrollment_end = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC)).end_dt


### PR DESCRIPTION
This Pr code aimed to remove the Ended/Expired Course Runs from the Endpoint
**/api/v1/search/all/**
You can test this scenario by
**1**- Creating an Enterprise Customer
**2**- Creating an Enterprise Customer Catalog
**3**- Creating a course with Ended Course Runs and some Active course Runs.
**4**- Associate this Course with enterprise on Via E-COMMERCE COURSE ADMINISTRATION Panel.
**5**- Then run these two cammands on discover shell
python manage.py refresh_course_metadata
python manage.py update_index  --disable-change-limit
**6**- Please check on the endpoint mentioned above.
**PRE-PR Results**:
All course runs will be visible in results.
**POST-PR Results**:
Course runs which are expired will not be visible in results.
