### PR TITLE
ENT-4444: Upgraded taxonomy-connector version to 1.9.0

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -146,8 +146,8 @@ class MinimalCourseSerializerTests(SiteMixin, TestCase):
         course = CourseFactory(authoring_organizations=[organizations], partner=self.partner)
         CourseRunFactory.create_batch(2, course=course)
         serializer = self.serializer_class(course, context={'request': request})
-        course_skill = CourseSkillsFactory(course_id=course.key)
-        CourseSkillsFactory(course_id=course.key, is_blacklisted=True)
+        course_skill = CourseSkillsFactory(course_key=course.key)
+        CourseSkillsFactory(course_key=course.key, is_blacklisted=True)
         expected = self.get_expected_data(course, course_skill, request)
         self.assertDictEqual(serializer.data, expected)
 
@@ -310,8 +310,8 @@ class CourseWithProgramsSerializerTests(CourseSerializerTests):
         super().setUp()
         self.request = make_request()
         self.course = CourseFactory(partner=self.partner)
-        self.course_skill = CourseSkillsFactory(course_id=self.course.key)
-        self.blacklisted_course_skill = CourseSkillsFactory(course_id=self.course.key, is_blacklisted=True)
+        self.course_skill = CourseSkillsFactory(course_key=self.course.key)
+        self.blacklisted_course_skill = CourseSkillsFactory(course_key=self.course.key, is_blacklisted=True)
         self.deleted_program = ProgramFactory(
             courses=[self.course],
             partner=self.partner,
@@ -1955,10 +1955,10 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         course.save()
         seat = SeatFactory(course_run=course_run)
         course_skill = CourseSkillsFactory(
-            course_id=course.key
+            course_key=course.key
         )
         CourseSkillsFactory(
-            course_id=course.key,
+            course_key=course.key,
             is_blacklisted=True,
         )
         serializer = self.serialize_course(course, request)
@@ -1985,7 +1985,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         course.save()
         seat = SeatFactory(course_run=course_run)
         course_skill = CourseSkillsFactory(
-            course_id=course.key
+            course_key=course.key
         )
         serializer = self.serialize_course(course, request)
         assert serializer.data["course_runs"] == self.get_expected_data(
@@ -2009,7 +2009,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         course.save()
         seat = SeatFactory(course_run=course_run)
         course_skill = CourseSkillsFactory(
-            course_id=course.key
+            course_key=course.key
         )
         expected = {
             'key': course.key,
@@ -2057,10 +2057,10 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         course.save()
         seat = SeatFactory(course_run=course_run)
         course_skill = CourseSkillsFactory(
-            course_id=course.key
+            course_key=course.key
         )
         CourseSkillsFactory(
-            course_id=course.key,
+            course_key=course.key,
             is_blacklisted=True,
         )
         expected = {
@@ -2174,8 +2174,8 @@ class CourseSearchModelSerializerTests(ElasticsearchTestMixin, TestCase, CourseS
     def test_data(self):
         request = make_request()
         course = CourseFactory()
-        course_skill = CourseSkillsFactory(course_id=course.key)
-        CourseSkillsFactory(course_id=course.key, is_blacklisted=True)
+        course_skill = CourseSkillsFactory(course_key=course.key)
+        CourseSkillsFactory(course_key=course.key, is_blacklisted=True)
         course_run = CourseRunFactory(course=course)
         course.course_runs.add(course_run)
         course.save()
@@ -2200,7 +2200,7 @@ class CourseRunSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase):
         program = ProgramFactory(courses=[course_run.course])
         self.reindex_courses(program)
         course_skill = CourseSkillsFactory(
-            course_id=course_run.course.key
+            course_key=course_run.course.key
         )
         serializer = self.serialize_course_run(course_run, request)
         assert serializer.data == self.get_expected_data(course_run, course_skill, request)

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -171,6 +171,7 @@ class SkillFactory(factory.django.DjangoModelFactory):
 
 class CourseSkillsFactory(factory.django.DjangoModelFactory):
     course_id = FuzzyText()
+    course_key = FuzzyText()
     skill = factory.SubFactory(SkillFactory)
     confidence = FuzzyDecimal(0.0, 1.0)
     is_blacklisted = False

--- a/course_discovery/apps/course_metadata/tests/test_views.py
+++ b/course_discovery/apps/course_metadata/tests/test_views.py
@@ -68,8 +68,8 @@ class TestCourseSkillView(TestCase):
 
     def _create_course_skills(self, course):
         """Create dummy course skills."""
-        course_skill1 = CourseSkillsFactory(course_id=course.key)
-        course_skill2 = CourseSkillsFactory(course_id=course.key)
+        course_skill1 = CourseSkillsFactory(course_key=course.key)
+        course_skill2 = CourseSkillsFactory(course_key=course.key)
         return [course_skill1, course_skill2]
 
     def test_get_user_not_logged_in(self):

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -580,7 +580,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.8.0
+taxonomy-connector==1.9.0
     # via -r requirements/base.in
 testfixtures==6.17.1
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -394,7 +394,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.8.0
+taxonomy-connector==1.9.0
     # via -r requirements/base.in
 unicode-slugify==0.1.3
     # via -r requirements/base.in


### PR DESCRIPTION
**JIRA Ticket:** [ENT-4444](https://openedx.atlassian.net/browse/ENT-4444)

__Description:__
This PR upgrades taxonomy-connector version to 1.9.0, new version contains the following changes.

1. A data migration to copy the values from the course_id field into the course_key field. 
2. Removal of all references to the `course_id` field in the code, NOT removing the `course_id` field from the model in the code.
3. Changing `null` back to `False` and `editable` back to `True` on the `course_key` field.