### PR TITLE
Add reserved keyword linter to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
           - docker exec -t discovery bash -c 'source /edx/app/discovery/discovery_env && cd /edx/app/discovery/discovery/ && make clean_static'
           - docker exec -t discovery bash -c 'source /edx/app/discovery/discovery_env && cd /edx/app/discovery/discovery/ && make static'
           - docker exec -t discovery bash -c 'source /edx/app/discovery/discovery_env && cd /edx/app/discovery/discovery/ && make quality'
+          - docker exec -t discovery bash -c 'source /edx/app/discovery/discovery_env && cd /edx/app/discovery/discovery/ && make check_keywords'
 
     - env: COMMAND=test:unittests
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 NODE_BIN=$(CURDIR)/node_modules/.bin
 
-.PHONY: accept clean clean_static detect_changed_source_translations extract_translations \
+.PHONY: accept clean clean_static check_keywords detect_changed_source_translations extract_translations \
 	help html_coverage migrate open-devstack production-requirements pull_translations quality requirements.js \
 	requirements start-devstack static stop-devstack test docs static.dev static.watch
 
@@ -108,3 +108,6 @@ detect_changed_source_translations: ## Check if translation files are up-to-date
 
 docs:
 	cd docs && make html
+
+check_keywords: ## Scan the Django models in all installed apps in this project for restricted field names
+	python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml --report_file stich_keyword_report.csv --system STITCH

--- a/db_keyword_overrides.yml
+++ b/db_keyword_overrides.yml
@@ -1,0 +1,10 @@
+# This file is used by the 'check_reserved_keywords' management command to allow specific field names to be overridden
+# when checking for conflicts with lists of restricted keywords used in various database/data warehouse tools.
+# For more information, see: https://github.com/edx/edx-django-release-util/release_util/management/commands/check_reserved_keywords.py
+#
+# overrides should be added in the following format:
+#   - ModelName.field_name
+---
+MYSQL:
+SNOWFLAKE:
+STITCH:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,7 +7,9 @@
 alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
 certifi==2019.11.28       # via requests
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
+cryptography==2.8         # via social-auth-core
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 docutils==0.16            # via sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/docs.in
@@ -17,6 +19,7 @@ jinja2==2.11.1            # via sphinx
 markupsafe==1.1.1         # via jinja2
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 packaging==20.3           # via sphinx
+pycparser==2.20           # via cffi
 pygments==2.6.1           # via sphinx
 pyjwt==1.7.1              # via social-auth-core
 pyparsing==2.4.6          # via packaging
@@ -24,10 +27,10 @@ python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3              # via babel
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via requests-oauthlib, social-auth-core, sphinx
-six==1.14.0               # via edx-sphinx-theme, packaging, social-auth-app-django, social-auth-core
+six==1.14.0               # via cryptography, edx-sphinx-theme, packaging, social-auth-app-django, social-auth-core
 snowballstemmer==2.0.0    # via sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in
-social-auth-core==3.2.0   # via social-auth-app-django
+social-auth-core==3.3.0   # via social-auth-app-django
 sphinx==2.4.4             # via -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
@@ -35,6 +38,7 @@ sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+unidecode==1.1.1          # via social-auth-core
 urllib3==1.25.8           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -23,9 +23,9 @@ click-log==0.3.2          # via edx-lint
 click==7.1.1              # via click-log, edx-lint
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-coverage==5.0.3           # via -r requirements/test.in, pytest-cov
-cryptography==2.8         # via authlib, paramiko, pyopenssl, requests
-ddt==1.3.0                # via -r requirements/test.in
+coverage==5.0.4           # via -r requirements/test.in, pytest-cov
+cryptography==2.8         # via authlib, paramiko, social-auth-core
+ddt==1.3.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-admin-sortable2==0.7.6  # via -r requirements/base.in
 django-appconf==1.0.3     # via django-compressor
@@ -70,11 +70,11 @@ drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensi
 dry-rest-permissions==0.1.10  # via -r requirements/base.in
 edx-analytics-data-api-client==0.15.5  # via -r requirements/base.in
 edx-auth-backends==3.0.2  # via -r requirements/base.in
-edx-ccx-keys==1.0.0       # via -r requirements/base.in
-edx-django-release-util==0.3.6  # via -r requirements/base.in
+edx-ccx-keys==1.0.1       # via -r requirements/base.in
+edx-django-release-util==0.4.1  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.2  # via -r requirements/base.in
+edx-drf-extensions==5.0.2  # via -r requirements/base.in
 edx-i18n-tools==0.5.0     # via -r requirements/local.in
 edx-lint==1.4.1           # via -r requirements/test.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions
