### PR TITLE
chore: remove pytest-django-ordering

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -117,7 +117,6 @@ distro==1.6.0
     #   edx-drf-extensions
     #   edx-i18n-tools
     #   jsonfield
-    #   pytest-django-ordering
     #   rest-condition
     #   taxonomy-connector
     #   xss-utils
@@ -426,17 +425,12 @@ pytest==6.2.5
     #   -r requirements/test.in
     #   pytest-cov
     #   pytest-django
-    #   pytest-django-ordering
     #   pytest-forked
     #   pytest-responses
     #   pytest-xdist
 pytest-cov==2.12.1
     # via -r requirements/test.in
 pytest-django==4.4.0
-    # via
-    #   -r requirements/test.in
-    #   pytest-django-ordering
-pytest-django-ordering==1.2.0
     # via -r requirements/test.in
 pytest-forked==1.3.0
     # via pytest-xdist

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -13,7 +13,6 @@ python-memcached
 pytest
 pytest-cov
 pytest-django
-pytest-django-ordering
 pytest-responses
 pytest-xdist
 responses


### PR DESCRIPTION
Changes:
- re-generates requirements/local.txt

Package removed due to [pytest-django>=3.9](https://pytest-django.readthedocs.io/en/latest/changelog.html?highlight=ordering#id10) is used that has [required
plugin's logic](https://github.com/pytest-dev/pytest-django/blob/master/pytest_django/plugin.py#L366) to preserve the order of tests like Django test runner
does.

https://github.com/edx/upgrades/issues/55#issuecomment-922457358