### PR TITLE
chore: taxonomy-version-upgrade-1.14.3

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -578,7 +578,7 @@ stevedore==3.4.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.14.2
+taxonomy-connector==1.14.3
     # via -r requirements/base.in
 testfixtures==6.18.3
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -404,7 +404,7 @@ stevedore==3.4.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.14.2
+taxonomy-connector==1.14.3
     # via -r requirements/base.in
 unicode-slugify==0.1.3
     # via -r requirements/base.in


### PR DESCRIPTION
This PR upgrades the version of `taxonomy-connector` to `1.14.3`. The following changes are included in this release: https://github.com/edx/taxonomy-connector/pull/71