### PR TITLE
chore: remove out of date comments for code that is no longer experimental

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1221,7 +1221,6 @@ class CourseWithProgramsSerializer(CourseSerializer):
         )
 
 
-# Experiment WS-1681: Course recommendations
 class CourseWithRecommendationsSerializer(DynamicFieldsMixin, TimestampModelSerializer):
     uuid = UUIDField(read_only=True, default=CreateOnlyDefault(uuid4))
     recommendations = serializers.SerializerMethodField()
@@ -1262,7 +1261,6 @@ class CourseRecommendationSerializer(MinimalCourseSerializer):
         model = Course
         fields = ('key', 'uuid', 'title', 'owners', 'image',
                   'short_description', 'type', 'url_slug', 'course_run_keys', 'marketing_url')
-# end experiment code
 
 
 class CatalogCourseSerializer(CourseSerializer):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2572,7 +2572,6 @@ class CollaboratorSerializerTests(TestCase):
         self.assertDictEqual(serializer.data, expected)
 
 
-# Experiment WS-1681: course recommendations
 class CourseRecommendationSerializerTests(MinimalCourseSerializerTests):
     serializer_class = CourseRecommendationSerializer
 
@@ -2656,4 +2655,3 @@ class CourseWithRecommendationSerializerTests(MinimalCourseSerializerTests):
             SeatFactory.create_batch(2, course_run=course_run)
         serializer = self.serializer_class(course_with_recs, context={'request': request, 'exclude_utm': 1})
         assert serializer.data['recommendations'][0]['marketing_url'] == recommended_course_0.marketing_url
-# end experiment code

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1576,10 +1576,8 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         response = self.client.patch(url, {'full_description': '<h1>Header</h1>'}, format='json')
         self.assertContains(response, 'Invalid HTML received: h1 tag is not allowed', status_code=400)
 
-    # Experiment WS-1681: course recommendations
     @responses.activate
     def test_recommendations(self):
         url = reverse('api:v1:course_recommendations-detail', kwargs={'key': self.course.key})
         response = self.client.get(url)
         assert response.status_code == 200
-    # end experiment code

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -500,7 +500,6 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         return super().retrieve(request, *args, **kwargs)
 
 
-# Experiment WS-1681: Course recommendations
 class CourseRecommendationViewSet(RetrieveModelMixin, viewsets.GenericViewSet):
     filter_backends = (DjangoFilterBackend, )
     lookup_field = 'key'

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1141,7 +1141,6 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
 
         return advertised_course_run
 
-    # Experiment WS-1681: Course recommendations
     def has_marketable_run(self):
         return any(run.is_marketable for run in self.course_runs.all())
 
@@ -1176,7 +1175,6 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
                 deduped.append(course)
                 seen.add(course)
         return deduped
-        # End Experiment WS-1681: Course recommendations
 
 
 class CourseEditor(TimeStampedModel):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2408,7 +2408,6 @@ class CourseUrlSlugHistoryTest(TestCase):
                            url_slug=slug_object.url_slug)]
 
 
-# Experiment WS-1681: Course recommendations
 class TestCourseRecommendations(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
We are productizing the course recommendations experiment, so this removes all comments saying the code is experimental