### PR TITLE
chore: upgrade authlib to latest beta for Django 3.2 support

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -36,3 +36,7 @@ django-webpack-loader<1.0.0
 # Just to avoid any issues pinning them. Remove after django32 deployment.
 cryptography==3.4.8
 pyjwt[crypto]==2.1.0
+
+# This version adds support for Django 3.2, so pinning the beta version for Django 3.2
+# Remove this pin once newer stable version is released
+authlib==1.0.0b1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -27,8 +27,10 @@ attrs==21.2.0
     # via
     #   jsonschema
     #   pytest
-authlib==0.15.4
-    # via simple-salesforce
+authlib==1.0.0b1
+    # via
+    #   -c requirements/constraints.txt
+    #   simple-salesforce
 babel==2.9.1
     # via sphinx
 backoff==1.11.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -17,8 +17,10 @@ amqp==2.6.1
     # via kombu
 asgiref==3.4.1
     # via django
-authlib==0.15.4
-    # via simple-salesforce
+authlib==1.0.0b1
+    # via
+    #   -c requirements/constraints.txt
+    #   simple-salesforce
 backoff==1.11.1
     # via -r requirements/base.in
 beautifulsoup4==4.10.0


### PR DESCRIPTION
This latest beta version has Django support so pinning this to that version 

Source: https://github.com/edx/upgrades/issues/56