### PR TITLE
feat: add course and program tags to Algolia index

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -52,7 +52,7 @@ def delegate_attributes(cls):
     facet_fields = ['availability_level', 'subject_names', 'levels', 'active_languages', 'staff_slugs']
     ranking_fields = ['availability_rank', 'product_recent_enrollment_count', 'promoted_in_spanish_index']
     result_fields = ['product_marketing_url', 'product_card_image_url', 'product_uuid', 'active_run_key',
-                     'active_run_start', 'active_run_type', 'owners', 'program_types', 'course_titles']
+                     'active_run_start', 'active_run_type', 'owners', 'program_types', 'course_titles', 'tags']
     object_id_field = ['custom_object_id', ]
     fields = search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -216,6 +216,10 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
         return False
 
     @property
+    def tags(self):
+        return [tag_name for tag_name in self.topics.names()]
+
+    @property
     def should_index(self):
         """Only index courses in the edX catalog with a non-hidden advertiseable course run, at least one owner, and
         a marketing url slug"""
@@ -316,6 +320,10 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
         if self.type:
             return [self.type.name]
         return None
+
+    @property
+    def tags(self):
+        return [tag_name for tag_name in self.topics]
 
     @property
     def availability_level(self):

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -217,7 +217,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
 
     @property
     def tags(self):
-        return [tag_name for tag_name in self.topics.names()]
+        return list(self.topics.names())
 
     @property
     def should_index(self):
@@ -323,7 +323,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     @property
     def tags(self):
-        return [tag_name for tag_name in self.topics]
+        return [topic.name for topic in self.topics]
 
     @property
     def availability_level(self):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -63,7 +63,7 @@ class EnglishProductIndex(BaseProductIndex):
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'))
     result_fields = (('product_marketing_url', 'marketing_url'), ('product_card_image_url', 'card_image_url'),
                      ('product_uuid', 'uuid'), 'active_run_key', 'active_run_start', 'active_run_type', 'owners',
-                     'course_titles')
+                     'course_titles', 'tags')
     # Algolia needs this
     object_id_field = (('custom_object_id', 'objectID'), )
     fields = search_fields + facet_fields + ranking_fields + result_fields + object_id_field
@@ -96,7 +96,7 @@ class SpanishProductIndex(BaseProductIndex):
                       'promoted_in_spanish_index')
     result_fields = (('product_marketing_url', 'marketing_url'), ('product_card_image_url', 'card_image_url'),
                      ('product_uuid', 'uuid'), 'active_run_key', 'active_run_start', 'active_run_type', 'owners',
-                     'course_titles')
+                     'course_titles', 'tags')
     # Algolia uses objectID as unique identifier. Can't use straight uuids because a program and a course could
     # have the same one, so we add 'course' or 'program' as a prefix
     object_id_field = (('custom_object_id', 'objectID'), )


### PR DESCRIPTION
Add tags to the algolia search index for both courses and programs
Support for experiment https://openedx.atlassian.net/browse/WS-1664 . 
Subtask: https://openedx.atlassian.net/browse/WS-1765