### PR TITLE
update semgrep rules: removed assertEqual equality check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,3 @@ jobs:
         name: django rules
         with:
           config: p/django
-      - uses: returntocorp/semgrep-action@v1
-        name: other rules
-        with:
-          config: https://semgrep.live/dlukeomalley:use-assertEqual-for-equality


### PR DESCRIPTION
Getting this error on the PR, looks like the config file is no longer available. I have created an issue in the repo for it, till then we removing the check for "other rules"

```
=== failed command's STDOUT:

    {"results": [], "errors": [{"type": "SemgrepError", "code": 2, "message": "Failed to download config from https://semgrep.live/dlukeomalley:use-assertEqual-for-equality: bad status code: 404 returned by config url: https://semgrep.live/dlukeomalley:use-assertEqual-for-equality"}, {"type": "SemgrepError", "code": 7, "message": "no valid configuration file found (1 configs were invalid)"}]}


=== failed command's STDERR:

    using config from https://semgrep.live/dlukeomalley:use-assertEqual-for-equality. Visit https://semgrep.dev/registry to see all public rules.
    downloading config...
```