### PR TITLE
fix: After django-cor-headers==3.2.0

### DIFF
--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -1,6 +1,5 @@
 # noinspection PyUnresolvedReferences
 from course_discovery.settings._debug_toolbar import *  # isort:skip
-from importlib_metadata import version
 
 from course_discovery.settings.production import *
 
@@ -15,22 +14,11 @@ LOGGING['handlers']['local'] = {
 INTERNAL_IPS = ('127.0.0.1',)
 
 CORS_ORIGIN_WHITELIST = (
-    'localhost:8734',   # frontend-app-learner-portal-enterprise
-    'localhost:18400',  # frontend-app-publisher
-    'localhost:18450',  # frontend-app-support-tools
-    'localhost:2000',   # frontend-app-learning
+    'http://localhost:8734',  # frontend-app-learner-portal-enterprise
+    'http://localhost:18400',  # frontend-app-publisher
+    'http://localhost:18450',  # frontend-app-support-tools
+    'http://localhost:2000',  # frontend-app-learning
 )
-
-# values are already updated above with default values but in
-# case of new version `django_cors_headers` they will get override.
-cors_major_version = int(version('django_cors_headers').split('.')[0])
-if cors_major_version >= 3:
-    CORS_ORIGIN_WHITELIST = (
-        'http://localhost:8734',  # frontend-app-learner-portal-enterprise
-        'http://localhost:18400',  # frontend-app-publisher
-        'http://localhost:18450',  # frontend-app-support-tools
-        'http://localhost:2000',  # frontend-app-learning
-    )
 
 ELASTICSEARCH_DSL['default']['hosts'] = 'edx.devstack.elasticsearch710:9200'
 

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -6,7 +6,6 @@ import certifi
 import memcache
 import MySQLdb
 import yaml
-from importlib_metadata import version
 
 from course_discovery.settings.base import *
 
@@ -37,12 +36,6 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
             vars()[key].update(value)
 
     vars().update(config_from_yaml)
-
-    # values are already updated above with default values but in
-    # case of new version they will get override.
-    cors_major_version = int(version('django_cors_headers').split('.')[0])
-    if cors_major_version >= 3 and vars().get('CORS_ORIGIN_WHITELIST_WITH_SCHEME'):
-        vars()['CORS_ORIGIN_WHITELIST'] = vars()['CORS_ORIGIN_WHITELIST_WITH_SCHEME']
 
     # Unpack media storage settings.
     # It's important we unpack here because of https://github.com/edx/configuration/pull/3307


### PR DESCRIPTION
After django-cor-headers==3.2.0 this condition is not require. Configurations already updated and merged.

`CORS_ORIGIN_WHITELIST_WITH_SCHEME` content moved into `CORS_ORIGIN_WHITELIST`
https://github.com/edx/edx-internal/pull/5362/files

In last PR will remove the `CORS_ORIGIN_WHITELIST_WITH_SCHEME` from edx-internal repo