### PR TITLE
Removing unused auth classes

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -103,28 +103,6 @@ class TypeaheadSerializationMixin:
 
 
 class OAuth2Mixin:
-    def generate_oauth2_token_header(self, user):
-        """ Generates a Bearer authorization header to simulate OAuth2 authentication. """
-        return 'Bearer {token}'.format(token=user.username)
-
-    def mock_user_info_response(self, user, status=200):
-        """ Mock the user info endpoint response of the OAuth2 provider. """
-
-        data = {
-            'family_name': user.last_name,
-            'preferred_username': user.username,
-            'given_name': user.first_name,
-            'email': user.email,
-        }
-
-        responses.add(
-            responses.GET,
-            settings.EDX_DRF_EXTENSIONS['OAUTH2_USER_INFO_URL'],
-            body=json.dumps(data),
-            content_type='application/json',
-            status=status
-        )
-
     def mock_access_token(self):
         responses.add(
             responses.POST,

--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -3,7 +3,6 @@
 import json
 
 import responses
-from django.conf import settings
 from haystack.query import SearchQuerySet
 from rest_framework.test import APIRequestFactory
 from rest_framework.test import APITestCase as RestAPITestCase

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -114,12 +114,6 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
         self.client.logout()
         self.assert_catalog_created(HTTP_AUTHORIZATION=generate_jwt_header_for_user(self.user))
 
-    @responses.activate
-    def test_create_with_oauth2_authentication(self):
-        self.client.logout()
-        self.mock_user_info_response(self.user)
-        self.assert_catalog_created(HTTP_AUTHORIZATION=self.generate_oauth2_token_header(self.user))
-
     def test_create_with_new_user(self):
         """ Verify that new users are created if the list of viewers includes the usernames of non-existent users. """
         new_viewer_username = 'new-guy'

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -6,7 +6,6 @@ from io import StringIO
 import ddt
 import pytest
 import pytz
-import responses
 from django.contrib.auth import get_user_model
 from rest_framework.reverse import reverse
 

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -376,9 +376,7 @@ LOGGING = {
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'edx_rest_framework_extensions.auth.jwt.authentication.JwtAuthentication',
-        'edx_rest_framework_extensions.auth.bearer.authentication.BearerAuthentication',
         'rest_framework.authentication.SessionAuthentication',
-        'rest_framework.authentication.BasicAuthentication',
     ),
     'DEFAULT_PAGINATION_CLASS': 'course_discovery.apps.api.pagination.PageNumberPagination',
     'DEFAULT_PERMISSION_CLASSES': (


### PR DESCRIPTION
BearerAuthentication and BasicAuthentication classes are not used by our system.
Additionally, BearerAuthentication is deprecated and will soon be removed from edx-drf-extensions.