### PR TITLE
Added another argument to create_or_update_partner command

### DIFF
--- a/course_discovery/apps/core/management/commands/create_or_update_partner.py
+++ b/course_discovery/apps/core/management/commands/create_or_update_partner.py
@@ -61,6 +61,12 @@ class Command(BaseCommand):
                             type=str,
                             default='',
                             help='API endpoint for accessing Partner program data.')
+        parser.add_argument('--lms-url',
+                            action='store',
+                            dest='lms_url',
+                            type=str,
+                            default='',
+                            help='API endpoint for accessing lms.')
         parser.add_argument('--marketing-site-api-url',
                             action='store',
                             dest='marketing_site_api_url',
@@ -111,6 +117,7 @@ class Command(BaseCommand):
                 'ecommerce_api_url': options.get('ecommerce_api_url'),
                 'organizations_api_url': options.get('organizations_api_url'),
                 'programs_api_url': options.get('programs_api_url'),
+                'lms_url': options.get('lms_url'),
                 'marketing_site_api_url': options.get('marketing_site_api_url'),
                 'marketing_site_url_root': options.get('marketing_site_url_root'),
                 'marketing_site_api_username': options.get('marketing_site_api_username'),


### PR DESCRIPTION
refresh_course_metadata command is failing in devstack provisioning due to lms_url not being set in partner during create_or_update_partner command.  Please suggest corrections/changes to match standard. 

[Devstack PR with matching changes](https://github.com/edx/devstack/pull/462)

[Example of failing devstack build](https://travis-ci.org/edx/devstack/jobs/624335686?utm_medium=notification&utm_source=github_status)

```
Error message:
 Executing Loader [http://edx.devstack.lms:18000/api/organizations/v0/]
2019-12-12 21:41:28,694 INFO 190 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:40 - Refreshing Organizations from http://edx.devstack.lms:18000/api/organizations/v0/...
2019-12-12 21:41:28,694 ERROR 190 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:32 - OrganizationsApiDataLoader failed!
Traceback (most recent call last):
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py", line 29, in execute_loader
    loader_class(*loader_args).ingest()
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py", line 44, in ingest
    response = self.api_client.get(self.api_url + '/organizations/', params=params).json()
AttributeError: 'NoneType' object has no attribute 'get'

```