### PR TITLE
Update dedupe script to use the `everything` manager

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/deduplicate_course_metadata_history.py
+++ b/course_discovery/apps/course_metadata/management/commands/deduplicate_course_metadata_history.py
@@ -3,8 +3,10 @@ Deduplicate course metadata history rows that were unnecessarily created while r
 refresh_course_metadata.
 
 This largely inherits the internals from the clean_duplicate_history management command
-provided by django-simple-history, with only one minor tweak (to ignore the `modified`
-field while comparing potentially duplicate records).
+provided by django-simple-history, with only two minor tweaks:
+
+1. Ignore the `modified` field while comparing potentially duplicate records.
+2. Use the `everything` model manager while fetching all model instances to process.
 
 Usage: identical to clean_duplicate_history:
 
@@ -14,6 +16,7 @@ Usage: identical to clean_duplicate_history:
 
 https://django-simple-history.readthedocs.io/en/latest/utils.html#clean-duplicate-history
 """
+from django.utils import timezone
 from simple_history.management.commands import clean_duplicate_history
 
 
@@ -23,10 +26,52 @@ class Command(clean_duplicate_history.Command):
         "while running refresh_course_metadata."
     )
 
+    def _process(self, to_process, date_back=None, dry_run=True):
+        """
+        The body of this method is copied VERBATIM from upstream except for the
+        following change:
+
+        Instead of calling model.objects.all(), we use model.everything.all()
+        whenever possible.
+        """
+        if date_back:
+            stop_date = timezone.now() - timezone.timedelta(minutes=date_back)
+        else:
+            stop_date = None
+
+        for model, history_model in to_process:
+            m_qs = history_model.objects
+            if stop_date:
+                m_qs = m_qs.filter(history_date__gte=stop_date)
+            found = m_qs.count()
+            self.log("{0} has {1} historical entries".format(model, found), 2)
+            if not found:
+                continue
+
+            # Break apart the query so we can add additional filtering
+
+            # This try block is the only part that differs from upstream
+            try:
+                model_query = model.everything.all()  # Attempting to use the `everything` manager.
+            except AttributeError:
+                model_query = model.objects.all()  # upstream's original behavior.
+
+            # If we're provided a stop date take the initial hit of getting the
+            # filtered records to iterate over
+            if stop_date:
+                model_query = model_query.filter(
+                    pk__in=(m_qs.values_list(model._meta.pk.name).distinct())
+                )
+
+            for o in model_query.iterator():
+                self._process_instance(o, model, stop_date=stop_date, dry_run=dry_run)
+
     def _check_and_delete(self, entry1, entry2, dry_run=True):
         """
-        We override upstream's _check_and_delete method with our own which ignores
-        changes in the `modified` field.
+        The body of this method is copied VERBATIM from upstream except for the
+        following change:
+
+        Ignore changes in the `modified` field.
         """
         delta = entry1.diff_against(entry2)
         if set(delta.changed_fields).issubset({"modified"}):  # This is the only line that differs from upstream.


### PR DESCRIPTION
Several models in this repo inherit the DraftModelMixin which overrides
the `objects` attribute to only return non-draft objects, but also
provides an `everything` model manager which returns all objects.  This
change to the deduplicate_course_metadata_history management command
makes use of the `everything` model manager so that draft instances of a
model are not skipped while deduplicating history.