### PR TITLE
Upgrading django-cors-header.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,7 +13,7 @@ elasticsearch-dsl>=7.2,<8.0
 transifex-client<0.13
 
 # FIXME: 3+ require schemes in CORS_ORIGIN_WHITELIST URLs - remember to update configuration when you remove this
-django-cors-headers<3
+django-cors-headers==3.2.0
 
 # sphinx has dropped support for python 3.5, latest version requires at least python3.6
 # see https://www.sphinx-doc.org/en/master/intro.html#prerequisites

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -136,7 +136,7 @@ django-compressor==2.4.1
     #   django-libsass
 django-contrib-comments==2.1.0
     # via -r requirements/base.in
-django-cors-headers==2.5.3
+django-cors-headers==3.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -630,7 +630,7 @@ vine==1.3.0
     # via
     #   amqp
     #   celery
-virtualenv==20.7.1
+virtualenv==20.7.2
     # via tox
 websocket-client==0.59.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -22,9 +22,9 @@ beautifulsoup4==4.9.3
     # via -r requirements/base.in
 billiard==3.6.4.0
     # via celery
-boto3==1.18.17
+boto3==1.18.18
     # via django-ses
-botocore==1.21.17
+botocore==1.21.18
     # via
     #   boto3
     #   s3transfer
@@ -106,7 +106,7 @@ django-compressor==2.4.1
     #   django-libsass
 django-contrib-comments==2.1.0
     # via -r requirements/base.in
-django-cors-headers==2.5.3
+django-cors-headers==3.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in


### PR DESCRIPTION
**PART1:**

https://openedx.atlassian.net/browse/BOM-1905
```
File "/edx/app/discovery/discovery/course_discovery/settings/test.py", line 1, in <module>
    from course_discovery.settings.base import *
  File "/edx/app/discovery/discovery/course_discovery/settings/base.py", line 7, in <module>
    from corsheaders.defaults import default_headers as corsheaders_default_headers
  File "/edx/app/discovery/discovery/.tox/django30/lib/python3.8/site-packages/corsheaders/__init__.py", line 1, in <module>
    from .checks import check_settings  # noqa: F401
  File "/edx/app/discovery/discovery/.tox/django30/lib/python3.8/site-packages/corsheaders/checks.py", line 7, in <module>
    from django.utils import six
ImportError: cannot import name 'six' from 'django.utils' (/edx/app/discovery/discovery/.tox/django30/lib/python3.8/site-packages/django/utils/__init__.py)
```

Change Log
https://github.com/adamchainz/django-cors-headers/blob/master/HISTORY.rst#300-2019-05-10


**NOTE:** Need to update the [configuration](https://github.com/edx/edx-internal/blob/master/ansible/vars/prod-edx.yml#L1156) as well

Configuration PR https://github.com/edx/edx-internal/pull/3434


----------------------------------------------------------------
**In 2nd part**
update the `django-autocomplete-light` as well.