### PR TITLE
Bring back imports-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2195,6 +2195,22 @@
         "resolve-cwd": "^2.0.0"
       }
     },
+    "imports-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.8.0.tgz",
+      "integrity": "sha512-kXWL7Scp8KQ4552ZcdVTeaQCZSLW+e6nJfp3cwUMB673T7Hr98Xjx5JK+ql7ADlJUvj1JS5O01RLbKoutN5QDQ==",
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "datatables.net-bs": "1.10.21",
     "extract-text-webpack-plugin": "4.0.0-beta.0",
     "file-loader": "6.1.0",
+    "imports-loader": "0.8.0",
     "jquery": "3.5.1",
     "node-sass": "4.14.1",
     "sass-loader": "10.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,14 @@ module.exports = {
                         name: 'font/[name]-[hash].[ext]'
                     }
                 }]
+            },
+            {
+                test: require.resolve('datatables.net'),
+                use: 'imports-loader?define=>false'
+            },
+            {
+                test: require.resolve('datatables.net-bs'),
+                use: 'imports-loader?define=>false'
             }
         ]
     },


### PR DESCRIPTION
My testing was bad, we do still need it. Couldn't make 1.1.0 work
quickly, so I'm sticking with 0.8.0 for now.