### PR TITLE
Fix a few Django admin bugs

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -77,7 +77,7 @@ class CourseAdmin(admin.ModelAdmin):
     ordering = ('key', 'title',)
     readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count',)
     search_fields = ('uuid', 'key', 'key_for_reruns', 'title',)
-    raw_id_fields = ('draft_version',)
+    raw_id_fields = ('canonical_course_run', 'draft_version',)
 
 
 @admin.register(CourseEditor)

--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -8,22 +8,7 @@ from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import (
     Course, CourseRun, CurriculumCourseMembership, CurriculumCourseRunExclusion, Pathway, Program
 )
-
-
-def filter_choices_to_render_with_order_preserved(self, selected_choices):
-    """
-    Preserves ordering of selected_choices when creating the choices queryset.
-
-    See https://codybonney.com/creating-a-queryset-from-a-list-while-preserving-order-using-django.
-
-    django-autocomplete's definition of this method on QuerySetSelectMixin loads selected choices in
-    order of primary key instead of the order in which the choices are actually stored.
-    """
-    clauses = ' '.join(['WHEN id={} THEN {}'.format(pk, i) for i, pk in enumerate(selected_choices)])
-    ordering = 'CASE {} END'.format(clauses)
-    self.choices.queryset = self.choices.queryset.filter(
-        pk__in=[c for c in selected_choices if c]
-    ).extra(select={'ordering': ordering}, order_by=('ordering',))
+from course_discovery.apps.course_metadata.widgets import SortedModelSelect2Multiple
 
 
 class ProgramAdminForm(forms.ModelForm):
@@ -31,32 +16,29 @@ class ProgramAdminForm(forms.ModelForm):
         model = Program
         fields = '__all__'
 
-        # Monkey patch filter_choices_to_render with our own definition which preserves ordering.
-        autocomplete.ModelSelect2Multiple.filter_choices_to_render = filter_choices_to_render_with_order_preserved
-
         widgets = {
-            'courses': autocomplete.ModelSelect2Multiple(
+            'courses': SortedModelSelect2Multiple(
                 url='admin_metadata:course-autocomplete',
                 attrs={
                     'data-minimum-input-length': 3,
                     'class': 'sortable-select',
                 },
             ),
-            'authoring_organizations': autocomplete.ModelSelect2Multiple(
+            'authoring_organizations': SortedModelSelect2Multiple(
                 url='admin_metadata:organisation-autocomplete',
                 attrs={
                     'data-minimum-input-length': 3,
                     'class': 'sortable-select',
                 }
             ),
-            'credit_backing_organizations': autocomplete.ModelSelect2Multiple(
+            'credit_backing_organizations': SortedModelSelect2Multiple(
                 url='admin_metadata:organisation-autocomplete',
                 attrs={
                     'data-minimum-input-length': 3,
                     'class': 'sortable-select',
                 }
             ),
-            'instructor_ordering': autocomplete.ModelSelect2Multiple(
+            'instructor_ordering': SortedModelSelect2Multiple(
                 url='admin_metadata:person-autocomplete',
                 attrs={
                     'data-minimum-input-length': 3,

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1873,7 +1873,9 @@ class Program(PkSearchableMixin, TimeStampedModel):
     )
     marketing_slug = models.CharField(
         help_text=_('Slug used to generate links to the marketing site'), unique=True, max_length=255, db_index=True)
-    courses = SortedManyToManyField(Course, related_name='programs')
+    # Normally you don't need this limit_choices_to line, because Course.objects will return official rows by default.
+    # But our Django admin form for this field does more low level querying than that and needs to be limited.
+    courses = SortedManyToManyField(Course, related_name='programs', limit_choices_to={'draft': False})
     order_courses_by_start_date = models.BooleanField(
         default=True, verbose_name='Order Courses By Start Date',
         help_text=_('If this box is not checked, courses will be ordered as in the courses select box above.')

--- a/course_discovery/apps/course_metadata/tests/test_widgets.py
+++ b/course_discovery/apps/course_metadata/tests/test_widgets.py
@@ -1,0 +1,19 @@
+import ddt
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.widgets import SortedModelSelect2Multiple
+
+
+@ddt.ddt
+class SortedModelSelect2MultipleTests(TestCase):
+    @ddt.data(
+        (['1', '2'], [1, 2, 3]),
+        (['2', '1'], [2, 1, 3]),
+        (['3'], [3, 1, 2]),
+    )
+    @ddt.unpack
+    def test_optgroups_are_sorted(self, value, result_order):
+        choices = ((1, 'one'), (2, 'two'), (3, 'three'))
+        widget = SortedModelSelect2Multiple(url='requiredurl', choices=choices)
+        result = widget.optgroups('test', value)
+        self.assertEqual(result_order, [x[1][0]['value'] for x in result])

--- a/course_discovery/apps/course_metadata/widgets.py
+++ b/course_discovery/apps/course_metadata/widgets.py
@@ -1,0 +1,32 @@
+from itertools import chain
+
+from dal import autocomplete
+
+
+class SortedModelSelect2Multiple(autocomplete.ModelSelect2Multiple):
+    def optgroups(self, name, value, attrs=None):
+        """
+        Return a sorted list of optgroups for this widget.
+
+        This is a simplified version of Django's version. The big difference is that we keep the results sorted and
+        only support one main group (because that's all we need right now).
+        """
+        selected = []
+        unselected = []
+        for index, (option_value, option_label) in enumerate(chain(self.choices)):
+            is_selected = str(option_value) in value
+            subgroup = [self.create_option(name, option_value, option_label, is_selected, index, attrs=attrs)]
+            item = (None, subgroup, index)
+            if is_selected:
+                selected.append(item)
+            else:
+                unselected.append(item)
+
+        ordered = []
+        for value_id in value:
+            for item in selected:
+                if value_id == str(item[1][0]['value']):
+                    ordered.append(item)
+                    break
+
+        return ordered + unselected


### PR DESCRIPTION
- Fixed the canonical course run of a course from showing a value
  even if it didn't have one. Just made it a raw id, since this
  field isn't often changed and doesn't need to be pretty.

- Fixed the 'courses' field of a Program from including drafts and
  from not showing the correct ordering.

https://openedx.atlassian.net/browse/DISCO-1535