### PR TITLE
jmyatt/revert storages breakages

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -603,7 +603,6 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
             body=json.dumps({'access_token': 'abcd', 'expires_in': 60}),
             status=200,
         )
-        # pylint: disable=no-member
         studio_url = '{root}/api/v1/course_runs/'.format(root=self.partner.studio_url.strip('/'))
         responses.add(responses.POST, studio_url, status=200)
         key = 'course-v1:{org}+{number}+1T2001'.format(org=course_data['org'], number=course_data['number'])
@@ -842,7 +841,6 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         from Studio. Other errors (PermissionDenied, ValidationError, Http404) are all caught and
         raised to the course endpoint, but some errors just create a response.
         '''
-        # pylint: disable=no-member
         studio_url = '{root}/api/v1/course_runs/'.format(root=self.partner.studio_url.strip('/'))
         responses.add(responses.POST, studio_url, status=400, body=b'Nope')
         response = self.create_course_and_course_run()

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -9,7 +9,6 @@ import responses
 from django.core.management import CommandError
 from django.http.response import HttpResponse
 from django.test import TestCase
-from edx_django_utils.cache import TieredCache
 from pytz import UTC
 from slumber.exceptions import HttpClientError
 
@@ -143,7 +142,6 @@ class CoursesApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     @ddt.unpack
     def test_ingest(self, partner_uses_publisher, on_new_publisher):
         """ Verify the method ingests data from the Courses API. """
-        TieredCache.dangerous_clear_all_tiers()
         api_data = self.mock_api()
         if not partner_uses_publisher:
             self.partner.publisher_url = None
@@ -173,7 +171,6 @@ class CoursesApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     @mock.patch('course_discovery.apps.course_metadata.data_loaders.api.push_to_ecommerce_for_course_run')
     def test_ingest_verified_deadline(self, mock_push_to_ecomm):
         """ Verify the method ingests data from the Courses API. """
-        TieredCache.dangerous_clear_all_tiers()
         api_data = self.mock_api()
 
         self.assertEqual(Course.objects.count(), 0)
@@ -1021,7 +1018,6 @@ class ProgramsApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     @responses.activate
     def test_ingest(self):
         """ Verify the method ingests data from the Organizations API. """
-        TieredCache.dangerous_clear_all_tiers()
         api_data = self.mock_api()
         self.assertEqual(Program.objects.count(), 0)
 
@@ -1056,7 +1052,6 @@ class ProgramsApiDataLoaderTests(DataLoaderTestMixin, TestCase):
 
     @responses.activate
     def test_ingest_with_existing_banner_image(self):
-        TieredCache.dangerous_clear_all_tiers()
         programs = self.mock_api()
 
         for program_data in programs:

--- a/course_discovery/apps/course_metadata/tests/test_lookups.py
+++ b/course_discovery/apps/course_metadata/tests/test_lookups.py
@@ -227,11 +227,8 @@ class AutoCompletePersonTests(SiteMixin, TestCase):
         response = self.client.get(reverse('admin_metadata:person-autocomplete') + '?q={q}'.format(q='ins'))
         assert response.status_code == 200
         data = json.loads(response.content.decode('utf-8'))
-        expected_results = [{'id': str(instructor.id), 'text': str(instructor), 'selected_text': str(instructor)}
-                            for instructor in self.instructors]
-
-        assert (sorted(data.get('results'), key=lambda x: sorted(x.keys())) ==
-                sorted(expected_results, key=lambda x: sorted(x.keys())))
+        expected_results = [{'id': instructor.id, 'text': str(instructor)} for instructor in self.instructors]
+        assert data.get('results') == expected_results
 
     def _set_user_is_staff_and_login(self, is_staff=True):
         self.client.logout()

--- a/course_discovery/apps/edx_haystack_extensions/tests/test_boosting.py
+++ b/course_discovery/apps/edx_haystack_extensions/tests/test_boosting.py
@@ -55,7 +55,6 @@ class TestSearchBoosting:
         search_results = SearchQuerySet().models(CourseRun).all()
         assert len(search_results) == 2
         assert search_results[0].score > search_results[1].score
-        # pylint: disable=no-member
         assert int(test_record.start.timestamp()) == int(search_results[0].start.timestamp())
 
     @pytest.mark.parametrize(

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -45,7 +45,7 @@ edx-rest-api-client
 elasticsearch
 html2text
 lxml
-jsonfield2
+jsonfield
 markdown
 pillow
 pycountry

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,5 +22,8 @@ transifex-client<0.13
 # FIXME: 3+ require schemes in CORS_ORIGIN_WHITELIST URLs - remember to update configuration when you remove this
 django-cors-headers<3
 
+# FIXME: 3.2 changed the 'id' field in responses from a number to a string - need to validate if that's a safe change
+django-autocomplete-light<3.2
+
 # jsonfield2 3.1.0 drops support for python 3.5
 jsonfield2==3.0.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,6 +24,3 @@ django-cors-headers<3
 
 # FIXME: 3.2 changed the 'id' field in responses from a number to a string - need to validate if that's a safe change
 django-autocomplete-light<3.2
-
-# jsonfield2 3.1.0 drops support for python 3.5
-jsonfield2==3.0.3

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,14 +12,14 @@ docutils==0.16            # via sphinx
 edx-sphinx-theme==1.5.0
 idna==2.8                 # via requests
 imagesize==1.2.0          # via sphinx
-jinja2==2.11.1            # via sphinx
+jinja2==2.10.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
-packaging==20.1           # via sphinx
+packaging==20.0           # via sphinx
 pygments==2.5.2           # via sphinx
 pyparsing==2.4.6          # via packaging
 pytz==2019.3              # via babel
 requests==2.22.0          # via sphinx
-six==1.14.0               # via edx-sphinx-theme, packaging
+six==1.13.0               # via edx-sphinx-theme, packaging
 snowballstemmer==2.0.0    # via sphinx
 sphinx==2.3.1
 sphinxcontrib-applehelp==1.0.1  # via sphinx
@@ -28,7 +28,7 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-urllib3==1.25.8           # via requests
+urllib3==1.25.7           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -26,7 +26,7 @@ ddt==1.2.2
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-admin-sortable2==0.7.5
 django-appconf==1.0.3     # via django-compressor
-django-autocomplete-light==3.5.1
+django-autocomplete-light==3.1.8
 django-choices==1.7.1
 django-compressor==2.4
 django-contrib-comments==1.9.2
@@ -45,18 +45,18 @@ django-simple-history==2.8.0
 django-solo==1.1.3
 django-sortedm2m==3.0.0
 django-stdimage==3.2.0
-django-storages==1.9.1
+django-storages==1.9
 django-taggit-autosuggest==0.3.8
 django-taggit-serializer==0.1.7
 django-taggit==1.2.0
 django-waffle==0.19.0
 django-webpack-loader==0.6.0
-django==1.11.28
+django==1.11.27
 djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
-docker-compose==1.25.4
+docker-compose==1.25.3
 docker[ssh]==4.1.0        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
@@ -71,7 +71,7 @@ edx-ccx-keys==1.0.0
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
 edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
+edx-drf-extensions==2.4.5
 edx-i18n-tools==0.5.0
 edx-lint==1.4.1
 edx-opaque-keys==2.0.1
@@ -100,7 +100,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==8.2.0     # via pytest
-newrelic==5.6.0.135       # via edx-django-utils
+newrelic==5.4.1.134       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 packaging==20.1           # via pytest, sphinx
@@ -154,7 +154,7 @@ selenium==3.141.0
 semantic-version==2.8.4   # via edx-drf-extensions
 simple-salesforce==0.74.3
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via astroid, bcrypt, cryptography, django-appconf, django-autocomplete-light, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, docker, docker-compose, dockerpty, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, libsass, mock, packaging, pathlib2, progressbar2, pyjwkest, pynacl, pyopenssl, pyrsistent, pytest-xdist, python-dateutil, python-utils, responses, social-auth-app-django, social-auth-core, stevedore, transifex-client, unicode-slugify, websocket-client
+six==1.14.0               # via astroid, bcrypt, cryptography, django-appconf, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, docker, docker-compose, dockerpty, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, libsass, mock, packaging, pathlib2, progressbar2, pyjwkest, pynacl, pyopenssl, pyrsistent, pytest-xdist, python-dateutil, python-utils, responses, social-auth-app-django, social-auth-core, stevedore, transifex-client, unicode-slugify, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -33,7 +33,7 @@ django-contrib-comments==1.9.2
 django-cors-headers==2.5.3
 django-debug-toolbar==1.11
 django-elasticsearch-debug-toolbar==2.0.0
-django-extensions==2.2.6
+django-extensions==2.2.5
 django-filter==2.2.0
 django-fsm==2.7.0
 django-guardian==1.5.1
@@ -45,7 +45,7 @@ django-simple-history==2.8.0
 django-solo==1.1.3
 django-sortedm2m==3.0.0
 django-stdimage==3.2.0
-django-storages==1.9
+django-storages==1.8
 django-taggit-autosuggest==0.3.8
 django-taggit-serializer==0.1.7
 django-taggit==1.2.0
@@ -56,54 +56,54 @@ djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
-docker-compose==1.25.3
+docker-compose==1.25.1
 docker[ssh]==4.1.0        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
 docutils==0.16            # via sphinx
 drf-dynamic-fields==0.3.1
-drf-extensions==0.6.0
+drf-extensions==0.5.0
 drf-haystack==1.8.2
 dry-rest-permissions==0.1.10
 edx-analytics-data-api-client==0.15.3
 edx-auth-backends==2.0.2
 edx-ccx-keys==1.0.0
 edx-django-release-util==0.3.6
-edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.4
+edx-django-sites-extensions==2.4.2
+edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-i18n-tools==0.5.0
 edx-lint==1.4.1
 edx-opaque-keys==2.0.1
-edx-rest-api-client==3.0.2
+edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.5.0
 elasticsearch==1.9.0
 execnet==1.7.1            # via pytest-xdist
 factory-boy==2.12.0
-faker==4.0.0              # via factory-boy
-freezegun==0.3.14
+faker==3.0.1              # via factory-boy
+freezegun==0.3.13
 future==0.18.2            # via pyjwkest
-html2text==2020.1.16
+html2text==2019.9.26
 idna==2.8                 # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0  # via jsonschema, path, pluggy, pytest
+importlib-metadata==1.4.0  # via jsonschema, path, pluggy, pytest
 isort==4.3.21
 itypes==1.1.0             # via coreapi
-jinja2==2.11.1            # via coreschema, sphinx
-jsonfield2==3.0.3
+jinja2==2.10.3            # via coreschema, sphinx
+jsonfield==2.0.2
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 libsass==0.19.4           # via django-libsass
-lxml==4.5.0
+lxml==4.4.2
 markdown==3.1.1
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5
-more-itertools==8.2.0     # via pytest
+more-itertools==8.1.0     # via pytest, zipp
 newrelic==5.4.1.134       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
-packaging==20.1           # via pytest, sphinx
+packaging==20.0           # via pytest, sphinx
 paramiko==2.7.1           # via docker
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
@@ -112,13 +112,12 @@ pbr==5.4.4                # via stevedore
 pillow==7.0.0
 pluggy==0.13.1            # via pytest
 polib==1.1.0              # via edx-i18n-tools
-progressbar2==3.47.0      # via django-stdimage
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0
 pycountry==19.8.18
 pycparser==2.19           # via cffi
-pycryptodomex==3.9.6      # via pyjwkest
+pycryptodomex==3.9.4      # via pyjwkest
 pygments==2.5.2           # via sphinx
 pyinotify==0.9.6
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
@@ -138,12 +137,11 @@ pytest-django==3.8.0
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-responses==0.4.0
 pytest-xdist==1.31.0
-pytest==5.3.5
+pytest==5.3.2
 python-dateutil==2.8.1
-python-utils==2.3.0       # via progressbar2
 python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3
-pyyaml==5.3               # via docker-compose, edx-django-release-util, edx-i18n-tools
+pyyaml==3.13              # via docker-compose, edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via django-compressor
 requests-oauthlib==1.3.0  # via social-auth-core
 requests[security]==2.22.0
@@ -154,7 +152,7 @@ selenium==3.141.0
 semantic-version==2.8.4   # via edx-drf-extensions
 simple-salesforce==0.74.3
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via astroid, bcrypt, cryptography, django-appconf, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, docker, docker-compose, dockerpty, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, libsass, mock, packaging, pathlib2, progressbar2, pyjwkest, pynacl, pyopenssl, pyrsistent, pytest-xdist, python-dateutil, python-utils, responses, social-auth-app-django, social-auth-core, stevedore, transifex-client, unicode-slugify, websocket-client
+six==1.13.0               # via astroid, bcrypt, cryptography, django-appconf, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, docker, docker-compose, dockerpty, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, jsonschema, libsass, mock, packaging, pathlib2, pyjwkest, pynacl, pyopenssl, pyrsistent, pytest-xdist, python-dateutil, responses, social-auth-app-django, social-auth-core, stevedore, unicode-slugify, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
@@ -167,9 +165,8 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-sqlparse==0.3.0           # via django-debug-toolbar
 stevedore==1.31.0         # via edx-opaque-keys
-testfixtures==6.11.0
+testfixtures==6.10.3
 text-unidecode==1.3       # via faker
 texttable==1.6.2          # via docker-compose
 transifex-client==0.12.5
@@ -178,12 +175,12 @@ unicode-slugify==0.1.3
 unicodecsv==0.14.1        # via djangorestframework-csv
 unidecode==1.1.1          # via unicode-slugify
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.8           # via elasticsearch, requests, selenium, transifex-client
+urllib3==1.25.7           # via requests, selenium
 wcwidth==0.1.8            # via pytest
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.11.2             # via astroid
 xss-utils==0.1.2
-zipp==1.1.0               # via importlib-metadata
+zipp==1.0.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -16,7 +16,7 @@ cryptography==2.8         # via pyopenssl, requests
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-admin-sortable2==0.7.5
 django-appconf==1.0.3     # via django-compressor
-django-autocomplete-light==3.5.1
+django-autocomplete-light==3.1.8
 django-choices==1.7.1
 django-compressor==2.4
 django-contrib-comments==1.9.2
@@ -34,13 +34,13 @@ django-simple-history==2.8.0
 django-solo==1.1.3
 django-sortedm2m==3.0.0
 django-stdimage==3.2.0
-django-storages==1.9.1
+django-storages==1.9
 django-taggit-autosuggest==0.3.8
 django-taggit-serializer==0.1.7
 django-taggit==1.2.0
 django-waffle==0.19.0
 django-webpack-loader==0.6.0
-django==1.11.28
+django==1.11.27
 djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
@@ -55,7 +55,7 @@ edx-ccx-keys==1.0.0
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
 edx-django-utils==2.0.4
-edx-drf-extensions==2.4.6
+edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.1
 edx-rest-api-client==3.0.2
 elasticsearch==1.9.0
@@ -73,7 +73,7 @@ lxml==4.5.0
 markdown==3.1.1
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6
-newrelic==5.6.0.135
+newrelic==5.4.1.134
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.4                # via stevedore
@@ -101,7 +101,7 @@ rjsmin==1.1.0             # via django-compressor
 semantic-version==2.8.4   # via edx-drf-extensions
 simple-salesforce==0.74.3
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via cryptography, django-appconf, django-autocomplete-light, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, libsass, progressbar2, pyjwkest, pyopenssl, python-dateutil, python-memcached, python-utils, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
+six==1.14.0               # via cryptography, django-appconf, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, libsass, progressbar2, pyjwkest, pyopenssl, python-dateutil, python-memcached, python-utils, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -21,7 +21,7 @@ django-choices==1.7.1
 django-compressor==2.4
 django-contrib-comments==1.9.2
 django-cors-headers==2.5.3
-django-extensions==2.2.6
+django-extensions==2.2.5
 django-filter==2.2.0
 django-fsm==2.7.0
 django-guardian==1.5.1
@@ -29,12 +29,12 @@ django-haystack==2.8.1
 django-libsass==0.8
 django-parler==2.0.1
 django-rest-swagger==2.2.0
-django-ses==0.8.14
+django-ses==0.8.13
 django-simple-history==2.8.0
 django-solo==1.1.3
 django-sortedm2m==3.0.0
 django-stdimage==3.2.0
-django-storages==1.9
+django-storages==1.8
 django-taggit-autosuggest==0.3.8
 django-taggit-serializer==0.1.7
 django-taggit==1.2.0
@@ -46,30 +46,30 @@ djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
 drf-dynamic-fields==0.3.1
-drf-extensions==0.6.0
+drf-extensions==0.5.0
 drf-haystack==1.8.2
 dry-rest-permissions==0.1.10
 edx-analytics-data-api-client==0.15.3
 edx-auth-backends==2.0.2
 edx-ccx-keys==1.0.0
 edx-django-release-util==0.3.6
-edx-django-sites-extensions==2.4.3
-edx-django-utils==2.0.4
+edx-django-sites-extensions==2.4.2
+edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-opaque-keys==2.0.1
-edx-rest-api-client==3.0.2
+edx-rest-api-client==1.9.2
 elasticsearch==1.9.0
 future==0.18.2            # via django-ses, pyjwkest
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==20.0.4
-html2text==2020.1.16
+html2text==2019.9.26
 idna==2.8                 # via requests
 itypes==1.1.0             # via coreapi
-jinja2==2.11.1            # via coreschema
-jsonfield2==3.0.3
+jinja2==2.10.3            # via coreschema
+jsonfield==2.0.2
 libsass==0.19.4           # via django-libsass
-lxml==4.5.0
+lxml==4.4.2
 markdown==3.1.1
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6
@@ -78,18 +78,16 @@ oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.4                # via stevedore
 pillow==7.0.0
-progressbar2==3.47.0      # via django-stdimage
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycountry==19.8.18
 pycparser==2.19           # via cffi
-pycryptodomex==3.9.6      # via pyjwkest
+pycryptodomex==3.9.4      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
 pyopenssl==19.1.0         # via requests
 python-dateutil==2.8.1
 python-memcached==1.59
-python-utils==2.3.0       # via progressbar2
 python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3
 pyyaml==5.3
@@ -101,7 +99,7 @@ rjsmin==1.1.0             # via django-compressor
 semantic-version==2.8.4   # via edx-drf-extensions
 simple-salesforce==0.74.3
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via cryptography, django-appconf, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, libsass, progressbar2, pyjwkest, pyopenssl, python-dateutil, python-memcached, python-utils, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
+six==1.13.0               # via cryptography, django-appconf, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, libsass, pyjwkest, pyopenssl, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
@@ -111,7 +109,7 @@ unicode-slugify==0.1.3
 unicodecsv==0.14.1        # via djangorestframework-csv
 unidecode==1.1.1          # via unicode-slugify
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.8           # via elasticsearch, requests
+urllib3==1.25.7           # via requests
 xss-utils==0.1.2
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Reverting recent commits that upgraded the version of django-storages from 1.8 to 1.91, a change which [removes support for the S3 boto backend](https://pypi.org/project/django-storages/1.9/#django-storages-changelog), which the code is still relying on.