### PR TITLE
fix: bug with how translated fields are loaded from fixture

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -271,7 +271,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         keys = ','.join([course.key for course in courses])
         url = '{root}?keys={keys}'.format(root=reverse('api:v1:course-list'), keys=keys)
 
-        with self.assertNumQueries(46):
+        with self.assertNumQueries(49):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_load_program_fixture.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_load_program_fixture.py
@@ -47,15 +47,19 @@ class TestLoadProgramFixture(TestCase):
         self.seat_type_verified = SeatTypeFactory(name='Verified', slug='verified')
         self.program_type_masters = ProgramTypeFactory(
             name='Masters',
+            name_t='Masters',
             slug='masters',
             applicable_seat_types=[self.seat_type_verified]
         )
+        self.program_type_masters_translation = self.program_type_masters.translations.all()[0]
 
         self.program_type_mm = ProgramTypeFactory(
             name='MicroMasters',
+            name_t='MicroMasters',
             slug='micromasters',
             applicable_seat_types=[self.seat_type_verified]
         )
+        self.program_type_mm_translation = self.program_type_mm.translations.all()[0]
 
         self.course = CourseFactory(partner=self.partner, authoring_organizations=[self.organization])
         self.course_run = CourseRunFactory(course=self.course)
@@ -112,22 +116,6 @@ class TestLoadProgramFixture(TestCase):
             '--client-secret', 'bar',
         )
 
-    def _set_up_masters_program_type(self):
-        """
-        Set DB to have a conflicting program type on load.
-        """
-        seat_type = SeatTypeFactory(
-            name='Something',
-            slug='something',
-        )
-        existing_program_type = ProgramTypeFactory(
-            name='Masters',
-            name_t='Masters',
-            slug='masters',
-            applicable_seat_types=[seat_type]
-        )
-        return existing_program_type
-
     def reset_db_state(self):
         Partner.objects.all().exclude(short_code='edx').delete()
         SeatType.objects.all().delete()
