### PR TITLE
ENT-3942: Added skill_names to the api/v1/courses endpoint

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -21,6 +21,7 @@ from rest_framework.fields import CreateOnlyDefault, UUIDField
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.relations import ManyRelatedField
 from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
+from taxonomy.models import CourseSkills
 
 from course_discovery.apps.api.fields import (
     HtmlField, ImageField, SlugRelatedFieldWithReadSerializer, SlugRelatedTranslatableField, StdImageSerializerField
@@ -1066,6 +1067,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
     collaborators = SlugRelatedFieldWithReadSerializer(slug_field='uuid', required=False, many=True,
                                                        queryset=Collaborator.objects.all(),
                                                        read_serializer=CollaboratorSerializer())
+    skill_names = serializers.SerializerMethodField()
 
     @classmethod
     def prefetch_queryset(cls, partner, queryset=None, course_runs=None):  # pylint: disable=arguments-differ
@@ -1109,7 +1111,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
             'syllabus_raw', 'outcome', 'original_image', 'card_image_url', 'canonical_course_run_key',
             'extra_description', 'additional_information', 'faq', 'learner_testimonials',
             'enrollment_count', 'recent_enrollment_count', 'topics', 'partner', 'key_for_reruns', 'url_slug',
-            'url_slug_history', 'url_redirects', 'course_run_statuses', 'editors', 'collaborators',
+            'url_slug_history', 'url_redirects', 'course_run_statuses', 'editors', 'collaborators', 'skill_names',
         )
         extra_kwargs = {
             'partner': {'write_only': True}
@@ -1129,6 +1131,10 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
         if obj.canonical_course_run:
             return obj.canonical_course_run.key
         return None
+
+    def get_skill_names(self, obj):
+        course_skills = CourseSkills.objects.select_related('skill').filter(course_id=obj.key)
+        return list(set(course_skill.skill.name for course_skill in course_skills))
 
     def create(self, validated_data):
         return Course.objects.create(**validated_data)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -197,6 +197,7 @@ class CourseSerializerTests(MinimalCourseSerializerTests):
             'course_run_statuses': course.course_run_statuses,
             'editors': CourseEditorSerializer(course.editors, many=True, read_only=True).data,
             'collaborators': [],
+            'skill_names': [],
         })
 
         return expected

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -66,7 +66,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         """ Verify the endpoint returns the details for a single course. """
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.key})
 
-        with self.assertNumQueries(37):
+        with self.assertNumQueries(40):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.serialize_course(self.course))
@@ -75,7 +75,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         """ Verify the endpoint returns the details for a single course with UUID. """
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.uuid})
 
-        with self.assertNumQueries(37):
+        with self.assertNumQueries(40):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, self.serialize_course(self.course))
@@ -84,7 +84,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         """ Verify the endpoint returns no deleted associated programs """
         ProgramFactory(courses=[self.course], status=ProgramStatus.Deleted)
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.key})
-        with self.assertNumQueries(37):
+        with self.assertNumQueries(40):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data.get('programs'), [])
@@ -97,7 +97,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         ProgramFactory(courses=[self.course], status=ProgramStatus.Deleted)
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.key})
         url += '?include_deleted_programs=1'
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(43):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -251,7 +251,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         """ Verify the endpoint returns a list of all courses. """
         url = reverse('api:v1:course-list')
 
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(28):
             response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(
@@ -268,7 +268,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
 
         # Known to be flaky prior to the addition of tearDown()
         # and logout() code which is the same number of additional queries
-        with self.assertNumQueries(42):
+        with self.assertNumQueries(45):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -278,7 +278,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         keys = ','.join([course.key for course in courses])
         url = '{root}?keys={keys}'.format(root=reverse('api:v1:course-list'), keys=keys)
 
-        with self.assertNumQueries(42):
+        with self.assertNumQueries(46):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -288,7 +288,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         uuids = ','.join([str(course.uuid) for course in courses])
         url = '{root}?uuids={uuids}'.format(root=reverse('api:v1:course-list'), uuids=uuids)
 
-        with self.assertNumQueries(42):
+        with self.assertNumQueries(45):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 


### PR DESCRIPTION
Description: This PR adds the skill_names attribute to the api/v1/courses endpoint

JIRA: https://openedx.atlassian.net/browse/ENT-3942

Test Instructions:
Browse to http://localhost:18381/api/v1/courses/ on devstack and verify the skill_names attribute