### PR TITLE
Fixing deprecated allow-tags attribute.

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -399,8 +399,8 @@ class CurriculumCourseMembershipInline(admin.StackedInline):
                 text=_("Edit course run exclusions"),
             )
         return _("(save and continue editing to create a link)")
+
     get_edit_link.short_description = _("Edit link")
-    get_edit_link.allow_tags = True
 
     extra = 0
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1625

Fixing deprecated allow-tags attribute from django-admin