### PR TITLE
Add org logo to minimal program serializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -361,24 +361,25 @@ class PositionSerializer(BaseModelSerializer):
 
 
 class MinimalOrganizationSerializer(BaseModelSerializer):
-    class Meta:
-        model = Organization
-        fields = ('uuid', 'key', 'name', 'auto_generate_course_run_keys',)
-        read_only_fields = ('auto_generate_course_run_keys',)
-
-
-class OrganizationSerializer(TaggitSerializer, MinimalOrganizationSerializer):
-    """Serializer for the ``Organization`` model."""
-    tags = TagListSerializerField()
     certificate_logo_image_url = serializers.SerializerMethodField()
-    logo_image_url = serializers.SerializerMethodField()
-    banner_image_url = serializers.SerializerMethodField()
 
     def get_certificate_logo_image_url(self, obj):
         image = getattr(obj, 'certificate_logo_image', None)
         if image:
             return image.url
         return None
+
+    class Meta:
+        model = Organization
+        fields = ('uuid', 'key', 'name', 'auto_generate_course_run_keys', 'certificate_logo_image_url',)
+        read_only_fields = ('auto_generate_course_run_keys',)
+
+
+class OrganizationSerializer(TaggitSerializer, MinimalOrganizationSerializer):
+    """Serializer for the ``Organization`` model."""
+    tags = TagListSerializerField()
+    logo_image_url = serializers.SerializerMethodField()
+    banner_image_url = serializers.SerializerMethodField()
 
     def get_logo_image_url(self, obj):
         image = getattr(obj, 'logo_image', None)
@@ -398,7 +399,6 @@ class OrganizationSerializer(TaggitSerializer, MinimalOrganizationSerializer):
 
     class Meta(MinimalOrganizationSerializer.Meta):
         fields = MinimalOrganizationSerializer.Meta.fields + (
-            'certificate_logo_image_url',
             'description',
             'homepage_url',
             'tags',

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1559,11 +1559,21 @@ class MinimalOrganizationSerializerTests(TestCase):
 
     @classmethod
     def get_expected_data(cls, organization):
+        certificate_logo_image_url = getattr(
+            getattr(
+                organization,
+                'certificate_logo_image',
+                None
+            ),
+            'url',
+            None
+        )
         return {
             'uuid': str(organization.uuid),
             'key': organization.key,
             'name': organization.name,
             'auto_generate_course_run_keys': organization.auto_generate_course_run_keys,
+            'certificate_logo_image_url': certificate_logo_image_url
         }
 
     def test_data(self):


### PR DESCRIPTION
Similar to https://github.com/edx/course-discovery/pull/2844 we need
to store this value when we scan so we can use a cached version in
services like credentials.