### PR TITLE
Improve create or update partner management command to take in more parameters

### DIFF
--- a/course_discovery/apps/core/management/commands/create_or_update_partner.py
+++ b/course_discovery/apps/core/management/commands/create_or_update_partner.py
@@ -16,12 +16,10 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--site-id',
                             action='store',
-                            dest='site_id',
                             type=int,
                             help='ID of the Site to update.')
         parser.add_argument('--site-domain',
                             action='store',
-                            dest='site_domain',
                             type=str,
                             required=True,
                             help='Site domain for the Partner')
@@ -39,55 +37,61 @@ class Command(BaseCommand):
                             help='Name for the specified Partner.')
         parser.add_argument('--courses-api-url',
                             action='store',
-                            dest='courses_api_url',
                             type=str,
                             default='',
                             help='API endpoint for accessing Partner course data.')
+        parser.add_argument('--lms-coursemode-api-url',
+                            action='store',
+                            type=str,
+                            default='',
+                            help='API endpoint for accessing Partner course mode data.')
         parser.add_argument('--ecommerce-api-url',
                             action='store',
-                            dest='ecommerce_api_url',
                             type=str,
                             default='',
                             help='API endpoint for accessing Partner ecommerce data.')
         parser.add_argument('--organizations-api-url',
                             action='store',
-                            dest='organizations_api_url',
                             type=str,
                             default='',
                             help='API endpoint for accessing Partner organization data.')
         parser.add_argument('--programs-api-url',
                             action='store',
-                            dest='programs_api_url',
                             type=str,
                             default='',
                             help='API endpoint for accessing Partner program data.')
         parser.add_argument('--lms-url',
                             action='store',
-                            dest='lms_url',
                             type=str,
                             default='',
                             help='API endpoint for accessing lms.')
+        parser.add_argument('--studio-url',
+                            action='store',
+                            type=str,
+                            default='',
+                            help='API endpoint for accessing studio.')
+        parser.add_argument('--publisher-url',
+                            action='store',
+                            type=str,
+                            default='',
+                            help='API endpoint for accessing Publisher.')
         parser.add_argument('--marketing-site-api-url',
                             action='store',
-                            dest='marketing_site_api_url',
                             type=str,
                             default='',
                             help='API endpoint for accessing Partner marketing site data.')
         parser.add_argument('--marketing-site-url-root',
                             action='store',
-                            dest='marketing_site_url_root',
                             type=str,
                             default='',
                             help='URL root for accessing Partner marketing site data.')
         parser.add_argument('--marketing-site-api-username',
                             action='store',
-                            dest='marketing_site_api_username',
                             type=str,
                             default='',
                             help='Username used for accessing Partner marketing site data.')
         parser.add_argument('--marketing-site-api-password',
                             action='store',
-                            dest='marketing_site_api_password',
                             type=str,
                             default='',
                             help='Password used for accessing Partner marketing site data.')
@@ -114,14 +118,17 @@ class Command(BaseCommand):
                 'site': site,
                 'name': partner_name,
                 'courses_api_url': options.get('courses_api_url'),
+                'lms_coursemode_api_url': options.get('lms_coursemode_api_url'),
                 'ecommerce_api_url': options.get('ecommerce_api_url'),
                 'organizations_api_url': options.get('organizations_api_url'),
                 'programs_api_url': options.get('programs_api_url'),
                 'lms_url': options.get('lms_url'),
+                'studio_url': options.get('studio_url'),
                 'marketing_site_api_url': options.get('marketing_site_api_url'),
                 'marketing_site_url_root': options.get('marketing_site_url_root'),
                 'marketing_site_api_username': options.get('marketing_site_api_username'),
                 'marketing_site_api_password': options.get('marketing_site_api_password'),
+                'publisher_url': options.get('publisher_url'),
             }
         )
         logger.info('Partner %s with code %s', 'created' if created else 'updated', partner_code)

--- a/course_discovery/apps/core/management/commands/tests/test_create_or_update_partner.py
+++ b/course_discovery/apps/core/management/commands/tests/test_create_or_update_partner.py
@@ -14,9 +14,13 @@ class CreateOrUpdatePartnerCommandTests(TestCase):
     partner_code = 'abc'
     partner_name = 'ABC Partner'
     courses_api_url = 'https://courses.fake.org/api/v1/courses/'
+    lms_coursemode_api_url = 'http://courses.fake.org/api/course_modes/v1/'
     ecommerce_api_url = 'https://ecommerce.fake.org/api/v1/courses/'
     organizations_api_url = 'https://orgs.fake.org/api/v1/organizations/'
     programs_api_url = 'https://programs.fake.org/api/v1/programs/'
