### PR TITLE
Support Masters-style CourseTypes

### DIFF
--- a/course_discovery/apps/course_metadata/publishers.py
+++ b/course_discovery/apps/course_metadata/publishers.py
@@ -312,6 +312,10 @@ class BaseMarketingSitePublisher:
             obj (CourseRun): string of the node id
             previous_obj (CourseRun): the old course run to redirect to
         """
+        if not obj.could_be_marketable or not previous_obj.could_be_marketable:
+            # We won't find them on the marketing site, so don't bother
+            return
+
         logger.info('Setting redirect from [%s] to [%s].', previous_obj.slug, obj.slug)
 
         node_id = self.node_id(obj)

--- a/course_discovery/apps/course_metadata/query.py
+++ b/course_discovery/apps/course_metadata/query.py
@@ -39,6 +39,8 @@ class CourseQuerySet(models.QuerySet):
         marketable = (
             ~Q(course_runs__slug='') &
             Q(course_runs__seats__isnull=False) &
+            Q(course_runs__draft=False) &
+            ~Q(course_runs__type__is_marketable=False) &
             Q(course_runs__status=CourseRunStatus.Published)
         )
 
@@ -114,6 +116,10 @@ class CourseRunQuerySet(models.QuerySet):
         ).exclude(
             # This will exclude any course run without seats (e.g., CCX runs).
             seats__isnull=True
+        ).filter(
+            draft=False
+        ).exclude(
+            type__is_marketable=False
         ).filter(
             status=CourseRunStatus.Published
         )

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -57,6 +57,11 @@ def add_masters_track_on_course(sender, instance, **kwargs):  # pylint: disable=
         us_currency = Currency.objects.get(code='USD')
 
         for course_run in instance.course_runs:
+            if course_run.type:
+                # We are in the middle of a transition to CourseRunType. If we have a type, we handle this elsewhere.
+                # See push_tracks_to_lms_for_course_run in utils.py.
+                continue
+
             Seat.objects.update_or_create(
                 course_run=course_run,
                 type=SeatType.objects.get(slug=Seat.MASTERS),
@@ -73,6 +78,11 @@ def publish_masters_track(sender, instance, **kwargs):  # pylint: disable=unused
     masters enrollment_mode created
     """
     seat = instance
+    if seat.course_run.type:
+        # We are in the middle of a transition to CourseRunType. If we have a type, pushing to LMS will be handled by
+        # push_tracks_to_lms_for_course_run.
+        return
+
     if seat.type.slug != Seat.MASTERS:
         logger.debug('Not going to publish non masters seat (type %s)', seat.type.slug)
         return

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -73,7 +73,7 @@ class SeatSignalsTests(TestCase):
     """ Tests for the signal to save seats model into database """
     def setUp(self):
         super().setUp()
-        self.course_runs = factories.CourseRunFactory.create_batch(3)
+        self.course_runs = factories.CourseRunFactory.create_batch(3, type=None)
         self.partner = factories.PartnerFactory()
         self.course = self.course_runs[0].course
         self.course.partner = self.partner

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -436,8 +436,6 @@ JWT_AUTH = {
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie'
-
 }
 
 SWAGGER_SETTINGS = {


### PR DESCRIPTION
Specifically:
- Pay attention to CourseRunType.is_marketable wherever we calculate marketability
- Create CourseModes on the LMS side if a track without a seat is approved during internal review using the new Publisher flow

I've left the old Masters support in place for now. It just early exits if the run is using CourseRunTypes.

https://openedx.atlassian.net/browse/DISCO-1459