### PR TITLE
EDUCATOR-4890 Empty strings should not be duplicated values

### DIFF
--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -218,6 +218,8 @@ def update_or_create_salesforce_course_run(instance, created, **kwargs):  # pyli
 def _build_external_key_sets(course_runs):
     """
     Helper function to extract two sets of ids from a list of course runs for use in filtering
+    However, the external_keys with null or empty string values are not included in the
+    returned external_key_set.
 
     Parameters:
         - course runs: a collection of course runs
@@ -228,7 +230,8 @@ def _build_external_key_sets(course_runs):
     external_key_set = set()
     course_run_ids = set()
     for course_run in course_runs:
-        external_key_set.add(course_run.external_key)
+        if course_run.external_key:
+            external_key_set.add(course_run.external_key)
         if course_run.id:
             course_run_ids.add(course_run.id)
 

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -358,6 +358,39 @@ class ExternalCourseKeySingleCollisionTests(ExternalCourseKeyTestDataMixin, Test
         curriculum_4.refresh_from_db()
         self.assertEqual(curriculum_4.program, new_program)
 
+    @ddt.data(
+        None,
+        '',
+    )
+    def test_external_course_key_null_or_empty(self, external_key_to_test):
+        course_run_1a = CourseRun.objects.get(key='course-run-id/course-1a/test')
+        course_run_1a.external_key = external_key_to_test
+        course_run_1a.save()
+
+        # Same course test
+        copy_course_run_1a = factories.CourseRunFactory(
+            course=self.course_1,
+            external_key=external_key_to_test,
+        )
+        self.assertEqual(course_run_1a.external_key, copy_course_run_1a.external_key)
+
+        # Same curriculum test but different courses
+        new_course_run = factories.CourseRunFactory(
+            external_key=external_key_to_test
+        )
+        new_course = new_course_run.course
+        factories.CurriculumCourseMembershipFactory(
+            course=new_course,
+            curriculum=self.curriculum_1,
+        )
+        self.assertEqual(course_run_1a.external_key, new_course_run.external_key)
+
+        # Same programs but different curriculum test
+        _, curriculum_4 = self._create_single_course_curriculum(external_key_to_test, 'curriculum_4')
+        curriculum_4.program = self.program_1
+        curriculum_4.save()
+        curriculum_4.refresh_from_db()
+
 
 class ExternalCourseKeyMultipleCollisionTests(ExternalCourseKeyTestDataMixin, TestCase):
 


### PR DESCRIPTION
See https://openedx.atlassian.net/browse/EDUCATOR-4890
We should not have empty strings as values within the duplicated external_key check.

@edx/masters-devs Please help review.