### PR TITLE
BOM-2018 : Use boto3 instead of boto with SES

### DIFF
--- a/requirements/production.in
+++ b/requirements/production.in
@@ -3,7 +3,6 @@
 -r github.in              # Forks and other dependencies not yet on PyPI
 -r base.in
 
-boto
 certifi
 django-ses
 gevent

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,7 +10,6 @@ authlib==0.14.3           # via simple-salesforce
 backoff==1.10.0           # via -r requirements/base.in
 beautifulsoup4==4.9.1     # via -r requirements/base.in
 boto3==1.14.61            # via django-ses
-boto==2.49.0              # via -r requirements/production.in
 botocore==1.17.61         # via boto3, s3transfer
 certifi==2020.6.20        # via -r requirements/production.in, requests
 cffi==1.14.3              # via cryptography


### PR DESCRIPTION
Amazon's SES is making a change on October 1st that will cause any email sent to this service via the older boto package to fail

`django-ses` is already using `boto3` to send emails since version 1.0.0, there is no need of boto package. [[Reference](https://github.com/django-ses/django-ses/releases/tag/v1.0.0)]

Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2018
