### PR TITLE
Serve static files in decentralized devstack ARCHBOM-1473

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial as app
+FROM ubuntu:xenial as discovery
 
 # System requirements.
 RUN apt-get update
@@ -33,7 +33,6 @@ ENV LC_ALL en_US.UTF-8
 RUN mkdir -p /edx/var/discovery/staticfiles
 RUN mkdir -p /edx/var/discovery/media
 ENV DJANGO_SETTINGS_MODULE course_discovery.settings.production
-ENV DISCOVERY_CFG /edx/app/discovery/devstack.yml
 
 # Working directory will be root of repo.
 WORKDIR /edx/app/discovery
@@ -61,6 +60,10 @@ EXPOSE 8381
 
 CMD gunicorn --bind=0.0.0.0:8381 --workers 2 --max-requests=1000 -c course_discovery/docker_gunicorn_configuration.py course_discovery.wsgi:application
 
-FROM app as newrelic
+FROM discovery as discovery-devstack
+ENV DISCOVERY_CFG /edx/app/discovery/devstack.yml
+RUN make static
+
+FROM discovery as discovery-newrelic
 RUN pip install newrelic
 CMD newrelic-admin run-program gunicorn --bind=0.0.0.0:8381 --workers 2 --max-requests=1000 -c course_discovery/docker_gunicorn_configuration.py course_discovery.wsgi:application

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial as discovery
+FROM ubuntu:xenial as app
 
 # System requirements.
 RUN apt-get update
@@ -60,10 +60,10 @@ EXPOSE 8381
 
 CMD gunicorn --bind=0.0.0.0:8381 --workers 2 --max-requests=1000 -c course_discovery/docker_gunicorn_configuration.py course_discovery.wsgi:application
 
-FROM discovery as discovery-devstack
+FROM app as devstack
 ENV DISCOVERY_CFG /edx/app/discovery/devstack.yml
 RUN make static
 
-FROM discovery as discovery-newrelic
+FROM app as newrelic
 RUN pip install newrelic
 CMD newrelic-admin run-program gunicorn --bind=0.0.0.0:8381 --workers 2 --max-requests=1000 -c course_discovery/docker_gunicorn_configuration.py course_discovery.wsgi:application

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,12 @@ check_keywords: ## Scan the Django models in all installed apps in this project 
 
 docker_build:
 	docker build . -f Dockerfile --target app -t openedx/discovery
+	docker build . -f Dockerfile --target devstack -t openedx/discovery:latest-devstack
 	docker build . -f Dockerfile --target newrelic -t openedx/discovery:latest-newrelic
 
 docker_tag: docker_build
 	docker tag openedx/discovery openedx/discovery:${GITHUB_SHA}
+	docker tag openedx/discovery:latest-devstack openedx/discovery:${GITHUB_SHA}-devstack
 	docker tag openedx/discovery:latest-newrelic openedx/discovery:${GITHUB_SHA}-newrelic
 
 docker_auth:
@@ -130,5 +132,7 @@ docker_auth:
 docker_push: docker_tag docker_auth ## push to docker hub
 	docker push 'openedx/discovery:latest'
 	docker push "openedx/discovery:${GITHUB_SHA}"
+	docker push 'openedx/discovery:latest-devstack'
+	docker push "openedx/discovery:${GITHUB_SHA}-devstack"
 	docker push 'openedx/discovery:latest-newrelic'
 	docker push "openedx/discovery:${GITHUB_SHA}-newrelic"

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -192,6 +192,9 @@ STATIC_ROOT = root('assets')
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 STATIC_URL = '/static/'
 
+# Is this a dev environment where static files need to be explicitly added to the URL configuration?
+STATIC_SERVE_EXPLICITLY = False
+
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = (
     root('static'),

--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -65,6 +65,9 @@ if settings.DEBUG:  # pragma: no cover
     # https://docs.djangoproject.com/en/1.11/howto/static-files/#serving-files-uploaded-by-a-user-during-development
     # This was modified to use LOCAL_MEDIA_URL to be able to server static files to external services like edx-mktg
     urlpatterns += static(settings.LOCAL_DISCOVERY_MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    # If using gunicorn instead of runserver in development, also need to explicitly serve static files
+    if settings.STATIC_SERVE_EXPLICITLY:
+        urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         import debug_toolbar
 

--- a/devstack.yml
+++ b/devstack.yml
@@ -38,6 +38,7 @@ DATABASES:
         PASSWORD: password
         PORT: 3306
         USER: discov001
+# Django won't serve static assets unless DEBUG is enabled
 DEBUG: true
 DEFAULT_PARTNER_ID: 1
 EDX_DRF_EXTENSIONS:

--- a/devstack.yml
+++ b/devstack.yml
@@ -38,6 +38,7 @@ DATABASES:
         PASSWORD: password
         PORT: 3306
         USER: discov001
+DEBUG: true
 DEFAULT_PARTNER_ID: 1
 EDX_DRF_EXTENSIONS:
     OAUTH2_USER_INFO_URL: http://127.0.0.1:8000/user_info
@@ -61,6 +62,7 @@ SECRET_KEY: Your secret key here
 SESSION_EXPIRE_AT_BROWSER_CLOSE: false
 SOCIAL_AUTH_EDX_OAUTH2_KEY: discovery-sso-key
 SOCIAL_AUTH_REDIRECT_IS_HTTPS: false
+STATIC_SERVE_EXPLICITLY: true
 STATICFILES_STORAGE: django.contrib.staticfiles.storage.StaticFilesStorage
 STATIC_ROOT: /edx/var/discovery/staticfiles
 TIME_ZONE: UTC


### PR DESCRIPTION
Explicitly add static file serving to the URL configuration in decentralized devstack, since we aren't using runserver (which does this automatically).  Also:

* Move all devstack-specific steps out of the base image creation
* Build the static assets just for the devstack image
* Turn on `DEBUG` for the devstack image (since otherwise no static or media files will be served)
* Build, tag, and upload the new devstack image