### PR TITLE
Exclude ended/expired course runs from endpoint

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1808,14 +1808,10 @@ class CourseSearchSerializer(HaystackSerializer):
 
     def get_course_runs(self, result):
         request = self.context['request']
-        query_params = request.GET
-        exclude_expire_course_run = query_params.get("exclude_expire_course_run", None)
-        # Check if exclude_expire_course_run is in queryparams then exclude the course runs whose end date is passed.
-        if exclude_expire_course_run:
-            course_runs = [course_run for course_run in result.object.course_runs.exclude(
-                end__lte=datetime.datetime.now(pytz.UTC))]
-        else:
-            course_runs = [course_run for course_run in result.object.course_runs.all()]
+        course_runs = result.object.course_runs.all()
+        # Check if exclude_expire_course_run is in query_params then exclude the course runs whose end date is passed.
+        if request.GET.get("exclude_expired_course_run"):
+            course_runs = course_runs.exclude(end__lte=datetime.datetime.now(pytz.UTC))
         return [
             {
                 'key': course_run.key,

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1825,7 +1825,7 @@ class CourseSearchSerializer(HaystackSerializer):
                 'estimated_hours': get_course_run_estimated_hours(course_run),
                 'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0
             }
-            for course_run in result.object.course_runs.all()
+            for course_run in result.object.course_runs.exclude(end__lte=datetime.datetime.now(pytz.UTC))
         ]
 
     def get_seat_types(self, result):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -58,9 +58,9 @@ def json_date_format(datetime_obj):
     return datetime_obj and datetime.datetime.strftime(datetime_obj, "%Y-%m-%dT%H:%M:%S.%fZ")
 
 
-def make_request():
+def make_request(query_param=None):
     user = UserFactory()
-    request = APIRequestFactory().get('/')
+    request = APIRequestFactory().get('/', query_param)
     request.user = user
     return request
 
@@ -1638,15 +1638,15 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
             authoring_organizations=[organization],
             sponsoring_organizations=[organization],
         )
-        course_run = CourseRunFactory(course=course, end=datetime.datetime.now(UTC) + datetime.timedelta(days=10))
+        course_run = CourseRunFactory(course=course)
         course.course_runs.add(course_run)
         course.save()
         seat = SeatFactory(course_run=course_run)
         serializer = self.serialize_course(course, request)
         assert serializer.data == self.get_expected_data(course, course_run, seat)
 
