### PR TITLE
test: Adding a test for django32 response headers and its cache valid…

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_cache.py
+++ b/course_discovery/apps/api/v1/tests/test_cache.py
@@ -158,7 +158,8 @@ class CompressedCacheResponseTest(TestCase):
 
         cached_response.render()
 
-        headers = cached_response.headers.copy()
+        headers = {k: (k, v) for k, v in cached_response.items()}
+
         response_dict = (
             cached_response.rendered_content,
             cached_response.status_code,

--- a/course_discovery/apps/api/v1/tests/test_cache.py
+++ b/course_discovery/apps/api/v1/tests/test_cache.py
@@ -152,7 +152,7 @@ class CompressedCacheResponseTest(TestCase):
                 return Response('test response')
 
         view_instance = TestView()
-        view_instance.headers = {'Test': 'foo'}
+        view_instance.headers = {'Test': 'foo'}  # pylint: disable=attribute-defined-outside-init
         cached_response = Response('')
         view_instance.finalize_response(request=self.request, response=cached_response)
 

--- a/course_discovery/apps/api/v1/tests/test_cache.py
+++ b/course_discovery/apps/api/v1/tests/test_cache.py
@@ -137,3 +137,34 @@ class CompressedCacheResponseTest(TestCase):
             headers = {k: (k, v) for k, v in cache_response.items()}
 
         return headers
+
+    def test_should_return_response_without_tuple_headers(self):
+        """ In django32 headers appeared as simple string."""
+        def key_func(**kwargs):  # pylint: disable=unused-argument
+            return self.cache_response_key
+
+        class TestView(views.APIView):
+            permission_classes = [permissions.AllowAny]
+            renderer_classes = [JSONRenderer]
+
+            @compressed_cache_response(key_func=key_func)
+            def get(self, request, *_args, **_kwargs):
+                return Response('test response')
+
+        view_instance = TestView()
+        view_instance.headers = {'Test': 'foo'}
+        cached_response = Response('')
+        view_instance.finalize_response(request=self.request, response=cached_response)
+
+        cached_response.render()
+
+        headers = cached_response.headers.copy()
+        response_dict = (
+            cached_response.rendered_content,
+            cached_response.status_code,
+            headers
+        )
+
+        cache.set('cache_response_key', response_dict)
+        response = view_instance.dispatch(request=self.request)
+        self.assertEqual(response['test'], 'foo')


### PR DESCRIPTION
In django22 `response header` was appearing as tuple but in django32 its behaviour has changed.

django22 = https://github.com/django/django/blob/stable/2.2.x/django/http/response.py#L138
django32 = https://github.com/django/django/blob/stable/3.2.x/django/http/response.py#L171


Related PR in [drf-extensions](https://github.com/chibisov/drf-extensions/pull/307/files)