### PR TITLE
Return 403 on non-publisher user writes

### DIFF
--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -23,6 +23,7 @@ from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.constants import COURSE_RUN_ID_REGEX
 from course_discovery.apps.course_metadata.models import Course, CourseEditor, CourseRun
 from course_discovery.apps.course_metadata.utils import ensure_draft_world
+from course_discovery.apps.publisher.utils import is_publisher_user
 
 log = logging.getLogger(__name__)
 
@@ -79,6 +80,9 @@ class CourseRunViewSet(viewsets.ModelViewSet):
 
         if edit_mode and q:
             raise EditableAndQUnsupported()
+
+        if edit_mode and (not self.request.user.is_staff and not is_publisher_user(self.request.user)):
+            raise PermissionDenied
 
         if edit_mode:
             queryset = CourseRun.objects.filter_drafts()

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -34,6 +34,7 @@ from course_discovery.apps.course_metadata.models import (
 from course_discovery.apps.course_metadata.utils import (
     create_missing_entitlement, ensure_draft_world, validate_course_number
 )
+from course_discovery.apps.publisher.utils import is_publisher_user
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,9 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
 
         if edit_mode and q:
             raise EditableAndQUnsupported()
+
+        if edit_mode and (not self.request.user.is_staff and not is_publisher_user(self.request.user)):
+            raise PermissionDenied
 
         if edit_mode:
             # Start with either draft versions or real versions of the courses


### PR DESCRIPTION
If a non-publisher user (a user without a group associated) tries to use publisher API, we now return a more forceful status code (rather than simply returning an empty set of courses or runs).

https://openedx.atlassian.net/browse/DISCO-1532