### PR TITLE
Wait for the official course to be set on the official course run

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1565,6 +1565,9 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
         official_version.slug = self.slug
         official_version.course = official_course
 
+        # During this save, the pre_save hook `ensure_external_key_uniquness__course_run` in signals.py
+        # is run. We rely on there being a save of the official version after the call to set_official_state
+        # and the setting of the official_course.
         official_version.save()
 
         if notify_services:

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -231,6 +231,13 @@ def ensure_external_key_uniquness__course_run(sender, instance, **kwargs):  # py
     """
     if not instance.external_key:
         return
+    # This is for the intermediate time between the official course run being created through
+    # utils.py set_official_state and before the Course reference is updated to the official course.
+    # See course_metadata/models.py under the CourseRun model inside of the update_or_create_official_version
+    # function for when the official run is created and when several lines later, the official course
+    # is added to it.
+    if not instance.draft and instance.course.draft:
+        return
     if instance.id:
         old_course_run = CourseRun.everything.get(pk=instance.pk)
         if instance.external_key == old_course_run.external_key and instance.course == old_course_run.course:


### PR DESCRIPTION
When setting official state for a course run, there is an
intermediate time after creating the official run, but before the
official course is set that would cause a duplicate external key
to be flagged. This now waits until the official course is set before
checking.