@@ -83,7 +83,7 @@ edx-sphinx-theme==1.5.0   # via -r requirements/docs.in
 elasticsearch==1.9.0      # via -c requirements/constraints.txt, -r requirements/base.in
 execnet==1.7.1            # via pytest-xdist
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.0.1              # via factory-boy
+faker==4.0.2              # via factory-boy
 freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via pyjwkest
 html2text==2020.1.16      # via -r requirements/base.in
@@ -115,7 +115,7 @@ pbr==5.4.4                # via stevedore
 pillow==7.0.0             # via -r requirements/base.in, django-stdimage
 pluggy==0.13.1            # via pytest
 polib==1.1.0              # via edx-i18n-tools
-progressbar2==3.50.0      # via django-stdimage
+progressbar2==3.50.1      # via django-stdimage
 psutil==1.2.1             # via edx-django-utils
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via -r requirements/test.in
@@ -132,7 +132,6 @@ pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via edx-opaque-keys
 pynacl==1.3.0             # via paramiko
-pyopenssl==19.1.0         # via requests
 pyparsing==2.4.6          # via packaging
 pyrsistent==0.15.7        # via jsonschema
 pytest-cov==2.8.1         # via -r requirements/test.in
@@ -141,27 +140,27 @@ pytest-django==3.8.0      # via -r requirements/test.in, pytest-django-ordering
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-responses==0.4.0   # via -r requirements/test.in
 pytest-xdist==1.31.0      # via -r requirements/test.in
-pytest==5.4.0             # via -r requirements/test.in, pytest-cov, pytest-django, pytest-django-ordering, pytest-forked, pytest-responses, pytest-xdist
+pytest==5.4.1             # via -r requirements/test.in, pytest-cov, pytest-django, pytest-django-ordering, pytest-forked, pytest-responses, pytest-xdist
 python-dateutil==2.8.1    # via -r requirements/base.in, drf-haystack, edx-drf-extensions, faker, freezegun
 python-utils==2.4.0       # via progressbar2
 python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3              # via -r requirements/base.in, babel, django
-pyyaml==5.3               # via docker-compose, edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via docker-compose, edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via django-compressor
 requests-oauthlib==1.3.0  # via social-auth-core
-requests[security]==2.23.0  # via -r requirements/base.in, algoliasearch, coreapi, docker, docker-compose, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, simple-salesforce, slumber, social-auth-core, sphinx
+requests==2.23.0          # via -r requirements/base.in, algoliasearch, coreapi, docker, docker-compose, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, simple-salesforce, slumber, social-auth-core, sphinx
 responses==0.10.12        # via -r requirements/test.in, pytest-responses
 rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.1.0             # via django-compressor
 selenium==3.141.0         # via -r requirements/test.in
 semantic-version==2.8.4   # via edx-drf-extensions
-simple-salesforce==0.75.3  # via -r requirements/base.in
+simple-salesforce==1.0.0  # via -r requirements/base.in
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via astroid, bcrypt, cryptography, django-appconf, django-autocomplete-light, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, docker, docker-compose, dockerpty, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, libsass, mock, packaging, pathlib2, progressbar2, pyjwkest, pynacl, pyopenssl, pyrsistent, pytest-xdist, python-dateutil, python-utils, responses, social-auth-app-django, social-auth-core, stevedore, transifex-client, unicode-slugify, websocket-client
+six==1.14.0               # via astroid, bcrypt, cryptography, django-appconf, django-autocomplete-light, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, docker, docker-compose, dockerpty, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, edx-sphinx-theme, freezegun, jsonschema, libsass, mock, packaging, pathlib2, progressbar2, pyjwkest, pynacl, pyrsistent, pytest-xdist, python-dateutil, python-utils, responses, social-auth-app-django, social-auth-core, stevedore, transifex-client, unicode-slugify, websocket-client
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.0   # via edx-auth-backends, social-auth-app-django
 soupsieve==2.0            # via beautifulsoup4
 sphinx==2.4.4             # via -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -179,10 +178,10 @@ transifex-client==0.12.5  # via -c requirements/constraints.txt, -r requirements
 typed-ast==1.4.1          # via astroid
 unicode-slugify==0.1.3    # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
