### PR TITLE
DISCO-1695: Sort course runs in courses in programs too

### DIFF
--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -129,8 +129,6 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             else:
                 course_runs = CourseRun.objects.filter(course__partner=partner)
 
-            course_runs = course_runs.order_by('start', 'id')
-
             if not get_query_param(self.request, 'include_hidden_course_runs'):
                 course_runs = course_runs.exclude(hidden=True)
 


### PR DESCRIPTION
Prevoiusly, we only sorted them inside of the course endpoint.