### PR TITLE
build: reverting django-cors-headers to older version.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,7 +13,7 @@ elasticsearch-dsl>=7.2,<8.0
 transifex-client<0.13
 
 # FIXME: 3+ require schemes in CORS_ORIGIN_WHITELIST URLs - remember to update configuration when you remove this
-django-cors-headers==3.2.0
+django-cors-headers<3
 
 # sphinx has dropped support for python 3.5, latest version requires at least python3.6
 # see https://www.sphinx-doc.org/en/master/intro.html#prerequisites

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -136,7 +136,7 @@ django-compressor==2.4.1
     #   django-libsass
 django-contrib-comments==2.1.0
     # via -r requirements/base.in
-django-cors-headers==3.2.0
+django-cors-headers==2.5.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -283,6 +283,7 @@ edx-sphinx-theme==3.0.0
     # via -r requirements/docs.in
 elasticsearch==7.13.4
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-elasticsearch-dsl-drf

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -106,7 +106,7 @@ django-compressor==2.4.1
     #   django-libsass
 django-contrib-comments==2.1.0
     # via -r requirements/base.in
-django-cors-headers==3.2.0
+django-cors-headers==2.5.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -233,6 +233,7 @@ edx-rest-api-client==5.4.0
     #   taxonomy-connector
 elasticsearch==7.13.4
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-elasticsearch-dsl-drf


### PR DESCRIPTION

Automatic revere PR is not working. I have made this manually.

It will revert this PR.
https://github.com/edx/course-discovery/pull/2783/files