### PR TITLE
build: upgrading django autocomplete light

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -21,8 +21,8 @@ django-cors-headers==3.2.0
 # see https://www.sphinx-doc.org/en/master/intro.html#prerequisites
 sphinx==2.4.4
 
-# FIXME: dal 3.5 requires you to include jquery yourself on the admin page -- needs a proper fix
-django-autocomplete-light<3.5
+# FIXME: dal 3.5.1 requires you to include jquery yourself on the admin page -- needs a proper fix
+django-autocomplete-light==3.5.0
 
 celery<5.0
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -125,7 +125,7 @@ django-admin-sortable2==1.0
     # via -r requirements/base.in
 django-appconf==1.0.4
     # via django-compressor
-django-autocomplete-light==3.4.1
+django-autocomplete-light==3.5.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -516,6 +516,7 @@ simplejson==3.17.5
 six==1.16.0
     # via
     #   bcrypt
+    #   django-autocomplete-light
     #   django-choices
     #   django-compressor
     #   django-elasticsearch-dsl

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -95,7 +95,7 @@ django-admin-sortable2==1.0
     # via -r requirements/base.in
 django-appconf==1.0.4
     # via django-compressor
-django-autocomplete-light==3.4.1
+django-autocomplete-light==3.5.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -366,6 +366,7 @@ simplejson==3.17.5
     # via django-rest-swagger
 six==1.16.0
     # via
+    #   django-autocomplete-light
     #   django-choices
     #   django-compressor
     #   django-elasticsearch-dsl


### PR DESCRIPTION
upgrading `django-autocomplete-light==3.5.0`
This is required to move on django3.2 upgrade process.

https://github.com/yourlabs/django-autocomplete-light/blob/master/CHANGELOG#L61

https://openedx.atlassian.net/browse/BOM-1905


Django30 error msg 
```
    import_module('%s.%s' % (app_config.name, module_to_search))
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/admin.py", line 2, in <module>
    from dal import autocomplete
  File "/edx/app/discovery/discovery/.tox/py38-django30/lib/python3.8/site-packages/dal/autocomplete.py", line 23, in <module>
    from .views import ViewMixin
  File "/edx/app/discovery/discovery/.tox/py38-django30/lib/python3.8/site-packages/dal/views.py", line 10, in <module>
    from django.utils import six
ImportError: cannot import name 'six' from 'django.utils' (/edx/app/discovery/discovery/.tox/py38-django30/lib/python3.8/site-packages/django/utils/__init__.py)
make: *** [Makefile:19: static] Error 1
```

Sandbox https://discovery-awais786.sandbox.edx.org/
I have tested it and it seems fine.