### PR TITLE
ENT-2663 Enterprise API: Include additional detail-level fields in Enterprise Catalog Courses List

### DIFF
--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -117,6 +117,7 @@ class BaseCourseIndex(OrganizationsMixin, BaseIndex):
     logo_image_urls = indexes.MultiValueField()
     sponsoring_organizations = indexes.MultiValueField(faceted=True)
     level_type = indexes.CharField(null=True, faceted=True)
+    outcome = indexes.CharField(model_attr='outcome', null=True)
     partner = indexes.CharField(model_attr='partner__short_code', null=True, faceted=True)
 
     def prepare_logo_image_urls(self, obj):
@@ -150,6 +151,7 @@ class CourseIndex(BaseCourseIndex, indexes.Indexable):
     status = indexes.CharField(model_attr='course_runs__status')
     start = indexes.DateTimeField(model_attr='course_runs__start', null=True)
     end = indexes.DateTimeField(model_attr='course_runs__end', null=True)
+    modified = indexes.DateTimeField(model_attr='modified', null=True)
     enrollment_start = indexes.DateTimeField(model_attr='course_runs__enrollment_start', null=True)
     enrollment_end = indexes.DateTimeField(model_attr='course_runs__enrollment_end', null=True)
     availability = indexes.CharField(model_attr='course_runs__availability')


### PR DESCRIPTION
Enterprise API: Include additional detail-level fields in Enterprise Catalog "Courses" list endpoint
The fields are: 
course detail -> outcome
course detail -> modifed
course detail -> level_type
course run detail -> staff
course run detail -> content_language

**Testing Scenario Before PR**:
1-Create an Enterprise Catalog.
2- Copy the Catalog_UUID and hit the URL
`http://localhost:18000/enterprise/api/v1/enterprise_catalogs/Catalog_UUID/?detail_fields=True
`
You will not observe the above-mentioned detail-level fields in the response.

**After PR:**
Hit the URL again
`http://localhost:18000/enterprise/api/v1/enterprise_catalogs/Catalog_UUID/?detail_fields=True
`
You will observe the above-mentioned detail-level fields in the response.

**Then**
Remove the `detail_fields` `query_param` from the request and detail-level fields will not be in the response.


