### PR TITLE
Updating RCM OAuth Client.

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -132,7 +132,7 @@ class OAuth2Mixin:
     def mock_access_token(self):
         responses.add(
             responses.POST,
-            self.partner.oauth2_provider_url + '/access_token',
+            self.partner.lms_url + '/oauth2/access_token',
             body=json.dumps({'access_token': 'abcd', 'expires_in': 60}),
             status=200,
         )

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -40,7 +40,8 @@ class OrganizationsApiDataLoader(AbstractDataLoader):
         logger.info('Refreshing Organizations from %s...', api_url)
 
         while page:
-            response = self.api_client.organizations().get(page=page, page_size=self.PAGE_SIZE)
+            params = {'page': page, 'page_size': self.PAGE_SIZE}
+            response = self.api_client.get(self.api_url + '/organizations/', params=params).json()
             count = response['count']
             results = response['results']
             logger.info('Retrieved %d organizations...', len(results))
@@ -143,7 +144,8 @@ class CoursesApiDataLoader(AbstractDataLoader):
     )
     def _make_request(self, page):
         logger.info('Requesting course run page %d...', page)
-        return self.api_client.courses().get(page=page, page_size=self.PAGE_SIZE, username=self.username)
+        params = {'page': page, 'page_size': self.PAGE_SIZE}
+        return self.api_client.get(self.api_url + '/courses/', params=params).json()
 
     def _process_response(self, response):
         results = response['results']
@@ -338,11 +340,8 @@ class EcommerceApiDataLoader(AbstractDataLoader):
 
     LOADER_MAX_RETRY = 2
 
-    def __init__(self, partner, api_url, access_token=None, token_type=None, max_workers=None,
-                 is_threadsafe=False, **kwargs):
-        super(EcommerceApiDataLoader, self).__init__(
-            partner, api_url, access_token, token_type, max_workers, is_threadsafe, **kwargs
-        )
+    def __init__(self, partner, api_url, max_workers=None, is_threadsafe=False, **kwargs):
+        super(EcommerceApiDataLoader, self).__init__(partner, api_url, max_workers, is_threadsafe, **kwargs)
         self.initial_page = 1
         self.enrollment_skus = []
         self.entitlement_skus = []
@@ -483,13 +482,16 @@ class EcommerceApiDataLoader(AbstractDataLoader):
             self.processing_failure_occurred = True
 
     def _request_course_runs(self, page):
-        return self.api_client.courses().get(page=page, page_size=self.PAGE_SIZE, include_products=True)
+        params = {'page': page, 'page_size': self.PAGE_SIZE, 'include_products': True}
+        return self.api_client.get(self.api_url + '/courses/', params=params).json()
 
     def _request_entitlements(self, page):
-        return self.api_client.products().get(page=page, page_size=self.PAGE_SIZE, product_class='Course Entitlement')
+        params = {'page': page, 'page_size': self.PAGE_SIZE, 'product_class': 'Course Entitlement'}
+        return self.api_client.get(self.api_url + '/products/', params=params).json()
 
     def _request_enrollment_codes(self, page):
-        return self.api_client.products().get(page=page, page_size=self.PAGE_SIZE, product_class='Enrollment Code')
+        params = {'page': page, 'page_size': self.PAGE_SIZE, 'product_class': 'Enrollment Code'}
+        return self.api_client.get(self.api_url + '/products/', params=params).json()
 
     def _process_course_runs(self, response):
         results = response['results']
@@ -825,11 +827,8 @@ class ProgramsApiDataLoader(AbstractDataLoader):
     image_height = 480
     XSERIES = None
 
-    def __init__(self, partner, api_url, access_token=None, token_type=None, max_workers=None,
-                 is_threadsafe=False, **kwargs):
-        super(ProgramsApiDataLoader, self).__init__(
-            partner, api_url, access_token, token_type, max_workers, is_threadsafe, **kwargs
-        )
+    def __init__(self, partner, api_url, max_workers=None, is_threadsafe=False):
+        super(ProgramsApiDataLoader, self).__init__(partner, api_url, max_workers, is_threadsafe)
         self.XSERIES = ProgramType.objects.get(name='XSeries')
 
     def ingest(self):
