### PR TITLE
feat: add taxonomy jobs data in /search/all and course detail apis

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -21,7 +21,7 @@ from rest_framework.fields import CreateOnlyDefault, UUIDField
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.relations import ManyRelatedField
 from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
-from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_course_jobs, get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.fields import (
     HtmlField, ImageField, SlugRelatedFieldWithReadSerializer, SlugRelatedTranslatableField, StdImageSerializerField
@@ -1077,6 +1077,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
                                                        read_serializer=CollaboratorSerializer())
     skill_names = serializers.SerializerMethodField()
     skills = serializers.SerializerMethodField()
+    jobs = serializers.SerializerMethodField()
 
     @classmethod
     def prefetch_queryset(cls, partner, queryset=None, course_runs=None):  # pylint: disable=arguments-differ
@@ -1121,7 +1122,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
             'extra_description', 'additional_information', 'faq', 'learner_testimonials',
             'enrollment_count', 'recent_enrollment_count', 'topics', 'partner', 'key_for_reruns', 'url_slug',
             'url_slug_history', 'url_redirects', 'course_run_statuses', 'editors', 'collaborators', 'skill_names',
-            'skills',
+            'skills', 'jobs',
         )
         extra_kwargs = {
             'partner': {'write_only': True}
@@ -1148,6 +1149,9 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
 
     def get_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.key)
+
+    def get_jobs(self, obj):
+        return get_course_jobs(obj.key)
 
     def create(self, validated_data):
         return Course.objects.create(**validated_data)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -201,6 +201,7 @@ class CourseSerializerTests(MinimalCourseSerializerTests):
             'collaborators': [],
             'skill_names': [course_skill.skill.name],
             'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
+            'jobs': [],
         })
 
         return expected
@@ -2031,6 +2032,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
             'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
+            'jobs': [],
             'course_ends': course.course_ends,
             'end_date': serialize_datetime(course.end_date),
             'organizations': [
@@ -2106,6 +2108,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
             'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
+            'jobs': [],
             'course_ends': course.course_ends,
             'end_date': serialize_datetime(course.end_date),
             'organizations': [
@@ -2161,6 +2164,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             'seat_types': [seat.type.slug],
             'skill_names': [course_skill.skill.name],
             'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
+            'jobs': [],
             'course_ends': course.course_ends,
             'end_date': serialize_datetime(course.end_date),
             'organizations': [
@@ -2248,6 +2252,7 @@ class CourseRunSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase):
             'seat_types': [seat.slug for seat in course_run.seat_types],
             'skill_names': [course_skill.skill.name],
             'skills': [{'name': course_skill.skill.name, 'description': course_skill.skill.description}],
+            'jobs': [],
             'image_url': course_run.image_url,
             'type': course_run.type_legacy,
             'level_type': course_run.level_type.name,

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -261,7 +261,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
 
         # Known to be flaky prior to the addition of tearDown()
         # and logout() code which is the same number of additional queries
-        with self.assertNumQueries(48):
+        with self.assertNumQueries(51):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -271,7 +271,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         keys = ','.join([course.key for course in courses])
         url = '{root}?keys={keys}'.format(root=reverse('api:v1:course-list'), keys=keys)
 
-        with self.assertNumQueries(46):
+        with self.assertNumQueries(51):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -281,7 +281,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         uuids = ','.join([str(course.uuid) for course in courses])
         url = '{root}?uuids={uuids}'.format(root=reverse('api:v1:course-list'), uuids=uuids)
 
-        with self.assertNumQueries(48):
+        with self.assertNumQueries(51):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -221,6 +221,7 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         'published': {'field': 'published', 'lookups': [LOOKUP_FILTER_TERM]},
         'skill_names': {'field': 'skill_names', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
         'skills': {'field': 'skills', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
+        'jobs': {'field': 'jobs', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
         'status': {'field': 'status', 'lookups': [LOOKUP_FILTER_TERM]},
         'start': {'field': 'start', 'lookups': [LOOKUP_QUERY_GT, LOOKUP_QUERY_GTE, LOOKUP_QUERY_LT, LOOKUP_QUERY_LTE]},
         'short_description': {

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django_elasticsearch_dsl import Index, fields
 from opaque_keys.edx.keys import CourseKey
-from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_course_jobs, get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.course_metadata.models import Course
 
@@ -48,6 +48,7 @@ class CourseDocument(BaseCourseDocument):
         'name': fields.TextField(),
         'description': fields.TextField(),
     })
+    jobs = fields.KeywordField(multi=True)
     status = fields.KeywordField(multi=True)
     start = fields.DateField(multi=True)
 
@@ -103,6 +104,9 @@ class CourseDocument(BaseCourseDocument):
 
     def prepare_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.key)
+
+    def prepare_jobs(self, obj):
+        return get_course_jobs(obj.key)
 
     def prepare_status(self, obj):
         return [course_run.status for course_run in filter_visible_runs(obj.course_runs)]

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django_elasticsearch_dsl import Index, fields
 from opaque_keys.edx.keys import CourseKey
-from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_course_jobs, get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.models import CourseRun
@@ -60,6 +60,7 @@ class CourseRunDocument(BaseCourseDocument):
         'name': fields.TextField(),
         'description': fields.TextField(),
     })
+    jobs = fields.KeywordField(multi=True)
     status = fields.KeywordField()
     start = fields.DateField()
     slug = fields.TextField()
@@ -122,6 +123,9 @@ class CourseRunDocument(BaseCourseDocument):
 
     def prepare_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.course.key)
