### PR TITLE
temporarily lock courserun table during ghost migration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,8 @@
 # The following users are the owners of all course-discovery files
 *       @Dillon-Dumesnil @jlajoie @jmyatt @mikix @xnick421
+
+# DENG-20: temporary lock on the CoureRun table while DE performs a gh-ost migration.
+# All PRs touching this model should be held off until DE is complete. PRs to other
+# models within this file are OK to be deployed.
+/course_discovery/apps/course_metadata/models.py @estute
+/course_discovery/apps/course_metadata/migrations/ @estute


### PR DESCRIPTION
I am working on a gh-ost migration for the course_metadata_courserun table. This is a long and complicated process. In a previous migration, the table in question was modified unbeknownst to us, and it resulted in further complicating the process and dragging it out further. This is the easiest way to "lock" a file. If someone changes the model and/or generates a new migration for that model, I will be considered a reviewer and can request the author to hold off on this work until we are in a better position or let it through, if it is for an unrelated model.