### PR TITLE
DISCO-1695: Order serialized runs inside a course

### DIFF
--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -129,6 +129,8 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             else:
                 course_runs = CourseRun.objects.filter(course__partner=partner)
 
+            course_runs = course_runs.order_by('start', 'id')
+
             if not get_query_param(self.request, 'include_hidden_course_runs'):
                 course_runs = course_runs.exclude(hidden=True)
 

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -38,10 +38,10 @@ class ProgramViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet
         # which happens when the queryset is stored in a class property.
         partner = self.request.site.partner
         q = self.request.query_params.get('q')
-        queryset = None
+        queryset = Program.objects.filter(partner=partner).order_by('id')
 
         if q:
-            queryset = Program.search(q)
+            queryset = Program.search(q, queryset=queryset)
 
         return self.get_serializer_class().prefetch_queryset(queryset=queryset, partner=partner)
 

--- a/course_discovery/apps/core/tests/factories.py
+++ b/course_discovery/apps/core/tests/factories.py
@@ -54,8 +54,8 @@ class StaffUserFactory(UserFactory):
 
 
 class PartnerFactory(factory.django.DjangoModelFactory):
-    name = factory.Sequence(lambda n: f'test-partner-{n}')  # pylint: disable=unnecessary-lambda
-    short_code = factory.Sequence(lambda n: f'test{n}')  # pylint: disable=unnecessary-lambda
+    name = factory.Sequence(lambda n: f'test-partner-{n}')
+    short_code = factory.Sequence(lambda n: f'test{n}')
     courses_api_url = f'{FuzzyUrlRoot().fuzz()}/api/courses/v1/'
     lms_coursemode_api_url = f'{FuzzyUrlRoot().fuzz()}/api/course_mode/v1/'
     ecommerce_api_url = f'{FuzzyUrlRoot().fuzz()}/api/v2/'

--- a/course_discovery/apps/taxonomy_support/tests/test_providers.py
+++ b/course_discovery/apps/taxonomy_support/tests/test_providers.py
@@ -22,7 +22,7 @@ discovery and its interface in taxonomy are always in sync.
 """
 
 from django.test import TestCase
-from taxonomy.validators import CourseMetadataProviderValidator  # pylint: disable=no-name-in-module,import-error
+from taxonomy.validators import CourseMetadataProviderValidator
 
 from course_discovery.apps.course_metadata.tests.factories import CourseFactory
 


### PR DESCRIPTION
When we serialize a course, we used to just use the default ordering (run creation order) for its runs. But this commit changes that to an explicit start date ordering.

This matches up with what a human would expect the ordering to be.