### PR TITLE
Pull title from Studio in RCM

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -238,6 +238,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
             'enrollment_end': self.parse_date(body['enrollment_end']),
             'hidden': body.get('hidden', False),
             'license': body.get('license') or '',  # license cannot be None
+            'title_override': body['name'],  # we support Studio edits, even though Publisher also owns titles
         }
 
         if not self.partner.uses_publisher or new_pub_fe:
@@ -245,7 +246,6 @@ class CoursesApiDataLoader(AbstractDataLoader):
 
         if not self.partner.uses_publisher:
             defaults.update({
-                'title_override': body['name'],
                 'short_description_override': body['short_description'],
                 'video': self.get_courserun_video(body),
                 'status': CourseRunStatus.Published,

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -189,7 +189,7 @@ class CoursesApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCas
             'enrollment_start': self.loader.parse_date(body['enrollment_start']),
             'enrollment_end': self.loader.parse_date(body['enrollment_end']),
             'card_image_url': None,
-            'title_override': None,
+            'title_override': body['name'],
             'short_description_override': None,
             'video': None,
             'hidden': body.get('hidden', False),
@@ -202,7 +202,6 @@ class CoursesApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCas
         if not partner_uses_publisher:
             expected_values.update({
                 'card_image_url': None,
-                'title_override': body['name'],
                 'short_description_override': self.loader.clean_string(body['short_description']),
                 'video': self.loader.get_courserun_video(body),
                 'status': CourseRunStatus.Published,


### PR DESCRIPTION
We want to re-support Studio edits of course run titles. So lets actually pull that data in again.

https://openedx.atlassian.net/browse/DISCO-1390