### PR TITLE
Algolia reindexing changes to keep 2U rules in place

### DIFF
--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -48,8 +48,15 @@ class BaseProductIndex(AlgoliaIndex):
 
     # Rules aren't automatically set in regular reindex_all, so set them explicitly
     def reindex_all(self, batch_size=1000):
+        # Since reindexing removes all the rules, we will need to recreate the 2U rules after reindexing
+        rules_to_create = self.get_rules()
+        existing_2U_XML_rules = []
+        for rule in self._AlgoliaIndex__index.iter_rules():  # pylint: disable=no-member
+            if 'objectID' in rule and '2U-XML' in rule['objectID']:
+                existing_2U_XML_rules.append(rule)
+        final_rules = rules_to_create + existing_2U_XML_rules
         super().reindex_all(batch_size)
-        self._AlgoliaIndex__index.replace_all_rules(self.get_rules())  # pylint: disable=no-member
+        self._AlgoliaIndex__index.replace_all_rules(final_rules)  # pylint: disable=no-member
 
 
 class EnglishProductIndex(BaseProductIndex):


### PR DESCRIPTION
This is a PR with changes needed to keep algolia 2U-XML rules in place after reindexing. 

In prospectus, we create a bunch of algolia rules to return custom data with courses. They are based on the XML file that we are provided with. These rules have objectId starting with '2U-XML'.

Since all rules get wiped after reindexing, this PR fetches these '2U-XML' algolia rules before reindexing and re-applies them after reindexing.