### PR TITLE
WS-1738 Course Recommendation Endpoint QA

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2615,7 +2615,7 @@ class CourseWithRecommendationSerializerTests(MinimalCourseSerializerTests):
             'recommendations': CourseRecommendationSerializer([recommended_course_0, recommended_course_1], many=True,
                                                               context=context).data
         }
-        serializer = self.serializer_class(course_with_recs, context={'request': request, 'exclude_utm': 1})
+        serializer = self.serializer_class(course_with_recs, context={'request': request})
         self.assertDictEqual(serializer.data, expected_data)
 
     def test_exclude_utm(self):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -20,16 +20,16 @@ from course_discovery.apps.api.fields import ImageField, StdImageSerializerField
 from course_discovery.apps.api.serializers import (
     AdditionalPromoAreaSerializer, AffiliateWindowSerializer, CatalogSerializer, CollaboratorSerializer,
     ContainedCourseRunsSerializer, ContainedCoursesSerializer, ContentTypeSerializer, CorporateEndorsementSerializer,
-    CourseEditorSerializer, CourseEntitlementSerializer, CourseRunSerializer, CourseRunWithProgramsSerializer,
-    CourseSerializer, CourseWithProgramsSerializer, CurriculumSerializer, DegreeCostSerializer,
-    DegreeDeadlineSerializer, EndorsementSerializer, FAQSerializer, FlattenedCourseRunWithCourseSerializer,
-    IconTextPairingSerializer, ImageSerializer, MinimalCourseRunSerializer, MinimalCourseSerializer,
-    MinimalOrganizationSerializer, MinimalPersonSerializer, MinimalProgramCourseSerializer, MinimalProgramSerializer,
-    NestedProgramSerializer, OrganizationSerializer, PathwaySerializer, PersonSerializer, PositionSerializer,
-    PrerequisiteSerializer, ProgramsAffiliateWindowSerializer, ProgramSerializer, ProgramTypeAttrsSerializer,
-    ProgramTypeSerializer, RankingSerializer, SeatSerializer, SubjectSerializer, TopicSerializer,
-    TypeaheadCourseRunSearchSerializer, TypeaheadProgramSearchSerializer, VideoSerializer,
-    get_lms_course_url_for_archived, get_utm_source_for_user
+    CourseEditorSerializer, CourseEntitlementSerializer, CourseRecommendationSerializer, CourseRunSerializer,
+    CourseRunWithProgramsSerializer, CourseSerializer, CourseWithProgramsSerializer,
+    CourseWithRecommendationsSerializer, CurriculumSerializer, DegreeCostSerializer, DegreeDeadlineSerializer,
+    EndorsementSerializer, FAQSerializer, FlattenedCourseRunWithCourseSerializer, IconTextPairingSerializer,
+    ImageSerializer, MinimalCourseRunSerializer, MinimalCourseSerializer, MinimalOrganizationSerializer,
+    MinimalPersonSerializer, MinimalProgramCourseSerializer, MinimalProgramSerializer, NestedProgramSerializer,
+    OrganizationSerializer, PathwaySerializer, PersonSerializer, PositionSerializer, PrerequisiteSerializer,
+    ProgramsAffiliateWindowSerializer, ProgramSerializer, ProgramTypeAttrsSerializer, ProgramTypeSerializer,
+    RankingSerializer, SeatSerializer, SubjectSerializer, TopicSerializer, TypeaheadCourseRunSearchSerializer,
+    TypeaheadProgramSearchSerializer, VideoSerializer, get_lms_course_url_for_archived, get_utm_source_for_user
 )
 from course_discovery.apps.api.tests.mixins import SiteMixin
 from course_discovery.apps.catalogs.tests.factories import CatalogFactory
@@ -140,6 +140,7 @@ class MinimalCourseSerializerTests(SiteMixin, TestCase):
         }
 
     def test_data(self):
+        self.maxDiff = None
         request = make_request()
         organizations = OrganizationFactory(partner=self.partner)
         course = CourseFactory(authoring_organizations=[organizations], partner=self.partner)
