### PR TITLE
BOM-2848: upgrade django-cors-headers to 3.8.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,10 +14,6 @@ elasticsearch-dsl>=7.2,<8.0
 # FIXME: 0.13+ requires python-slugify, which conflicts with unicode-slugify
 transifex-client<0.13
 
-# This version has `rename settings` but old names are preserved as aliases for backward compatibility.
-# stilling not supporting django32. Greater version has the support. Will update in next PR.
-django-cors-headers==3.5.0
-
 # sphinx has dropped support for python 3.5, latest version requires at least python3.6
 # see https://www.sphinx-doc.org/en/master/intro.html#prerequisites
 sphinx==2.4.4

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -137,10 +137,8 @@ django-compressor==2.4.1
     #   django-libsass
 django-contrib-comments==2.1.0
     # via -r requirements/base.in
-django-cors-headers==3.5.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-cors-headers==3.8.0
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via edx-django-utils
 django-debug-toolbar==3.2.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -107,10 +107,8 @@ django-compressor==2.4.1
     #   django-libsass
 django-contrib-comments==2.1.0
     # via -r requirements/base.in
-django-cors-headers==3.5.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-cors-headers==3.8.0
+    # via -r requirements/base.in
 django-crum==0.7.9
     # via edx-django-utils
 django-dynamic-filenames==1.2.0


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2848

Following is the changelog for django-cors-headers post v3.5.0, It seems that we are good to go to the latest version.

<img width="1045" alt="Screen Shot 2021-09-23 at 8 26 41 PM" src="https://user-images.githubusercontent.com/23311265/134536888-1d4ae19d-eeb3-4950-9cde-5413c04472f9.png">

