### PR TITLE
add content_language_search_facet_name to CourseRunSerializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -844,6 +844,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         queryset=LanguageTag.objects.all().order_by('name'),
         help_text=_('Language in which the course is administered')
     )
+    content_language_search_facet_name = serializers.SerializerMethodField()
     transcript_languages = serializers.SlugRelatedField(
         required=False, many=True, slug_field='code', queryset=LanguageTag.objects.all().order_by('name')
     )
@@ -886,9 +887,9 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
             'level_type', 'availability', 'mobile_available', 'hidden', 'reporting_type', 'eligible_for_financial_aid',
             'first_enrollable_paid_seat_price', 'has_ofac_restrictions', 'ofac_comment',
             'enrollment_count', 'recent_enrollment_count', 'expected_program_type', 'expected_program_name',
-            'course_uuid', 'estimated_hours',
+            'course_uuid', 'estimated_hours', 'content_language_search_facet_name',
         )
-        read_only_fields = ('enrollment_count', 'recent_enrollment_count',)
+        read_only_fields = ('enrollment_count', 'recent_enrollment_count','content_language_search_facet_name',)
 
     def get_instructors(self, obj):  # pylint: disable=unused-argument
         # This field is deprecated. Use the staff field.
@@ -896,6 +897,12 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
 
     def get_estimated_hours(self, obj):
         return get_course_run_estimated_hours(obj)
+
+    def get_content_language_search_facet_name(self, obj):
+        language = obj.language
+        if language is None:
+            return None
+        return language.get_search_facet_display(translate=True)
 
     def update_video(self, instance, video_data):
         # A separate video object is a historical concept. These days, we really just use the link address. So

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -889,7 +889,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
             'enrollment_count', 'recent_enrollment_count', 'expected_program_type', 'expected_program_name',
             'course_uuid', 'estimated_hours', 'content_language_search_facet_name',
         )
-        read_only_fields = ('enrollment_count', 'recent_enrollment_count','content_language_search_facet_name',)
+        read_only_fields = ('enrollment_count', 'recent_enrollment_count', 'content_language_search_facet_name',)
 
     def get_instructors(self, obj):  # pylint: disable=unused-argument
         # This field is deprecated. Use the staff field.

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -633,6 +633,7 @@ class CourseRunSerializerTests(MinimalCourseRunBaseTestSerializer):
             'eligible_for_financial_aid': course_run.eligible_for_financial_aid,
             'hidden': course_run.hidden,
             'content_language': course_run.language.code,
+            'content_language_search_facet_name': course_run.language.get_search_facet_display(translate=True),
             'transcript_languages': [],
             'min_effort': course_run.min_effort,
             'max_effort': course_run.max_effort,

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -316,7 +316,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
             # to be included.
             filtered_course_run = CourseRunFactory(course=course)
 
-            with self.assertNumQueries(31, threshold=3):
+            with self.assertNumQueries(35, threshold=3):
                 response = self.client.get(url)
 
             assert response.status_code == 200

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -69,7 +69,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         """ Verify the endpoint returns the details for a single course. """
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(14, threshold=3):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -81,7 +81,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(15, threshold=3):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data.get('programs') == []
@@ -108,7 +108,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
 
         url = reverse('api:v1:course_run-detail', kwargs={'key': self.course_run.key})
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(15, threshold=3):
             response = self.client.get(url)
             assert response.status_code == 200
             assert response.data.get('programs') == []
@@ -980,7 +980,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         """ Verify the endpoint returns a list of all course runs. """
         url = reverse('api:v1:course_run-list')
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(17, threshold=3):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -993,7 +993,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         """ Verify the endpoint returns a list of all course runs sorted by start date. """
         url = '{root}?ordering=start'.format(root=reverse('api:v1:course_run-list'))
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(17, threshold=3):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -1009,7 +1009,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(42, threshold=2):
+        with self.assertNumQueries(45, threshold=3):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])


### PR DESCRIPTION
In order to add the "Language" search facet to the Enterprise Learner Portal and have an exact match of language names to correspond with edx.org/search, I added the content language search facet name to the `CourseRunSerializer` such that it appears in the necessary API response for enterprise-catalog, e.g.:

```
{
  "content_language": "zh-cmn",
  "content_language_search_facet_name": "Chinese - Mandarin",
  ...
}
```

See https://github.com/edx/enterprise-catalog/pull/278 for how this will be used by enterprise-catalog.

**Alternatives considered**
1. Using the `langcodes` package in enterprise-catalog to parse the existing `content_language` field that includes the language code, e.g. "en-us". However, this approach did not work due to how edx.org/search formats the Chinese languages (e.g., "Chinese - Mandarin" vs. "Mandarin Chinese", which throws off the A-Z sorting).
2. Data duplication of the `LanguageTag` model in enterprise-catalog.