### PR TITLE
Fix jsi18n view error

### DIFF
--- a/course_discovery/apps/core/tests/test_views.py
+++ b/course_discovery/apps/core/tests/test_views.py
@@ -77,3 +77,15 @@ class AutoAuthTests(SiteMixin, TestCase):
 
         # Verify that the user has superuser permissions
         self.assertTrue(user.is_superuser)
+
+
+class OtherViewsTests(TestCase):
+    """ Other small view tests """
+
+    def test_javascript_catalog_view(self):
+        """
+        Verify that JavaScriptCatalog view is accessible by reversing 'javascript-catalog'
+        """
+        url = reverse('javascript-catalog')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/course_discovery/urls.py
+++ b/course_discovery/urls.py
@@ -45,7 +45,7 @@ urlpatterns = oauth2_urlpatterns + [
     url(r'^language-tags/', include('course_discovery.apps.ietf_language_tags.urls', namespace='language_tags')),
     url(r'^comments/', include('django_comments.urls')),
     url(r'^i18n/', include('django.conf.urls.i18n')),
-    url(r'^jsi18n/$', JavaScriptCatalog, name='javascript-catalog'),
+    url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
 ]
 


### PR DESCRIPTION
Simple fix for a missing `as_view()` in `jsi18n` URL. The current syntax is not valid. See https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#module-django.views.i18n

This will resolve an annoying error when URL `jsi18n` is accessed
```
 File "/openedx/venv/lib/python3.5/site-packages/django/core/handlers/base.py", line 113, in _get_response
     response = wrapped_callback(request, *callback_args, **callback_kwargs)
 TypeError: __init__() takes 1 positional argument but 2 were given
```