@@ -2547,3 +2548,85 @@ class CollaboratorSerializerTests(TestCase):
         }
 
         self.assertDictEqual(serializer.data, expected)
+
+
+# Experiment WS-1681: course recommendations
+class CourseRecommendationSerializerTests(MinimalCourseSerializerTests):
+    serializer_class = CourseRecommendationSerializer
+
+    @classmethod
+    def get_expected_data(cls, course, request):
+        context = {'request': request}
+
+        return {
+            'key': course.key,
+            'uuid': str(course.uuid),
+            'title': course.title,
+            'owners': MinimalOrganizationSerializer(course.authoring_organizations, many=True, context=context).data,
+            'image': ImageField().to_representation(course.image_url),
+            'short_description': course.short_description,
+            'type': course.type.uuid,
+            'url_slug': None,
+            'course_run_keys': [course_run.key for course_run in course.course_runs.all()],
+            'marketing_url': '{url}?{params}'.format(
+                url=course.marketing_url,
+                params=urlencode({
+                    'utm_source': request.user.username,
+                    'utm_medium': request.user.referral_tracking_id,
+                })
+            ),
+        }
+
+    def test_exclude_utm(self):
+        request = make_request()
+        course = CourseFactory()
+        serializer = self.serializer_class(course, context={'request': request, 'exclude_utm': 1})
+
+        self.assertEqual(serializer.data['marketing_url'], course.marketing_url)
+
+
+class CourseWithRecommendationSerializerTests(MinimalCourseSerializerTests):
+    serializer_class = CourseWithRecommendationsSerializer
+
+    @classmethod
+    def get_expected_data(cls, course, request):
+        return {
+            'uuid': str(course.uuid),
+            'recommendations': [],
+        }
+
+    def test_course_with_recommendations(self):
+        self.maxDiff = None
+        request = make_request()
+        context = {'request': request}
+        organization = OrganizationFactory(partner=self.partner)
+        subject = SubjectFactory(partner=self.partner)
+        course_with_recs = CourseFactory(authoring_organizations=[organization], subjects=[subject],
+                                         partner=self.partner)
+        recommended_course_0 = CourseFactory(partner=self.partner)
+        recommended_course_1 = CourseFactory(authoring_organizations=[organization], subjects=[subject],
+                                             partner=self.partner)
+        CourseRunFactory.create_batch(2, course=recommended_course_0)
+        CourseRunFactory.create_batch(2, course=recommended_course_1)
+        ProgramFactory(courses=[course_with_recs, recommended_course_0], partner=self.partner)
+
+        expected_data = {
+            'uuid': str(course_with_recs.uuid),
+            'recommendations': CourseRecommendationSerializer([recommended_course_0, recommended_course_1], many=True,
+                                                              context=context).data
+        }
+        serializer = self.serializer_class(course_with_recs, context={'request': request, 'exclude_utm': 1})
+        self.assertDictEqual(serializer.data, expected_data)
+
+    def test_exclude_utm(self):
+        request = make_request()
+        organization = OrganizationFactory(partner=self.partner)
+        subject = SubjectFactory(partner=self.partner)
+        course_with_recs = CourseFactory(authoring_organizations=[organization], subjects=[subject],
+                                         partner=self.partner)
+        recommended_course_0 = CourseFactory(authoring_organizations=[organization], subjects=[subject],
+                                             partner=self.partner)
+        CourseRunFactory.create_batch(2, course=recommended_course_0)
+        serializer = self.serializer_class(course_with_recs, context={'request': request, 'exclude_utm': 1})
+        self.assertEqual(serializer.data['recommendations'][0]['marketing_url'], recommended_course_0.marketing_url)
+# end experiment code

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1560,3 +1560,11 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.uuid})
         response = self.client.patch(url, {'full_description': '<h1>Header</h1>'}, format='json')
         self.assertContains(response, 'Invalid HTML received: h1 tag is not allowed', status_code=400)
