### PR TITLE
[WIP][BD-14] Ensure editing organizations reactivates them in LMS/Studio

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -246,6 +246,15 @@ class Organization(CachedMixin, TimeStampedModel):
             'name': self.certificate_name or self.name,
             'short_name': self.key,
             'description': self.description,
+            # Whether the organization in LMS/Studio is:
+            #  (a) not-yet-existent,
+            #  (b) existing and active, or
+            #  (c) existing but currently inactive;
+            # editing it in Discovery should result in the LMS organization
+            # being set to Active. We explicitly pass in {'active': True}
+            # to handle case (c). Otherwise, the LMS/Studio organization would be left
+            # as Inactive.
+            'active': True,
         }
         logo = self.certificate_logo_image
         if logo:


### PR DESCRIPTION
```
Since LMS/Studio organizations have been completely backfilled,
there are now hundreds of Inactive organizations in the
edxapp database. Inactive organizations are not surfaced to
users, and hence are effectively non-existent.

If an organization is created or edited in Discovery, one
would expect that it is a "real" organization and should
therefore appear as Active in LMS/Studio. This commit
ensures that saving an organization in Discovery tells
LMS to mark the organization as Active if it currently
exists as Inactive.
```

https://openedx.atlassian.net/browse/TNL-7913