-unidecode==1.1.1          # via unicode-slugify
+unidecode==1.1.1          # via social-auth-core, unicode-slugify
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.8           # via elasticsearch, requests, selenium, transifex-client
-wcwidth==0.1.8            # via pytest
+wcwidth==0.1.9            # via pytest
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.11.2             # via astroid
 xss-utils==0.1.2          # via -r requirements/base.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,7 +15,7 @@ cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==2.8         # via authlib, pyopenssl, requests
+cryptography==2.8         # via authlib, social-auth-core
 defusedxml==0.6.0         # via djangorestframework-xml, python3-openid, social-auth-core
 django-admin-sortable2==0.7.6  # via -r requirements/base.in
 django-appconf==1.0.3     # via django-compressor
@@ -55,11 +55,11 @@ drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensi
 dry-rest-permissions==0.1.10  # via -r requirements/base.in
 edx-analytics-data-api-client==0.15.5  # via -r requirements/base.in
 edx-auth-backends==3.0.2  # via -r requirements/base.in
-edx-ccx-keys==1.0.0       # via -r requirements/base.in
-edx-django-release-util==0.3.6  # via -r requirements/base.in
+edx-ccx-keys==1.0.1       # via -r requirements/base.in
+edx-django-release-util==0.4.1  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.2  # via -r requirements/base.in
+edx-drf-extensions==5.0.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==4.0.1  # via -c requirements/constraints.txt, -r requirements/base.in
 elasticsearch==1.9.0      # via -c requirements/constraints.txt, -r requirements/base.in
@@ -82,7 +82,7 @@ oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.4                # via stevedore
 pillow==7.0.0             # via -r requirements/base.in, django-stdimage
-progressbar2==3.50.0      # via django-stdimage
+progressbar2==3.50.1      # via django-stdimage
 psutil==1.2.1             # via edx-django-utils
 pycountry==19.8.18        # via -r requirements/base.in
 pycparser==2.20           # via cffi
@@ -90,30 +90,29 @@ pycryptodomex==3.9.7      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
-pyopenssl==19.1.0         # via requests
 python-dateutil==2.8.1    # via -r requirements/base.in, drf-haystack, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
 python-utils==2.4.0       # via progressbar2
 python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3              # via -r requirements/base.in, django, django-ses
-pyyaml==5.3               # via -r requirements/production.in, edx-django-release-util
+pyyaml==5.3.1             # via -r requirements/production.in, edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
 requests-oauthlib==1.3.0  # via social-auth-core
-requests[security]==2.23.0  # via -r requirements/base.in, algoliasearch, coreapi, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, simple-salesforce, slumber, social-auth-core
+requests==2.23.0          # via -r requirements/base.in, algoliasearch, coreapi, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, simple-salesforce, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.1.0             # via django-compressor
 semantic-version==2.8.4   # via edx-drf-extensions
-simple-salesforce==0.75.3  # via -r requirements/base.in
+simple-salesforce==1.0.0  # via -r requirements/base.in
 simplejson==3.17.0        # via django-rest-swagger
-six==1.14.0               # via cryptography, django-appconf, django-autocomplete-light, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, libsass, progressbar2, pyjwkest, pyopenssl, python-dateutil, python-memcached, python-utils, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
+six==1.14.0               # via cryptography, django-appconf, django-autocomplete-light, django-choices, django-compressor, django-contrib-comments, django-extensions, django-parler, django-simple-history, django-taggit-serializer, django-waffle, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, libsass, progressbar2, pyjwkest, python-dateutil, python-memcached, python-utils, social-auth-app-django, social-auth-core, stevedore, unicode-slugify
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.0   # via edx-auth-backends, social-auth-app-django
 soupsieve==2.0            # via beautifulsoup4
 stevedore==1.32.0         # via edx-opaque-keys
 unicode-slugify==0.1.3    # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
-unidecode==1.1.1          # via unicode-slugify
+unidecode==1.1.1          # via social-auth-core, unicode-slugify
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.8           # via elasticsearch, requests
 xss-utils==0.1.2          # via -r requirements/base.in


### PR DESCRIPTION
This adds the reserved keyword linter into the CI flow for this app. Once https://github.com/edx/edx-django-release-util/pull/35 lands, I will cut a proper release of edx-django-release-util and rerun `make upgrade` using the pypi hosted version of the code.

There are currently violations for both MYSQL and SNOWFLAKE keywords in this IDA, so I am only running the linter for STITCH keywords. In the future, if we change the field names in question, we can run the linter for those other database systems. I could also add the current violations to the whitelist/override file. I'm open to suggestions.