### PR TITLE
ENT-3947: Version upgrade for taxonomy-connector.

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -185,7 +185,7 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via django, django-debug-toolbar
 stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
-taxonomy-connector==1.2.1  # via -r requirements/base.in
+taxonomy-connector==1.3.0  # via -r requirements/base.in
 testfixtures==6.17.0      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
 texttable==1.6.3          # via docker-compose

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -123,7 +123,7 @@ social-auth-core==4.0.2   # via -c requirements/constraints.txt, edx-auth-backen
 soupsieve==2.1            # via beautifulsoup4
 sqlparse==0.4.1           # via django
 stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
-taxonomy-connector==1.2.1  # via -r requirements/base.in
+taxonomy-connector==1.3.0  # via -r requirements/base.in
 unicode-slugify==0.1.3    # via -r requirements/base.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 unidecode==1.1.2          # via unicode-slugify


### PR DESCRIPTION
__Description:__
Version upgrade for taxonomy-connector, new version contains [these](https://github.com/edx/taxonomy-connector/pull/36/files) changes.