### PR TITLE
ENT-4443: Upgraded taxonomy-connector version to 1.8.0

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,8 +12,10 @@ certifi==2020.12.5
     # via requests
 chardet==4.0.0
     # via requests
-docutils==0.17
-    # via sphinx
+docutils==0.16
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   sphinx
 edx-sphinx-theme==2.1.0
     # via -r requirements/docs.in
 idna==2.10

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -133,7 +133,7 @@ django-model-utils==4.1.1
     # via taxonomy-connector
 django-nine==0.2.4
     # via django-elasticsearch-dsl-drf
-django-object-actions==3.0.1
+django-object-actions==3.0.2
     # via -r requirements/base.in
 django-parler==2.2
     # via -r requirements/base.in
@@ -224,8 +224,10 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docutils==0.17
-    # via sphinx
+docutils==0.16
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   sphinx
 drf-dynamic-fields==0.3.1
     # via -r requirements/base.in
 drf-extensions==0.7.0
@@ -419,7 +421,7 @@ pytest-cov==2.11.1
     # via -r requirements/test.in
 pytest-django-ordering==1.2.0
     # via -r requirements/test.in
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via
     #   -r requirements/test.in
     #   pytest-django-ordering
@@ -514,7 +516,6 @@ six==1.15.0
     #   django-simple-history
     #   django-taggit-serializer
     #   djangorestframework-csv
-    #   docker
     #   dockerpty
     #   edx-auth-backends
     #   edx-ccx-keys
@@ -579,7 +580,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.6.2
+taxonomy-connector==1.8.0
     # via -r requirements/base.in
 testfixtures==6.17.1
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -18,9 +18,9 @@ beautifulsoup4==4.9.3
     # via -r requirements/base.in
 billiard==3.6.4.0
     # via celery
-boto3==1.17.45
+boto3==1.17.49
     # via django-ses
-botocore==1.20.45
+botocore==1.20.49
     # via
     #   boto3
     #   s3transfer
@@ -98,7 +98,7 @@ django-model-utils==4.1.1
     # via taxonomy-connector
 django-nine==0.2.4
     # via django-elasticsearch-dsl-drf
-django-object-actions==3.0.1
+django-object-actions==3.0.2
     # via -r requirements/base.in
 django-parler==2.2
     # via -r requirements/base.in
@@ -394,7 +394,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.6.2
+taxonomy-connector==1.8.0
     # via -r requirements/base.in
 unicode-slugify==0.1.3
     # via -r requirements/base.in


### PR DESCRIPTION
**JIRA Ticket:** [ENT-4443](https://openedx.atlassian.net/browse/ENT-4443)

__Description:__
This PR contains version bump of `taxonomy-connector`, the new version adds a new column `course_key` in `CouseSkills` model of taxonomy. This new model will replace the old `course_id` column in subsequent releases.