### PR TITLE
Filter unmarketable runs from searches

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -603,7 +603,6 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
             body=json.dumps({'access_token': 'abcd', 'expires_in': 60}),
             status=200,
         )
-        # pylint: disable=no-member
         studio_url = '{root}/api/v1/course_runs/'.format(root=self.partner.studio_url.strip('/'))
         responses.add(responses.POST, studio_url, status=200)
         key = 'course-v1:{org}+{number}+1T2001'.format(org=course_data['org'], number=course_data['number'])
@@ -842,7 +841,6 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         from Studio. Other errors (PermissionDenied, ValidationError, Http404) are all caught and
         raised to the course endpoint, but some errors just create a response.
         '''
-        # pylint: disable=no-member
         studio_url = '{root}/api/v1/course_runs/'.format(root=self.partner.studio_url.strip('/'))
         responses.add(responses.POST, studio_url, status=400, body=b'Nope')
         response = self.create_course_and_course_run()

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -290,6 +290,15 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         data = response.json()
         assert data['objects']['results'] == [self.serialize_course_run_search(visible_run)]
 
+    def test_non_marketable_runs_excluded(self):
+        """Search results should not include non-marketable runs."""
+        marketable_run = CourseRunFactory(course__partner=self.partner, type__is_marketable=True)
+        CourseRunFactory(course__partner=self.partner, type__is_marketable=False)
+
+        response = self.get_response()
+        data = response.json()
+        self.assertListEqual(data['objects']['results'], [self.serialize_course_run_search(marketable_run)])
+
     def test_results_filtered_by_default_partner(self):
         """ Verify the search results only include items related to the default partner if no partner is
         specified on the request. If a partner is included, the data should be filtered to the requested partner. """

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -40,6 +40,10 @@ TITLE_FIELD_BOOST = 25.0
 ORG_FIELD_BOOST = TITLE_FIELD_BOOST
 
 
+def filter_visible_runs(course_runs):
+    return course_runs.exclude(type__is_marketable=False)
+
+
 class OrganizationsMixin:
     def format_organization(self, organization):
         return '{key}: {name}'.format(key=organization.key, name=organization.name)
@@ -172,7 +176,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
         return 'course:{}'.format(obj.key)
 
     def prepare_course_runs(self, obj):
-        return [course_run.key for course_run in obj.course_runs.all()]
+        return [course_run.key for course_run in filter_visible_runs(obj.course_runs)]
 
     def prepare_expected_learning_items(self, obj):
         return [item.value for item in obj.expected_learning_items.all()]
@@ -181,7 +185,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
         return [prerequisite.name for prerequisite in obj.prerequisites.all()]
 
     def prepare_org(self, obj):
-        course_run = obj.course_runs.all().first()
+        course_run = filter_visible_runs(obj.course_runs).first()
         if course_run:
             return CourseKey.from_string(course_run.key).org
         return None
@@ -190,7 +194,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
         return obj.first_enrollable_paid_seat_price
 
     def prepare_seat_types(self, obj):
-        seat_types = [seat.slug for course_run in obj.course_runs.all() for seat in course_run.seat_types]
+        seat_types = [seat.slug for run in filter_visible_runs(obj.course_runs) for seat in run.seat_types]
         return list(set(seat_types))
 
     def prepare_subject_uuids(self, obj):
@@ -198,7 +202,8 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
 
     def prepare_languages(self, obj):
         return {
-            self._prepare_language(course_run.language) for course_run in obj.course_runs.all() if course_run.language
+            self._prepare_language(course_run.language) for course_run in filter_visible_runs(obj.course_runs)
+            if course_run.language
         }
 
 
@@ -222,7 +227,6 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     language = indexes.CharField(null=True, faceted=True)
     transcript_languages = indexes.MultiValueField(faceted=True)
     pacing_type = indexes.CharField(model_attr='pacing_type', null=True, faceted=True)
-    is_marketable = indexes.BooleanField(model_attr='type__is_marketable', faceted=True)
     marketing_url = indexes.CharField(null=True)
     slug = indexes.CharField(model_attr='slug', null=True)
     seat_types = indexes.MultiValueField(model_attr='seat_types__slug', null=True, faceted=True)
@@ -253,6 +257,9 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
         return qset.prefetch_related(
             'seats__type',
         )
+
+    def index_queryset(self, using=None):
+        return filter_visible_runs(super().index_queryset(using=using))
 
     def prepare_aggregation_key(self, obj):
         # Aggregate CourseRuns by Course key since that is how we plan to dedup CourseRuns on the marketing site.

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -145,6 +145,7 @@ class CourseRunTypeFactory(factory.DjangoModelFactory):
     uuid = factory.LazyFunction(uuid4)
     name = FuzzyText()
     slug = FuzzyText()
+    is_marketable = True
 
     class Meta:
         model = CourseRunType

--- a/course_discovery/apps/edx_haystack_extensions/tests/test_boosting.py
+++ b/course_discovery/apps/edx_haystack_extensions/tests/test_boosting.py
@@ -55,7 +55,6 @@ class TestSearchBoosting:
         search_results = SearchQuerySet().models(CourseRun).all()
         assert len(search_results) == 2
         assert search_results[0].score > search_results[1].score
-        # pylint: disable=no-member
         assert int(test_record.start.timestamp()) == int(search_results[0].start.timestamp())
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Don't have course runs that are listed as non-marketable (like Masters or Empty runs) show up in endpoint searches that fuel the marketing site.

https://openedx.atlassian.net/browse/DISCO-1589