### PR TITLE
fix: catch ecommerce exception

### DIFF
--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -23,6 +23,7 @@ from course_discovery.apps.api.v1.exceptions import EditableAndQUnsupported
 from course_discovery.apps.core.utils import SearchQuerySetWrapper
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.constants import COURSE_RUN_ID_REGEX
+from course_discovery.apps.course_metadata.exceptions import EcommerceSiteAPIClientException
 from course_discovery.apps.course_metadata.models import Course, CourseEditor, CourseRun
 from course_discovery.apps.course_metadata.utils import ensure_draft_world
 from course_discovery.apps.publisher.utils import is_publisher_user
@@ -312,7 +313,10 @@ class CourseRunViewSet(ValidElasticSearchQueryRequiredMixin, viewsets.ModelViewS
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
-        serializer.save()
+        try:
+            serializer.save()
+        except EcommerceSiteAPIClientException as error:
+            return Response(str(error), status=status.HTTP_400_BAD_REQUEST)
         return Response(serializer.data)
 
     # pylint: disable=arguments-differ


### PR DESCRIPTION
The ecommerce exception thrown from `push_to_ecommerce_for_course_run` here: https://github.com/edx/course-discovery/blob/cb7aff0f0f5933f4c623bbad4bc0facd0b31ebf9/course_discovery/apps/course_metadata/utils.py#L494-L495 is not handled by the course run viewset and this causes 500 error to be displayed on publisher when it calls it for PC Review and default django html response is returned which is illegible.

|Before|After|
|----|-----|
|<img width="881" alt="Screenshot 2021-12-28 at 4 53 37 PM" src="https://user-images.githubusercontent.com/40633976/147563733-64b84749-2203-4ef5-8830-4510c7e82e22.png">|<img width="897" alt="Screenshot 2021-12-28 at 4 49 05 PM" src="https://user-images.githubusercontent.com/40633976/147563698-73db9781-32bc-411e-8040-16e58f2ca123.png">|