### PR TITLE
[SE-3515] Handle JSON decoder error if api fails

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -792,12 +792,14 @@ class ProgramsApiDataLoader(AbstractDataLoader):
 
         while page:
             params = {'page': page, 'page_size': self.PAGE_SIZE}
-            response = self.api_client.get(self.api_url + '/programs/', params=params).json()
-            count = response['count']
-            results = response['results']
+            response = self.api_client.get(self.api_url + '/programs/', params=params)
+            response.raise_for_status()
+            response_json = response.json()
+            count = response_json['count']
+            results = response_json['results']
             logger.info('Retrieved %d programs...', len(results))
 
-            if response['next']:
+            if response_json['next']:
                 page += 1
             else:
                 page = None


### PR DESCRIPTION
This PR ports #2793 to master branch. It handles the JSON decoder error that is seen if the program api returns 404 when running refresh_course_metadata command. It checks the status code of the response before calling the json() method.

**Jira Tickets:** [OSPR-5363
](https://openedx.atlassian.net/browse/OSPR-5363)
**Testing Instructions:**
- Ensure no programs are indexed. Running the command `/edx/bin/manage.discovery update_index --disable-change-limit` should show 0 programs.
- Run command `/edx/bin/manage.discovery refresh_course_metadata`.
- Verify command succeeds without any errors.

**Reviewers:**

- [ ] @Dillon-Dumesnil 