### PR TITLE
feat: Management command to add assets to edx Org

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/add_logos_to_organization.py
+++ b/course_discovery/apps/course_metadata/management/commands/add_logos_to_organization.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
         try:
             # We search by partner here because right now, the default provisioned org does not have a name, but has "edX" as the partner
             organization = Organization.objects.filter(
-                partner=self._get_partner_by_name(partner_name),
+                partner__short_code=partner_name
             )[:1].get()
             assets = self._open_assets(
                 logo=kwargs.get("logo"),
@@ -39,13 +39,6 @@ class Command(BaseCommand):
 
         except Organization.DoesNotExist as no_organization_exists:
             raise CommandError from no_organization_exists
-
-    def _get_partner_by_name(self, partner_name):
-        try:
-            partner = Partner.objects.get(short_code=partner_name)
-            return partner
-        except Partner.DoesNotExist as no_partner_exists:
-            raise CommandError from no_partner_exists
 
     def _open_assets(self, **kwargs):
         assets = {}

--- a/course_discovery/apps/course_metadata/management/commands/add_logos_to_organization.py
+++ b/course_discovery/apps/course_metadata/management/commands/add_logos_to_organization.py
@@ -1,0 +1,46 @@
+""" Command to add logo, certificate logo, and banner image to an organization """
+from django.core.files import File
+from django.core.management.base import BaseCommand, CommandError
+
+from course_discovery.apps.core.models import Partner
+from course_discovery.apps.course_metadata.models import Organization
+
+
+class Command(BaseCommand):
+    """
+    Uploads given images to an organization. This command is meant to be run
+    from a provisioning script and not by hand.
+    """
+    def add_arguments(self, parser):
+        parser.add_argument('--partner', default='edX')
+        parser.add_argument('--logo', default='/edx/app/discovery/discovery/provision-temp/assets/demo-asset-logo.png')
+        parser.add_argument('--certificate_logo', default='/edx/app/discovery/discovery/provision-temp/assets/demo-asset-certificate-logo.png')
+        parser.add_argument('--banner_image', default='/edx/app/discovery/discovery/provision-temp/assets/demo-asset-banner-image.png')
+
+    def handle(self, *args, **kwargs):
+        partner_name = kwargs.get('partner')
+        logo_path = kwargs.get("logo")
+        certificate_logo_path = kwargs.get('certificate_logo')
+        banner_image_path = kwargs.get('banner_image')
+        try:
+            organization = Organization.objects.get(partner=self._get_partner_by_name(partner_name))
+            logo = File(open(logo_path, 'rb'))
+            certificate_logo = File(open(certificate_logo_path, 'rb'))
+            banner_image = File(open(banner_image_path, 'rb'))
+            organization.logo_image = logo
+            organization.certificate_logo_image = certificate_logo
+            organization.banner_image = banner_image
+            organization.save()
+            logo.close()
+            certificate_logo.close()
+            banner_image.close()
+        except (Organization.DoesNotExist, OSError) as e:
+            print(CommandError(e))
+
+    def _get_partner_by_name(self, partner_name):
+        try:
+            partner = Partner.objects.filter(name=partner_name)[:1].get()
+            return partner
+        except Partner.DoesNotExist:
+            raise CommandError(f"Partner {partner_name} does not exist or could not be found.")
+

--- a/course_discovery/apps/course_metadata/management/commands/add_logos_to_organization.py
+++ b/course_discovery/apps/course_metadata/management/commands/add_logos_to_organization.py
@@ -2,7 +2,6 @@
 from django.core.files import File
 from django.core.management.base import BaseCommand, CommandError
 
-from course_discovery.apps.core.models import Partner
 from course_discovery.apps.course_metadata.models import Organization
 
 
@@ -22,7 +21,8 @@ class Command(BaseCommand):
         partner_name = kwargs.get("partner")
 
         try:
-            # We search by partner here because right now, the default provisioned org does not have a name, but has "edx" as the partner
+            # We search by partner here because right now, the default provisioned
+            # org does not have a name, but has "edx" as the partner
             organization = Organization.objects.filter(
                 partner__short_code=partner_name
             )[:1].get()

--- a/course_discovery/apps/course_metadata/management/commands/add_logos_to_organization.py
+++ b/course_discovery/apps/course_metadata/management/commands/add_logos_to_organization.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     """
 
     def add_arguments(self, parser):
-        parser.add_argument("--partner", default="edX")
+        parser.add_argument("--partner", default="edx")
         parser.add_argument("--logo")
         parser.add_argument("--certificate_logo")
         parser.add_argument("--banner_image")
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         partner_name = kwargs.get("partner")
 
         try:
-            # We search by partner here because right now, the default provisioned org does not have a name, but has "edX" as the partner
+            # We search by partner here because right now, the default provisioned org does not have a name, but has "edx" as the partner
             organization = Organization.objects.filter(
                 partner__short_code=partner_name
             )[:1].get()

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_add_logos_to_organization.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_add_logos_to_organization.py
@@ -4,22 +4,12 @@ from unittest import mock
 import pytest
 from django.core.files import File
 from django.core.management import call_command
-from django.core.management.base import CommandError
-from django.db import models
 from django.test import TestCase
-import factory
 
-
-from course_discovery.apps.core.models import Partner
-from course_discovery.apps.course_metadata.management.commands.add_logos_to_organization import (
-    Command,
-)
+from course_discovery.apps.course_metadata.management.commands.add_logos_to_organization import Command
 from course_discovery.apps.course_metadata.models import Organization
-from course_discovery.apps.course_metadata.tests.factories import (
-    ImageFactory,
-    OrganizationFactory,
-    PartnerFactory,
-)
+from course_discovery.apps.course_metadata.tests.factories import OrganizationFactory, PartnerFactory
+
 
 class AddLogosToOrganizationTest(TestCase):
     def setUp(self):
@@ -27,7 +17,7 @@ class AddLogosToOrganizationTest(TestCase):
         self.partner = PartnerFactory(short_code="testx")
         self.organization = OrganizationFactory(partner=self.partner, name="testx")
         self.logo = mock.MagicMock(spec=File, name="logo")
-        self.logo.name="logo"
+        self.logo.name = "logo"
         self.certificate_logo = mock.MagicMock(spec=File, name="certificate_logo")
         self.certificate_logo.name = "certificate_logo"
         self.banner_image = mock.MagicMock(spec=File, name="banner_image")
@@ -61,9 +51,9 @@ class AddLogosToOrganizationTest(TestCase):
             call_command(
                 Command(),
                 partner="testx",
-                logo='/',
-                certificate_logo='/',
-                banner_image='/',
+                logo="/",
+                certificate_logo="/",
+                banner_image="/",
             )
             self.organization.refresh_from_db()
-            assert  "/media/organization/logos/" in self.organization.logo_image.path
+            assert "/media/organization/logos/" in self.organization.logo_image.path

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_add_logos_to_organization.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_add_logos_to_organization.py
@@ -1,0 +1,69 @@
+""" Tests for adding logos command """
+from unittest import mock
+
+import pytest
+from django.core.files import File
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import models
+from django.test import TestCase
+import factory
+
+
+from course_discovery.apps.core.models import Partner
+from course_discovery.apps.course_metadata.management.commands.add_logos_to_organization import (
+    Command,
+)
+from course_discovery.apps.course_metadata.models import Organization
+from course_discovery.apps.course_metadata.tests.factories import (
+    ImageFactory,
+    OrganizationFactory,
+    PartnerFactory,
+)
+
+class AddLogosToOrganizationTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = PartnerFactory(short_code="testx")
+        self.organization = OrganizationFactory(partner=self.partner, name="testx")
+        self.logo = mock.MagicMock(spec=File, name="logo")
+        self.logo.name="logo"
+        self.certificate_logo = mock.MagicMock(spec=File, name="certificate_logo")
+        self.certificate_logo.name = "certificate_logo"
+        self.banner_image = mock.MagicMock(spec=File, name="banner_image")
+        self.banner_image.name = "banner image"
+
+    def test_partner_not_found(self):
+        with pytest.raises(Exception):
+            call_command(Command())
+
+    def test_image_paths_not_found(self):
+        with pytest.raises(Exception):
+            call_command(
+                Command(),
+                partner="testx",
+            )
+
+    @pytest.mark.django_db
+    def test_two_organizations_with_same_partner_returns_correct_org(self):
+        new_org = OrganizationFactory(partner=self.partner, name="notx")
+        assert len(Organization.objects.all()) > 1
+        self.organization.logo_image = None
+        new_org.logo_image = None
+        with mock.patch(
+            "course_discovery.apps.course_metadata.management.commands.add_logos_to_organization.Command._open_assets",
+            return_value={
+                "logo": self.logo,
+                "certificate_logo": self.certificate_logo,
+                "banner_image": self.banner_image,
+            },
+        ):
+            call_command(
+                Command(),
+                partner="testx",
+                logo='/',
+                certificate_logo='/',
+                banner_image='/',
+            )
+            self.organization.refresh_from_db()
+            assert  "/media/organization/logos/" in self.organization.logo_image.path


### PR DESCRIPTION
This command, when used by a provisioning script, will load logos for
the edX organization so that a program certificate can be created
locally.