### PR TITLE
Revert back so our UUID field on course run object remains readonly 

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -134,7 +134,7 @@ class CourseRunAdmin(admin.ModelAdmin):
     )
     ordering = ('key',)
     raw_id_fields = ('course', 'draft_version',)
-    readonly_fields = ('enrollment_count', 'recent_enrollment_count',)
+    readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count',)
     search_fields = ('uuid', 'key', 'title_override', 'course__title', 'slug', 'external_key')
     save_error = False
 


### PR DESCRIPTION
In django admin, we should keep the UUID field of the course_run object readonly still to keep from others modify that field.
Please review @mikix 