### PR TITLE
Revert "Fix recent drop table migration"

### DIFF
--- a/course_discovery/apps/publisher/migrations/0089_drop_tables.py
+++ b/course_discovery/apps/publisher/migrations/0089_drop_tables.py
@@ -96,6 +96,10 @@ class Migration(migrations.Migration):
             model_name='coursestate',
             name='course',
         ),
+        migrations.AlterUniqueTogether(
+            name='courseuserrole',
+            unique_together=set([]),
+        ),
         migrations.RemoveField(
             model_name='courseuserrole',
             name='changed_by',


### PR DESCRIPTION
Reverts edx/course-discovery#2390

Turns out removing the unique together is necessary when removing fields involved in the unique-together later. And stage's data issue was just bad stage data.