### PR TITLE
ENT-4158: Add skill description to search all and course detail endpoint

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -21,7 +21,7 @@ from rest_framework.fields import CreateOnlyDefault, UUIDField
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.relations import ManyRelatedField
 from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
-from taxonomy.utils import get_whitelisted_course_skills
+from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.fields import (
     HtmlField, ImageField, SlugRelatedFieldWithReadSerializer, SlugRelatedTranslatableField, StdImageSerializerField
@@ -1077,6 +1077,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
                                                        queryset=Collaborator.objects.all(),
                                                        read_serializer=CollaboratorSerializer())
     skill_names = serializers.SerializerMethodField()
+    skills = serializers.SerializerMethodField()
 
     @classmethod
     def prefetch_queryset(cls, partner, queryset=None, course_runs=None):  # pylint: disable=arguments-differ
@@ -1121,6 +1122,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
             'extra_description', 'additional_information', 'faq', 'learner_testimonials',
             'enrollment_count', 'recent_enrollment_count', 'topics', 'partner', 'key_for_reruns', 'url_slug',
             'url_slug_history', 'url_redirects', 'course_run_statuses', 'editors', 'collaborators', 'skill_names',
+            'skills',
         )
         extra_kwargs = {
             'partner': {'write_only': True}
@@ -1144,6 +1146,9 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
     def get_skill_names(self, obj):
         course_skills = get_whitelisted_course_skills(obj.key)
         return list(set(course_skill.skill.name for course_skill in course_skills))
+
+    def get_skills(self, obj):
+        return get_whitelisted_serialized_skills(obj.key)
 
     def create(self, validated_data):
         return Course.objects.create(**validated_data)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -200,6 +200,7 @@ class CourseSerializerTests(MinimalCourseSerializerTests):
             'editors': CourseEditorSerializer(course.editors, many=True, read_only=True).data,
             'collaborators': [],
             'skill_names': [course_skill.skill.name],
+            'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
         })
 
         return expected
@@ -2030,6 +2031,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             ],
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
+            'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
             'course_ends': course.course_ends,
             'end_date': serialize_datetime(course.end_date),
             'organizations': [
@@ -2104,6 +2106,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             ],
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
+            'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
             'course_ends': course.course_ends,
             'end_date': serialize_datetime(course.end_date),
             'organizations': [
@@ -2158,6 +2161,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             ],
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
+            'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
             'course_ends': course.course_ends,
             'end_date': serialize_datetime(course.end_date),
             'organizations': [
@@ -2244,6 +2248,7 @@ class CourseRunSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase):
             'number': CourseKey.from_string(course_run.key).course,
             'seat_types': [seat.slug for seat in course_run.seat_types],
             'skill_names': [course_skill.skill.name],
+            'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
             'image_url': course_run.image_url,
             'type': course_run.type_legacy,
             'level_type': course_run.level_type.name,

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -261,7 +261,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
 
         # Known to be flaky prior to the addition of tearDown()
         # and logout() code which is the same number of additional queries
-        with self.assertNumQueries(45):
+        with self.assertNumQueries(48):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -281,7 +281,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         uuids = ','.join([str(course.uuid) for course in courses])
         url = '{root}?uuids={uuids}'.format(root=reverse('api:v1:course-list'), uuids=uuids)
 
-        with self.assertNumQueries(45):
+        with self.assertNumQueries(48):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -168,9 +168,9 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
     @factory.django.mute_signals(signals.post_save)
     @ddt.data(
         (list_path, CourseRunSearchDocumentSerializer,
-         ['results', 0, 'program_types', 0], ProgramStatus.Deleted, 3),
+         ['results', 0, 'program_types', 0], ProgramStatus.Deleted, 5),
         (list_path, CourseRunSearchDocumentSerializer,
-         ['results', 0, 'program_types', 0], ProgramStatus.Unpublished, 3),
+         ['results', 0, 'program_types', 0], ProgramStatus.Unpublished, 5),
         (detailed_path,
          CourseRunSearchModelSerializer,
          ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 21),
