### PR TITLE
feat: upgrade `django-autocomplete-light` to latest version.

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -37,7 +37,6 @@ social-auth-app-django<5.0.0
 # latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2.
 # See  comment.
 
-
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,9 +18,6 @@ transifex-client<0.13
 # see https://www.sphinx-doc.org/en/master/intro.html#prerequisites
 sphinx==2.4.4
 
-# FIXME: dal 3.5.1 requires you to include jquery yourself on the admin page -- needs a proper fix
-django-autocomplete-light==3.5.0
-
 celery<5.0
 
 # latest version of edx-lint is pulling code-annotations and code-annotations is pulling python-slugify and

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -125,7 +125,7 @@ django-admin-sortable2==1.0
     # via -r requirements/base.in
 django-appconf==1.0.4
     # via django-compressor
-django-autocomplete-light==3.5.0
+django-autocomplete-light==3.8.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -95,10 +95,8 @@ django-admin-sortable2==1.0
     # via -r requirements/base.in
 django-appconf==1.0.4
     # via django-compressor
-django-autocomplete-light==3.5.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-autocomplete-light==3.8.2
+    # via -r requirements/base.in
 django-choices==1.7.2
     # via -r requirements/base.in
 django-compressor==2.4.1


### PR DESCRIPTION
Still not compatible with django32.

https://github.com/yourlabs/django-autocomplete-light/blob/master/CHANGELOG#L61

Latest version working fine on sandbox
https://discovery-awais786.sandbox.edx.org/admin/course_metadata/program/1/change/