-    def test_expired_and_current_course_run(self):
-        request = make_request()
+    def test_exclude_expired_and_keep_current_course_run(self):
+        request = make_request({'exclude_expire_course_run': True})
         organization = OrganizationFactory()
         course = CourseFactory(
             subjects=SubjectFactory.create_batch(3),
@@ -1662,7 +1662,7 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
         assert serializer.data["course_runs"] == self.get_expected_data(course, course_run, seat)["course_runs"]
 
     def test_exclude_expired_course_run(self):
-        request = make_request()
+        request = make_request({'exclude_expire_course_run': True})
         organization = OrganizationFactory()
         course = CourseFactory(
             subjects=SubjectFactory.create_batch(3),

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1645,6 +1645,22 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
         serializer = self.serialize_course(course, request)
         assert serializer.data == self.get_expected_data(course, course_run, seat)
 
+    def test_expired_and_current_course_run(self):
+        request = make_request()
+        organization = OrganizationFactory()
+        course = CourseFactory(
+            subjects=SubjectFactory.create_batch(3),
+            authoring_organizations=[organization],
+            sponsoring_organizations=[organization],
+        )
+        course_run = CourseRunFactory(course=course, end=datetime.datetime.now(UTC) + datetime.timedelta(days=10))
+        course_run_expired = CourseRunFactory(course=course)
+        course.course_runs.add(course_run, course_run_expired)
+        course.save()
+        seat = SeatFactory(course_run=course_run)
+        serializer = self.serialize_course(course, request)
+        assert serializer.data["course_runs"] == self.get_expected_data(course, course_run, seat)["course_runs"]
+
     def test_exclude_expired_course_run(self):
         request = make_request()
         organization = OrganizationFactory()

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1638,12 +1638,52 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
             authoring_organizations=[organization],
             sponsoring_organizations=[organization],
         )
-        course_run = CourseRunFactory(course=course)
+        course_run = CourseRunFactory(course=course, end=datetime.datetime.now(UTC) + datetime.timedelta(days=10))
         course.course_runs.add(course_run)
         course.save()
         seat = SeatFactory(course_run=course_run)
         serializer = self.serialize_course(course, request)
         assert serializer.data == self.get_expected_data(course, course_run, seat)
+
+    def test_exclude_expired_course_run(self):
+        request = make_request()
+        organization = OrganizationFactory()
+        course = CourseFactory(
+            subjects=SubjectFactory.create_batch(3),
+            authoring_organizations=[organization],
+            sponsoring_organizations=[organization],
+        )
+        course_run = CourseRunFactory(course=course)
+        course.course_runs.add(course_run)
+        course.save()
+        seat = SeatFactory(course_run=course_run)
+        expected = {
+            'key': course.key,
+            'title': course.title,
+            'short_description': course.short_description,
+            'full_description': course.full_description,
+            'content_type': 'course',
+            'aggregation_key': 'course:{}'.format(course.key),
+            'card_image_url': course.card_image_url,
+            'image_url': course.image_url,
+            'course_runs': [],
+            'uuid': str(course.uuid),
+            'subjects': [subject.name for subject in course.subjects.all()],
+            'languages': [
+                serialize_language(course_run.language) for course_run in course.course_runs.all()
+                if course_run.language
+            ],
+            'seat_types': [seat.type],
+            'organizations': [
+                '{key}: {name}'.format(
+                    key=course.sponsoring_organizations.first().key,
+                    name=course.sponsoring_organizations.first().name,
+                )
+            ]
+        }
+
+        serializer = self.serialize_course(course, request)
+        self.assertDictEqual(serializer.data, expected)
 
     @classmethod
     def get_expected_data(cls, course, course_run, seat):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -60,7 +60,10 @@ def json_date_format(datetime_obj):
 
 def make_request(query_param=None):
     user = UserFactory()
-    request = APIRequestFactory().get('/', query_param)
+    if query_param:
+        request = APIRequestFactory().get('/', query_param)
+    else:
+        request = APIRequestFactory().get('/')
     request.user = user
     return request
 
@@ -1646,7 +1649,7 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
         assert serializer.data == self.get_expected_data(course, course_run, seat)
 
     def test_exclude_expired_and_keep_current_course_run(self):
-        request = make_request({'exclude_expire_course_run': True})
+        request = make_request({'exclude_expired_course_run': True})
         organization = OrganizationFactory()
         course = CourseFactory(
             subjects=SubjectFactory.create_batch(3),
@@ -1662,7 +1665,7 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
         assert serializer.data["course_runs"] == self.get_expected_data(course, course_run, seat)["course_runs"]
 
     def test_exclude_expired_course_run(self):
-        request = make_request({'exclude_expire_course_run': True})
+        request = make_request({'exclude_expired_course_run': True})
         organization = OrganizationFactory()
         course = CourseFactory(
             subjects=SubjectFactory.create_batch(3),


### PR DESCRIPTION
This PR removes the Ended/Expired Course Runs from the Endpoint.
`/api/v1/search/all/`
**Important Note:**
Expired Courses will be removed only when `exclude_expire_course_run` QUERY PARAM will be added in the endpoint.

You can test this scenario by
1- Creating an Enterprise Customer
2- Creating an Enterprise Customer Catalog
3- Creating a course with Ended Course Runs and some Active course Runs.
4- Associate this Course with enterprise on Via E-COMMERCE COURSE ADMINISTRATION Panel.
5- Then run these two commands on discover shell
python manage.py refresh_course_metadata
python manage.py update_index --disable-change-limit
6- Please check on the endpoint mentioned above.
**PRE-PR Results:**
All course runs will be visible in results.
**POST-PR Results**:
Course runs which are expired will not be visible in results.

[ENT-1470](https://openedx.atlassian.net/browse/ENT-1470)