### PR TITLE
ENT-4445: Remove all usages of CourseSkills.course_id from the code

### DIFF
--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -170,7 +170,6 @@ class SkillFactory(factory.django.DjangoModelFactory):
 
 
 class CourseSkillsFactory(factory.django.DjangoModelFactory):
-    course_id = FuzzyText()
     course_key = FuzzyText()
     skill = factory.SubFactory(SkillFactory)
     confidence = FuzzyDecimal(0.0, 1.0)

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -580,7 +580,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.9.0
+taxonomy-connector==1.11.1
     # via -r requirements/base.in
 testfixtures==6.17.1
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -394,7 +394,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.9.0
+taxonomy-connector==1.11.1
     # via -r requirements/base.in
 unicode-slugify==0.1.3
     # via -r requirements/base.in


### PR DESCRIPTION
**JIRA Ticket:** [ENT-4445](https://openedx.atlassian.net/browse/ENT-4445)

__Description:__

This PR contains taxonomy-connector version upgrade and removal of the remaining usages of `CourseSkills.course_id` column. taxonomy-connector version upgrade contains migrations for removing `CourseSkills.course_id` from the database and also removal of the remaining of its usages.