### PR TITLE
ENT-3918: Create a new django admin page to view course skills

### DIFF
--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 COURSE_ID_REGEX = r'[^/+]+(/|\+)[^/+]+'
 COURSE_RUN_ID_REGEX = r'[^/+]+(/|\+)[^/+]+(/|\+)[^/]+'
+COURSE_SKILLS_URL_NAME = "course_skills"
 COURSE_UUID_REGEX = r'[0-9a-f-]+'
 
 MASTERS_PROGRAM_TYPE_SLUG = 'masters'

--- a/course_discovery/apps/course_metadata/static/admin/css/skills-tags.css
+++ b/course_discovery/apps/course_metadata/static/admin/css/skills-tags.css
@@ -1,0 +1,19 @@
+.list-item {
+    background-color: silver;
+    padding: 4px !important;
+    border-radius: 14px;
+    margin-bottom: 5px;
+    width: max-content;
+    list-style: none;
+    display: inline;
+    cursor: pointer;
+}
+
+.item{
+    padding-left: 0px !important;
+    max-width: 70%;
+}
+
+.paragraph{
+    color: red;
+}

--- a/course_discovery/apps/course_metadata/templates/admin/course_metadata/course_skills.html
+++ b/course_discovery/apps/course_metadata/templates/admin/course_metadata/course_skills.html
@@ -1,0 +1,43 @@
+{% extends 'admin/base_site.html' %}
+{% load i18n static admin_urls %}
+
+{% block extrastyle %}
+  <link rel="stylesheet" type="text/css" href="{% static 'admin/css/skills-tags.css' %}"/>
+{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans "Home" %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; {% if has_change_permission %}
+    <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+  {% else %}
+    {{ opts.verbose_name_plural|capfirst }}
+  {% endif %}
+  &rsaquo; {% if has_change_permission %}
+    <a href="{% url opts|admin_urlname:'change' course.pk %}">
+      {{ course|truncatewords:"18" }}
+    </a>
+  {% else %}
+    {{ course|capfirst }}
+  {% endif %}
+  &rsaquo;
+  {% trans "Course Skills" %}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+    <h1>{{ "Course Skills for "|add:course.title }}</h1>
+    {% if course_skills %}
+        <ul class="item">
+            {% for course_skill in course_skills %}
+            <li class="list-item">{{ course_skill.skill.name }}</li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p class="paragraph">No course skills found...</p>
+    {% endif %}
+</div>
+
+{% endblock %}

--- a/course_discovery/apps/course_metadata/tests/test_views.py
+++ b/course_discovery/apps/course_metadata/tests/test_views.py
@@ -1,0 +1,94 @@
+import ddt
+import six
+from django.conf import settings
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+from pytest import mark
+from taxonomy.models import CourseSkills, Skill
+
+from course_discovery.apps.core.tests.factories import UserFactory
+from course_discovery.apps.course_metadata.constants import COURSE_SKILLS_URL_NAME
+from course_discovery.apps.course_metadata.tests.factories import CourseFactory
+from course_discovery.apps.course_metadata.views import CourseSkillsView
+
+
+@ddt.ddt
+@mark.django_db
+@override_settings(ROOT_URLCONF="course_discovery.urls")
+class TestCourseSkillView(TestCase):
+    """
+    Tests for CourseSkillView GET endpoint.
+    """
+    def setUp(self):
+        """
+        Test set up
+        """
+        super().setUp()
+        self.user = UserFactory.create(is_staff=True, is_active=True)
+        self.user.set_password('QWERTY')
+        self.user.save()
+        self.course = CourseFactory()
+        self.admin_context = {
+            'has_permission': True,
+            'opts': self.course._meta,
+        }
+        self.client = Client()
+        self.view_url = reverse(
+            "admin:" + COURSE_SKILLS_URL_NAME,
+            args=(self.course.pk,)
+        )
+        self.context_parameters = CourseSkillsView.ContextParameters
+
+    def _login(self):
+        """Log user in."""
+        assert self.client.login(username=self.user.username, password='QWERTY')
+
+    def _test_admin_context(self, actual_context):
+        """Test admin context."""
+        expected_context = {}
+        expected_context.update(self.admin_context)
+
+        for context_key, expected_value in six.iteritems(expected_context):
+            assert actual_context[context_key] == expected_value
+
+    def _test_get_response(self, response, course_skills):
+        """Test view GET response."""
+        if course_skills:
+            skills_name = [course_skill.skill.name for course_skill in course_skills]
+            # get sorted list of skills to match it with API results
+            sorted_skill_names = list(CourseSkills.objects.filter(
+                skill__name__in=skills_name
+            ))
+        else:
+            sorted_skill_names = course_skills
+        assert response.status_code == 200
+        self._test_admin_context(response.context)
+        assert list(response.context[self.context_parameters.COURSE_SKILLS]) == sorted_skill_names
+        assert response.context[self.context_parameters.COURSE] == self.course
+
+    def _create_course_skills(self, course):
+        """Create dummy course skills."""
+        skill1 = Skill(external_id=1, name='machine learning')
+        skill2 = Skill(external_id=2, name='python')
+        course_skill1 = CourseSkills(course_id=course.key, skill=skill1, confidence=2)
+        course_skill2 = CourseSkills(course_id=course.key, skill=skill2, confidence=3)
+        return [course_skill1, course_skill2]
+
+    def test_get_user_not_logged_in(self):
+        """Tests response if user is not logged in."""
+        assert settings.SESSION_COOKIE_NAME not in self.client.cookies  # precondition check - no session cookie
+        response = self.client.get(self.view_url)
+        assert response.status_code == 302
+
+    def test_get_no_course_skills(self):
+        """Tests response when a course has no skills."""
+        self._login()
+        response = self.client.get(self.view_url)
+        self._test_get_response(response, [])
+
+    def test_get_course_skills(self):
+        """Tests if course skills are returned in response correctly."""
+        self._login()
+        course_skills = self._create_course_skills(self.course)
+        response = self.client.get(self.view_url)
+        self._test_get_response(response, course_skills)

--- a/course_discovery/apps/course_metadata/views.py
+++ b/course_discovery/apps/course_metadata/views.py
@@ -1,11 +1,14 @@
-from django.contrib import messages
+from django.contrib import admin, messages
+from django.contrib.auth import get_permission_codename
 from django.http import Http404, HttpResponseRedirect
+from django.shortcuts import render
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
-from django.views.generic import TemplateView, UpdateView
+from django.views.generic import TemplateView, UpdateView, View
+from taxonomy.models import CourseSkills
 
 from course_discovery.apps.course_metadata.forms import CourseRunSelectionForm
-from course_discovery.apps.course_metadata.models import Program
+from course_discovery.apps.course_metadata.models import Course, Program
 
 
 class QueryPreviewView(TemplateView):
@@ -37,3 +40,66 @@ class CourseRunSelectionAdmin(UpdateView):
 
     def get_success_url(self):
         return reverse('admin:course_metadata_program_change', args=(self.object.id,))
+
+
+class CourseSkillsView(View):
+    """
+    Course Skills view.
+
+    For displaying course skills of a particular course.
+    """
+    template = 'admin/course_metadata/course_skills.html'
+
+    class ContextParameters:
+        """
+        Namespace-style class for custom context parameters.
+        """
+        COURSE_SKILLS = 'course_skills'
+        COURSE = 'course'
+
+    @staticmethod
+    def _get_admin_context(request, course):
+        """
+        Build admin context.
+        """
+        opts = course._meta
+        codename = get_permission_codename('change', opts)
+        has_change_permission = request.user.has_perm('%s.%s' % (opts.app_label, codename))
+        return {
+            'has_change_permission': has_change_permission,
+            'opts': opts
+        }
+
+    def _get_view_context(self, course_pk):
+        """
+        Return the default context parameters.
+        """
+        course = Course.objects.get(id=course_pk)
+        course_skills = CourseSkills.objects.filter(course_id=course.key)
+        return {
+            self.ContextParameters.COURSE: course,
+            self.ContextParameters.COURSE_SKILLS: course_skills
+        }
+
+    def _build_context(self, request, course_pk):
+        """
+        Build admin and view context used by the template.
+        """
+        context = self._get_view_context(course_pk)
+        context.update(admin.site.each_context(request))
+        context.update(self._get_admin_context(request, context['course']))
+        return context
+
+    def get(self, request, course_pk):
+        """
+        Handle GET request - renders the template.
+
+        Arguments:
+            request (django.http.request.HttpRequest): Request instance
+            course_pk (str): Primary key of the course
+
+        Returns:
+            django.http.response.HttpResponse: HttpResponse
+        """
+        context = self._build_context(request, course_pk)
+        return render(request, self.template, context)

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -65,6 +65,7 @@ THIRD_PARTY_APPS = [
     'xss_utils',
     'algoliasearch_django',
     'taxonomy',
+    'django_object_actions',
 ]
 
 ALGOLIA = {

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -31,6 +31,7 @@ djangorestframework-csv
 djangorestframework-xml
 django-elasticsearch-dsl
 django-elasticsearch-dsl-drf
+django-object-actions
 drf-dynamic-fields
 drf-extensions
 dry-rest-permissions

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -135,6 +135,8 @@ django-model-utils==4.1.1
     # via taxonomy-connector
 django-nine==0.2.4
     # via django-elasticsearch-dsl-drf
+django-object-actions==3.0.1
+    # via -r requirements/base.in
 django-parler==2.2
     # via -r requirements/base.in
 django-rest-swagger==2.2.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -98,6 +98,8 @@ django-model-utils==4.1.1
     # via taxonomy-connector
 django-nine==0.2.4
     # via django-elasticsearch-dsl-drf
+django-object-actions==3.0.1
+    # via -r requirements/base.in
 django-parler==2.2
     # via -r requirements/base.in
 django-rest-swagger==2.2.0


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-3918

This PR adds an endpoint to view skills belonging to a particular course. 

**To test the changes:**

- Go to Course Metadata -> Courses
- Click on any course 
- A button "VIEW COURSE SKILLS" next to history button
- Clicking on that button would redirect to a new page where you can view skills related to that course

**Example:**

**Course Detail Page**
<img width="1314" alt="Screenshot 2021-01-19 at 6 08 46 PM" src="https://user-images.githubusercontent.com/55431213/105038640-66635900-5a81-11eb-9102-daf0b498ee15.png">

**Course Skills Page**
<img width="584" alt="Screenshot 2021-01-19 at 5 37 36 PM" src="https://user-images.githubusercontent.com/55431213/105035578-0a96d100-5a7d-11eb-86af-c070c74ba676.png">
