### PR TITLE
ENT-3761: Added skill names as a filter for course and course run search

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -460,7 +460,7 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
             self.serialize_program_search(other_program),
         ]
 
-    @ddt.data((True, 8), (False, 8))
+    @ddt.data((True, 11), (False, 11))
     @ddt.unpack
     def test_query_count_exclude_expired_course_run(self, exclude_expired, expected_queries):
         """ Verify that there is no query explosion when excluding expired course runs. """
@@ -689,7 +689,7 @@ class AggregateCatalogSearchViewSetTests(mixins.SerializationMixin, mixins.Login
             'count': 1,
             'facets': {}
         }
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(6):
             response = self.client.post(self.path, data=data, format='json')
 
         assert response.json() == expected

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -214,6 +214,7 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         'pacing_type': {'field': 'pacing_type', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
         'partner': {'field': 'partner.lower', 'lookups': [LOOKUP_FILTER_TERM]},
         'published': {'field': 'published', 'lookups': [LOOKUP_FILTER_TERM]},
+        'skill_names': {'field': 'skill_names', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
         'status': {'field': 'status', 'lookups': [LOOKUP_FILTER_TERM]},
         'start': {'field': 'start', 'lookups': [LOOKUP_QUERY_GT, LOOKUP_QUERY_GTE, LOOKUP_QUERY_LT, LOOKUP_QUERY_LTE]},
         'short_description': {

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django_elasticsearch_dsl import Index, fields
 from opaque_keys.edx.keys import CourseKey
+from taxonomy.models import CourseSkills
 
 from course_discovery.apps.course_metadata.models import Course
 
@@ -38,6 +39,7 @@ class CourseDocument(BaseCourseDocument):
     languages = fields.KeywordField(multi=True)
     modified = fields.DateField()
     prerequisites = fields.KeywordField(multi=True)
+    skill_names = fields.KeywordField(multi=True)
     status = fields.KeywordField(multi=True)
     start = fields.DateField(multi=True)
 
@@ -80,6 +82,10 @@ class CourseDocument(BaseCourseDocument):
     def prepare_seat_types(self, obj):
         seat_types = [seat.slug for run in filter_visible_runs(obj.course_runs) for seat in run.seat_types]
         return list(set(seat_types))
+
+    def prepare_skill_names(self, obj):
+        course_skills = CourseSkills.objects.select_related('skill').filter(course_id=obj.key)
+        return list(set(course_skill.skill.name for course_skill in course_skills))
 
     def prepare_status(self, obj):
         return [course_run.status for course_run in filter_visible_runs(obj.course_runs)]

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django_elasticsearch_dsl import Index, fields
 from opaque_keys.edx.keys import CourseKey
+from taxonomy.models import CourseSkills
 
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.models import CourseRun
@@ -54,6 +55,7 @@ class CourseRunDocument(BaseCourseDocument):
     pacing_type = fields.KeywordField()
     program_types = fields.KeywordField(multi=True)
     published = fields.BooleanField()
+    skill_names = fields.KeywordField(multi=True)
     status = fields.KeywordField()
     start = fields.DateField()
     slug = fields.TextField()
@@ -109,6 +111,10 @@ class CourseRunDocument(BaseCourseDocument):
 
     def prepare_seat_types(self, obj):
         return [seat_type.slug for seat_type in obj.seat_types]
+
+    def prepare_skill_names(self, obj):
+        course_skills = CourseSkills.objects.select_related('skill').filter(course_id=obj.course.key)
+        return list(set(course_skill.skill.name for course_skill in course_skills))
 
     def prepare_staff_uuids(self, obj):
         return [str(staff.uuid) for staff in obj.staff.all()]

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
@@ -1,5 +1,6 @@
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
+from taxonomy.models import CourseSkills
 
 from course_discovery.apps.api.serializers import ContentTypeSerializer, CourseRunWithProgramsSerializer
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.serializers import BaseDjangoESDSLFacetSerializer
@@ -20,6 +21,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
     end = serializers.SerializerMethodField()
     enrollment_start = serializers.SerializerMethodField()
     enrollment_end = serializers.SerializerMethodField()
+    skill_names = serializers.SerializerMethodField()
 
     def get_start(self, obj):
         return self.handle_datetime_field(obj.start)
@@ -32,6 +34,10 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
 
     def get_enrollment_end(self, obj):
         return self.handle_datetime_field(obj.enrollment_end)
+
+    def get_skill_names(self, result):
+        course_skills = CourseSkills.objects.select_related('skill').filter(course_id=result.course_key)
+        return list(set(course_skill.skill.name for course_skill in course_skills))
 
     class Meta:
         """
@@ -68,6 +74,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
             'program_types',
             'published',
             'seat_types',
+            'skill_names',
             'short_description',
             'staff_uuids',
             'start',

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -4,6 +4,7 @@ import factory
 from django.db.models.signals import post_save
 from factory.fuzzy import FuzzyChoice, FuzzyDateTime, FuzzyDecimal, FuzzyInteger, FuzzyText
 from pytz import UTC
+from taxonomy.models import CourseSkills, Skill
 
 from course_discovery.apps.core.tests.factories import PartnerFactory, UserFactory, add_m2m_data
 from course_discovery.apps.core.tests.utils import FuzzyURL
@@ -155,6 +156,26 @@ class CourseRunTypeFactory(factory.django.DjangoModelFactory):
     def tracks(self, create, extracted, **kwargs):
         if create:  # pragma: no cover
             add_m2m_data(self.tracks, extracted)
+
+
+class SkillFactory(factory.django.DjangoModelFactory):
+    external_id = FuzzyText()
+    name = FuzzyText()
+    info_url = FuzzyURL()
+    type_id = FuzzyText()
+    type_name = FuzzyText()
+
+    class Meta:
+        model = Skill
+
+
+class CourseSkillsFactory(factory.django.DjangoModelFactory):
+    course_id = FuzzyText()
+    skill = factory.SubFactory(SkillFactory)
+    confidence = FuzzyDecimal(0.0, 1.0)
+
+    class Meta:
+        model = CourseSkills
 
 
 class CourseTypeFactory(factory.django.DjangoModelFactory):

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -601,7 +601,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
                 )
 
     def test_nondraft_does_not_collide_with_draft(self):
-        with self.assertNumQueries(FuzzyInt(71, 1)):
+        with self.assertNumQueries(FuzzyInt(73, 1)):
             factories.CourseRunFactory(
                 course=self.course_1,
                 draft=False,
@@ -611,7 +611,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
             )
 
     def test_collision_does_not_include_drafts(self):
-        with self.assertNumQueries(FuzzyInt(71, 1)):
+        with self.assertNumQueries(FuzzyInt(73, 1)):
             course_run = factories.CourseRunFactory(
                 course=self.course_1,
                 draft=False,


### PR DESCRIPTION
**Description**: This PR adds skill_names as a filter for course and course_run search using elasticsearch DSL

**JIRA**: https://openedx.atlassian.net/browse/ENT-3761

**Test instructions:**
1: Update docker images if not done recently and deploy branch and recreate indexes
cd path_to_devstack
git pull
make dev.pull.discovery
make discovery-down
make discovery-up
cd path_to_course-discovery
git checkout iahmad/ENT-3761-2
git pull
make discovery-shell
python manage.py search_index --create
python manage.py update_index --disable-change-limit
2: Open http://localhost:18381/api/v1/search/all/ and login
3: Verify skill_names as a search attribute ... http://localhost:18381/api/v1/search/all/?skill_names=[some%20skill]