### PR TITLE
Updating prefetch related call to reduce DB queries

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1900,7 +1900,7 @@ class CourseSearchSerializer(HaystackSerializer):
         There are 2 course_run.all() calls in serializerMethodFields, so let's
         prefetch their objects to reduce the number of queries we have.
         """
-        prefetch_related_objects([instance.object], 'course_runs__seats')
+        prefetch_related_objects([instance.object], 'course_runs__seats__type')
         return super().to_representation(instance)
 
     def get_course_runs(self, result):
@@ -1981,7 +1981,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
         return result.object.type_legacy
 
     def to_representation(self, instance):
-        prefetch_related_objects([instance.object], 'seats')
+        prefetch_related_objects([instance.object], 'seats__type')
         return super().to_representation(instance)
 
     class Meta:

--- a/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
@@ -137,7 +137,7 @@ class AffiliateWindowViewSetTests(ElasticsearchTestMixin, SerializationMixin, AP
         self.assertEqual(response.status_code, 403)
 
         catalog.viewers = [self.user]
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(11):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -230,7 +230,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         query = 'title:' + title
         url = '{root}?q={query}'.format(root=reverse('api:v1:course-list'), query=query)
 
-        with self.assertNumQueries(70, threshold=3):
+        with self.assertNumQueries(74, threshold=3):
             response = self.client.get(url)
             self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 


### PR DESCRIPTION
Was in new relic and noticed there was a resurgence of seat type DB calls. Updated a prefetch to bring that number back down (locally went from 200 queries to 56 on my search/all/ endpoint).