### PR TITLE
build: program fixtures now exclude language tags

### DIFF
--- a/course_discovery/apps/edx_catalog_extensions/api/v1/tests/test_views.py
+++ b/course_discovery/apps/edx_catalog_extensions/api/v1/tests/test_views.py
@@ -26,7 +26,6 @@ from course_discovery.apps.course_metadata.tests.factories import (
 from course_discovery.apps.edx_catalog_extensions.api.v1.views import (
     DistinctCountsAggregateSearchViewSet, ProgramFixtureView
 )
-from course_discovery.apps.ietf_language_tags.models import LanguageTag
 
 
 class DistinctCountsAggregateSearchViewSetTests(SerializationMixin, LoginMixin,
@@ -356,7 +355,6 @@ class ProgramFixtureViewTests(APITestCase):
             LevelType: (5, 15),
             LevelTypeTranslation: (1, 100),
             Video: (20, 60),
-            LanguageTag: (10, 30),
         }
 
         actual_appearances_by_model_label = defaultdict(set)

--- a/course_discovery/apps/edx_catalog_extensions/api/v1/views.py
+++ b/course_discovery/apps/edx_catalog_extensions/api/v1/views.py
@@ -18,6 +18,7 @@ from course_discovery.apps.course_metadata.models import (
 )
 from course_discovery.apps.edx_catalog_extensions.api.serializers import DistinctCountsAggregateFacetSearchSerializer
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.distinct_counts.query import DistinctCountsSearchQuerySet
+from course_discovery.apps.ietf_language_tags.models import LanguageTag
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +144,7 @@ def load_program_fixture(programs):
         CourseRun: set(course_run_pks),
         CurriculumCourseRunExclusion: set(exclusion_pks),
     }
-    excluded_models = {Site, Partner, User}
+    excluded_models = {Site, Partner, User, LanguageTag}
     return load_related(pks_to_load, excluded_models)
 
 


### PR DESCRIPTION
(also hopefully exclude their translations)
rationale is that the languages are created primarily through
migrations (which is a weird practice for picklist tables, y'all!), so
it's not really necessary to recreate them. I'm a bit worried about
that approach, though, since not all languages defined in production
discovery are created on a fresh provision, but it seems very likely
that this will cover our use case so /shrug