### PR TITLE
Send credit seats to ecom just like verified seats

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1751,7 +1751,7 @@ class Seat(DraftModelMixin, TimeStampedModel):
     ENTITLEMENT_MODES = [VERIFIED, PROFESSIONAL]
     REQUIRES_AUDIT_SEAT = [VERIFIED]
     # Seat types that we don't push to ecommerce -- they are either manually or never created as products
-    NON_PRODUCT_MODES = [CREDIT, MASTERS]
+    NON_PRODUCT_MODES = [MASTERS]
     # Seat types that may not be purchased without first purchasing another Seat type.
     # EX: 'credit' seats may not be purchased without first purchasing a 'verified' Seat.
     SEATS_WITH_PREREQUISITES = [CREDIT]


### PR DESCRIPTION
Uh, this might be all we need?

`NON_PRODUCT_MODES` is only used in one place: `push_to_ecommerce_for_course_run`, which is used by both new and old publisher. 

As far as I can tell, there should be no harm in sending it as well for old publisher.