### PR TITLE
fix: django.utils.http.limited_parse_qsl() is removed.

### DIFF
--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import math
-from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit
+from urllib.parse import parse_qsl, urlencode, urljoin
 
 from django.db.models.fields.related import ManyToManyField
 from django.utils.translation import ugettext as _

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -1,10 +1,9 @@
 import functools
 import logging
 import math
-from urllib.parse import urlencode, urljoin
+from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit
 
 from django.db.models.fields.related import ManyToManyField
-from django.utils.http import limited_parse_qsl
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import HTTPError
@@ -76,7 +75,7 @@ def update_query_params_with_body_data(func_to_decorate):
         encoded_data = urlencode(_data, True)
         _mutable = request.query_params._mutable  # pylint: disable=protected-access
         request.query_params._mutable = True  # pylint: disable=protected-access
-        for key, value in limited_parse_qsl(encoded_data):
+        for key, value in parse_qsl(encoded_data):
             request.query_params.appendlist(key, value)
         request.query_params._mutable = _mutable  # pylint: disable=protected-access
 


### PR DESCRIPTION
Adding new compatible method.
```
The undocumented django.utils.http.limited_parse_qsl() function is removed. 
Please use urllib.parse.parse_qsl() instead.
```

https://openedx.atlassian.net/browse/BOM-2644

https://docs.djangoproject.com/en/3.2/releases/3.2/#miscellaneous