### PR TITLE
feat: add management command for removing programtypes from migr.s

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/remove_program_types_from_migrations.py
+++ b/course_discovery/apps/course_metadata/management/commands/remove_program_types_from_migrations.py
@@ -1,0 +1,21 @@
+"""
+Remove migration-borne program type records (e.g. to make way for fixture-loaded data)
+"""
+from django.core.management import BaseCommand
+
+from course_discovery.apps.course_metadata.models import ProgramType
+
+# from migration code
+# see 0191_add_microbachelors_program_type and 0090_degree_curriculum_reset
+MB_PROGRAM_TYPES = ("microbachelors",)
+M_PROGRAM_TYPES = ("masters",)
+
+
+class Command(BaseCommand):
+    """
+    Remove ProgramTypes with slugs matching those created by migrations
+    """
+    # pylint: disable=unused-argument
+    def handle(self, *args, **kwargs):
+        program_types = ProgramType.objects.filter(slug__in=MB_PROGRAM_TYPES + M_PROGRAM_TYPES)
+        program_types.delete()


### PR DESCRIPTION
In https://github.com/edx/course-discovery/pull/3121 I was removing complexity in how fixtures are loaded, because I didn't fully understand why it needed to be as complex as it was. I understand why it is that complex now; it's because the discovery migrations add records to the database which we need to clear out to make room for the fixture (which will create records using ids from production). This command is intended to clear out the unnecessary records, making way for the fixtures we'll load.