### PR TITLE
Disallow editing fields that comprise course run keys

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -92,7 +92,7 @@ class CourseAdmin(admin.ModelAdmin):
     list_display = ('uuid', 'key', 'key_for_reruns', 'title', 'draft',)
     list_filter = ('partner',)
     ordering = ('key', 'title',)
-    readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count', 'active_url_slug', 'key',)
+    readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count', 'active_url_slug', 'key', 'number')
     search_fields = ('uuid', 'key', 'key_for_reruns', 'title',)
     raw_id_fields = ('canonical_course_run', 'draft_version',)
     autocomplete_fields = ['canonical_course_run']
@@ -163,7 +163,7 @@ class CourseRunAdmin(admin.ModelAdmin):
     )
     ordering = ('key',)
     raw_id_fields = ('course', 'draft_version',)
-    readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count', 'hidden')
+    readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count', 'hidden', 'key')
     search_fields = ('uuid', 'key', 'title_override', 'course__title', 'slug', 'external_key')
     save_error = False
 
@@ -327,7 +327,7 @@ class OrganizationAdmin(admin.ModelAdmin):
     list_display = ('uuid', 'key', 'name',)
     inlines = [OrganizationUserRoleInline, ]
     list_filter = ('partner',)
-    readonly_fields = ('uuid',)
+    readonly_fields = ('uuid', 'key')
     search_fields = ('uuid', 'name', 'key',)
 
 


### PR DESCRIPTION
Recently an edit of a course key broke both Data Eng data tests and an Enterprise catalog data sync job, necessitating a change to disallow editing of that field in django admin.  After the RCA for the incident it occurs to me that we still allow editing of course run keys directly, so this disables that as well as course number and org key (both used in generation of course key).  We have also found that edits to org key alone can break Data Eng jobs, so for that reason as well we should lock this down since so many users have full access to django admin.