### PR TITLE
add is_enrollable field to search/all endpoint for course and courseruns

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1975,7 +1975,8 @@ class CourseSearchSerializer(HaystackSerializer):
             'max_effort': course_run.max_effort,
             'weeks_to_complete': course_run.weeks_to_complete,
             'estimated_hours': get_course_run_estimated_hours(course_run),
-            'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0
+            'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0,
+            'is_enrollable': course_run.is_enrollable,
         }
         if detail_fields:
             course_run_detail.update(
@@ -2047,6 +2048,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
     availability = serializers.SerializerMethodField()
     first_enrollable_paid_seat_price = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
+    is_enrollable = serializers.SerializerMethodField()
 
     def get_availability(self, result):
         return result.object.availability
@@ -2056,6 +2058,9 @@ class CourseRunSearchSerializer(HaystackSerializer):
 
     def get_type(self, result):
         return result.object.type_legacy
+
+    def get_is_enrollable(self, result):
+        return result.object.is_enrollable
 
     class Meta:
         field_aliases = COMMON_SEARCH_FIELD_ALIASES
@@ -2073,6 +2078,7 @@ class CourseRunSearchSerializer(HaystackSerializer):
             'go_live_date',
             'has_enrollable_seats',
             'image_url',
+            'is_enrollable',
             'key',
             'language',
             'level_type',

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1988,6 +1988,7 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
                 'weeks_to_complete': course_run.weeks_to_complete,
                 'estimated_hours': get_course_run_estimated_hours(course_run),
                 'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0,
+                'is_enrollable': course_run.is_enrollable,
                 'staff': MinimalPersonSerializer(course_run.staff, many=True,
                                                  context={'request': request}).data,
                 'content_language': course_run.language.code if course_run.language else None,
@@ -2040,7 +2041,8 @@ class CourseSearchSerializerTests(TestCase, CourseSearchSerializerMixin):
                 'max_effort': course_run.max_effort,
                 'weeks_to_complete': course_run.weeks_to_complete,
                 'estimated_hours': get_course_run_estimated_hours(course_run),
-                'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0
+                'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0,
+                'is_enrollable': course_run.is_enrollable,
             }],
             'uuid': str(course.uuid),
             'subjects': [subject.name for subject in course.subjects.all()],
@@ -2142,6 +2144,7 @@ class CourseRunSearchSerializerTests(ElasticsearchTestMixin, TestCase):
             'has_enrollable_seats': course_run.has_enrollable_seats,
             'first_enrollable_paid_seat_sku': course_run.first_enrollable_paid_seat_sku(),
             'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price,
+            'is_enrollable': course_run.is_enrollable,
         }
 
 


### PR DESCRIPTION
The `is_enrollable` field is already included in the list/detail response for course runs. However, the `is_enrollable` field is not present on the "/search/all" endpoint.

For Enterprise, we'd like to avoid duplicating logic that already exists in course-discovery. That said, we'd like to expose the `is_enrollable` field in the response for the "/search/all" endpoint. This will effectively eliminate our need to duplicate the logic that already exists to compute `is_enrollable`.