### PR TITLE
Fix error management failure on empty response

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -33,7 +33,11 @@ def _fatal_code(ex):
 
     That means don't retry any 4XX code, except 429, which is rate limiting.
     """
-    return ex.response.status_code != 429 and 400 <= ex.response.status_code < 500  # pylint: disable=no-member
+    return (
+        ex.response is not None and
+        ex.response.status_code != 429 and
+        400 <= ex.response.status_code < 500
+    )  # pylint: disable=no-member
 
 
 class CoursesApiDataLoader(AbstractDataLoader):


### PR DESCRIPTION
Sometimes, the response object passed to the _fatal_code callback is
None. This causes an AttributeError which prevents users from debugging
the underlying error.