### PR TITLE
add staff in raw fields

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -18,7 +18,9 @@ from course_discovery.apps.course_metadata.constants import COURSE_SKILLS_URL_NA
 from course_discovery.apps.course_metadata.exceptions import (
     MarketingSiteAPIClientException, MarketingSitePublisherException
 )
-from course_discovery.apps.course_metadata.forms import CourseAdminForm, PathwayAdminForm, ProgramAdminForm
+from course_discovery.apps.course_metadata.forms import (
+    CourseAdminForm, CourseRunAdminForm, PathwayAdminForm, ProgramAdminForm
+)
 from course_discovery.apps.course_metadata.models import *  # pylint: disable=wildcard-import
 from course_discovery.apps.course_metadata.views import CourseSkillsView
 
@@ -72,8 +74,8 @@ class ProgramEligibilityFilter(admin.SimpleListFilter):
 class SeatInline(admin.TabularInline):
     model = Seat
     extra = 1
-    readonly_fields = ('_upgrade_deadline',)
-    raw_id_fields = ('draft_version', )
+    readonly_fields = ('_upgrade_deadline', )
+    raw_id_fields = ('draft_version', 'currency')
 
 
 class PositionInline(admin.TabularInline):
@@ -210,6 +212,7 @@ class CourseRunAdmin(admin.ModelAdmin):
     readonly_fields = ('uuid', 'enrollment_count', 'recent_enrollment_count', 'hidden', 'key')
     search_fields = ('uuid', 'key', 'title_override', 'course__title', 'slug', 'external_key')
     save_error = False
+    form = CourseRunAdminForm
 
     def response_change(self, request, obj):
         if self.save_error:

--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -90,6 +90,35 @@ class CourseAdminForm(forms.ModelForm):
         exclude = ('slug', 'url_slug', )
 
 
+class CourseRunAdminForm(forms.ModelForm):
+    class Meta:
+        model = CourseRun
+        fields = '__all__'
+        widgets = {
+            'staff': SortedModelSelect2Multiple(
+                url='admin_metadata:person-autocomplete',
+                attrs={
+                    'data-minimum-input-length': 3,
+                    'class': 'sortable-select',
+                },
+            ),
+            'transcript_languages': SortedModelSelect2Multiple(
+                url='language_tags:language-tag-autocomplete',
+                attrs={
+                    'data-minimum-input-length': 3,
+                    'class': 'sortable-select',
+                },
+            ),
+            'video_translation_languages': SortedModelSelect2Multiple(
+                url='language_tags:language-tag-autocomplete',
+                attrs={
+                    'data-minimum-input-length': 3,
+                    'class': 'sortable-select',
+                },
+            ),
+        }
+
+
 class PathwayAdminForm(forms.ModelForm):
     class Meta:
         model = Pathway


### PR DESCRIPTION
### Background
Lately the PC team has seen Discovery taking a lot of time to load, specially when it comes to course run pages.
e.g: https://discovery.edx.org/admin/course_metadata/courserun/21473/change/

### Investigation
This was happening because of the fact that `django-admin` needs to fetch all of the related data to populate `admin` page(provided above) for each `course_run`.In order to optimize the page load time, there was a need to fetch only relevant data.During the discovery, following fields are identified which would be fetched only on-demand:
1. `draft_version` in Inline Seat Model.
2. `upgrade_deadline` in Inline Seat Model.
3. 'Staff' list.
4. 'Transcript Languages' list.
5. 'Video Translation Languages` list.
### Actions
1. `draft_version` and `currency` fields inside Inline Seat Model are added to `raw_id_fields`.Now, they would be loaded only on demand.
#### Before
<img width="80" alt="Screen Shot 2021-03-08 at 6 47 21 PM" src="https://user-images.githubusercontent.com/15120237/110329651-ba7cc980-803e-11eb-8e19-7d7b5ac9c7ea.png">

#### After
<img width="94" alt="Screen Shot 2021-03-08 at 6 50 55 PM" src="https://user-images.githubusercontent.com/15120237/110330125-38d96b80-803f-11eb-842e-1d3e7f9a6a96.png">

2. A custom widget is added to the `CourseRunAdmin` which will give suggestions as per the input of three characters and load only on selection.
#### Before
<img width="805" alt="Screen Shot 2021-03-08 at 6 52 48 PM" src="https://user-images.githubusercontent.com/15120237/110330363-7d650700-803f-11eb-837d-c063eda70fff.png">

####  After
<img width="563" alt="Screen Shot 2021-03-07 at 6 03 29 AM" src="https://user-images.githubusercontent.com/15120237/110330410-88b83280-803f-11eb-97ea-9546737279e3.png">

[DISCO-1677](https://openedx.atlassian.net/browse/DISCO-1677)