@@ -840,7 +839,8 @@ class ProgramsApiDataLoader(AbstractDataLoader):
         logger.info('Refreshing programs from %s...', api_url)
 
         while page:
-            response = self.api_client.programs.get(page=page, page_size=self.PAGE_SIZE)
+            params = {'page': page, 'page_size': self.PAGE_SIZE}
+            response = self.api_client.get(self.api_url + '/programs/', params=params).json()
             count = response['count']
             results = response['results']
             logger.info('Retrieved %d programs...', len(results))

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -1,34 +1,19 @@
 import responses
-from edx_rest_api_client.auth import SuppliedJwtAuth
-from edx_rest_api_client.client import EdxRestApiClient
 
+from course_discovery.apps.api.v1.tests.test_views.mixins import OAuth2Mixin
 from course_discovery.apps.course_metadata.tests.factories import PartnerFactory
-
-ACCESS_TOKEN = 'secret'
-ACCESS_TOKEN_TYPE = 'JWT'
-
-
-class ApiClientTestMixin:
-    def test_api_client(self):
-        """ Verify the property returns an API client with the correct authentication. """
-        loader = self.loader_class(self.partner, self.api_url, ACCESS_TOKEN, ACCESS_TOKEN_TYPE)
-        client = loader.api_client
-        self.assertIsInstance(client, EdxRestApiClient)
-        # NOTE (CCB): My initial preference was to mock the constructor and ensure the correct auth arguments
-        # were passed. However, that seems nearly impossible. This is the next best alternative. It is brittle, and
-        # may break if we ever change the underlying request class of EdxRestApiClient.
-        self.assertIsInstance(client._store['session'].auth, SuppliedJwtAuth)  # pylint: disable=protected-access
 
 
 # pylint: disable=not-callable
-class DataLoaderTestMixin:
+class DataLoaderTestMixin(OAuth2Mixin):
     loader_class = None
     partner = None
 
     def setUp(self):
         super(DataLoaderTestMixin, self).setUp()
         self.partner = PartnerFactory()
-        self.loader = self.loader_class(self.partner, self.api_url, ACCESS_TOKEN, ACCESS_TOKEN_TYPE)
+        self.loader = self.loader_class(self.partner, self.api_url)
+        self.mock_access_token()
 
     @property
     def api_url(self):  # pragma: no cover
@@ -38,10 +23,9 @@ class DataLoaderTestMixin:
         """ Asserts the API was called with the correct number of calls, and the appropriate Authorization header. """
         self.assertEqual(len(responses.calls), expected_num_calls)
         if check_auth:
-            self.assertEqual(responses.calls[0].request.headers['Authorization'], 'JWT {}'.format(ACCESS_TOKEN))
+            # 'JWT abcd' is the default value that comes from the mock_access_token function called in setUp
+            self.assertEqual(responses.calls[1].request.headers['Authorization'], 'JWT abcd')
 
     def test_init(self):
         """ Verify the constructor sets the appropriate attributes. """
         self.assertEqual(self.loader.partner.short_code, self.partner.short_code)
-        self.assertEqual(self.loader.access_token, ACCESS_TOKEN)
-        self.assertEqual(self.loader.token_type, ACCESS_TOKEN_TYPE.lower())

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_analytics_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_analytics_api.py
@@ -53,7 +53,6 @@ class AnalyticsAPIDataLoaderTests(DataLoaderTestMixin, TestCase):
         self._define_course_metadata()
 
         url = '{root_url}course_summaries/'.format(root_url=self.api_url)
-
         responses.add(
             method=responses.GET,
             url=url,

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -18,7 +18,7 @@ from course_discovery.apps.course_metadata.data_loaders.api import (
     AbstractDataLoader, CoursesApiDataLoader, EcommerceApiDataLoader, OrganizationsApiDataLoader, ProgramsApiDataLoader
 )
 from course_discovery.apps.course_metadata.data_loaders.tests import JPEG, JSON, mock_data
-from course_discovery.apps.course_metadata.data_loaders.tests.mixins import ApiClientTestMixin, DataLoaderTestMixin
+from course_discovery.apps.course_metadata.data_loaders.tests.mixins import DataLoaderTestMixin
 from course_discovery.apps.course_metadata.models import (
     Course, CourseEntitlement, CourseRun, CourseRunType, CourseType, Organization, Program, ProgramType, Seat, SeatType
 )
@@ -57,7 +57,7 @@ class AbstractDataLoaderTest(TestCase):
 
 
 @ddt.ddt
-class OrganizationsApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCase):
+class OrganizationsApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     loader_class = OrganizationsApiDataLoader
 
     @property
