### PR TITLE
Fix LMS read timeout on running migrations

### DIFF
--- a/course_discovery/apps/core/models.py
+++ b/course_discovery/apps/core/models.py
@@ -166,7 +166,12 @@ class Partner(TimeStampedModel):
         if not self.lms_url:
             return None
 
-        return OAuthAPIClient(self.lms_url.strip('/'), self.oauth2_client_id, self.oauth2_client_secret)
+        return OAuthAPIClient(
+            self.lms_url.strip('/'),
+            self.oauth2_client_id,
+            self.oauth2_client_secret,
+            timeout=settings.OAUTH_API_TIMEOUT
+        )
 
 
 class SalesforceConfiguration(models.Model):

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -294,6 +294,9 @@ BACKEND_SERVICE_EDX_OAUTH2_KEY = "discovery-backend-service-key"
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = "discovery-backend-service-secret"
 BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://127.0.0.1:8000/oauth2"
 
+# OAuth request timeout: either a (connect, read) tuple or a float, in seconds.
+OAUTH_API_TIMEOUT = (3.05, 1)
+
 # Request the user's permissions in the ID token
 EXTRA_SCOPE = ['permissions']
 


### PR DESCRIPTION
When running the install_es_indexes command, the discovery app connects
with the LMS. The default read timeout of 1s is sometimes too low, and
the command crashes. Here, we make use of the `timeout=` keyword
argument of the  OAuthAPIClient constructor to manually set the timeout.
We set it in the django settings to the default value of the class
constructor, such that existing platforms are not affected, but this
setting is customizable across environments.

See:
https://discuss.overhang.io/t/error-during-new-setup-no-module-named-ecommerce-settings-tutor/681/10
https://github.com/edx/edx-rest-api-client/pull/62#issuecomment-646526313