### PR TITLE
upgrade edx-drf-extensions to 2.4.4 (take 2)

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -436,8 +436,6 @@ JWT_AUTH = {
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie'
-
 }
 
 SWAGGER_SETTINGS = {

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -16,7 +16,7 @@ jinja2==2.10.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==19.2           # via sphinx
 pygments==2.4.2           # via sphinx
-pyparsing==2.4.3          # via packaging
+pyparsing==2.4.4          # via packaging
 pytz==2019.3              # via babel
 requests==2.22.0          # via sphinx
 six==1.13.0               # via edx-sphinx-theme, packaging

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 apipkg==1.5               # via execnet
-astroid==2.3.2            # via pylint, pylint-celery
+astroid==2.3.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 babel==2.7.0              # via sphinx
@@ -73,7 +73,7 @@ edx-ccx-keys==1.0.0
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.1
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.4
 edx-i18n-tools==0.4.8
 edx-lint==1.4.1
 edx-opaque-keys==2.0.0
@@ -102,7 +102,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==7.2.0     # via pytest, zipp
-newrelic==5.2.1.129       # via edx-django-utils
+newrelic==5.2.2.130       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 packaging==19.2           # via pytest, sphinx
@@ -130,7 +130,7 @@ pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.9.0            # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0         # via requests
-pyparsing==2.4.3          # via packaging
+pyparsing==2.4.4          # via packaging
 pytest-cov==2.8.1
 pytest-django-ordering==1.2.0
 pytest-django==3.6.0
@@ -143,7 +143,7 @@ python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3
 pyyaml==3.13              # via docker-compose, edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via django-compressor
-requests-oauthlib==1.2.0  # via social-auth-core
+requests-oauthlib==1.3.0  # via social-auth-core
 requests[security]==2.20.1
 responses==0.10.6
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -152,7 +152,7 @@ selenium==3.141.0
 semantic-version==2.8.2   # via edx-drf-extensions
 simple-salesforce==0.74.3
 simplejson==3.16.0        # via django-rest-swagger
-six==1.12.0               # via astroid, bcrypt, cryptography, django-appconf, django-extensions, django-simple-history, django-sortedm2m, django-taggit-serializer, djangorestframework-csv, docker, docker-compose, docker-pycreds, dockerpty, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, libsass, mock, packaging, pathlib2, pyjwkest, pynacl, pyopenssl, pytest-xdist, python-dateutil, responses, social-auth-app-django, social-auth-core, stevedore, unicode-slugify, websocket-client
+six==1.13.0               # via astroid, bcrypt, cryptography, django-appconf, django-extensions, django-simple-history, django-sortedm2m, django-taggit-serializer, djangorestframework-csv, docker, docker-compose, docker-pycreds, dockerpty, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, libsass, mock, packaging, pathlib2, pyjwkest, pynacl, pyopenssl, pytest-xdist, python-dateutil, responses, social-auth-app-django, social-auth-core, stevedore, unicode-slugify, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -55,7 +55,7 @@ edx-ccx-keys==1.0.0
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.1
-edx-drf-extensions==2.4.2
+edx-drf-extensions==2.4.4
 edx-opaque-keys==2.0.0
 edx-rest-api-client==1.9.2
 elasticsearch==1.9.0
@@ -71,8 +71,8 @@ jsonfield==2.0.2
 libsass==0.19.4           # via django-libsass
 markdown==3.1.1
 markupsafe==1.1.1         # via jinja2
-mysqlclient==1.4.4
-newrelic==5.2.1.129
+mysqlclient==1.4.5
+newrelic==5.2.2.130
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.3                # via stevedore
@@ -91,7 +91,7 @@ python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3
 pyyaml==5.1.2
 rcssmin==1.0.6            # via django-compressor
-requests-oauthlib==1.2.0  # via social-auth-core
+requests-oauthlib==1.3.0  # via social-auth-core
 requests[security]==2.22.0
 rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.1.0             # via django-compressor


### PR DESCRIPTION
- Upgrade edx-drf-extensions to 2.4.4
- Other upgrades coming with `make upgrade`
- Remove unused JWT_AUTH_REFRESH_COOKIE setting.

ARCH-418, ARCH-1269, ARCH-1044