### PR TITLE
feat: upgrade django-cor-headers to 3.5.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,8 +14,9 @@ elasticsearch-dsl>=7.2,<8.0
 # FIXME: 0.13+ requires python-slugify, which conflicts with unicode-slugify
 transifex-client<0.13
 
-# FIXME: 3+ require schemes in CORS_ORIGIN_WHITELIST URLs - remember to update configuration when you remove this
-django-cors-headers==3.2.0
+# This version has `rename settings` but old names are preserved as aliases for backward compatibility.
+# stilling not supporting django32. Greater version has the support. Will update in next PR.
+django-cors-headers==3.5.0
 
 # sphinx has dropped support for python 3.5, latest version requires at least python3.6
 # see https://www.sphinx-doc.org/en/master/intro.html#prerequisites

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -55,7 +55,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.6
+urllib3==1.26.7
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -137,7 +137,7 @@ django-compressor==2.4.1
     #   django-libsass
 django-contrib-comments==2.1.0
     # via -r requirements/base.in
-django-cors-headers==3.2.0
+django-cors-headers==3.5.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -342,7 +342,7 @@ mock==4.0.3
     # via -r requirements/test.in
 mysqlclient==2.0.3
     # via -r requirements/test.in
-newrelic==6.10.0.165
+newrelic==7.0.0.166
     # via edx-django-utils
 oauthlib==3.1.1
     # via
@@ -609,7 +609,7 @@ unidecode==1.3.2
     # via unicode-slugify
 uritemplate==3.0.1
     # via coreapi
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   elasticsearch
     #   requests

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -23,9 +23,9 @@ beautifulsoup4==4.10.0
     # via -r requirements/base.in
 billiard==3.6.4.0
     # via celery
-boto3==1.18.45
+boto3==1.18.46
     # via django-ses
-botocore==1.21.45
+botocore==1.21.46
     # via
     #   boto3
     #   s3transfer
@@ -107,7 +107,7 @@ django-compressor==2.4.1
     #   django-libsass
 django-contrib-comments==2.1.0
     # via -r requirements/base.in
-django-cors-headers==3.2.0
+django-cors-headers==3.5.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -274,7 +274,7 @@ markupsafe==2.0.1
     # via jinja2
 mysqlclient==2.0.3
     # via -r requirements/production.in
-newrelic==6.10.0.165
+newrelic==7.0.0.166
     # via
     #   -r requirements/production.in
     #   edx-django-utils
@@ -409,7 +409,7 @@ unidecode==1.3.2
     # via unicode-slugify
 uritemplate==3.0.1
     # via coreapi
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   botocore
     #   elasticsearch


### PR DESCRIPTION
https://github.com/adamchainz/django-cors-headers/blob/main/HISTORY.rst#370-2021-01-25

```
Following Django’s example in Ticket #31670 for replacing the term “whitelist”, plus an aim to make the setting names more comprehensible, the following settings have been renamed:

CORS_ORIGIN_WHITELIST -> CORS_ALLOWED_ORIGINS
CORS_ORIGIN_REGEX_WHITELIST -> CORS_ALLOWED_ORIGIN_REGEXES
CORS_ORIGIN_ALLOW_ALL -> CORS_ALLOW_ALL_ORIGINS
The old names will continue to work as aliases, with the new ones taking precedence.
```

Next PR with 3.7.0 wil be django32 compatible.