+    lms_url = 'http://courses.fake.org/'
+    studio_url = 'http://studio.fake.org/'
+    publisher_url = 'http://publisher.fake.org/'
     marketing_site_api_url = 'https://www.fake.org/api/v1/courses/'
     marketing_site_url_root = 'https://www.fake.org/'
     marketing_site_api_username = 'marketing-username'
@@ -27,9 +31,13 @@ class CreateOrUpdatePartnerCommandTests(TestCase):
         self.assertEqual(partner.short_code, self.partner_code)
         self.assertEqual(partner.name, self.partner_name)
         self.assertEqual(partner.courses_api_url, self.courses_api_url)
+        self.assertEqual(partner.lms_coursemode_api_url, self.lms_coursemode_api_url)
         self.assertEqual(partner.ecommerce_api_url, self.ecommerce_api_url)
         self.assertEqual(partner.organizations_api_url, self.organizations_api_url)
         self.assertEqual(partner.programs_api_url, self.programs_api_url)
+        self.assertEqual(partner.lms_url, self.lms_url)
+        self.assertEqual(partner.studio_url, self.studio_url)
+        self.assertEqual(partner.publisher_url, self.publisher_url)
         self.assertEqual(partner.marketing_site_api_url, self.marketing_site_api_url)
         self.assertEqual(partner.marketing_site_url_root, self.marketing_site_url_root)
         self.assertEqual(partner.marketing_site_api_username, self.marketing_site_api_username)
@@ -51,9 +59,13 @@ class CreateOrUpdatePartnerCommandTests(TestCase):
             'site_domain': 'site-domain',
             'partner_name': 'name',
             'courses_api_url': 'courses-api-url',
+            'lms_coursemode_api_url': 'lms-coursemode-api-url',
             'ecommerce_api_url': 'ecommerce-api-url',
             'organizations_api_url': 'organizations-api-url',
             'programs_api_url': 'programs-api-url',
+            'lms_url': 'lms-url',
+            'studio_url': 'studio-url',
+            'publisher_url': 'publisher-url',
             'marketing_site_api_url': 'marketing-site-api-url',
             'marketing_site_url_root': 'marketing-site-url-root',
             'marketing_site_api_username': 'marketing-site-api-username',
@@ -73,9 +85,13 @@ class CreateOrUpdatePartnerCommandTests(TestCase):
             partner_code=self.partner_code,
             partner_name=self.partner_name,
             courses_api_url=self.courses_api_url,
+            lms_coursemode_api_url=self.lms_coursemode_api_url,
             ecommerce_api_url=self.ecommerce_api_url,
             organizations_api_url=self.organizations_api_url,
             programs_api_url=self.programs_api_url,
+            lms_url=self.lms_url,
+            studio_url=self.studio_url,
+            publisher_url=self.publisher_url,
             marketing_site_api_url=self.marketing_site_api_url,
             marketing_site_url_root=self.marketing_site_url_root,
             marketing_site_api_username=self.marketing_site_api_username,
@@ -102,9 +118,13 @@ class CreateOrUpdatePartnerCommandTests(TestCase):
 
         self.partner_name = 'Updated Partner'
         self.courses_api_url = 'https://courses.updated.org/api/v1/courses/'
+        self.lms_coursemode_api_url = 'http://courses.updated.org/api/course_modes/v1/'
         self.ecommerce_api_url = 'https://ecommerce.updated.org/api/v1/courses/'
         self.organizations_api_url = 'https://orgs.updated.org/api/v1/organizations/'
         self.programs_api_url = 'https://programs.updated.org/api/v1/programs/'
+        self.lms_url = 'http://courses.updated.org/'
+        self.studio_url = 'http://studio.updated.org/'
+        self.publisher_url = 'http://publisher.updated.org/'
         self.marketing_site_api_url = 'https://www.updated.org/api/v1/courses/'
         self.marketing_site_url_root = 'https://www.updated.org/'
         self.marketing_site_api_username = 'updated-username'
@@ -116,9 +136,13 @@ class CreateOrUpdatePartnerCommandTests(TestCase):
             partner_code=self.partner_code,
             partner_name=self.partner_name,
             courses_api_url=self.courses_api_url,
+            lms_coursemode_api_url=self.lms_coursemode_api_url,
             ecommerce_api_url=self.ecommerce_api_url,
             organizations_api_url=self.organizations_api_url,
             programs_api_url=self.programs_api_url,
+            lms_url=self.lms_url,
+            studio_url=self.studio_url,
+            publisher_url=self.publisher_url,
             marketing_site_api_url=self.marketing_site_api_url,
             marketing_site_url_root=self.marketing_site_url_root,
             marketing_site_api_username=self.marketing_site_api_username,


### PR DESCRIPTION
Adds in the lms course mode api url (unsure if this is used, but
can't hurt), studio url, and publisher url. 

Relates to https://github.com/edx/devstack/pull/684

Implements partial functionality of https://openedx.atlassian.net/browse/DISCO-1673