+
+    def prepare_jobs(self, obj):
+        return get_course_jobs(obj.key)
 
     def prepare_staff_uuids(self, obj):
         return [str(staff.uuid) for staff in obj.staff.all()]

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -3,7 +3,7 @@ import datetime
 import pytz
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
-from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_course_jobs, get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.api import serializers as cd_serializers
 from course_discovery.apps.api.serializers import ContentTypeSerializer, CourseWithProgramsSerializer
@@ -26,6 +26,7 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
     seat_types = serializers.SerializerMethodField()
     skill_names = serializers.SerializerMethodField()
     skills = serializers.SerializerMethodField()
+    jobs = serializers.SerializerMethodField()
     end_date = serializers.SerializerMethodField()
     course_ends = serializers.SerializerMethodField()
 
@@ -87,6 +88,9 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
     def get_skills(self, result):
         return get_whitelisted_serialized_skills(result.key)
 
+    def get_jobs(self, result):
+        return get_course_jobs(result.key)
+
     def get_end_date(self, result):
         return self.handle_datetime_field(result.end_date)
 
@@ -127,6 +131,7 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
             'seat_types',
             'skill_names',
             'skills',
+            'jobs',
             'end_date',
             'course_ends',
             'subjects',

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
@@ -1,6 +1,6 @@
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
-from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_course_jobs, get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.serializers import ContentTypeSerializer, CourseRunWithProgramsSerializer
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.serializers import BaseDjangoESDSLFacetSerializer
@@ -23,6 +23,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
     enrollment_end = serializers.SerializerMethodField()
     skill_names = serializers.SerializerMethodField()
     skills = serializers.SerializerMethodField()
+    jobs = serializers.SerializerMethodField()
 
     def get_start(self, obj):
         return self.handle_datetime_field(obj.start)
@@ -42,6 +43,9 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
 
     def get_skills(self, result):
         return get_whitelisted_serialized_skills(result.course_key)
+
+    def get_jobs(self, result):
+        return get_course_jobs(result.key)
 
     class Meta:
         """
@@ -80,6 +84,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
             'seat_types',
             'skill_names',
             'skills',
+            'jobs',
             'short_description',
             'staff_uuids',
             'start',

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -601,7 +601,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
                 )
 
     def test_nondraft_does_not_collide_with_draft(self):
-        with self.assertNumQueries(FuzzyInt(75, 1)):
+        with self.assertNumQueries(FuzzyInt(77, 1)):
             factories.CourseRunFactory(
                 course=self.course_1,
                 draft=False,
@@ -611,7 +611,7 @@ class ExternalCourseKeyDraftTests(ExternalCourseKeyTestDataMixin, TestCase):
             )
 
     def test_collision_does_not_include_drafts(self):
-        with self.assertNumQueries(FuzzyInt(75, 1)):
+        with self.assertNumQueries(FuzzyInt(77, 1)):
             course_run = factories.CourseRunFactory(
                 course=self.course_1,
                 draft=False,

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -583,7 +583,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.12.0
+taxonomy-connector==1.12.2
     # via -r requirements/base.in
 testfixtures==6.18.0
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -401,7 +401,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.12.0
+taxonomy-connector==1.12.2
     # via -r requirements/base.in
 unicode-slugify==0.1.3
     # via -r requirements/base.in


### PR DESCRIPTION
**JIRA:** https://openedx.atlassian.net/browse/ENT-4583

**Description:** This will add `jobs` data from taxonomy in `/search/all` and `course detail` endpoint.