### PR TITLE
Exclude Ended course runs from endpoint api/v1/search/all/

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1806,7 +1806,7 @@ class CourseSearchSerializer(HaystackSerializer):
                 'estimated_hours': get_course_run_estimated_hours(course_run),
                 'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0
             }
-            for course_run in result.object.course_runs.all()
+            for course_run in result.object.course_runs.exclude(end__lte=datetime.datetime.now(pytz.UTC))
         ]
 
     def get_seat_types(self, result):


### PR DESCRIPTION
This Pr code aimed to remove the Ended/Expired Course Runs from the Endpoint
/api/v1/search/all/
You can test this scenario by
1- Creating an Enterprise Customer
2- Creating an Enterprise Customer Catalog
3- Creating a course with Ended Course Runs and some Active course Runs.
4- Associate this Course with enterprise on Via E-COMMERCE COURSE ADMINISTRATION Panel.
5- Then run these two cammands on discover shell
python manage.py refresh_course_metadata
python manage.py update_index --disable-change-limit
6- Please check on the endpoint mentioned above.
PRE-PR Results:
All course runs will be visible in results.
POST-PR Results:
Course runs which are expired will not be visible in results.