### PR TITLE
Fix recent drop table migration

### DIFF
--- a/course_discovery/apps/publisher/migrations/0089_drop_tables.py
+++ b/course_discovery/apps/publisher/migrations/0089_drop_tables.py
@@ -96,10 +96,6 @@ class Migration(migrations.Migration):
             model_name='coursestate',
             name='course',
         ),
-        migrations.AlterUniqueTogether(
-            name='courseuserrole',
-            unique_together=set([]),
-        ),
         migrations.RemoveField(
             model_name='courseuserrole',
             name='changed_by',


### PR DESCRIPTION
The unique togethers for a certain publisher table are different in stage and prod for some reason? So this commit just stops trying to alter the unique-together before deleting the model.