### PR TITLE
feat: add recent_enrollment_count in program list endpoint

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1549,7 +1549,7 @@ class MinimalProgramSerializer(FlexFieldsSerializerMixin, BaseModelSerializer):
             'uuid', 'title', 'subtitle', 'type', 'type_attrs', 'status', 'marketing_slug', 'marketing_url',
             'banner_image', 'hidden', 'courses', 'authoring_organizations', 'card_image_url',
             'is_program_eligible_for_one_click_purchase', 'degree', 'curricula', 'marketing_hook',
-            'total_hours_of_effort',
+            'total_hours_of_effort', 'recent_enrollment_count',
         )
         read_only_fields = ('uuid', 'marketing_url', 'banner_image')
 
@@ -1709,7 +1709,7 @@ class ProgramSerializer(MinimalProgramSerializer):
             'faq', 'credit_backing_organizations', 'corporate_endorsements', 'job_outlook_items',
             'individual_endorsements', 'languages', 'transcript_languages', 'subjects', 'price_ranges',
             'staff', 'credit_redemption_overview', 'applicable_seat_types', 'instructor_ordering',
-            'enrollment_count', 'recent_enrollment_count', 'topics', 'credit_value',
+            'enrollment_count', 'topics', 'credit_value',
         )
 
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1040,6 +1040,7 @@ class MinimalProgramSerializerTests(TestCase):
             'curricula': [],
             'marketing_hook': program.marketing_hook,
             'total_hours_of_effort': program.total_hours_of_effort,
+            'recent_enrollment_count': 0,
         }
 
     def test_data(self):


### PR DESCRIPTION
We index `recent_enrollment_count` field for courses but this field is not available for programs in Algolia. We use programs list endpoint to fetch all content metadata in enterprise_catalogs that is then indexed. This PR is about making `recent_enrollment_count` field available for programs as well. 
JIRA: https://openedx.atlassian.net/browse/ENT-5142

Changes:
- Added `recent_enrollment_count` in `MinimalProgramSerializer`
- Removed `recent_enrollment_count` from `ProgramSerializer` 