+
+    # Experiment WS-1681: course recommendations
+    @responses.activate
+    def test_recommendations(self):
+        url = reverse('api:v1:course_recommendations-detail', kwargs={'key': self.course.key})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+    # end experiment code

--- a/course_discovery/apps/api/v1/urls.py
+++ b/course_discovery/apps/api/v1/urls.py
@@ -10,7 +10,7 @@ from course_discovery.apps.api.v1.views.collaborators import CollaboratorViewSet
 from course_discovery.apps.api.v1.views.comments import CommentViewSet
 from course_discovery.apps.api.v1.views.course_editors import CourseEditorViewSet
 from course_discovery.apps.api.v1.views.course_runs import CourseRunViewSet
-from course_discovery.apps.api.v1.views.courses import CourseViewSet
+from course_discovery.apps.api.v1.views.courses import CourseRecommendationViewSet, CourseViewSet
 from course_discovery.apps.api.v1.views.currency import CurrencyView
 from course_discovery.apps.api.v1.views.level_types import LevelTypeViewSet
 from course_discovery.apps.api.v1.views.organizations import OrganizationViewSet
@@ -45,6 +45,7 @@ router = routers.SimpleRouter()
 router.register(r'catalogs', CatalogViewSet)
 router.register(r'comments', CommentViewSet, basename='comment')
 router.register(r'courses', CourseViewSet, basename='course')
+router.register(r'course_recommendations', CourseRecommendationViewSet, basename='course_recommendations')
 router.register(r'course_editors', CourseEditorViewSet, basename='course_editor')
 router.register(r'course_runs', CourseRunViewSet, basename='course_run')
 router.register(r'collaborators', CollaboratorViewSet, basename='collaborator')

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -16,6 +16,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters as rest_framework_filters
 from rest_framework import status, viewsets
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.permissions import SAFE_METHODS, IsAuthenticated
 from rest_framework.response import Response
 from taxonomy.signals.signals import UPDATE_COURSE_SKILLS
@@ -490,3 +491,13 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             create_missing_entitlement(course)
 
         return super().retrieve(request, *args, **kwargs)
+
+
+# Experiment WS-1681: Course recommendations
+class CourseRecommendationViewSet(RetrieveModelMixin, viewsets.GenericViewSet):
+    filter_backends = (DjangoFilterBackend, )
+    lookup_field = 'key'
+    lookup_value_regex = COURSE_ID_REGEX
+    permission_classes = (IsAuthenticated, IsCourseEditorOrReadOnly,)
+    serializer_class = serializers.CourseWithRecommendationsSerializer
+    queryset = serializers.MinimalCourseSerializer.prefetch_queryset()

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1134,28 +1134,16 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
         Recommended set of courses for upsell after finishing a course. Returns de-duped list of Courses that:
         A) belong in the same program as given Course
         B) share the same subject AND same organization (or at least one)