@@ -98,7 +98,7 @@ class OrganizationsApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, T
         self.loader.ingest()
 
         # Verify the API was called with the correct authorization header
-        self.assert_api_called(1)
+        self.assert_api_called(2)
 
         # Verify the Organizations were created correctly
         expected_num_orgs = len(api_data)
@@ -144,7 +144,7 @@ class OrganizationsApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, T
 
 
 @ddt.ddt
-class CoursesApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCase):
+class CoursesApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     loader_class = CoursesApiDataLoader
 
     @property
@@ -242,7 +242,7 @@ class CoursesApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCas
             self.loader.ingest()
 
         # Verify the API was called with the correct authorization header
-        self.assert_api_called(1)
+        self.assert_api_called(2)
 
         # Verify the CourseRuns were created correctly
         expected_num_course_runs = len(api_data)
@@ -268,7 +268,7 @@ class CoursesApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCas
             self.loader.ingest()
 
         # Verify the API was called with the correct authorization header
-        self.assert_api_called(1)
+        self.assert_api_called(2)
 
         runs = CourseRun.objects.all()
         # Run with a verified entitlement, but no change in end date
@@ -522,7 +522,7 @@ class CoursesApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCas
 
 
 @ddt.ddt
-class EcommerceApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCase):
+class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     loader_class = EcommerceApiDataLoader
 
     @property
@@ -800,7 +800,7 @@ class EcommerceApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestC
         self.loader.ingest()
 
         # Verify the API was called with the correct authorization header
-        self.assert_api_called(3)
+        self.assert_api_called(4)
 
         for datum in loaded_seat_data:
             self.assert_seats_loaded(datum, products_api_data)
@@ -937,7 +937,7 @@ class EcommerceApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestC
 
 
 @ddt.ddt
-class ProgramsApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCase):
+class ProgramsApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     loader_class = ProgramsApiDataLoader
 
     @property
@@ -1031,7 +1031,7 @@ class ProgramsApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCa
         self.loader.ingest()
 
         # Verify the API was called with the correct authorization header
-        self.assert_api_called(2)
+        self.assert_api_called(3)
 
         # Verify the Programs were created correctly
         self.assertEqual(Program.objects.count(), len(api_data))
@@ -1073,7 +1073,7 @@ class ProgramsApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCa
 
         self.loader.ingest()
         # Verify the API was called with the correct authorization header
-        self.assert_api_called(2)
+        self.assert_api_called(3)
 
         for program in programs:
             self.assert_program_loaded(program)

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_marketing_site.py
@@ -122,7 +122,7 @@ class AbstractMarketingSiteDataLoaderTestMixin(DataLoaderTestMixin):
     def test_api_client_login_failure(self):
         self.mock_login_response(failure=True)
         with self.assertRaises(Exception):
-            self.loader.api_client  # pylint: disable=pointless-statement
+            self.loader.marketing_api_client()
 
     def test_constructor_without_credentials(self):
         """ Verify the constructor raises an exception if the Partner has no marketing site credentials set. """

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -2,13 +2,11 @@ import concurrent.futures
 import itertools
 import logging
 
-import jwt
 import waffle
 from django.apps import apps
 from django.core.management import BaseCommand, CommandError
 from django.db import connection
 from django.db.models.signals import post_delete, post_save
-from edx_rest_api_client.client import EdxRestApiClient
 
 from course_discovery.apps.api.cache import api_change_receiver, set_api_timestamp
 from course_discovery.apps.core.models import Partner
