### PR TITLE
chore: log warning for SF resourcse not found

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/tests/test_update_course_run_in_salesforce.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_update_course_run_in_salesforce.py
@@ -3,9 +3,12 @@ from unittest import mock
 from django.contrib.sites.models import Site
 from django.core.management import call_command
 from django.test import TestCase
+from simple_salesforce.exceptions import SalesforceResourceNotFound
+from testfixtures import LogCapture
 
 from course_discovery.apps.core.models import Partner
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
+from course_discovery.apps.course_metadata.management.commands.update_course_run_in_salesforce import logger
 from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseRunType
 
 
@@ -21,10 +24,11 @@ class TestUpdateCourseRunInSalesforce(TestCase):
             short_code='edx'
         )
         self.salesforce_util_path = 'course_discovery.apps.course_metadata.utils.SalesforceUtil'
+        self.run_key = 'course-v1:edX+DemoX+Demo_Course'
 
         course = Course.objects.create(partner=self.partner, key='test-org-course', title='Title')
         course_type = CourseRunType.objects.get(slug=CourseRunType.AUDIT)
-        CourseRun.objects.create(course=course, key='course-v1:edX+DemoX+Demo_Course', type=course_type,
+        CourseRun.objects.create(course=course, key=self.run_key, type=course_type,
                                  status=CourseRunStatus.Published, salesforce_id='SomeSalesforceId')
 
     def test_update_course_run(self):
@@ -33,3 +37,18 @@ class TestUpdateCourseRunInSalesforce(TestCase):
         with mock.patch(self.salesforce_util_path) as mock_salesforce_util:
             call_command('update_course_run_in_salesforce')
             mock_salesforce_util().update_course_run.assert_called()
+
+    def test_update_course_run_resource_not_found(self):
+        """Test Cases: update course runs logs resource not found error"""
+
+        with mock.patch(self.salesforce_util_path) as mock_salesforce_util:
+            mock_salesforce_util().update_course_run.side_effect = SalesforceResourceNotFound('/test', 404, 'test', {})
+            with LogCapture(logger.name) as log_capture:
+                call_command('update_course_run_in_salesforce')
+                log_capture.check(
+                    (
+                        logger.name,
+                        'WARNING',
+                        'Entity deleted from SalesForce [{}]'.format(self.run_key),
+                    )
+                )

--- a/course_discovery/apps/course_metadata/management/commands/update_course_run_in_salesforce.py
+++ b/course_discovery/apps/course_metadata/management/commands/update_course_run_in_salesforce.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.core.management import BaseCommand, CommandError
+from simple_salesforce.exceptions import SalesforceResourceNotFound
 
 from course_discovery.apps.core.models import Partner
 from course_discovery.apps.course_metadata.models import CourseRun
@@ -24,6 +25,8 @@ class Command(BaseCommand):
                     try:
                         util.update_course_run(course_run)
                         logger.info('Successfully synced the salesforce {key}'.format(key=course_run.key))
+                    except SalesforceResourceNotFound:
+                        logger.warning('Entity deleted from SalesForce [%s]', course_run.key)
                     except Exception:  # pylint: disable=broad-except
                         logger.exception('Failed to sync data for course [%s]', course_run.key)
                         failed_course_runs.append(course_run.key)


### PR DESCRIPTION
log warning for SF resourcse not found instead of failing the command.