### PR TITLE
Fix docker push CI step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:focal as app
 
 # System requirements.
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
 	apt-get upgrade -qy
 RUN apt-get install --yes \


### PR DESCRIPTION
The tzdata package was prompting the user to enter a timezone.
This PR tells apt/dpkg to knock off trying to ask us anything.

(In this particular case, that means sticking with the default
timezone of UTC, which seems fine.)