### PR TITLE
If the TEST_ELASTICSEARCH_URL is set, use it to overide the hostname.

### DIFF
--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -18,7 +18,7 @@ CORS_ORIGIN_WHITELIST = (
     'localhost:18450',  # frontend-app-support-tools
 )
 
-HAYSTACK_CONNECTIONS['default']['URL'] = 'http://edx.devstack.elasticsearch:9200/'
+ELASTICSEARCH_DSL['default']['hosts'] = os.environ.get('TEST_ELASTICSEARCH_URL', 'edx.devstack.elasticsearch7:9200')
 
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 


### PR DESCRIPTION
…hostname.

