### PR TITLE
Add boto to production requirements

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -191,8 +191,8 @@ unicodecsv==0.14.1        # via djangorestframework-csv
 unidecode==1.1.1          # via unicode-slugify
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.9           # via elasticsearch, requests, selenium, transifex-client
-virtualenv==20.0.24       # via tox
-wcwidth==0.2.4            # via pytest
+virtualenv==20.0.25       # via tox
+wcwidth==0.2.5            # via pytest
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.11.2             # via astroid
 xss-utils==0.1.3          # via -r requirements/base.in

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -3,6 +3,7 @@
 -r github.in              # Forks and other dependencies not yet on PyPI
 -r base.in
 
+boto
 certifi
 django-ses
 gevent

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,8 +9,9 @@ algoliasearch==1.20.0     # via algoliasearch-django
 authlib==0.14.3           # via simple-salesforce
 backoff==1.10.0           # via -r requirements/base.in
 beautifulsoup4==4.9.1     # via -r requirements/base.in
-boto3==1.14.8             # via django-ses
-botocore==1.17.8          # via boto3, s3transfer
+boto3==1.14.9             # via django-ses
+boto==2.49.0              # via -r requirements/production.in
+botocore==1.17.9          # via boto3, s3transfer
 certifi==2020.6.20        # via -r requirements/production.in, requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests


### PR DESCRIPTION
```
It's used by stage/prod Discovery, but was only installed
incidentally as a transitive dependency. When it was no
longer transitively required, the boto requirement was
removed, breaking stage Discovery.

This adds boto as a direct production requirement.
```