### PR TITLE
ENT-3778: Ability to add end_date as a content filter in Enterprise Catalogs

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2023,6 +2023,8 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             ],
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
+            'course_ends': course.course_ends,
+            'end_date': serialize_datetime(course.end_date),
             'organizations': [
                 '{key}: {name}'.format(
                     key=course.sponsoring_organizations.first().key,
@@ -2091,6 +2093,8 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             ],
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
+            'course_ends': course.course_ends,
+            'end_date': serialize_datetime(course.end_date),
             'organizations': [
                 '{key}: {name}'.format(
                     key=course.sponsoring_organizations.first().key,
@@ -2143,6 +2147,8 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             ],
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
+            'course_ends': course.course_ends,
+            'end_date': serialize_datetime(course.end_date),
             'organizations': [
                 '{key}: {name}'.format(
                     key=course.sponsoring_organizations.first().key,

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -201,6 +201,11 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
             ],
         },
         'end': {'field': 'end', 'lookups': [LOOKUP_QUERY_GT, LOOKUP_QUERY_GTE, LOOKUP_QUERY_LT, LOOKUP_QUERY_LTE]},
+        'end_date': {
+            'field': 'end_date',
+            'lookups': [LOOKUP_QUERY_GT, LOOKUP_QUERY_GTE, LOOKUP_QUERY_LT, LOOKUP_QUERY_LTE]
+        },
+        'course_ends': {'field': 'course_ends.raw', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
         # FIXME: 'enrollment_mode' is a legacy field. It keeps being supported now, but should be deleted.
         'enrollment_mode': {'field': 'type.lower', 'lookups': [LOOKUP_FILTER_TERM]},
         'has_enrollable_seats': {'field': 'has_enrollable_seats', 'lookups': [LOOKUP_FILTER_TERM]},

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -925,6 +925,37 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
         )
 
     @property
+    def end_date(self):
+        """
+        Returns the "end" date of the course run falling at the last. Every course run has an end date and this property
+        returns the max value of those end dates.
+        """
+        course_runs = self.course_runs.all()
+        last_course_run_end = None
+        if course_runs:
+            try:
+                last_course_run_end = max(
+                    course_run.end
+                    for course_run in course_runs
+                    if course_run.end is not None and course_run.status == CourseRunStatus.Published
+                )
+            except ValueError:
+                last_course_run_end = None
+        return last_course_run_end
+
+    @property
+    def course_ends(self):
+        """
+        Returns a string depending on if course.end_date falls in past or future. Course.end_date is the "end" date of
+        the last course run.
+        """
+        now = datetime.datetime.now(pytz.UTC)
+        if not self.end_date or self.end_date > now:
+            return _('Future')
+        else:
+            return _('Past')
+
+    @property
     def first_enrollable_paid_seat_price(self):
         """
         Sort the course runs with sorted rather than order_by to avoid

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -33,6 +33,10 @@ class CourseDocument(BaseCourseDocument):
     course_runs = fields.KeywordField(multi=True)
     expected_learning_items = fields.KeywordField(multi=True)
     end = fields.DateField(multi=True)
+    course_ends = fields.TextField(
+        fields={'raw': fields.KeywordField(), 'lower': fields.TextField(analyzer=case_insensitive_keyword)}
+    )
+    end_date = fields.DateField()
     enrollment_start = fields.DateField(multi=True)
     enrollment_end = fields.DateField(multi=True)
     first_enrollable_paid_seat_price = fields.IntegerField()
@@ -66,6 +70,12 @@ class CourseDocument(BaseCourseDocument):
 
     def prepare_end(self, obj):
         return [course_run.end for course_run in filter_visible_runs(obj.course_runs)]
+
+    def prepare_end_date(self, obj):
+        return obj.end_date
+
+    def prepare_course_ends(self, obj):
+        return str(obj.course_ends)
 
     def prepare_enrollment_start(self, obj):
         return [course_run.enrollment_start for course_run in filter_visible_runs(obj.course_runs)]

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -25,6 +25,8 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
     course_runs = serializers.SerializerMethodField()
     seat_types = serializers.SerializerMethodField()
     skill_names = serializers.SerializerMethodField()
+    end_date = serializers.SerializerMethodField()
+    course_ends = serializers.SerializerMethodField()
 
     def course_run_detail(self, request, detail_fields, course_run):
         course_run_detail = {
@@ -81,6 +83,12 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
         course_skills = get_whitelisted_course_skills(result.key)
         return list(set(course_skill.skill.name for course_skill in course_skills))
 
+    def get_end_date(self, result):
+        return self.handle_datetime_field(result.end_date)
+
+    def get_course_ends(self, result):
+        return str(result.course_ends)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         request = self.context['request']
@@ -114,6 +122,8 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
             'uuid',
             'seat_types',
             'skill_names',
+            'end_date',
+            'course_ends',
             'subjects',
             'languages',
             'organizations',

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -161,6 +161,36 @@ class TestCourse(TestCase):
         ]
         self.assertEqual(sorted(out_of_order_runs, key=course.course_run_sort), expected_order)
 
+    now = datetime.datetime.now(pytz.UTC)
+
+    @ddt.data(
+        (now + datetime.timedelta(days=10), now + datetime.timedelta(days=20), True, now + datetime.timedelta(days=20)),
+        (None, now + datetime.timedelta(days=10), True, now + datetime.timedelta(days=10)),
+        (None, None, True, None),
+        (None, None, False, None)
+    )
+    @ddt.unpack
+    def test_end_date(self, end1, end2, create_course_runs, expected):
+        """ Verify the property returns the appropriate end_date value based on the course run end dates. """
+        course = factories.CourseFactory.create()
+        # To test the scenario when a course has no course runs
+        if create_course_runs:
+            factories.CourseRunFactory(course=course, end=end1)
+            factories.CourseRunFactory(course=course, end=end2)
+        self.assertEqual(course.end_date, expected)
+
+    @ddt.data(
+        (now + datetime.timedelta(days=10), 'Future'),
+        (now - datetime.timedelta(days=10), 'Past'),
+        (None, 'Future')
+    )
+    @ddt.unpack
+    def test_course_ends(self, end, expected):
+        """ Verify the property returns the appropriate 'course_ends' string based on the end_date value. """
+        course = factories.CourseFactory.create()
+        factories.CourseRunFactory(course=course, end=end)
+        self.assertEqual(course.course_ends, expected)
+
 
 class TestCourseUpdateMarketingUnpublish(MarketingSitePublisherTestMixin, TestCase):
     @classmethod


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-3778

This PR adds the ability to use "end_date" field as a catalog filter in Enterprise Catalogs. Course "end_date" field is basically the "end" date of its last course run.

**Testing Instructions:**

**Note**: You will need to pull latest discovery image if you haven't done it recently
- cd path_to_devstack
- git pull
- make dev.pull.discovery
- make discovery-down
- make discovery-up
- cd path_to_course-discovery
- git checkout sameen/ENT-3778
- git pull
- make discovery-shell
- python manage.py search_index --create
- python manage.py update_index --disable-change-limit
- hit the search-all endpoint with the added query facet: http://localhost:18381/api/v1/search/all/?course_ends=Past OR Future

Or you can create a test catalog in LMS admin with the given content_filter to test the changes

`{
    "content_type":"course",
    "course_ends":"Past"
}`

**Test Catalog**
<img width="901" alt="Screenshot 2021-01-29 at 5 23 15 PM" src="https://user-images.githubusercontent.com/55431213/106274831-b21ebb00-6256-11eb-892e-01aa5bae243f.png">

**Results**

<img width="1210" alt="Screenshot 2021-01-29 at 5 28 20 PM" src="https://user-images.githubusercontent.com/55431213/106275299-6587af80-6257-11eb-9f84-5287c9dfd5d6.png">



