### PR TITLE
Revert "WS-1116 update person endpoint to accept slug as well as uuid"

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_people.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_people.py
@@ -170,14 +170,7 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
 
     def test_get_single_person_with_publisher_user(self):
         """ Verify the endpoint returns the details for a single person. """
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.uuid})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.data, self.serialize_person(self.person))
-
-    def test_get_single_person_with_publisher_user_using_slug(self):
-        """ Verify the endpoint returns the details for a single person. """
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.slug})
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.data, self.serialize_person(self.person))
@@ -185,7 +178,7 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
     def test_get_without_authentication(self):
         """ Verify the endpoint shows auth error when the details for a single person unauthenticated """
         self.client.logout()
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.uuid})
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
 
@@ -376,7 +369,7 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
 
     def test_update_without_drupal_client_settings(self):
         """ Verify that if credentials are missing api will return the error. """
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.uuid})
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
         self.partner.marketing_site_api_username = None
         self.partner.save()
         data = self._update_person_data()
@@ -396,7 +389,7 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
 
     def test_update_with_api_exception(self):
         """ Verify that if the serializer fails, error message is logged and update fails"""
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.uuid})
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
         data = self._update_person_data()
         with mock.patch.object(MarketingSitePeople, 'update_or_publish_person', return_value={}):
             with mock.patch(
@@ -419,7 +412,7 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
     @override_switch('publish_person_to_marketing_site', False)
     def test_update_without_waffle_switch(self):
         """ Verify update endpoint proceeds if waffle switch is disabled. """
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.uuid})
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
         data = self._update_person_data()
         with mock.patch.object(MarketingSitePeople, 'update_or_publish_person') as cm:
             response = self.client.patch(url, data, format='json')
@@ -429,7 +422,7 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
 
     def test_update(self):
         """Verify that people data can be updated using endpoint."""
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.uuid})
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
 
         data = self._update_person_data()
 
@@ -483,7 +476,7 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
         """
         Verify that if the people has no position a new position is created while updating people
         """
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.uuid})
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
 
         data = self._update_person_data()
         Position.objects.all().delete()
@@ -497,7 +490,7 @@ class PersonViewSetTests(SerializationMixin, APITestCase):
         self.assertEqual(updated_person.position.title, data['position']['title'])
 
     def test_update_with_org_restrictions(self):
-        url = reverse('api:v1:person-detail', kwargs={'pk': self.person.uuid})
+        url = reverse('api:v1:person-detail', kwargs={'uuid': self.person.uuid})
         url = url + '?org=invalid-org'
 
         data = self._update_person_data()

--- a/course_discovery/apps/api/v1/views/people.py
+++ b/course_discovery/apps/api/v1/views/people.py
@@ -1,8 +1,5 @@
 import logging
-import re
-from uuid import UUID
 
-from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
 from rest_framework.permissions import DjangoModelPermissions
@@ -12,7 +9,6 @@ from course_discovery.apps.api import filters, serializers
 from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.pagination import PageNumberPagination
 from course_discovery.apps.api.serializers import MetadataWithRelatedChoices
-from course_discovery.apps.course_metadata.constants import COURSE_UUID_REGEX
 from course_discovery.apps.course_metadata.exceptions import MarketingSiteAPIClientException, PersonToMarketingException
 
 logger = logging.getLogger(__name__)
@@ -24,42 +20,14 @@ class PersonViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
 
     filter_backends = (DjangoFilterBackend,)
     filterset_class = filters.PersonFilter
-    lookup_fields = ['uuid', 'slug']
-    lookup_value_regex = '[0-9a-z-]+'
-    serializer_class = serializers.PersonSerializer
+    lookup_field = 'uuid'
+    lookup_value_regex = '[0-9a-f-]+'
     permission_classes = (DjangoModelPermissions,)
     queryset = serializers.PersonSerializer.prefetch_queryset()
+    serializer_class = serializers.PersonSerializer
     pagination_class = PageNumberPagination
     metadata_class = MetadataWithRelatedChoices
     metadata_related_choices_whitelist = ('organization',)
-
-    course_uuid_regex = re.compile(COURSE_UUID_REGEX)
-
-    # override get_object to allow multiple lookup fields
-    def get_object(self):
-
-        def is_valid_uuid(uuid_to_test):
-            try:
-                _ = UUID(uuid_to_test, version=4)
-            except ValueError:
-                return False
-            return True
-
-        queryset = self.filter_queryset(self.get_queryset())
-
-        key = self.kwargs['pk']
-        if is_valid_uuid(key):
-            filter_key = 'uuid'
-        else:
-            filter_key = 'slug'
-
-        filter_kwargs = {filter_key: key}
-        obj = get_object_or_404(queryset, **filter_kwargs)
-
-        # May raise a permission denied
-        self.check_object_permissions(self.request, obj)
-
-        return obj
 
     def create(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
Reverts edx/course-discovery#2645
Turns out there was already a way to do this using /people?slug=blah. No point in cluttering up the endpoint 