### PR TITLE
Update devstack settings JWT_AUTH to enable inter-service communicati…

### DIFF
--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -22,13 +22,21 @@ HAYSTACK_CONNECTIONS['default']['URL'] = 'http://edx.devstack.elasticsearch:9200
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 
 JWT_AUTH.update({
-    # Must match public signing key used in LMS.
+    'JWT_SECRET_KEY': 'lms-secret',
+    'JWT_ISSUER': 'http://localhost:18000/oauth2',
+    'JWT_AUDIENCE': None,
+    'JWT_VERIFY_AUDIENCE': False,
     'JWT_PUBLIC_SIGNING_JWK_SET': (
         '{"keys": [{"kid": "devstack_key", "e": "AQAB", "kty": "RSA", "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu'
         '48BUI5VcVtUWIPqzRK_LDSlZYh9D0YFL0ZTxIrlb6Tn3Xz7pYvpIAeYuQv3_H5p8tbz7Fb8r63c1828wXPITVTv8f7oxx5W3lFFgpFAyYMmROC'
         '4Ee9qG5T38LFe8_oAuFCEntimWxN9F3P-FJQy43TL7wG54WodgiM0EgzkeLr5K6cDnyckWjTuZbWI-4ffcTgTZsL_Kq1owa_J2ngEfxMCObnzG'
         'y5ZLcTUomo4rZLjghVpq6KZxfS6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw"}]}'
     ),
+    'JWT_ISSUERS': [{
+        'AUDIENCE': 'lms-key',
+        'ISSUER': 'http://localhost:18000/oauth2',
+        'SECRET_KEY': 'lms-secret',
+    }],
 })
 
 # MEDIA CONFIGURATION


### PR DESCRIPTION
…on during local development.  The problem is that the `devstack` setting inherits the useless JWT_ISSUER defaults from `base`, and edx-drf-extensions (or something) fails hard on a mismatched JWT_ISSUER now (even if there is a good entry in JWT_ISSUERS (plural)).