### PR TITLE
Upgrading edx-auth-backends version.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -34,7 +34,3 @@ social-auth-core<4.0.3
 # latest version of edx-lint is pulling code-annotations and code-annotations is pulling python-slugify and
 # python-slugify is conflicting with unicode-slugify
 edx-lint<=1.6
-
-
-# latest version causing issues in IDAs.
-edx-auth-backends==3.3.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -30,7 +30,7 @@ pygments==2.7.4
     # via sphinx
 pyparsing==2.4.7
     # via packaging
-pytz==2020.5
+pytz==2021.1
     # via babel
 requests==2.25.1
     # via sphinx

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -237,10 +237,8 @@ dry-rest-permissions==0.1.10
     # via -r requirements/base.in
 edx-analytics-data-api-client==0.17.0
     # via -r requirements/base.in
-edx-auth-backends==3.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-auth-backends==3.3.2
+    # via -r requirements/base.in
 edx-ccx-keys==1.2.0
     # via -r requirements/base.in
 edx-django-release-util==1.0.0
@@ -458,7 +456,7 @@ python-utils==2.5.5
     # via progressbar2
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2020.5
+pytz==2021.1
     # via
     #   -r requirements/base.in
     #   babel

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -191,10 +191,8 @@ dry-rest-permissions==0.1.10
     # via -r requirements/base.in
 edx-analytics-data-api-client==0.17.0
     # via -r requirements/base.in
-edx-auth-backends==3.3.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-auth-backends==3.3.2
+    # via -r requirements/base.in
 edx-ccx-keys==1.2.0
     # via -r requirements/base.in
 edx-django-release-util==1.0.0
@@ -316,7 +314,7 @@ python-utils==2.5.5
     # via progressbar2
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2020.5
+pytz==2021.1
     # via
     #   -r requirements/base.in
     #   celery


### PR DESCRIPTION
It brings pyjwt=1.17 which is compatible version with IDAs.
pyjwt greater version has issues.