### PR TITLE
ENT-3892: Course Skills view link should not appear for draft courses, Also added success message when course skills are updated successfully.

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -100,7 +100,21 @@ class CourseAdmin(DjangoObjectActions, admin.ModelAdmin):
     search_fields = ('uuid', 'key', 'key_for_reruns', 'title',)
     raw_id_fields = ('canonical_course_run', 'draft_version',)
     autocomplete_fields = ['canonical_course_run']
-    change_actions = ('course_skills',)
+    change_actions = ('course_skills', )
+
+    def get_change_actions(self, request, object_id, form_url):
+        """
+        Get a list of change actions.
+
+        Hide `Course Skills` action button for draft courses.
+        """
+        actions = super().get_change_actions(request, object_id, form_url)
+        actions = list(actions)
+
+        if not Course.objects.filter(id=object_id).exists():
+            actions.remove('course_skills')
+
+        return actions
 
     def course_skills(self, request, obj):
         """

--- a/course_discovery/apps/course_metadata/views.py
+++ b/course_discovery/apps/course_metadata/views.py
@@ -1,7 +1,7 @@
 from django.contrib import admin, messages
 from django.contrib.auth import get_permission_codename
 from django.http import Http404, HttpResponseRedirect
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import TemplateView, UpdateView, View
@@ -79,7 +79,7 @@ class CourseSkillsView(View):
         """
         Return the default context parameters.
         """
-        course = Course.objects.get(id=course_pk)
+        course = get_object_or_404(Course, id=course_pk)
         course_skills = get_whitelisted_course_skills(course.key)
         excluded_skills = get_blacklisted_course_skills(course.key)
         return {
@@ -139,10 +139,9 @@ class CourseSkillsView(View):
             for skill_id in form.cleaned_data['include_skills']:
                 remove_course_skill_from_blacklist(course.key, skill_id)
 
-        context = self._build_context(request, course_pk)
-        context['exclude_skills_form'] = self.form(
-            context[self.ContextParameters.COURSE_SKILLS],
-            context[self.ContextParameters.EXCLUDED_SKILLS],
-        )
+        message = _('The course skills were updated successfully.')
+        messages.add_message(self.request, messages.SUCCESS, message)
 
-        return render(request, self.template, context)
+        return HttpResponseRedirect(
+            reverse('admin:course_skills', args=(course_pk,))
+        )


### PR DESCRIPTION
__Description:__
Course skills page was throwing 500 error for draft courses, this PR fixes that, as well as hides the course skill page link for draft courses.