-        in priority over of A then B
+        in priority of A over B
         """
-        recommended_courses = []
-        # flatten a list of programs that has a list of courses
-        recommended_courses.extend(list(itertools.chain.from_iterable(
-            [program.courses.all() for program in self.programs.all()])))
-        course_subjects = [Q(subjects=subject) for subject in self.subjects.all()]
-        organizations = [Q(authoring_organizations=org) for org in self.authoring_organizations.all()]
-        recommended_courses.extend(list(Course.objects
-                                        .filter(*course_subjects)
-                                        .filter(*organizations)
-                                        .all()))
-        # filters out calling course
-        recommended_courses = [course for course in recommended_courses if course.key != self.key]
-        deduped_courses = []
-        seen = set()
-        for course in recommended_courses:
-            if course not in seen:
-                deduped_courses.append(course)
-                seen.add(course)
-
-        return deduped_courses
+        recommended_courses = (
+            Course.objects.filter(
+                subjects__in=self.subjects.all(),
+                authoring_organizations__in=self.authoring_organizations.all()
+            ) | Course.objects.filter(
+                programs__in=self.programs.all()
+            )).exclude(key=self.key).distinct()
+        return recommended_courses
 
 
 class CourseEditor(TimeStampedModel):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2424,7 +2424,7 @@ class TestCourseRecommendations(TestCase):
         self.course1_with_subject = factories.CourseFactory(subjects=[cooking])
         self.course2_with_subject = factories.CourseFactory(subjects=[cooking])
         self.course3_with_different_subject = factories.CourseFactory(subjects=[brewing])
-        self.course4_with_2_subjects = factoriest.CourseFactory(subjects=[brewing, cooking])
+        self.course4_with_2_subjects = factories.CourseFactory(subjects=[brewing, cooking])
         self.course5_with_subject = factories.CourseFactory(subjects=[not_cooking])
         self.course6_with_subject = factories.CourseFactory(subjects=[not_brewing])
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2421,12 +2421,12 @@ class TestCourseRecommendations(TestCase):
 
         self.org1 = factories.OrganizationFactory()
 
-        self.course1_with_subject = factories.CourseFactory(subjects=[cooking])
-        self.course2_with_subject = factories.CourseFactory(subjects=[cooking])
-        self.course3_with_different_subject = factories.CourseFactory(subjects=[brewing])
-        self.course4_with_2_subjects = factories.CourseFactory(subjects=[brewing, cooking])
-        self.course5_with_subject = factories.CourseFactory(subjects=[not_cooking])
-        self.course6_with_subject = factories.CourseFactory(subjects=[not_brewing])
+        self.course1_with_subject = factories.CourseFactory(key='course1', subjects=[cooking])
+        self.course2_with_subject = factories.CourseFactory(key='course2', subjects=[cooking])
+        self.course3_with_different_subject = factories.CourseFactory(key='course3', subjects=[brewing])
+        self.course4_with_2_subjects = factories.CourseFactory(key='course4', subjects=[brewing, cooking])
+        self.course5_with_subject = factories.CourseFactory(key='course5', subjects=[not_cooking])
+        self.course6_with_subject = factories.CourseFactory(key='course6', subjects=[not_brewing])
 
         self.course1_with_subject.authoring_organizations.add(self.org1)
         self.course3_with_different_subject.authoring_organizations.add(self.org1)
@@ -2449,3 +2449,9 @@ class TestCourseRecommendations(TestCase):
         assert self.course3_with_different_subject in course1_recs
         assert self.course4_with_2_subjects in course1_recs
         assert self.course5_with_subject in course1_recs
+
+    def test_matching_subject_org_recommendations(self):
+        course4_recs = self.course4_with_2_subjects.recommendations()
+        assert len(course4_recs) == 2
+        assert self.course1_with_subject in course4_recs
+        assert self.course3_with_different_subject in course4_recs

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2424,7 +2424,7 @@ class TestCourseRecommendations(TestCase):
         self.course1_with_subject = factories.CourseFactory(subjects=[cooking])
         self.course2_with_subject = factories.CourseFactory(subjects=[cooking])
         self.course3_with_different_subject = factories.CourseFactory(subjects=[brewing])
-        self.course4_with_2_subjects = factories.CourseFactory(subjects=[brewing, cooking])
+        self.course4_with_2_subjects = factoriest.CourseFactory(subjects=[brewing, cooking])
         self.course5_with_subject = factories.CourseFactory(subjects=[not_cooking])
         self.course6_with_subject = factories.CourseFactory(subjects=[not_brewing])
 

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -16,6 +16,7 @@ CORS_ORIGIN_WHITELIST = (
     'localhost:8734',   # frontend-app-learner-portal-enterprise
     'localhost:18400',  # frontend-app-publisher
     'localhost:18450',  # frontend-app-support-tools
+    'localhost:2000',   # frontend-app-learning
 )
 
 ELASTICSEARCH_DSL['default']['hosts'] = 'edx.devstack.elasticsearch7:9200'


### PR DESCRIPTION
Refines some of the django querysets used and clears up the logic for the endpoint as the endpoint was returning an incorrect amount of courses during QA. Also adds an additional test for check for organization and subject matching.