@@ -209,10 +209,10 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
 
     @ddt.data(
         ([{'title': 'Software Testing', 'excluded': True}], 3),
-        ([{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True}], 3),
-        ([{'title': 'Software Testing', 'excluded': False}, {'title': 'Software Testing 2', 'excluded': False}], 3),
+        ([{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True}], 7),
+        ([{'title': 'Software Testing', 'excluded': False}, {'title': 'Software Testing 2', 'excluded': False}], 7),
         ([{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True},
-          {'title': 'Software Testing 3', 'excluded': False}], 5),
+          {'title': 'Software Testing 3', 'excluded': False}], 9),
     )
     @ddt.unpack
     def test_excluded_course_run(self, course_runs, expected_queries):
@@ -460,7 +460,7 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
             self.serialize_program_search(other_program),
         ]
 
-    @ddt.data((True, 11), (False, 11))
+    @ddt.data((True, 16), (False, 16))
     @ddt.unpack
     def test_query_count_exclude_expired_course_run(self, exclude_expired, expected_queries):
         """ Verify that there is no query explosion when excluding expired course runs. """
@@ -518,7 +518,7 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         upcoming = CourseRunFactory(course__partner=self.partner, start=now + datetime.timedelta(weeks=4))
         course_run_keys = [course_run.key for course_run in [archived, current, starting_soon, upcoming]]
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(12):
             response = self.get_response({"ordering": ordering})
         assert response.status_code == 200
         assert response.data['objects']['count'] == 4

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -220,6 +220,7 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         'partner': {'field': 'partner.lower', 'lookups': [LOOKUP_FILTER_TERM]},
         'published': {'field': 'published', 'lookups': [LOOKUP_FILTER_TERM]},
         'skill_names': {'field': 'skill_names', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
+        'skills': {'field': 'skills', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
         'status': {'field': 'status', 'lookups': [LOOKUP_FILTER_TERM]},
         'start': {'field': 'start', 'lookups': [LOOKUP_QUERY_GT, LOOKUP_QUERY_GTE, LOOKUP_QUERY_LT, LOOKUP_QUERY_LTE]},
         'short_description': {

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django_elasticsearch_dsl import Index, fields
 from opaque_keys.edx.keys import CourseKey
-from taxonomy.utils import get_whitelisted_course_skills
+from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.course_metadata.models import Course
 
@@ -44,6 +44,10 @@ class CourseDocument(BaseCourseDocument):
     modified = fields.DateField()
     prerequisites = fields.KeywordField(multi=True)
     skill_names = fields.KeywordField(multi=True)
+    skills = fields.NestedField(properties={
+        'name': fields.TextField(),
+        'description': fields.TextField(),
+    })
     status = fields.KeywordField(multi=True)
     start = fields.DateField(multi=True)
 
@@ -96,6 +100,9 @@ class CourseDocument(BaseCourseDocument):
     def prepare_skill_names(self, obj):
         course_skills = get_whitelisted_course_skills(obj.key)
         return list(set(course_skill.skill.name for course_skill in course_skills))
+
+    def prepare_skills(self, obj):
+        return get_whitelisted_serialized_skills(obj.key)
 
     def prepare_status(self, obj):
         return [course_run.status for course_run in filter_visible_runs(obj.course_runs)]

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -3,7 +3,7 @@ import datetime
 import pytz
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
-from taxonomy.utils import get_whitelisted_course_skills
+from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.api import serializers as cd_serializers
 from course_discovery.apps.api.serializers import ContentTypeSerializer, CourseWithProgramsSerializer
@@ -25,6 +25,7 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
     course_runs = serializers.SerializerMethodField()
     seat_types = serializers.SerializerMethodField()
     skill_names = serializers.SerializerMethodField()
+    skills = serializers.SerializerMethodField()
     end_date = serializers.SerializerMethodField()
     course_ends = serializers.SerializerMethodField()
 
@@ -83,6 +84,9 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
         course_skills = get_whitelisted_course_skills(result.key)
         return list(set(course_skill.skill.name for course_skill in course_skills))
 
+    def get_skills(self, result):
+        return get_whitelisted_serialized_skills(result.key)
+
     def get_end_date(self, result):
         return self.handle_datetime_field(result.end_date)
 
@@ -122,6 +126,7 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
             'uuid',
             'seat_types',
             'skill_names',
+            'skills',
             'end_date',
             'course_ends',
             'subjects',

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
@@ -1,6 +1,6 @@
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
-from taxonomy.utils import get_whitelisted_course_skills
+from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.serializers import ContentTypeSerializer, CourseRunWithProgramsSerializer
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.serializers import BaseDjangoESDSLFacetSerializer
@@ -22,6 +22,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
     enrollment_start = serializers.SerializerMethodField()
     enrollment_end = serializers.SerializerMethodField()
     skill_names = serializers.SerializerMethodField()
+    skills = serializers.SerializerMethodField()
 
     def get_start(self, obj):
         return self.handle_datetime_field(obj.start)
@@ -38,6 +39,9 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
     def get_skill_names(self, result):
         course_skills = get_whitelisted_course_skills(result.course_key)
         return list(set(course_skill.skill.name for course_skill in course_skills))
+
+    def get_skills(self, result):
+        return get_whitelisted_serialized_skills(result.course_key)
 
     class Meta:
         """
@@ -75,6 +79,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
             'published',
             'seat_types',
             'skill_names',
+            'skills',
             'short_description',
             'staff_uuids',
             'start',

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -164,6 +164,7 @@ class SkillFactory(factory.django.DjangoModelFactory):
     info_url = FuzzyURL()
     type_id = FuzzyText()
     type_name = FuzzyText()
+    description = FuzzyText(length=300)
 
     class Meta:
         model = Skill

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -531,7 +531,7 @@ class ExternalCourseKeyDBTests(TestCase, ExternalCourseKeyTestMixin):
                 course_run.external_key = course_run_ca.external_key
                 course_run.save()
 
-        with self.assertNumQueries(FuzzyInt(34, 1)):
+        with self.assertNumQueries(FuzzyInt(36, 1)):
             course_run.external_key = 'some-safe-key'
             course_run.save()
 
@@ -554,7 +554,7 @@ class ExternalCourseKeyDBTests(TestCase, ExternalCourseKeyTestMixin):
                 course_run.external_key = course_run_ba.external_key
                 course_run.save()
 
-        with self.assertNumQueries(FuzzyInt(34, 1)):
+        with self.assertNumQueries(FuzzyInt(36, 1)):
             course_run.external_key = 'some-safe-key'
             course_run.save()
 
@@ -601,7 +601,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
                 )
 
     def test_nondraft_does_not_collide_with_draft(self):
-        with self.assertNumQueries(FuzzyInt(73, 1)):
+        with self.assertNumQueries(FuzzyInt(75, 1)):
             factories.CourseRunFactory(
                 course=self.course_1,
                 draft=False,
@@ -611,7 +611,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
             )
 
     def test_collision_does_not_include_drafts(self):
-        with self.assertNumQueries(FuzzyInt(73, 1)):
+        with self.assertNumQueries(FuzzyInt(75, 1)):
             course_run = factories.CourseRunFactory(
                 course=self.course_1,
                 draft=False,

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -580,7 +580,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.11.1
+taxonomy-connector==1.11.2
     # via -r requirements/base.in
 testfixtures==6.17.1
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -394,7 +394,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.11.1
+taxonomy-connector==1.11.2
     # via -r requirements/base.in
 unicode-slugify==0.1.3
     # via -r requirements/base.in


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/ENT-4158

This PR adds a new field called "skills" in `search/all` and course detail endpoint which returns an array of objects, holding skills belonging to a course alongwith their descriptions. 

Example:
<img width="692" alt="Screenshot 2021-05-26 at 1 51 27 PM" src="https://user-images.githubusercontent.com/55431213/119631776-a40a3100-be29-11eb-92f0-18afb8d05a32.png">



