### PR TITLE
chore: update django-autocomplete-light

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,7 @@ backoff
 beautifulsoup4
 django
 django-admin-sortable2
-django-autocomplete-light
+django-autocomplete-light==3.9.0rc1
 django-choices
 django-compressor
 django-contrib-comments

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -124,7 +124,7 @@ django-admin-sortable2==1.0
     # via -r requirements/base.in
 django-appconf==1.0.5
     # via django-compressor
-django-autocomplete-light==3.8.2
+django-autocomplete-light==3.9.0rc1
     # via -r requirements/base.in
 django-choices==1.7.2
     # via -r requirements/base.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -95,7 +95,7 @@ django-admin-sortable2==1.0
     # via -r requirements/base.in
 django-appconf==1.0.5
     # via django-compressor
-django-autocomplete-light==3.8.2
+django-autocomplete-light==3.9.0rc1
     # via -r requirements/base.in
 django-choices==1.7.2
     # via -r requirements/base.in


### PR DESCRIPTION
Changes:
- update django-autocomplete-light version to RC [3.9.0rc1](https://pypi.org/project/django-autocomplete-light/3.9.0rc1/)
- 3.9.0rc1 is compatible with both Django3.2 and Django2.2.24

Important fix in the RC: https://github.com/yourlabs/django-autocomplete-light/commit/3397ad5424d621021efb0af67be08ff46e7d4533

I'm proposing to consider using RC version and upgrade as soon as release version will be uploaded to PYPI.

I've tested this version with both Django2.2.4 and Django3.2.
Checked all admin forms. Hopefully didn't miss anything.

---
Issues still in master but not released in a new RC or a release version:
- https://github.com/yourlabs/django-autocomplete-light/commit/561c9cc56aa94aed88e54e85127ec6d65021667f
- https://github.com/yourlabs/django-autocomplete-light/commit/23a8052295553258fdfefd3d06bd8d48a4168c39
- https://github.com/yourlabs/django-autocomplete-light/commit/925bed816586a41bf5f959eb5b041e84b49d94eb

---
Edx upgrades task: https://github.com/edx/upgrades/issues/20

---
There are some screenshots (not all cases).
<img width="1046" alt="Screenshot 2021-09-30 at 19 48 15" src="https://user-images.githubusercontent.com/877401/135499744-46537448-17ec-4f91-9d40-1c9f033e0bcc.png">
<img width="1204" alt="Screenshot 2021-09-30 at 19 45 32" src="https://user-images.githubusercontent.com/877401/135499746-c3490487-b973-44b2-977d-06200600b713.png">
<img width="1162" alt="Screenshot 2021-09-30 at 19 45 01" src="https://user-images.githubusercontent.com/877401/135499748-733cef13-3210-4669-ab0f-c3cc958c8fa4.png">
<img width="1223" alt="Screenshot 2021-09-30 at 19 44 27" src="https://user-images.githubusercontent.com/877401/135499749-9770da76-2dde-4ad5-9785-a2fdddb592b2.png">


