### PR TITLE
Exclude to-be decommisioned partners from RCM

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -67,7 +67,10 @@ class Command(BaseCommand):
                 signal.disconnect(receiver=api_change_receiver, sender=model)
 
         # For each partner defined...
-        partners = Partner.objects.all()
+        # We are excluding Harvard Medical School Global Academy and MIT Professional Education
+        # as they are being decommissioned as part of https://openedx.atlassian.net/browse/ENT-2632 (HMSGA)
+        # and https://openedx.atlassian.net/browse/ENT-2491 (MITPE)
+        partners = Partner.objects.exclude(short_code__in=['hmsga', 'mitpe'])
 
         # If a specific partner was indicated, filter down the set
         partner_code = options.get('partner_code')


### PR DESCRIPTION
We are excluding Harvard Medical School Global Academy and MITProfessionalX as part of this work.