### PR TITLE
MST-151 Add the error messages handling while saving the curriculum

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -1,5 +1,6 @@
 from adminsortable2.admin import SortableAdminMixin
 from django.contrib import admin, messages
+from django.db.utils import IntegrityError
 from django.forms import CheckboxSelectMultiple, ModelForm
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -433,6 +434,12 @@ class CurriculumCourseRunExclusionAdmin(admin.ModelAdmin):
 class CurriculumAdmin(admin.ModelAdmin):
     list_display = ('uuid', 'program', 'name', 'is_active')
     inlines = (CurriculumProgramMembershipInline, CurriculumCourseMembershipInline)
+
+    def save_model(self, request, obj, form, change):
+        try:
+            super().save_model(request, obj, form, change)
+        except IntegrityError:
+            logger.exception('A database integrity error occurred while saving curriculum [%s].', obj.uuid)
 
 
 class CurriculumAdminInline(admin.StackedInline):


### PR DESCRIPTION
@edx/masters-devs-cosmonauts and @Dillon-Dumesnil Please review
We need to add this error handling so it shows clear error messages when encountering newly introduced integrity errors.
See the screenshot below

![curriculumsaveerror](https://user-images.githubusercontent.com/16839373/89536264-a2ea1380-d7c5-11ea-95fb-296c5b4c1ffb.png)
