### PR TITLE
Allow credit/honor seats in Publisher

### DIFF
--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -283,7 +283,8 @@ def ensure_draft_world(obj, course_type=None):
             )
 
         draft_course.save()
-        return draft_course
+        # must re-get from db to ensure related fields like course_runs are updated (refresh_from_db isn't enough)
+        return Course.everything.get(pk=draft_course.pk)
     else:
         raise Exception('Ensure draft world only accepts Courses and Course Runs.')
 


### PR DESCRIPTION
For new Publisher-oriented endpoints that update seats, we want to allow but ignore existing credit or honor seats.

This is transitionary. We will eventually support them using the new CourseType support.

https://openedx.atlassian.net/browse/DISCO-1413