### PR TITLE
Avoid saving seats that don't match

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -556,6 +556,15 @@ class EcommerceApiDataLoader(AbstractDataLoader):
                 seat_type=certificate_type, sku=sku
             )
             logger.warning(msg)
+            self.processing_failure_occurred = True
+            return
+        if course_run.type and not course_run.type.tracks.filter(seat_type=seat_type).exists():
+            logger.warning(
+                'Seat type {seat_type} is not compatible with course run type {run_type} for course run {key}'.format(
+                    seat_type=seat_type.slug, run_type=course_run.type.slug, key=course_run.key,
+                )
+            )
+            self.processing_failure_occurred = True
             return
 
         credit_provider = attributes.get('credit_provider')
@@ -688,6 +697,15 @@ class EcommerceApiDataLoader(AbstractDataLoader):
                 mode=mode_name, title=title, sku=sku
             )
             logger.warning(msg)
+            self.processing_failure_occurred = True
+            return None
+        if course.type and mode not in course.type.entitlement_types.all():
+            logger.warning(
+                'Seat type {seat_type} is not compatible with course type {course_type} for course {uuid}'.format(
+                    seat_type=mode.slug, course_type=course.type.slug, uuid=course_uuid,
+                )
+            )
+            self.processing_failure_occurred = True
             return None
 
         defaults = {

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_load_program_fixture.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_load_program_fixture.py
@@ -234,14 +234,15 @@ class TestLoadProgramFixture(TestCase):
 
         # create existing verified seat with different pk than fixture and
         # a second seat type with the same pk but different values
-        SeatType.objects.create(id=99, name='Verified', slug='verified')
+        new_pk = self.seat_type_verified.id + 1
+        SeatType.objects.create(id=new_pk, name='Verified', slug='verified')
         SeatType.objects.create(id=self.seat_type_verified.id, name='Test', slug='test')
         self._call_load_program_fixture([str(self.program.uuid)])
 
         stored_program = Program.objects.get(uuid=self.program.uuid)
         stored_seat_type = stored_program.type.applicable_seat_types.first()
 
-        self.assertEqual(stored_seat_type.id, 99)
+        self.assertEqual(stored_seat_type.id, new_pk)
         self.assertEqual(stored_seat_type.name, self.seat_type_verified.name)
 
     @responses.activate


### PR DESCRIPTION
If a course has a CourseType or a course run has a CourseRunType, and the ecommerce RCM loader tries to save an incompatible seat or entitlement, refuse with a warning.

https://openedx.atlassian.net/browse/DISCO-1384

It does not fail the job... but other similar warnings didn't either. So I didn't change that behavior. But feels like maybe it should?