### PR TITLE
celery configuration according to the used celery version

### DIFF
--- a/course_discovery/celery.py
+++ b/course_discovery/celery.py
@@ -1,6 +1,9 @@
 from celery import Celery
 
 app = Celery('discovery')
+
+app.conf.task_protocol = 1
+
 # namespace='CELERY' means all celery-related configuration keys should have a `CELERY_` prefix.
 app.config_from_object('django.conf:settings', namespace='CELERY')
 

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -592,32 +592,31 @@ EMSI_CLIENT_SECRET = ''
 ################################### BEGIN CELERY ###################################
 
 # Message configuration
-CELERY_TASK_SERIALIZER = 'json'
+CELERY_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_ACCEPT_CONTENT = ['json']
-CELERY_TASK_COMPRESSION = 'gzip'
-CELERY_RESULT_COMPRESSION = 'gzip'
+CELERY_COMPRESSION = 'gzip'
+CELERY_MESSAGE_COMPRESSION = 'gzip'
 
 # Results configuration
-CELERY_TASK_IGNORE_RESULT = False
-CELERY_TASK_STORE_ERRORS_EVEN_IF_IGNORED = True
+CELERY_IGNORE_RESULT = False
 
 # Events configuration
-CELERY_TASK_TRACK_STARTED = True
-CELERY_WORKER_SEND_TASK_EVENTS = True
-CELERY_TASK_SEND_SENT_EVENT = True
+CELERY_TRACK_STARTED = True
+CELERY_SEND_EVENTS = True
+CELERY_SEND_SENT_EVENT = True
 
 # Prevent Celery from removing handlers on the root logger. Allows setting custom logging handlers.
-CELERY_WORKER_HIJACK_ROOT_LOGGER = False
+CELERYD_HIJACK_ROOT_LOGGER = False
 
-CELERY_TASK_DEFAULT_EXCHANGE = 'discovery'
-CELERY_TASK_DEFAULT_ROUTING_KEY = 'discovery'
-CELERY_TASK_DEFAULT_QUEUE = 'discovery.default'
+CELERY_DEFAULT_EXCHANGE = 'discovery'
+CELERY_DEFAULT_ROUTING_KEY = 'discovery'
+CELERY_DEFAULT_QUEUE = 'discovery.default'
 
 # Celery Broker
 CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', '')
 
-CELERY_TASK_ALWAYS_EAGER = False
+CELERY_ALWAYS_EAGER = False
 
 ################################### END CELERY ###################################
 

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -77,7 +77,7 @@ ENABLE_PUBLISHER = True
 
 ORG_BASE_LOGO_URL = "http://discovery:18381/media/"
 
-CELERY_TASK_ALWAYS_EAGER = False
+CELERY_ALWAYS_EAGER = False
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -69,7 +69,7 @@ REST_FRAMEWORK['DEFAULT_THROTTLE_CLASSES'] = ()
 
 ################################### BEGIN CELERY ###################################
 
-CELERY_TASK_ALWAYS_EAGER = True
+CELERY_ALWAYS_EAGER = True
 
 CELERY_TASK_IGNORE_RESULT = True
 


### PR DESCRIPTION
**Description:** Rename celery setting key names according to the celery version(`4.4.7`) that we are using. 
Please see [Celery Documentation](https://docs.celeryproject.org/en/v4.4.7/userguide/configuration.html)