### PR TITLE
Updates to improve performance of the Program and affiliate apis

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1020,7 +1020,7 @@ class MinimalCourseSerializer(DynamicFieldsMixin, TimestampModelSerializer):
         # queryset passed in happens to be empty.
         queryset = queryset if queryset is not None else Course.objects.all()
 
-        return queryset.select_related('partner', 'type').prefetch_related(
+        return queryset.select_related('partner', 'type', 'canonical_course_run').prefetch_related(
             'authoring_organizations',
             Prefetch('entitlements', queryset=CourseEntitlementSerializer.prefetch_queryset()),
             Prefetch('course_runs', queryset=MinimalCourseRunSerializer.prefetch_queryset(queryset=course_runs)),
@@ -1111,6 +1111,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
             Prefetch('course_runs', queryset=CourseRunSerializer.prefetch_queryset(queryset=course_runs)),
             Prefetch('authoring_organizations', queryset=OrganizationSerializer.prefetch_queryset(partner)),
             Prefetch('sponsoring_organizations', queryset=OrganizationSerializer.prefetch_queryset(partner)),
+            Prefetch('entitlements', queryset=CourseEntitlementSerializer.prefetch_queryset()),
         )
 
     class Meta(MinimalCourseSerializer.Meta):

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -1010,7 +1010,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(39, threshold=2):
+        with self.assertNumQueries(42, threshold=2):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -105,7 +105,7 @@ class TestProgramViewSet(SerializationMixin):
         """ Verify the endpoint returns the details for a single program. """
         program = self.create_program()
 
-        with django_assert_num_queries(FuzzyInt(56, 2)):
+        with django_assert_num_queries(FuzzyInt(57, 2)):
             response = self.assert_retrieve_success(program)
         # property does not have the right values while being indexed
         del program._course_run_weeks_to_complete
@@ -158,7 +158,7 @@ class TestProgramViewSet(SerializationMixin):
             partner=self.partner)
         # property does not have the right values while being indexed
         del program._course_run_weeks_to_complete
-        with django_assert_num_queries(FuzzyInt(44, 1)):  # travis is often 43
+        with django_assert_num_queries(FuzzyInt(40, 1)):  # travis is often 43
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
         assert course_list == list(program.courses.all())
@@ -167,7 +167,7 @@ class TestProgramViewSet(SerializationMixin):
         """ Verify the endpoint returns data for a program even if the program's courses have no course runs. """
         course = CourseFactory(partner=self.partner)
         program = ProgramFactory(courses=[course], partner=self.partner)
-        with django_assert_num_queries(FuzzyInt(31, 2)):
+        with django_assert_num_queries(FuzzyInt(32, 2)):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -2249,8 +2249,18 @@ class Program(PkSearchableMixin, TimeStampedModel):
 
     @property
     def entitlements(self):
-        applicable_seat_types = set(self.type.applicable_seat_types.all())
-        return CourseEntitlement.objects.filter(mode__in=applicable_seat_types, course__in=self.courses.all())
+        """
+        Property to retrieve all of the entitlements in a Program.
+        """
+        # Warning: The choice to not use a filter method on the queryset here was deliberate. The filter
+        # method resulted in a new queryset being made which results in the prefetch_related cache being
+        # ignored.
+        return [
+            entitlement
+            for course in self.courses.all()
+            for entitlement in course.entitlements.all()
+            if entitlement.mode in set(self.type.applicable_seat_types.all())
+        ]
 
     @property
     def seat_types(self):


### PR DESCRIPTION
This PR removes the usage of a filter from the `entitlements` method. When you use filter is breaks the usage of prefetch because another queryset is generated.