### PR TITLE
WS-2162: chore: taxonomy-connector version upgrade to 1.14.2

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -35,7 +35,7 @@ backports.entry-points-selectable==1.1.0
     # via virtualenv
 bcrypt==3.2.0
     # via paramiko
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
     # via -r requirements/base.in
 billiard==3.6.4.0
     # via celery
@@ -70,7 +70,7 @@ coverage==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==3.4.7
+cryptography==3.4.8
     # via
     #   authlib
     #   paramiko
@@ -154,7 +154,7 @@ django-elasticsearch-dsl==7.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-elasticsearch-dsl-drf
-django-elasticsearch-dsl-drf==0.22.1
+django-elasticsearch-dsl-drf==0.22.2
     # via -r requirements/base.in
 django-extensions==3.1.3
     # via -r requirements/base.in
@@ -168,7 +168,7 @@ django-libsass==0.9
     # via -r requirements/base.in
 django-model-utils==4.1.1
     # via taxonomy-connector
-django-nine==0.2.4
+django-nine==0.2.5
     # via django-elasticsearch-dsl-drf
 django-object-actions==3.0.2
     # via -r requirements/base.in
@@ -221,7 +221,7 @@ djangorestframework-csv==2.1.1
     # via -r requirements/base.in
 djangorestframework-xml==2.0.0
     # via -r requirements/base.in
-docker[ssh]==5.0.0
+docker[ssh]==5.0.2
     # via docker-compose
 docker-compose==1.29.2
     # via -r requirements/local.in
@@ -251,7 +251,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.in
 edx-django-sites-extensions==3.1.0
     # via -r requirements/base.in
-edx-django-utils==4.3.0
+edx-django-utils==4.4.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -293,7 +293,7 @@ execnet==1.9.0
     # via pytest-xdist
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==8.12.0
+faker==8.12.1
     # via factory-boy
 filelock==3.0.12
     # via
@@ -309,7 +309,7 @@ idna==3.2
     # via requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.6.4
+importlib-metadata==4.8.1
     # via -r requirements/base.in
 iniconfig==1.1.1
     # via pytest
@@ -345,7 +345,7 @@ mock==4.0.3
     # via -r requirements/test.in
 mysqlclient==2.0.3
     # via -r requirements/test.in
-newrelic==6.8.0.163
+newrelic==6.8.1.164
     # via edx-django-utils
 oauthlib==3.1.1
     # via
@@ -364,13 +364,13 @@ path==16.2.0
     # via edx-i18n-tools
 pbr==5.6.0
     # via stevedore
-pillow==8.3.1
+pillow==8.3.2
     # via
     #   -r requirements/base.in
     #   django-stdimage
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via
     #   pytest
     #   tox
@@ -424,7 +424,7 @@ pyparsing==2.4.7
     # via packaging
 pyrsistent==0.18.0
     # via jsonschema
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -585,7 +585,7 @@ stevedore==3.4.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.14.1
+taxonomy-connector==1.14.2
     # via -r requirements/base.in
 testfixtures==6.18.1
     # via -r requirements/test.in
@@ -609,7 +609,7 @@ unicode-slugify==0.1.3
     # via -r requirements/base.in
 unicodecsv==0.14.1
     # via djangorestframework-csv
-unidecode==1.2.0
+unidecode==1.3.0
     # via unicode-slugify
 uritemplate==3.0.1
     # via coreapi

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -19,13 +19,13 @@ authlib==0.15.4
     # via simple-salesforce
 backoff==1.11.1
     # via -r requirements/base.in
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
     # via -r requirements/base.in
 billiard==3.6.4.0
     # via celery
-boto3==1.18.27
+boto3==1.18.37
     # via django-ses
-botocore==1.21.27
+botocore==1.21.37
     # via
     #   boto3
     #   s3transfer
@@ -48,7 +48,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==3.4.7
+cryptography==3.4.8
     # via
     #   authlib
     #   pyjwt
@@ -120,7 +120,7 @@ django-elasticsearch-dsl==7.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-elasticsearch-dsl-drf
-django-elasticsearch-dsl-drf==0.22.1
+django-elasticsearch-dsl-drf==0.22.2
     # via -r requirements/base.in
 django-extensions==3.1.3
     # via -r requirements/base.in
@@ -134,7 +134,7 @@ django-libsass==0.9
     # via -r requirements/base.in
 django-model-utils==4.1.1
     # via taxonomy-connector
-django-nine==0.2.4
+django-nine==0.2.5
     # via django-elasticsearch-dsl-drf
 django-object-actions==3.0.2
     # via -r requirements/base.in
@@ -209,7 +209,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.in
 edx-django-sites-extensions==3.1.0
     # via -r requirements/base.in
-edx-django-utils==4.3.0
+edx-django-utils==4.4.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -253,7 +253,7 @@ html2text==2020.1.16
     # via -r requirements/base.in
 idna==3.2
     # via requests
-importlib-metadata==4.6.4
+importlib-metadata==4.8.1
     # via -r requirements/base.in
 itypes==1.2.0
     # via coreapi
@@ -277,7 +277,7 @@ markupsafe==2.0.1
     # via jinja2
 mysqlclient==2.0.3
     # via -r requirements/production.in
-newrelic==6.8.0.163
+newrelic==6.8.1.164
     # via
     #   -r requirements/production.in
     #   edx-django-utils
@@ -289,7 +289,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 pbr==5.6.0
     # via stevedore
-pillow==8.3.1
+pillow==8.3.2
     # via
     #   -r requirements/base.in
     #   django-stdimage
@@ -403,13 +403,13 @@ stevedore==3.4.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.14.1
+taxonomy-connector==1.14.2
     # via -r requirements/base.in
 unicode-slugify==0.1.3
     # via -r requirements/base.in
 unicodecsv==0.14.1
     # via djangorestframework-csv
-unidecode==1.2.0
+unidecode==1.3.0
     # via unicode-slugify
 uritemplate==3.0.1
     # via coreapi


### PR DESCRIPTION
The new version of the taxonomy-connector [these](https://github.com/edx/taxonomy-connector/pull/70/files) changes.