### PR TITLE
Added mode slugs to Course Type OPTIONS

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -2258,12 +2258,15 @@ class MetadataWithType(MetadataWithRelatedChoices):
             'course_run_types': [{
                 'uuid': course_run_type.uuid,
                 'name': course_run_type.name,
+                'modes': [track.mode.slug for track in course_run_type.tracks.all()],
             } for course_run_type in course_type.course_run_types.all()],
             'tracks': [
                 TrackSerializer(track).data for track
                 in TrackSerializer.prefetch_queryset().filter(courseruntype__coursetype=course_type).distinct()
             ],
-        } for course_type in CourseType.objects.all()]
+        } for course_type in CourseType.objects.prefetch_related(
+            'course_run_types__tracks__mode', 'entitlement_types'
+        ).all()]
         return info
 
     def get_field_info(self, field):

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1577,7 +1577,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         CourseEntitlementFactory(course=self.course, mode=SeatTypeFactory.verified())
 
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.uuid})
-        with self.assertNumQueries(45, threshold=0):
+        with self.assertNumQueries(37, threshold=0):
             response = self.client.options(url)
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
The mode slugs will be used by Publisher to determine if masters
is present for a given course_run_type and optionally show fields
based on that information (i.e. external key)

DISCO-1092