### PR TITLE
Fix: Fixing error with django32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['py38']
-        django-version: ['django22', 'django30', 'django31', 'django32']
+        django-version: ['django22', 'django30', 'django31']
         status: [ '' ]
         include:
           - python-version: 'py38'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['py38']
-        django-version: ['django22', 'django30', 'django31']
+        django-version: ['django22', 'django30', 'django31', 'django32']
+
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ jobs:
       matrix:
         python-version: ['py38']
         django-version: ['django22', 'django30', 'django31', 'django32']
-
+        status: [ '' ]
+        include:
+          - python-version: 'py38'
+            django-version: 'django32'
+            status: 'ignored'
 
     steps:
       - uses: actions/checkout@v2

--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -106,14 +106,14 @@ class CompressedCacheResponse(CacheResponse):
 
                 # django 3.0 has not .items() method, django 3.2 has not ._headers
                 if hasattr(response, '_headers'):
-                    headers = response._headers.copy()
+                    headers = response._headers.copy()  # pylint: disable=protected-access
                 else:
                     headers = {k: (k, v) for k, v in response.items()}
 
                 response_triple = (
                     zlib.compress(response.rendered_content),
                     response.status_code,
-                    headers,  # pylint: disable=protected-access
+                    headers
                 )
                 self.cache.set(key, response_triple, self.timeout)
         else:

--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -103,10 +103,17 @@ class CompressedCacheResponse(CacheResponse):
                 # Put the response in the cache only if there are no cache errors, response errors,
                 # and the format is json. We avoid caching for the BrowsableAPIRenderer so that users don't see
                 # different usernames that are cached from the BrowsableAPIRenderer html
+
+                # django 3.0 has not .items() method, django 3.2 has not ._headers
+                if hasattr(response, '_headers'):
+                    headers = response._headers.copy()
+                else:
+                    headers = {k: (k, v) for k, v in response.items()}
+
                 response_triple = (
                     zlib.compress(response.rendered_content),
                     response.status_code,
-                    response._headers.copy(),  # pylint: disable=protected-access
+                    headers,  # pylint: disable=protected-access
                 )
                 self.cache.set(key, response_triple, self.timeout)
         else:

--- a/course_discovery/apps/api/v1/tests/test_cache.py
+++ b/course_discovery/apps/api/v1/tests/test_cache.py
@@ -132,7 +132,7 @@ class CompressedCacheResponseTest(TestCase):
         django 3.0 has not .items() method, django 3.2 has not ._headers
         """
         if hasattr(cache_response, '_headers'):
-            headers = cache_response._headers.copy()
+            headers = cache_response._headers.copy()  # pylint: disable=protected-access
         else:
             headers = {k: (k, v) for k, v in cache_response.items()}
 

--- a/course_discovery/apps/api/v1/tests/test_cache.py
+++ b/course_discovery/apps/api/v1/tests/test_cache.py
@@ -44,7 +44,7 @@ class CompressedCacheResponseTest(TestCase):
         response_triple = (
             uncompressed_cached_response.rendered_content,
             uncompressed_cached_response.status_code,
-            uncompressed_cached_response._headers.copy(),  # pylint: disable=protected-access
+            self.get_header(uncompressed_cached_response)
         )
         cache.set(self.cache_response_key, response_triple)
 
@@ -74,7 +74,7 @@ class CompressedCacheResponseTest(TestCase):
         response_triple = (
             zlib.compress(compressed_cached_response.rendered_content),
             compressed_cached_response.status_code,
-            compressed_cached_response._headers.copy(),  # pylint: disable=protected-access
+            self.get_header(compressed_cached_response)
         )
         cache.set(self.cache_response_key, response_triple)
 
@@ -126,3 +126,14 @@ class CompressedCacheResponseTest(TestCase):
             assert cache.get(self.cache_response_key) is not None
         else:
             assert cache.get(self.cache_response_key) is None
+
+    def get_header(self, cache_response):
+        """
+        django 3.0 has not .items() method, django 3.2 has not ._headers
+        """
+        if hasattr(cache_response, '_headers'):
+            headers = cache_response._headers.copy()
+        else:
+            headers = {k: (k, v) for k, v in cache_response.items()}
+
+        return headers

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{22,30,31}
+envlist = py38-django{22,30,31,32}
 skipsdist=true
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     django22: -r requirements/django.txt
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.1,<3.3
     -r{toxinidir}/requirements/local.txt
 passenv =
     CONN_MAX_AGE


### PR DESCRIPTION
`_header` is missing in django3.2

https://docs.djangoproject.com/en/3.2/releases/3.2/#requests-and-responses

```
def test_should_handle_getting_compressed_response_from_cache(self):
        """ Verify that the decorator correctly returns compressed responses """
        def key_func(**kwargs):  # pylint: disable=unused-argument
            return self.cache_response_key
    
        class TestView(views.APIView):
            permission_classes = [permissions.AllowAny]
            renderer_classes = [JSONRenderer]
    
            @compressed_cache_response(key_func=key_func)
            def get(self, request, *_args, **_kwargs):
                return Response('test response')
    
        view_instance = TestView()
        view_instance.headers = {}  # pylint: disable=attribute-defined-outside-init
        compressed_cached_response = Response('compressed cached test response')
        view_instance.finalize_response(request=self.request, response=compressed_cached_response)
        compressed_cached_response.render()
    
        # Rendered content is compressed before response goes into the cache
        response_triple = (
            zlib.compress(compressed_cached_response.rendered_content),
            compressed_cached_response.status_code,
>           compressed_cached_response._headers.copy(),  # pylint: disable=protected-access
        )
E       AttributeError: 'Response' object has no attribute '_headers'
```

https://github.com/chibisov/drf-extensions/commit/61d658011f6a57001040e7e27e60dbab8ea467d5#diff-0928b44091c9bc3eb81f228119aadff20e60ababd4a4e3e8500076a72df119a7R88

https://openedx.atlassian.net/browse/BOM-2818