### PR TITLE
fix: add django version condition on access of response headers

### DIFF
--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -1,8 +1,8 @@
-import django
 import logging
 import time
 import zlib
 
+import django
 from django.conf import settings
 from django.core.cache import cache
 from django.http.response import HttpResponse

--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -1,3 +1,4 @@
+import django
 import logging
 import time
 import zlib
@@ -129,7 +130,10 @@ class CompressedCacheResponse(CacheResponse):
                 decompressed_content = compressed_content
 
             response = HttpResponse(content=decompressed_content, status=status)
-            response.headers = headers  # pylint: disable=protected-access
+            if django.VERSION >= (3, 2):
+                response.headers = headers  # pylint: disable=protected-access
+            else:
+                response._headers = headers  # pylint: disable=protected-access
 
         if not hasattr(response, '_closable_objects'):
             response._closable_objects = []  # pylint: disable=protected-access


### PR DESCRIPTION
Need to add django version condition to support both Django 3.2 and Django 2.2