### PR TITLE
Give analytics service a larger timeout, during RCM

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/analytics_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/analytics_api.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class AnalyticsAPIDataLoader(AbstractDataLoader):
 
-    API_TIMEOUT = 120  # time in seconds
+    API_TIMEOUT = 300  # time in seconds
 
     def __init__(self, partner, api_url, max_workers=None, is_threadsafe=False):
         super().__init__(partner, api_url, max_workers, is_threadsafe)


### PR DESCRIPTION
We were seeing some timeouts during normal RCM runs. We think it just needs a bit more time.