@@ -145,7 +133,9 @@ class TestLoadProgramFixture(TestCase):
 
         fixture = json_serializer.Serializer().serialize([
             self.program_type_masters,
+            self.program_type_masters_translation,
             self.program_type_mm,
+            self.program_type_mm_translation,
             self.organization,
             self.seat_type_verified,
             self.program,
@@ -201,91 +191,6 @@ class TestLoadProgramFixture(TestCase):
         assert stored_course_run.key == self.course_run.key
 
     @responses.activate
-    def test_update_existing_program_type(self):
-
-        fixture = json_serializer.Serializer().serialize([
-            self.organization,
-            self.seat_type_verified,
-            self.program_type_masters,
-            self.program,
-        ])
-        self._mock_fixture_response(fixture)
-        self.reset_db_state()
-
-        existing_program_type = self._set_up_masters_program_type()
-
-        self._call_load_program_fixture([str(self.program.uuid)])
-
-        stored_program = Program.objects.get(uuid=self.program.uuid)
-
-        # assert existing DB value is used
-        stored_program_type = stored_program.type
-        assert stored_program_type == existing_program_type
-
-        # assert existing DB value is updated to match fixture
-        stored_seat_types = list(stored_program_type.applicable_seat_types.all())
-        assert len(stored_seat_types) == 1
-        assert stored_seat_types[0].name == self.seat_type_verified.name
-
-    @responses.activate
-    def test_remapping_courserun_programtype(self):
-        """
-        Tests whether the remapping of program types works for the course run field that points to them
-        """
-        self.course_run.expected_program_type = self.program_type_masters
-        self.course_run.save()
-        fixture = json_serializer.Serializer().serialize([
-            self.program_type_masters,
-            self.program_type_mm,
-            self.organization,
-            self.seat_type_verified,
-            self.program,
-            self.program_mm,
-            self.curriculum_program_membership,
-            self.curriculum_course_membership,
-            self.curriculum,
-            self.course,
-            self.course_mm,
-            self.course_run,
-        ])
-        self._mock_fixture_response(fixture)
-        self.reset_db_state()
-
-        existing_program_type = self._set_up_masters_program_type()
-
-        self._call_load_program_fixture([str(self.program.uuid)])
-
-        stored_courserun = CourseRun.objects.get(key=self.course_run.key)
-        stored_program_type = stored_courserun.expected_program_type
-
-        assert existing_program_type == stored_program_type
-
-    @responses.activate
-    def test_existing_seat_types(self):
-
-        fixture = json_serializer.Serializer().serialize([
-            self.organization,
-            self.seat_type_verified,
-            self.program_type_masters,
-            self.program,
-        ])
-        self._mock_fixture_response(fixture)
-        self.reset_db_state()
-
-        # create existing verified seat with different pk than fixture and
-        # a second seat type with the same pk but different values
-        new_pk = self.seat_type_verified.id + 1
-        SeatType.objects.create(id=new_pk, name='Verified', slug='verified')
-        SeatType.objects.create(id=self.seat_type_verified.id, name='Test', slug='test')
-        self._call_load_program_fixture([str(self.program.uuid)])
-
-        stored_program = Program.objects.get(uuid=self.program.uuid)
-        stored_seat_type = stored_program.type.applicable_seat_types.first()
-
-        assert stored_seat_type.id == new_pk
-        assert stored_seat_type.name == self.seat_type_verified.name
-
-    @responses.activate
     def test_fail_on_save_error(self):
 
         fixture = json_serializer.Serializer().serialize([
@@ -306,31 +211,12 @@ class TestLoadProgramFixture(TestCase):
         assert re.match(expected_msg, str(err.value))
 
     @responses.activate
-    def test_fail_on_constraint_error(self):
-
-        # duplicate programs should successfully save but fail final constraint check
-        fixture = json_serializer.Serializer().serialize([
-            self.program,
-            self.program,
-            self.seat_type_verified,
-            self.program_type_masters,
-        ])
-        self._mock_fixture_response(fixture)
-        self.reset_db_state()
-
-        with pytest.raises(IntegrityError) as err:
-            self._call_load_program_fixture([str(self.program.uuid)])
-        expected_msg = (
-            r'Checking database constraints failed trying to load fixtures. Unable to save program\(s\):'
-        ).format(pk=self.organization.id)
-        assert re.match(expected_msg, err.value.args[0])
-
-    @responses.activate
     def test_ignore_program_external_key(self):
         fixture = json_serializer.Serializer().serialize([
             self.organization,
             self.seat_type_verified,
             self.program_type_masters,
+            self.program_type_masters_translation,
             self.program,
         ])
         self._mock_fixture_response(fixture)
@@ -344,55 +230,3 @@ class TestLoadProgramFixture(TestCase):
         ])
 
         Program.objects.get(uuid=self.program.uuid)
-
-    @responses.activate
-    def test_update_existing_data(self):
-
-        fixture = json_serializer.Serializer().serialize([
-            self.organization,
-            self.seat_type_verified,
-            self.program_type_masters,
-            self.program,
-            self.curriculum,
-            self.course,
-            self.course_run,
-            self.curriculum_course_membership,
-        ])
-        self._mock_fixture_response(fixture)
-        self._call_load_program_fixture([str(self.program.uuid)])
-
-        self.program.title = 'program-title-modified'
-        self.course.title = 'course-title-modified'
-        new_course = CourseFactory(partner=self.partner, authoring_organizations=[self.organization])
-        new_course_run = CourseRunFactory(course=new_course)
-        new_course_membership = CurriculumCourseMembershipFactory(course=new_course, curriculum=self.curriculum)
-
-        fixture = json_serializer.Serializer().serialize([
-            self.organization,
-            self.seat_type_verified,
-            self.program_type_masters,
-            self.program,
-            self.curriculum,
-            self.course,
-            self.course_run,
-            self.curriculum_course_membership,
-            new_course_membership,
-            new_course,
-            new_course_run,
-        ])
-        responses.reset()
-        self._mock_oauth_request()
-        self._mock_fixture_response(fixture)
-        self.reset_db_state()
-        self._call_load_program_fixture([str(self.program.uuid)])
-
-        stored_program = Program.objects.get(uuid=self.program.uuid)
-        assert stored_program.title == 'program-title-modified'
-
-        stored_program_courses = stored_program.curricula.first().course_curriculum.all()
-        modified_existing_course = stored_program_courses.get(uuid=self.course.uuid)
-        stored_new_course = stored_program_courses.get(uuid=new_course.uuid)
-
-        assert len(stored_program_courses) == 2
-        assert modified_existing_course.title == 'course-title-modified'
-        assert stored_new_course.key == new_course.key


### PR DESCRIPTION
JIRA:[EDUCATOR-5112](https://openedx.atlassian.net/browse/EDUCATOR-5112)

It always confused me why we had so much asymmetry to how we loaded these fixtures. I tested it without and it seems to work just fine.