### PR TITLE
chore: upgrading `django-autocomplete-light` to latest version. 

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -21,8 +21,8 @@ django-cors-headers==3.2.0
 # see https://www.sphinx-doc.org/en/master/intro.html#prerequisites
 sphinx==2.4.4
 
-# FIXME: dal 3.5.1 requires you to include jquery yourself on the admin page -- needs a proper fix
-django-autocomplete-light==3.5.0
+# FIXME: Taking it to the lastest version. Still missing django32 support.
+django-autocomplete-light==3.8.0
 
 celery<5.0
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -83,7 +83,7 @@ defusedxml==0.7.1
     #   djangorestframework-xml
     #   python3-openid
     #   social-auth-core
-distlib==0.3.2
+distlib==0.3.3
     # via virtualenv
 distro==1.6.0
     # via docker-compose
@@ -125,7 +125,7 @@ django-admin-sortable2==1.0
     # via -r requirements/base.in
 django-appconf==1.0.4
     # via django-compressor
-django-autocomplete-light==3.5.0
+django-autocomplete-light==3.8.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -442,7 +442,7 @@ pytest-forked==1.3.0
     # via pytest-xdist
 pytest-responses==0.5.0
     # via -r requirements/test.in
-pytest-xdist==2.3.0
+pytest-xdist==2.4.0
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via
@@ -583,7 +583,7 @@ stevedore==3.4.0
     #   edx-opaque-keys
 taxonomy-connector==1.14.2
     # via -r requirements/base.in
-testfixtures==6.18.1
+testfixtures==6.18.2
     # via -r requirements/test.in
 text-unidecode==1.3
     # via faker

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -8,7 +8,7 @@ click==8.0.1
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.2.0
+pip-tools==6.3.0
     # via -r requirements/pip_tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -23,9 +23,9 @@ beautifulsoup4==4.10.0
     # via -r requirements/base.in
 billiard==3.6.4.0
     # via celery
-boto3==1.18.44
+boto3==1.18.45
     # via django-ses
-botocore==1.21.44
+botocore==1.21.45
     # via
     #   boto3
     #   s3transfer
@@ -95,7 +95,7 @@ django-admin-sortable2==1.0
     # via -r requirements/base.in
 django-appconf==1.0.4
     # via django-compressor
-django-autocomplete-light==3.5.0
+django-autocomplete-light==3.8.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in


### PR DESCRIPTION
chore: upgrading `django-autocomplete-light` to latest version. Stil not supporting django32.

https://github.com/yourlabs/django-autocomplete-light/blob/master/CHANGELOG#L61


django32 support merged in this PR https://github.com/yourlabs/django-autocomplete-light/commit/3397ad5424d621021efb0af67be08ff46e7d4533 but not released.

https://openedx.atlassian.net/browse/BOM-2845