### PR TITLE
EDUCATOR-5376: Remove individual endorsements from program form in django admin

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -198,14 +198,15 @@ class ProgramAdmin(admin.ModelAdmin):
     exclude = ('card_image_url',)
 
     # ordering the field display on admin page.
+    # individual_endorsements hidden to prevent confusion (EDUCATOR-5376)
     fields = (
         'uuid', 'title', 'subtitle', 'marketing_hook', 'status', 'type', 'partner', 'banner_image', 'banner_image_url',
         'card_image', 'marketing_slug', 'overview', 'credit_redemption_overview', 'video', 'total_hours_of_effort',
         'weeks_to_complete', 'min_hours_effort_per_week', 'max_hours_effort_per_week', 'courses',
         'order_courses_by_start_date', 'custom_course_runs_display', 'excluded_course_runs', 'authoring_organizations',
         'credit_backing_organizations', 'one_click_purchase_enabled', 'hidden', 'corporate_endorsements', 'faq',
-        'individual_endorsements', 'job_outlook_items', 'expected_learning_items', 'instructor_ordering',
-        'enrollment_count', 'recent_enrollment_count', 'credit_value',
+        'job_outlook_items', 'expected_learning_items', 'instructor_ordering', 'enrollment_count',
+        'recent_enrollment_count', 'credit_value',
     )
 
     save_error = False

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -327,7 +327,7 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
             'field-min_hours_effort_per_week', 'field-max_hours_effort_per_week', 'field-courses',
             'field-order_courses_by_start_date', 'field-custom_course_runs_display', 'field-excluded_course_runs',
             'field-authoring_organizations', 'field-credit_backing_organizations', 'field-one_click_purchase_enabled',
-            'field-hidden', 'field-corporate_endorsements', 'field-faq', 'field-individual_endorsements',
+            'field-hidden', 'field-corporate_endorsements', 'field-faq',
             'field-job_outlook_items', 'field-expected_learning_items', 'field-instructor_ordering',
             'field-enrollment_count', 'field-recent_enrollment_count', 'field-credit_value',
         ]


### PR DESCRIPTION
[EDUCATOR-5376](https://openedx.atlassian.net/browse/EDUCATOR-5376)

The individual endorsements have been removed from the Django Admin.

![Screen Shot 2020-10-29 at 11 44 31 AM](https://user-images.githubusercontent.com/1639231/97597596-60a72b80-19dc-11eb-8b16-69233f85f037.png)
