### PR TITLE
update course skills on course metadata field update

### DIFF
--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -94,9 +94,10 @@ def reviewable_data_has_changed(obj, new_key_vals, exempt_fields=None):
         exempt_fields (list): List of field names where a change does not affect review status
 
     Returns:
-        bool for whether data for any reviewable fields has changed
+        list of changed field names
     """
     changed = False
+    changed_fields = []
     exempt_fields = exempt_fields or []
     for key, new_value in [x for x in new_key_vals if x[0] not in exempt_fields]:
         original_value = getattr(obj, key, None)
@@ -114,7 +115,13 @@ def reviewable_data_has_changed(obj, new_key_vals, exempt_fields=None):
                         changed = True
         elif new_value != original_value:
             changed = True
-    return changed
+        else:
+            changed = False
+
+        if changed:
+            changed_fields.append(key)
+
+    return changed_fields
 
 
 def conditional_decorator(condition, decorator):

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -352,9 +352,12 @@ class CourseRunViewSet(ValidElasticSearchQueryRequiredMixin, viewsets.ModelViewS
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
-        changed = reviewable_data_has_changed(
-            course_run, serializer.validated_data.items(), CourseRun.STATUS_CHANGE_EXEMPT_FIELDS)
-        response = self._update_course_run(course_run, draft, changed, serializer, request, prices)
+        changed_fields = reviewable_data_has_changed(
+            course_run,
+            serializer.validated_data.items(),
+            CourseRun.STATUS_CHANGE_EXEMPT_FIELDS
+        )
+        response = self._update_course_run(course_run, draft, bool(changed_fields), serializer, request, prices)
 
         self.update_course_run_image_in_studio(course_run)
 

--- a/course_discovery/apps/course_metadata/apps.py
+++ b/course_discovery/apps/course_metadata/apps.py
@@ -14,3 +14,4 @@ class CourseMetadataConfig(AppConfig):
         ImageFile.LOAD_TRUNCATED_IMAGES = True
         # noinspection PyUnresolvedReferences
         import course_discovery.apps.course_metadata.signals  # pylint: disable=import-outside-toplevel,unused-import
+        from course_discovery import celery_app  # pylint: disable=import-outside-toplevel,unused-import

--- a/course_discovery/celery_app.py
+++ b/course_discovery/celery_app.py
@@ -1,0 +1,9 @@
+import os
+
+from celery import Celery
+
+# Set the default configuration module, if one is not aleady defined.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'discovery.settings.local')
+
+app = Celery('discovery')
+app.config_from_object('django.conf:settings', namespace='CELERY')

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -586,3 +586,47 @@ EMSI_API_ACCESS_TOKEN_URL = 'https://auth.emsicloud.com/connect/token'
 EMSI_API_BASE_URL = 'https://emsiservices.com'
 EMSI_CLIENT_ID = ''
 EMSI_CLIENT_SECRET = ''
+
+
+################################### BEGIN CELERY ###################################
+
+# Message configuration
+CELERY_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_COMPRESSION = 'gzip'
+CELERY_MESSAGE_COMPRESSION = 'gzip'
+
+# Events configuration
+CELERY_TRACK_STARTED = True
+CELERY_SEND_EVENTS = True
+CELERY_SEND_SENT_EVENT = True
+
+# Prevent Celery from removing handlers on the root logger. Allows setting custom logging handlers.
+# See http://celery.readthedocs.io/en/latest/userguide/configuration.html#worker-hijack-root-logger.
+CELERYD_HIJACK_ROOT_LOGGER = False
+
+CELERY_DEFAULT_EXCHANGE = 'discovery'
+CELERY_DEFAULT_ROUTING_KEY = 'discovery'
+CELERY_DEFAULT_QUEUE = 'discovery.default'
+
+# Celery Broker
+CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', '')
+
+# Disable connection pooling. Connections may be severed by load balancers.
+# This forces the application to connect explicitly to the broker each time
+# rather than assume a long-lived connection.
+BROKER_POOL_LIMIT = 0
+BROKER_CONNECTION_TIMEOUT = 1
+
+# Use heartbeats to prevent broker connection loss. When the broker
+# is behind a load balancer, the load balancer may timeout Celery's
+# connection to the broker, causing messages to be lost.
+BROKER_HEARTBEAT = 10.0
+BROKER_HEARTBEAT_CHECKRATE = 2
+
+CELERY_ALWAYS_EAGER = False
+
+################################### END CELERY ###################################
+
+FIRE_UPDATE_COURSE_SKILLS_SIGNAL = False

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -77,6 +77,8 @@ ENABLE_PUBLISHER = True
 
 ORG_BASE_LOGO_URL = "http://discovery:18381/media/"
 
+CELERY_ALWAYS_EAGER = False
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -1,3 +1,5 @@
+import tempfile
+
 from course_discovery.settings.base import *
 from course_discovery.settings.shared.test import *
 
@@ -64,3 +66,15 @@ SITE_CACHE_TTL = 0
 
 # Disable throttling during most testing, as it just adds queries
 REST_FRAMEWORK['DEFAULT_THROTTLE_CLASSES'] = ()
+
+################################### BEGIN CELERY ###################################
+
+CELERY_ALWAYS_EAGER = True
+
+CELERY_IGNORE_RESULT = True
+
+CELERY_RESULT_BACKEND = 'file://{}'.format(tempfile.TemporaryDirectory())
+
+CELERY_BROKER_URL = 'memory://localhost/'
+
+################################### END CELERY ###################################

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -54,6 +54,7 @@ pycountry
 python-dateutil
 pytz
 requests
+redis
 simple-salesforce
 social-auth-app-django
 unicode-slugify

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,9 +17,6 @@ django-cors-headers<3
 faker==5.0.0
 factory-boy==3.1.0
 
-# Latest build fetches celery with it, we might want to handle it separately
-taxonomy-connector==1.2.0
-
 # jsonfield2 3.1.0 drops support for python 3.5
 jsonfield2<3.1.0
 
@@ -29,3 +26,8 @@ sphinx==2.4.4
 
 # FIXME: dal 3.5 requires you to include jquery yourself on the admin page -- needs a proper fix
 django-autocomplete-light<3.5
+
+celery<5.0
+
+# latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2
+social-auth-core<4.0.3

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -15,7 +15,7 @@ imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==20.8           # via sphinx
-pygments==2.7.3           # via sphinx
+pygments==2.7.4           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytz==2020.5              # via babel
 requests==2.25.1          # via sphinx

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,6 +7,7 @@
 alabaster==0.7.12         # via sphinx
 algoliasearch-django==1.7.2  # via -r requirements/base.in
 algoliasearch==1.20.0     # via algoliasearch-django
+amqp==2.6.1               # via kombu
 apipkg==1.5               # via execnet
 appdirs==1.4.4            # via virtualenv
 astroid==2.4.2            # via pylint, pylint-celery
@@ -16,7 +17,9 @@ babel==2.9.0              # via sphinx
 backoff==1.10.0           # via -r requirements/base.in
 bcrypt==3.2.0             # via paramiko
 beautifulsoup4==4.9.3     # via -r requirements/base.in
+billiard==3.6.3.0         # via celery
 cached-property==1.5.2    # via docker-compose
+celery==4.4.7             # via -c requirements/constraints.txt, taxonomy-connector
 certifi==2020.12.5        # via elasticsearch, requests
 cffi==1.14.4              # via bcrypt, cryptography, pynacl
 chardet==4.0.0            # via requests
@@ -80,11 +83,11 @@ edx-ccx-keys==1.1.0       # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, taxonomy-connector
-edx-drf-extensions==6.2.0  # via -r requirements/base.in
+edx-drf-extensions==6.3.0  # via -r requirements/base.in
 edx-i18n-tools==0.5.3     # via -r requirements/local.in
 edx-lint==1.6             # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions
-edx-rest-api-client==5.2.3  # via -r requirements/base.in, taxonomy-connector
+edx-rest-api-client==5.3.0  # via -r requirements/base.in, taxonomy-connector
 edx-sphinx-theme==1.6.0   # via -r requirements/docs.in
 elasticsearch-dsl==7.3.0  # via -c requirements/constraints.txt, -r requirements/base.in, django-elasticsearch-dsl, django-elasticsearch-dsl-drf
 elasticsearch==7.10.1     # via -c requirements/constraints.txt, -r requirements/base.in, django-elasticsearch-dsl-drf, elasticsearch-dsl
@@ -103,6 +106,7 @@ itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema, sphinx
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
 jsonschema==3.2.0         # via docker-compose
+kombu==4.6.11             # via celery
 lazy-object-proxy==1.4.3  # via astroid
 libsass==0.20.1           # via django-libsass
 lxml==4.6.2               # via -r requirements/base.in
@@ -129,7 +133,7 @@ pycodestyle==2.6.0        # via -r requirements/test.in
 pycountry==20.7.3         # via -r requirements/base.in
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.9      # via pyjwkest
-pygments==2.7.3           # via sphinx
+pygments==2.7.4           # via sphinx
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
@@ -152,10 +156,11 @@ python-dotenv==0.15.0     # via docker-compose
 python-memcached==1.59    # via -r requirements/test.in
 python-utils==2.4.0       # via progressbar2
 python3-openid==3.2.0     # via social-auth-core
-pytz==2020.5              # via -r requirements/base.in, babel, django, taxonomy-connector
+pytz==2020.5              # via -r requirements/base.in, babel, celery, django, taxonomy-connector
 pywatchman==1.4.1         # via -r requirements/local.in
 pyyaml==5.3.1             # via docker-compose, edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via django-compressor
+redis==3.5.3              # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.25.1          # via -r requirements/base.in, algoliasearch, coreapi, docker, docker-compose, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, responses, simple-salesforce, slumber, social-auth-core, sphinx
 responses==0.12.1         # via -r requirements/test.in, pytest-responses
@@ -169,7 +174,7 @@ six==1.15.0               # via astroid, bcrypt, cryptography, django-choices, d
 slumber==0.7.1            # via edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==4.0.2   # via edx-auth-backends, social-auth-app-django
+social-auth-core==4.0.2   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.1            # via beautifulsoup4
 sphinx==2.4.4             # via -c requirements/constraints.txt, -r requirements/docs.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -180,22 +185,23 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via django, django-debug-toolbar
 stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
-taxonomy-connector==1.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
+taxonomy-connector==1.2.1  # via -r requirements/base.in
 testfixtures==6.17.0      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 texttable==1.6.3          # via docker-compose
 toml==0.10.2              # via pylint, pytest, tox
-tox==3.21.0               # via -r requirements/test.in
+tox==3.21.1               # via -r requirements/test.in
 transifex-client==0.12.5  # via -c requirements/constraints.txt, -r requirements/local.in
 unicode-slugify==0.1.3    # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 unidecode==1.1.2          # via unicode-slugify
 uritemplate==3.0.1        # via coreapi
 urllib3==1.26.2           # via elasticsearch, requests, responses, selenium, transifex-client
-virtualenv==20.3.0        # via tox
+vine==1.3.0               # via amqp, celery
+virtualenv==20.3.1        # via tox
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.12.1             # via astroid
-xss-utils==0.1.4          # via -r requirements/base.in
+xss-utils==0.2.0          # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,11 +6,14 @@
 #
 algoliasearch-django==1.7.2  # via -r requirements/base.in
 algoliasearch==1.20.0     # via algoliasearch-django
+amqp==2.6.1               # via kombu
 authlib==0.15.2           # via simple-salesforce
 backoff==1.10.0           # via -r requirements/base.in
 beautifulsoup4==4.9.3     # via -r requirements/base.in
-boto3==1.16.51            # via django-ses
-botocore==1.19.51         # via boto3, s3transfer
+billiard==3.6.3.0         # via celery
+boto3==1.16.53            # via django-ses
+botocore==1.19.53         # via boto3, s3transfer
+celery==4.4.7             # via -c requirements/constraints.txt, taxonomy-connector
 certifi==2020.12.5        # via -r requirements/production.in, elasticsearch, requests
 cffi==1.14.4              # via cryptography
 chardet==4.0.0            # via requests
@@ -63,9 +66,9 @@ edx-ccx-keys==1.1.0       # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, taxonomy-connector
-edx-drf-extensions==6.2.0  # via -r requirements/base.in
+edx-drf-extensions==6.3.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions
-edx-rest-api-client==5.2.3  # via -r requirements/base.in, taxonomy-connector
+edx-rest-api-client==5.3.0  # via -r requirements/base.in, taxonomy-connector
 elasticsearch-dsl==7.3.0  # via -c requirements/constraints.txt, -r requirements/base.in, django-elasticsearch-dsl, django-elasticsearch-dsl-drf
 elasticsearch==7.10.1     # via -c requirements/constraints.txt, -r requirements/base.in, django-elasticsearch-dsl-drf, elasticsearch-dsl
 future==0.18.2            # via django-ses, pyjwkest
@@ -78,6 +81,7 @@ itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 jmespath==0.10.0          # via boto3, botocore
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in
+kombu==4.6.11             # via celery
 libsass==0.20.1           # via django-libsass
 lxml==4.6.2               # via -r requirements/base.in
 markdown==3.3.3           # via -r requirements/base.in
@@ -100,31 +104,33 @@ python-dateutil==2.8.1    # via -r requirements/base.in, botocore, edx-drf-exten
 python-memcached==1.59    # via -r requirements/production.in
 python-utils==2.4.0       # via progressbar2
 python3-openid==3.2.0     # via social-auth-core
-pytz==2020.5              # via -r requirements/base.in, django, django-ses, taxonomy-connector
+pytz==2020.5              # via -r requirements/base.in, celery, django, django-ses, taxonomy-connector
 pyyaml==5.3.1             # via -r requirements/production.in, edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
+redis==3.5.3              # via -r requirements/base.in
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.25.1          # via -r requirements/base.in, algoliasearch, coreapi, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, simple-salesforce, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.1.0             # via django-compressor
-s3transfer==0.3.3         # via boto3
+s3transfer==0.3.4         # via boto3
 semantic-version==2.8.5   # via edx-drf-extensions
 simple-salesforce==1.10.1  # via -r requirements/base.in
 simplejson==3.17.2        # via django-rest-swagger
 six==1.15.0               # via cryptography, django-choices, django-compressor, django-elasticsearch-dsl, django-elasticsearch-dsl-drf, django-simple-history, django-taggit-serializer, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, elasticsearch-dsl, libsass, progressbar2, pyjwkest, python-dateutil, python-memcached, python-utils, social-auth-app-django, social-auth-core, unicode-slugify
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==4.0.2   # via edx-auth-backends, social-auth-app-django
+social-auth-core==4.0.2   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.1            # via beautifulsoup4
 sqlparse==0.4.1           # via django
 stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
-taxonomy-connector==1.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
+taxonomy-connector==1.2.1  # via -r requirements/base.in
 unicode-slugify==0.1.3    # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 unidecode==1.1.2          # via unicode-slugify
 uritemplate==3.0.1        # via coreapi
 urllib3==1.26.2           # via botocore, elasticsearch, requests
-xss-utils==0.1.4          # via -r requirements/base.in
+vine==1.3.0               # via amqp, celery
+xss-utils==0.2.0          # via -r requirements/base.in
 zope.event==4.5.0         # via gevent
 zope.interface==5.2.0     # via gevent
 


### PR DESCRIPTION
**Description:** If a skills relavant course field is updated than fire signal so that a background task in taxonomy update the course skills. Currently we are only interested in `full_description` course field.

**JIRA:** [ENT-3758](https://openedx.atlassian.net/browse/ENT-3758)

**Blocked By:** https://github.com/edx/taxonomy-connector/pull/34