### PR TITLE
feat: Due to new version of django-cor-headers added two settings in …

### DIFF
--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -1,5 +1,7 @@
 # noinspection PyUnresolvedReferences
 from course_discovery.settings._debug_toolbar import *  # isort:skip
+from importlib_metadata import version
+
 from course_discovery.settings.production import *
 
 DEBUG = True
@@ -18,6 +20,16 @@ CORS_ORIGIN_WHITELIST = (
     'localhost:18450',  # frontend-app-support-tools
     'localhost:2000',   # frontend-app-learning
 )
+
+# values are already updated above with default values but in
+# case of new version `django_cors_headers` they will get override.
+if version('django_cors_headers') == '3.2.0':
+    CORS_ORIGIN_WHITELIST == (
+        'http://localhost:8734',  # frontend-app-learner-portal-enterprise
+        'http://localhost:18400',  # frontend-app-publisher
+        'http://localhost:18450',  # frontend-app-support-tools
+        'http://localhost:2000',  # frontend-app-learning
+    )
 
 ELASTICSEARCH_DSL['default']['hosts'] = 'edx.devstack.elasticsearch710:9200'
 

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -23,7 +23,8 @@ CORS_ORIGIN_WHITELIST = (
 
 # values are already updated above with default values but in
 # case of new version `django_cors_headers` they will get override.
-if version('django_cors_headers') == '3.2.0':
+cors_major_version = int(version('django_cors_headers').split('.')[0])
+if cors_major_version >= 3:
     CORS_ORIGIN_WHITELIST == (
         'http://localhost:8734',  # frontend-app-learner-portal-enterprise
         'http://localhost:18400',  # frontend-app-publisher

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -6,6 +6,7 @@ import certifi
 import memcache
 import MySQLdb
 import yaml
+from importlib_metadata import version
 
 from course_discovery.settings.base import *
 
@@ -36,6 +37,11 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
             vars()[key].update(value)
 
     vars().update(config_from_yaml)
+
+    # values are already updated above with default values but in
+    # case of new version they will get override.
+    if version('django_cors_headers') == '3.2.0' and vars().get('CORS_ORIGIN_WHITELIST_WITH_SCHEME'):
+        vars()['CORS_ORIGIN_WHITELIST'] = vars()['CORS_ORIGIN_WHITELIST_WITH_SCHEME']
 
     # Unpack media storage settings.
     # It's important we unpack here because of https://github.com/edx/configuration/pull/3307

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -40,7 +40,8 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
 
     # values are already updated above with default values but in
     # case of new version they will get override.
-    if version('django_cors_headers') == '3.2.0' and vars().get('CORS_ORIGIN_WHITELIST_WITH_SCHEME'):
+    cors_major_version = int(version('django_cors_headers').split('.')[0])
+    if cors_major_version >= 3 and vars().get('CORS_ORIGIN_WHITELIST_WITH_SCHEME'):
         vars()['CORS_ORIGIN_WHITELIST'] = vars()['CORS_ORIGIN_WHITELIST_WITH_SCHEME']
 
     # Unpack media storage settings.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -61,3 +61,4 @@ social-auth-app-django
 unicode-slugify
 xss-utils
 taxonomy-connector
+importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -40,3 +40,6 @@ algoliasearch<2.0.0
 
 # latest version causing issues in IDAs.
 django-webpack-loader<1.0.0
+
+# greater version need testing. It will require another PR.
+edx-drf-extensions<7.0.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -244,6 +244,7 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/base.in
 edx-auth-backends==3.3.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
 edx-ccx-keys==1.2.1
@@ -259,7 +260,10 @@ edx-django-utils==4.2.0
     #   edx-rest-api-client
     #   taxonomy-connector
 edx-drf-extensions==6.6.0
-    # via -r requirements/base.in
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-i18n-tools==0.7.0
     # via -r requirements/local.in
 edx-lint==1.6
@@ -277,7 +281,7 @@ edx-rest-api-client==5.4.0
     #   taxonomy-connector
 edx-sphinx-theme==3.0.0
     # via -r requirements/docs.in
-elasticsearch==7.13.4
+elasticsearch==7.14.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -293,7 +297,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==8.10.3
+faker==8.11.0
     # via factory-boy
 filelock==3.0.12
     # via
@@ -309,6 +313,8 @@ idna==3.2
     # via requests
 imagesize==1.2.0
     # via sphinx
+importlib-metadata==4.6.3
+    # via -r requirements/base.in
 iniconfig==1.1.1
     # via pytest
 isort==5.9.3
@@ -343,7 +349,7 @@ mock==4.0.3
     # via -r requirements/test.in
 mysqlclient==2.0.3
     # via -r requirements/test.in
-newrelic==6.6.0.162
+newrelic==6.8.0.163
     # via edx-django-utils
 oauthlib==3.1.1
     # via
@@ -495,7 +501,7 @@ requests==2.26.0
     #   sphinx
 requests-oauthlib==1.3.0
     # via social-auth-core
-responses==0.13.3
+responses==0.13.4
     # via
     #   -r requirements/test.in
     #   pytest-responses
@@ -549,10 +555,12 @@ snowballstemmer==2.1.0
     # via sphinx
 social-auth-app-django==4.0.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
 social-auth-core==4.0.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   edx-auth-backends
     #   social-auth-app-django
@@ -622,7 +630,7 @@ vine==1.3.0
     # via
     #   amqp
     #   celery
-virtualenv==20.7.0
+virtualenv==20.7.1
     # via tox
 websocket-client==0.59.0
     # via
@@ -632,6 +640,8 @@ wrapt==1.12.1
     # via astroid
 xss-utils==0.3.0
     # via -r requirements/base.in
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -12,7 +12,7 @@ pip-tools==6.2.0
     # via -r requirements/pip_tools.in
 tomli==1.2.1
     # via pep517
-wheel==0.36.2
+wheel==0.37.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -10,7 +10,7 @@ pep517==0.11.0
     # via pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip_tools.in
-tomli==1.2.0
+tomli==1.2.1
     # via pep517
 wheel==0.36.2
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -22,9 +22,9 @@ beautifulsoup4==4.9.3
     # via -r requirements/base.in
 billiard==3.6.4.0
     # via celery
-boto3==1.18.12
+boto3==1.18.17
     # via django-ses
-botocore==1.21.12
+botocore==1.21.17
     # via
     #   boto3
     #   s3transfer
@@ -141,7 +141,7 @@ django-parler==2.2
     # via -r requirements/base.in
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
-django-ses==2.2.0
+django-ses==2.2.1
     # via -r requirements/production.in
 django-simple-history==3.0.0
     # via -r requirements/base.in
@@ -202,6 +202,7 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/base.in
 edx-auth-backends==3.3.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
 edx-ccx-keys==1.2.1
@@ -217,7 +218,10 @@ edx-django-utils==4.2.0
     #   edx-rest-api-client
     #   taxonomy-connector
 edx-drf-extensions==6.6.0
-    # via -r requirements/base.in
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via
     #   -r requirements/base.in
@@ -227,7 +231,7 @@ edx-rest-api-client==5.4.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
-elasticsearch==7.13.4
+elasticsearch==7.14.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -243,9 +247,9 @@ future==0.18.2
     # via
     #   django-ses
     #   pyjwkest
-gevent==21.1.2
+gevent==21.8.0
     # via -r requirements/production.in
-greenlet==1.1.0
+greenlet==1.1.1
     # via gevent
 gunicorn==20.1.0
     # via -r requirements/production.in
@@ -253,6 +257,8 @@ html2text==2020.1.16
     # via -r requirements/base.in
 idna==3.2
     # via requests
+importlib-metadata==4.6.3
+    # via -r requirements/base.in
 itypes==1.2.0
     # via coreapi
 jinja2==3.0.1
@@ -275,7 +281,7 @@ markupsafe==2.0.1
     # via jinja2
 mysqlclient==2.0.3
     # via -r requirements/production.in
-newrelic==6.6.0.162
+newrelic==6.8.0.163
     # via
     #   -r requirements/production.in
     #   edx-django-utils
@@ -386,10 +392,12 @@ slumber==0.7.1
     # via edx-rest-api-client
 social-auth-app-django==4.0.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
 social-auth-core==4.0.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   edx-auth-backends
     #   social-auth-app-django
@@ -422,6 +430,8 @@ vine==1.3.0
     #   celery
 xss-utils==0.3.0
     # via -r requirements/base.in
+zipp==3.5.0
+    # via importlib-metadata
 zope.event==4.5.0
     # via gevent
 zope.interface==5.4.0


### PR DESCRIPTION
First Phase
refactor: Due to new version of django-cor-headers added two settings in internal repo and now picking as per installed version.

Internal Repo PR
https://github.com/edx/edx-internal/pull/3434/files


---------------

Second Phase
After merging and deploy above PRs merge this 
https://github.com/edx/course-discovery/pull/2783

---------------
After all above steps we can renamed the settings name
 `DISCOVERY_CORS_ORIGIN_WHITELIST_NEW` to `DISCOVERY_CORS_ORIGIN_WHITELIST` and maintained only 1 list