### PR TITLE
Don't allow course key to be edited in django admin

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -92,7 +92,7 @@ class CourseAdmin(admin.ModelAdmin):
     list_display = ('uuid', 'key', 'key_for_reruns', 'title', 'draft',)
     list_filter = ('partner',)
     ordering = ('key', 'title',)
-    readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count', 'active_url_slug',)
+    readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count', 'active_url_slug', 'key',)
     search_fields = ('uuid', 'key', 'key_for_reruns', 'title',)
     raw_id_fields = ('canonical_course_run', 'draft_version',)
     autocomplete_fields = ['canonical_course_run']


### PR DESCRIPTION
Recently we hit a problem where a staff user thought to edit a course key in an attempt to remove the course from view of the course team in Publisher.  The new value did not satisfy the pattern expected in various places in the system (in this case, an Enterprise catalog job in platform hit a high error rate on a url reverse function).  

Rather than add validation for this field, I'm just removing edit access since we don't currently support any use case around changing these.  However, see the note on this in the Decision section of [this ADR on the topic](https://github.com/edx/course-discovery/blob/master/docs/decisions/0006-disallow-course-number-changes-in-publisher.rst) - it might make sense to re-enable editing course keys at a future date.