### PR TITLE
WS-1804: Fix Recommendations

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2608,10 +2608,10 @@ class CourseWithRecommendationSerializerTests(MinimalCourseSerializerTests):
                                              partner=self.partner)
         course_run_0 = CourseRunFactory.create_batch(2, course=recommended_course_0)[0]
         SeatFactory.create_batch(2, course_run=course_run_0)
-        
+
         course_run_1 = CourseRunFactory.create_batch(2, course=recommended_course_1)[0]
         SeatFactory.create_batch(2, course_run=course_run_1)
-    
+
         ProgramFactory(courses=[course_with_recs, recommended_course_0], partner=self.partner)
 
         expected_data = {

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2606,8 +2606,12 @@ class CourseWithRecommendationSerializerTests(MinimalCourseSerializerTests):
         recommended_course_0 = CourseFactory(partner=self.partner)
         recommended_course_1 = CourseFactory(authoring_organizations=[organization], subjects=[subject],
                                              partner=self.partner)
-        CourseRunFactory.create_batch(2, course=recommended_course_0)
-        CourseRunFactory.create_batch(2, course=recommended_course_1)
+        course_run_0 = CourseRunFactory.create_batch(2, course=recommended_course_0)[0]
+        SeatFactory.create_batch(2, course_run=course_run_0)
+        
+        course_run_1 = CourseRunFactory.create_batch(2, course=recommended_course_1)[0]
+        SeatFactory.create_batch(2, course_run=course_run_1)
+    
         ProgramFactory(courses=[course_with_recs, recommended_course_0], partner=self.partner)
 
         expected_data = {
@@ -2626,7 +2630,8 @@ class CourseWithRecommendationSerializerTests(MinimalCourseSerializerTests):
                                          partner=self.partner)
         recommended_course_0 = CourseFactory(authoring_organizations=[organization], subjects=[subject],
                                              partner=self.partner)
-        CourseRunFactory.create_batch(2, course=recommended_course_0)
+        for course_run in CourseRunFactory.create_batch(2, course=recommended_course_0):
+            SeatFactory.create_batch(2, course_run=course_run)
         serializer = self.serializer_class(course_with_recs, context={'request': request, 'exclude_utm': 1})
         assert serializer.data['recommendations'][0]['marketing_url'] == recommended_course_0.marketing_url
 # end experiment code

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1129,6 +1129,7 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
 
         return advertised_course_run
 
+    # Experiment WS-1681: Course recommendations
     def has_marketable_run(self):
         for course_run in self.course_runs.all():
             if course_run.is_marketable:
@@ -1158,7 +1159,15 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
             .distinct()
             .all())
 
-        return [*program_courses, *subject_org_courses]
+        # coercing to set destroys order, looping to remove dupes on union
+        seen = set()
+        deduped = []
+        for course in [*program_courses, *subject_org_courses]:
+            if course not in seen and course.has_marketable_run():
+                deduped.append(course)
+                seen.add(course)
+        return deduped
+        # End Experiment WS-1681: Course recommendations
 
 
 class CourseEditor(TimeStampedModel):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1129,6 +1129,12 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
 
         return advertised_course_run
 
+    def has_marketable_run(self):
+        for course_run in self.course_runs.all():
+            if course_run.is_marketable:
+                return True
+        return False
+
     def recommendations(self):
         """
         Recommended set of courses for upsell after finishing a course. Returns de-duped list of Courses that:
@@ -1136,8 +1142,10 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
         B) share the same subject AND same organization (or at least one)
         in priority of A over B
         """
-        program_courses = list(Course.objects.filter(
-            programs__in=self.programs.all())
+        program_courses = list(
+            Course.objects.filter(
+                programs__in=self.programs.all()
+            )
             .exclude(key=self.key)
             .distinct()
             .all())

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1131,10 +1131,7 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
 
     # Experiment WS-1681: Course recommendations
     def has_marketable_run(self):
-        for course_run in self.course_runs.all():
-            if course_run.is_marketable:
-                return True
-        return False
+        return any(run.is_marketable for run in self.course_runs.all())
 
     def recommendations(self):
         """


### PR DESCRIPTION
Added deduping upon union of query results while maintaining order. Also added a check to see if a course is marketable/has a marketable course run as it would lead to courses missing on Prospectus (only marketable courses have pages).