### PR TITLE
fix: allow publisher to remove video from course

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -989,6 +989,21 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         self.assertDictEqual(response.data, self.serialize_course(course))
 
     @responses.activate
+    def test_remove_video_from_course(self):
+        url = reverse('api:v1:course-detail', kwargs={'key': self.course.uuid})
+        course_data = {
+            'video': {'src': ''},
+        }
+
+        assert self.course.video is not None
+
+        response = self.client.patch(url, course_data, format='json')
+        assert response.status_code == 200
+
+        course = Course.everything.get(uuid=self.course.uuid, draft=True)
+        assert course.video is None
+
+    @responses.activate
     def test_update_with_level_type(self):
         beginner = LevelTypeFactory()
         beginner.set_current_language('en')

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -343,11 +343,14 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             course.entitlements.exclude(mode__in=entitlement_types).delete()
             course.entitlements.set(entitlements)
 
-        # Save video if a new video source is provided
-        if (video_data and video_data.get('src') and
-           (not course.video or video_data.get('src') != course.video.src)):
-            video, __ = Video.objects.get_or_create(src=video_data['src'])
-            course.video = video
+        # Save video if a new video source is provided, also allow removing the video from course
+        if video_data:
+            video_url = video_data.get('src')
+            if not video_url and course.video:
+                course.video = None
+            elif video_url and (not course.video or video_url != course.video.src):
+                video, __ = Video.objects.get_or_create(src=video_data['src'])
+                course.video = video
 
         # Save image and convert to the correct format
         if image_data and isinstance(image_data, str) and image_data.startswith('data:image'):


### PR DESCRIPTION
Currently, there is no way in the Publisher to remove video links from a course. Now PCs and course teams can remove course about video from the course using Publisher.

DISCO-1736