@@ -26,16 +24,16 @@ from course_discovery.apps.course_metadata.models import Course, DataLoaderConfi
 logger = logging.getLogger(__name__)
 
 
-def execute_loader(loader_class, *loader_args, **loader_kwargs):
+def execute_loader(loader_class, *loader_args):
     try:
-        loader_class(*loader_args, **loader_kwargs).ingest()
+        loader_class(*loader_args).ingest()
         return True
     except Exception:  # pylint: disable=broad-except
         logger.exception('%s failed!', loader_class.__name__)
         return False
 
 
-def execute_parallel_loader(loader_class, *loader_args, **loader_kwargs):
+def execute_parallel_loader(loader_class, *loader_args):
     """
     ProcessPoolExecutor uses the multiprocessing module. Multiprocessing forks processes,
     causing connection objects to be copied across processes. The key goal when running
@@ -51,7 +49,7 @@ def execute_parallel_loader(loader_class, *loader_args, **loader_kwargs):
     """
     connection.close()
 
-    return execute_loader(loader_class, *loader_args, **loader_kwargs)
+    return execute_loader(loader_class, *loader_args)
 
 
 class Command(BaseCommand):
@@ -62,25 +60,6 @@ class Command(BaseCommand):
             '--partner_code',
             help='The short code for a specific partner to refresh.'
         )
-
-    def get_access_token(self, partner, token_type):
-        """
-        Obtain an access token from the LMS for general API access.
-        """
-        logger.info('Retrieving access token for partner [%s]', partner.short_code)
-
-        access_token_url = '{root}/access_token'.format(root=partner.oauth2_provider_url)
-        try:
-            access_token, __ = EdxRestApiClient.get_oauth_access_token(
-                access_token_url, partner.oauth2_client_id, partner.oauth2_client_secret, token_type
-            )
-        except Exception:
-            logger.exception('No access token acquired through client_credential flow.')
-            raise
-
-        username = jwt.decode(access_token, verify=False)['preferred_username']
-        kwargs = {'username': username} if username else {}
-        return access_token, kwargs
 
     def handle(self, *args, **options):
         # We only want to invalidate the API response cache once data loading
@@ -103,7 +82,6 @@ class Command(BaseCommand):
             raise CommandError('No partners available!')
 
         success = True
-        token_type = 'JWT'
         for partner in partners:
 
             # The Linux kernel implements copy-on-write when fork() is called to create a new
@@ -167,10 +145,6 @@ class Command(BaseCommand):
             if waffle.switch_is_active('parallel_refresh_pipeline'):
                 futures = []
                 for stage in pipeline:
-                    # Retrieve a new access token for each stage of the pipeline, so that the access token
-                    # won't timeout between long data loads via the APIs used.
-                    access_token, kwargs = self.get_access_token(partner, token_type)
-
                     with concurrent.futures.ProcessPoolExecutor() as executor:
                         for loader_class, api_url, max_workers in stage:
                             if api_url:
@@ -180,32 +154,22 @@ class Command(BaseCommand):
                                     loader_class,
                                     partner,
                                     api_url,
-                                    access_token,
-                                    token_type,
                                     max_workers,
                                     is_threadsafe,
-                                    **kwargs,
                                 ))
 
                 success = success and all(f.result() for f in futures)
             else:
                 # Flatten pipeline and run serially.
                 for loader_class, api_url, max_workers in itertools.chain(*(stage for stage in pipeline)):
-                    # Retrieve a new access token for each flattened stage of the pipeline, so that the access token
-                    # won't timeout between long data loads via the APIs used.
-                    access_token, kwargs = self.get_access_token(partner, token_type)
-
                     if api_url:
                         logger.info('Executing Loader [{}]'.format(api_url))
                         success = execute_loader(
                             loader_class,
                             partner,
                             api_url,
-                            access_token,
-                            token_type,
                             max_workers,
                             is_threadsafe,
-                            **kwargs,
                         ) and success
 
             # TODO Cleanup CourseRun overrides equivalent to the Course values.


### PR DESCRIPTION
This is being undertaken as part of a fix for receiving a
connection reset error in the ecommerce data loader.
The old client would not reauthenticate a request if the
old token expired. The new client will which should fix this
issue.