### PR TITLE
WS-1738: Course Recommendation endpoint QA

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1134,28 +1134,16 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
         Recommended set of courses for upsell after finishing a course. Returns de-duped list of Courses that:
         A) belong in the same program as given Course
         B) share the same subject AND same organization (or at least one)
-        in priority over of A then B
+        in priority of A over B
         """
-        recommended_courses = []
-        # flatten a list of programs that has a list of courses
-        recommended_courses.extend(list(itertools.chain.from_iterable(
-            [program.courses.all() for program in self.programs.all()])))
-        course_subjects = [Q(subjects=subject) for subject in self.subjects.all()]
-        organizations = [Q(authoring_organizations=org) for org in self.authoring_organizations.all()]
-        recommended_courses.extend(list(Course.objects
-                                        .filter(*course_subjects)
-                                        .filter(*organizations)
-                                        .all()))
-        # filters out calling course
-        recommended_courses = [course for course in recommended_courses if course.key != self.key]
-        deduped_courses = []
-        seen = set()
-        for course in recommended_courses:
-            if course not in seen:
-                deduped_courses.append(course)
-                seen.add(course)
-
-        return deduped_courses
+        recommended_courses = (
+            Course.objects.filter(
+                subjects__in=self.subjects.all(),
+                authoring_organizations__in=self.authoring_organizations.all()
+            ) | Course.objects.filter(
+                programs__in=self.programs.all()
+            )).exclude(key=self.key).distinct()
+        return recommended_courses
 
 
 class CourseEditor(TimeStampedModel):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1136,14 +1136,21 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
         B) share the same subject AND same organization (or at least one)
         in priority of A over B
         """
-        recommended_courses = (
+        program_courses = list(Course.objects.filter(
+            programs__in=self.programs.all())
+            .exclude(key=self.key)
+            .distinct()
+            .all())
+
+        subject_org_courses = list(
             Course.objects.filter(
                 subjects__in=self.subjects.all(),
                 authoring_organizations__in=self.authoring_organizations.all()
-            ) | Course.objects.filter(
-                programs__in=self.programs.all()
-            )).exclude(key=self.key).distinct()
-        return recommended_courses
+            ).exclude(key=self.key)
+            .distinct()
+            .all())
+
+        return [*program_courses, *subject_org_courses]
 
 
 class CourseEditor(TimeStampedModel):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2438,6 +2438,11 @@ class TestCourseRecommendations(TestCase):
             self.course3_with_different_subject,
             self.course5_with_subject])
 
+        self.program2 = factories.ProgramFactory(courses=[
+            self.course2_with_subject,
+            self.course3_with_different_subject,
+            self.course6_with_subject])
+
     def test_no_course_recommendations(self):
         unique_subject = factories.SubjectFactory(name="Unique Subject")
         course_with_unique_subject = factories.CourseFactory(subjects=[unique_subject])
@@ -2457,10 +2462,6 @@ class TestCourseRecommendations(TestCase):
         assert self.course3_with_different_subject in course4_recs
 
     def test_recommendation_ordering(self):
-        self.program2 = factories.ProgramFactory(courses=[
-            self.course2_with_subject,
-            self.course3_with_different_subject,
-            self.course6_with_subject])
         self.course2_with_subject.authoring_organizations.add(self.org2)
         self.course4_with_2_subjects.authoring_organizations.add(self.org2)
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2421,12 +2421,12 @@ class TestCourseRecommendations(TestCase):
 
         self.org1 = factories.OrganizationFactory()
 
-        self.course1_with_subject = factories.CourseFactory(subjects=[cooking])
-        self.course2_with_subject = factories.CourseFactory(subjects=[cooking])
-        self.course3_with_different_subject = factories.CourseFactory(subjects=[brewing])
-        self.course4_with_2_subjects = factories.CourseFactory(subjects=[brewing, cooking])
-        self.course5_with_subject = factories.CourseFactory(subjects=[not_cooking])
-        self.course6_with_subject = factories.CourseFactory(subjects=[not_brewing])
+        self.course1_with_subject = factories.CourseFactory(key='course1', subjects=[cooking])
+        self.course2_with_subject = factories.CourseFactory(key='course2', subjects=[cooking])
+        self.course3_with_different_subject = factories.CourseFactory(key='course3', subjects=[brewing])
+        self.course4_with_2_subjects = factories.CourseFactory(key='course4', subjects=[brewing, cooking])
+        self.course5_with_subject = factories.CourseFactory(key='course5', subjects=[not_cooking])
+        self.course6_with_subject = factories.CourseFactory(key='course6', subjects=[not_brewing])
 
         self.course1_with_subject.authoring_organizations.add(self.org1)
         self.course3_with_different_subject.authoring_organizations.add(self.org1)
@@ -2449,3 +2449,9 @@ class TestCourseRecommendations(TestCase):
         assert self.course3_with_different_subject in course1_recs
         assert self.course4_with_2_subjects in course1_recs
         assert self.course5_with_subject in course1_recs
+
+    def test_matching_subject_org_recommendations(self):
+        course4_recs = self.course4_with_2_subjects.recommendations()
+        assert len(course4_recs) == 2
+        assert self.course1_with_subject in course4_recs
+        assert self.course3_with_different_subject in course4_recs

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2420,6 +2420,7 @@ class TestCourseRecommendations(TestCase):
         not_brewing = factories.SubjectFactory(name="Not Brewing")
 
         self.org1 = factories.OrganizationFactory()
+        self.org2 = factories.OrganizationFactory()
 
         self.course1_with_subject = factories.CourseFactory(key='course1', subjects=[cooking])
         self.course2_with_subject = factories.CourseFactory(key='course2', subjects=[cooking])
@@ -2436,7 +2437,6 @@ class TestCourseRecommendations(TestCase):
             self.course1_with_subject,
             self.course3_with_different_subject,
             self.course5_with_subject])
-        self.program2 = factories.ProgramFactory(courses=[self.course2_with_subject])
 
     def test_no_course_recommendations(self):
         unique_subject = factories.SubjectFactory(name="Unique Subject")
@@ -2455,3 +2455,17 @@ class TestCourseRecommendations(TestCase):
         assert len(course4_recs) == 2
         assert self.course1_with_subject in course4_recs
         assert self.course3_with_different_subject in course4_recs
+
+    def test_recommendation_ordering(self):
+        self.program2 = factories.ProgramFactory(courses=[
+            self.course2_with_subject,
+            self.course3_with_different_subject,
+            self.course6_with_subject])
+        self.course2_with_subject.authoring_organizations.add(self.org2)
+        self.course4_with_2_subjects.authoring_organizations.add(self.org2)
+
+        course2_recs = self.course2_with_subject.recommendations()
+        assert len(course2_recs) == 3
+        assert course2_recs[0].key == 'course3'
+        assert course2_recs[1].key == 'course6'
+        assert course2_recs[2].key == 'course4'


### PR DESCRIPTION
Refined to use querysets for de-duping and exclusion of calling course. Added an additional test to check for matching both subjects and organizations.