### PR TITLE
fix: fixing wsgi issue.

### DIFF
--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -108,7 +108,7 @@ class CompressedCacheResponse(CacheResponse):
                 if hasattr(response, '_headers'):
                     headers = response._headers.copy()  # pylint: disable=protected-access
                 else:
-                    headers = response.headers.copy()
+                    headers = {k: (k, v) for k, v in response.items()}
 
                 response_triple = (
                     zlib.compress(response.rendered_content),
@@ -129,7 +129,9 @@ class CompressedCacheResponse(CacheResponse):
                 decompressed_content = compressed_content
 
             response = HttpResponse(content=decompressed_content, status=status)
-            response.headers = headers  # pylint: disable=protected-access
+
+            for k, v in headers.values():
+                response[k] = v
 
         if not hasattr(response, '_closable_objects'):
             response._closable_objects = []  # pylint: disable=protected-access


### PR DESCRIPTION
https://github.com/chibisov/drf-extensions/pull/307 It has header issue fix with `django3.2`

https://github.com/chibisov/drf-extensions/issues/267 wsgi tuple issue.

https://github.com/chibisov/drf-extensions/pull/268 tuple issue fixed.


Issue discovery faced on prod.
```
Traceback (most recent call last):
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 55, in handle
    self.handle_request(listener_name, req, client, addr)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/gunicorn/workers/ggevent.py", line 127, in handle_request
    super().handle_request(listener_name, req, sock, addr)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/gunicorn/workers/base_async.py", line 108, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/newrelic/api/wsgi_application.py", line 679, in _nr_wsgi_application_wrapper_
    result = _WSGIApplicationMiddleware(wrapped,
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/newrelic/api/wsgi_application.py", line 207, in __init__
    self.iterable = self.application(self.request_environ,
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/newrelic/api/wsgi_application.py", line 570, in _nr_wsgi_application_wrapper_
    return wrapped(*args, **kwargs)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/django/core/handlers/wsgi.py", line 142, in __call__
    start_response(status, response_headers)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/newrelic/api/wsgi_application.py", line 427, in start_response
    if should_insert_html():
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/newrelic/api/wsgi_application.py", line 422, in should_insert_html
    if content_type.split(';')[0] not in allowed_content_type:
AttributeError: 'tuple' object has no attribute 'split'
```