### PR TITLE
DISCO add 'school/' to marketing url

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -484,7 +484,7 @@ class Organization(CachedMixin, TimeStampedModel):
     @property
     def marketing_url(self):
         if self.slug and self.partner:
-            return urljoin(self.partner.marketing_site_url_root, self.slug)
+            return urljoin(self.partner.marketing_site_url_root, 'school/' + self.slug)
 
         return None
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -1059,8 +1059,8 @@ class OrganizationTests(TestCase):
 
     def test_marketing_url(self):
         """ Verify the property creates a complete marketing URL. """
-        expected = '{root}/{slug}'.format(root=self.organization.partner.marketing_site_url_root.strip('/'),
-                                          slug=self.organization.slug)
+        expected = '{root}/school/{slug}'.format(root=self.organization.partner.marketing_site_url_root.strip('/'),
+                                                 slug=self.organization.slug)
         self.assertEqual(self.organization.marketing_url, expected)
 
     def test_marketing_url_without_slug(self):


### PR DESCRIPTION
Add back 'school/' to marketing_url property in the Organization class.