### PR TITLE
Update pytest.ini to set django settings as an option

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = course_discovery.settings.test
 testpaths = course_discovery/apps
-addopts = -n2 --dist=loadscope --cov=course_discovery --cov-report term --cov-config=.coveragerc --no-cov-on-fail
+addopts = --ds=course_discovery.settings.test -n2 --dist=loadscope --cov=course_discovery --cov-report term --cov-config=.coveragerc --no-cov-on-fail


### PR DESCRIPTION
There is a priority system for setting the django settings
variable (see https://pytest-django.readthedocs.io/en/latest/configuring_django.html#order-of-choosing-settings).
In short: command line option --ds, environment var DJANGO_SETTINGS_MODULE, then DJANGO_SETTINGS_MODULE option listed in the configuration file (pytest.ini, tox.ini, etc.).
This change updates it so when you run pytest when shelled into the
container, you appropriately use the test settings file when you run pytest directly.

Normally when shelling in, we source the discovery_env file (/edx/app/discovery/discovery_env)
and that file sets the DJANGO_SETTINGS_MODULE environment variable to use
the devstack settings file.