### PR TITLE
DISCO-1599 fix img size reset

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -640,7 +640,7 @@ class CleanHtmlTests(TestCase):
 <p>Ordered item3 with <em>italics</em> , <strong>bold</strong> , <em>underline</em> , ~~strikethrough~~ , <strong><em>~~_all</em>~~_</strong></p>
 </li>
 </ol>
-<p><img alt="" src="file:////Users/myuser/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_image001.png" /></p>"""),
+<p><img src='file:////Users/myuser/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_image001.png' width='276' height='208' /></p>"""),
     )
     @ddt.unpack
     def test_clean_html(self, content, expected):

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -648,6 +648,7 @@ class HTML2TextWithLangSpans(html2text.HTML2Text):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.in_lang_span = False
+        self.images_with_size = True
 
     def handle_tag(self, tag, attrs, start):
         super().handle_tag(tag, attrs, start)


### PR DESCRIPTION
- when an img tag with size attributes was saved in an htmlfield,
  then that record was saved a second time, the size attributes
  were lost.  We now explicitly set a config on the HTML2Text class
  inorder to properly allow processing of size attributes on img's.