### PR TITLE
DISCO-1607: Add stockrecord with sku into ecom request

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -178,6 +178,7 @@ class TestSerializeSeatForEcommerceApi(TestCase):
             'expires': serialize_datetime(calculated_seat_upgrade_deadline(seat)),
             'price': str(seat.price),
             'product_class': 'Seat',
+            'stockrecords': [{'partner_sku': seat.sku}],
             'attribute_values': [
                 {
                     'name': 'certificate_type',
@@ -189,6 +190,10 @@ class TestSerializeSeatForEcommerceApi(TestCase):
                 }
             ]
         }
+        self.assertEqual(actual, expected)
+        seat.sku = None
+        actual = serialize_seat_for_ecommerce_api(seat, mode)
+        expected['stockrecords'][0]['partner_sku'] = None
         self.assertEqual(actual, expected)
 
 

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -415,6 +415,7 @@ def serialize_seat_for_ecommerce_api(seat, mode):
         'expires': serialize_datetime(calculated_seat_upgrade_deadline(seat)),
         'price': str(seat.price),
         'product_class': 'Seat',
+        'stockrecords': [{'partner_sku': getattr(seat, 'sku', None)}],
         'attribute_values': [
             {
                 'name': 'certificate_type',


### PR DESCRIPTION
We use the sku in order to get the seat we want to update