### PR TITLE
refactoring: get rid of outdated django-taggit-serializer package

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -20,7 +20,7 @@ from rest_framework import serializers
 from rest_framework.fields import CreateOnlyDefault, UUIDField
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.relations import ManyRelatedField
-from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
+from taggit.serializers import TaggitSerializer, TagListSerializerField
 from taxonomy.utils import get_whitelisted_course_skills, get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.fields import (

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -54,7 +54,6 @@ THIRD_PARTY_APPS = [
     'django_sites_extensions',
     'taggit',
     'taggit_autosuggest',
-    'taggit_serializer',
     'solo',
     'webpack_loader',
     'parler',

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -23,7 +23,6 @@ django-stdimage
 django-storages
 django-taggit
 django-taggit-autosuggest
-django-taggit-serializer
 django-waffle
 django-webpack-loader
 djangorestframework

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -192,10 +192,7 @@ django-taggit==1.5.1
     # via
     #   -r requirements/base.in
     #   django-taggit-autosuggest
-    #   django-taggit-serializer
 django-taggit-autosuggest==0.3.8
-    # via -r requirements/base.in
-django-taggit-serializer==0.1.7
     # via -r requirements/base.in
 django-waffle==2.2.1
     # via
@@ -521,7 +518,6 @@ six==1.16.0
     #   django-compressor
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
-    #   django-taggit-serializer
     #   djangorestframework-csv
     #   dockerpty
     #   edx-auth-backends

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -160,10 +160,7 @@ django-taggit==1.5.1
     # via
     #   -r requirements/base.in
     #   django-taggit-autosuggest
-    #   django-taggit-serializer
 django-taggit-autosuggest==0.3.8
-    # via -r requirements/base.in
-django-taggit-serializer==0.1.7
     # via -r requirements/base.in
 django-waffle==2.2.1
     # via
@@ -371,7 +368,6 @@ six==1.16.0
     #   django-compressor
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
-    #   django-taggit-serializer
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-ccx-keys


### PR DESCRIPTION
The django-taggit-serializer library has been vendored in django-taggit,
now hosted by jazzband:
https://github.com/jazzband/help/issues/91#issuecomment-871498498

Thus, we can get rid of this package and simply change the import paths.
This is necessary for Django 3.2 compatibility.

Close https://github.com/edx/upgrades/issues/18