### PR TITLE
BOM-1412: Update deprecated javascript_catalog view

### DIFF
--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -21,7 +21,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
-from django.views.i18n import javascript_catalog
+from django.views.i18n import JavaScriptCatalog
 
 from course_discovery.apps.api.views import SwaggerSchemaView
 from course_discovery.apps.core import views as core_views
@@ -46,7 +46,7 @@ urlpatterns = oauth2_urlpatterns + [
     url(r'^language-tags/', include('course_discovery.apps.ietf_language_tags.urls', namespace='language_tags')),
     url(r'^comments/', include('django_comments.urls')),
     url(r'^i18n/', include('django.conf.urls.i18n')),
-    url(r'^jsi18n/$', javascript_catalog, name='javascript-catalog'),
+    url(r'^jsi18n/$', JavaScriptCatalog, name='javascript-catalog'),
     url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
 ]
 


### PR DESCRIPTION
JIRA: [BOM-1412](https://openedx.atlassian.net/browse/BOM-1412)

### Changes
- Replace `django.views.i18n import javascript_catalog` with from `django.views.i18n import JavaScriptCatalog` as former is deprecated in Django 2.0

