### PR TITLE
feat: csv data loader

### DIFF
--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -8,6 +8,11 @@ COURSE_UUID_REGEX = r'[0-9a-f-]+'
 
 MASTERS_PROGRAM_TYPE_SLUG = 'masters'
 
+IMAGE_TYPES = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+}
+
 
 class PathwayType(Enum):
     """ Allowed values for Pathway.pathway_type """

--- a/course_discovery/apps/course_metadata/data_loaders/__init__.py
+++ b/course_discovery/apps/course_metadata/data_loaders/__init__.py
@@ -18,7 +18,7 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
     LOADER_MAX_RETRY = 3
     PAGE_SIZE = 50
 
-    def __init__(self, partner, api_url, max_workers=None, is_threadsafe=False):
+    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False):
         """
         Arguments:
             partner (Partner): Partner which owns the APIs and data being loaded
@@ -27,7 +27,7 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
             is_threadsafe (bool): True if multiple threads can be used to write data.
         """
         self.partner = partner
-        self.api_url = api_url.strip('/')
+        self.api_url = api_url.strip('/') if api_url else api_url
         self.api_client = self.partner.oauth_api_client
         self.username = self.get_username_from_client(self.api_client)
 

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -1,0 +1,398 @@
+"""
+Data loader responsible for creating course and course runs entries in Database
+provided a csv containing the required information.
+"""
+import csv
+import logging
+
+from django.conf import settings
+from django.db.models import Q
+from django.urls import reverse
+
+from course_discovery.apps.core.utils import serialize_datetime
+from course_discovery.apps.course_metadata.data_loaders import AbstractDataLoader
+from course_discovery.apps.course_metadata.models import (
+    Collaborator, Course, CourseRun, CourseRunPacing, CourseRunType, CourseType, Organization, Person, ProgramType
+)
+from course_discovery.apps.course_metadata.utils import download_and_save_course_image
+from course_discovery.apps.ietf_language_tags.models import LanguageTag
+
+logger = logging.getLogger(__name__)
+
+
+class CSVDataLoader(AbstractDataLoader):
+    PROGRAM_TYPES = [
+        ProgramType.XSERIES,
+        ProgramType.MASTERS,
+        ProgramType.MICROMASTERS,
+        ProgramType.MICROBACHELORS,
+        ProgramType.PROFESSIONAL_PROGRAM_WL,
+        ProgramType.PROFESSIONAL_CERTIFICATE
+    ]
+
+    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None):
+        super().__init__(partner, api_url, max_workers, is_threadsafe)
+
+        try:
+            self.reader = csv.DictReader(open(csv_path, 'r'))
+        except FileNotFoundError:
+            logger.exception("Error opening csv file at path {}".format(csv_path))
+            raise  # re-raising exception to avoid moving the code flow
+
+    def ingest(self):  # pylint: disable=too-many-statements
+        logger.info("Initiating CSV data loader flow.")
+        for row in self.reader:
+
+            row = self.transform_dict_keys(row)
+            course_title = row['title']
+            org_key = row['organization']
+
+            logger.info('Starting data import flow for {}'.format(course_title))
+            if not Organization.objects.filter(key=org_key).exists():
+                logger.error("Organization {} does not exist in database. Skipping CSV loader for course {}".format(
+                    org_key,
+                    course_title
+                ))
+                continue
+
+            try:
+                course_type = CourseType.objects.get(name=row['course_enrollment_track'])
+                course_run_type = CourseRunType.objects.get(name=row['course_run_enrollment_track'])
+            except CourseType.DoesNotExist:
+                logger.exception("CourseType {} does not exist in the database.".format(
+                    row['course_enrollment_track']
+                ))
+                continue
+            except CourseRunType.DoesNotExist:
+                logger.exception("CourseRunType {} does not exist in the database.".format(
+                    row['course_run_enrollment_track']
+                ))
+                continue
+
+            course_key = self.get_course_key(org_key, row['number'])
+
+            course = Course.objects.filter_drafts(key=course_key, partner=self.partner).first()
+            if course:
+                course_run = CourseRun.objects.filter_drafts(course=course).first()
+                logger.info("Course {} is located in the database.".format(course_key))
+            else:
+                logger.info("Course key {} could not be found in database, creating the course.".format(course_key))
+                try:
+                    _ = self._create_course(row, course_type.uuid, course_run_type.uuid)
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception("Error occurred when attempting to create a new course against key {}".format(
+                        course_key
+                    ))
+                    continue
+                course = Course.everything.get(key=course_key, partner=self.partner)
+                course_run = CourseRun.everything.filter(course=course).first()
+
+            is_downloaded = download_and_save_course_image(course, row['image'])
+            if not is_downloaded:
+                logger.error("Unexpected error happened while downloading image for course {}".format(
+                    course_key
+                ))
+                continue
+
+            try:
+                self._update_course(row, course)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("An unknown error occurred while updating course information")
+                continue
+
+            # No need to update the course run if the run is already in the review
+            if not course_run.in_review:
+                try:
+                    self._update_course_run(row, course_run)
+                    course_run.refresh_from_db()
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception("An unknown error occurred while updating course run information")
+                    continue
+
+            try:
+                self._complete_run_review(row, course_run)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("An unknown error occurred while completing course run review")
+
+            logger.info("Course and course run updated successfully for course key {}".format(course_key))
+        logger.info("CSV loader ingest pipeline has completed.")
+
+    def _create_course_api_request_data(self, data, course_type_uuid, course_run_type_uuid):
+        """
+        Given a data dictionary, return a reduced data representation in dict
+        which will be used as input for course creation via course api.
+        """
+        pricing = self.get_pricing_representation(data['verified_price'])
+
+        # TODO: make appropriate timezone adjustment when it is confirmed if time values are in EST or UTC
+        course_run_creation_fields = {
+            'pacing_type': self.get_pacing_type(data['course_pacing']),
+            'start': self.get_formatted_datetime_string(f"{data['start_date']} {data['start_time']}"),
+            'end': self.get_formatted_datetime_string(f"{data['end_date']} {data['end_time']}"),
+            'run_type': str(course_run_type_uuid),
+            'prices': pricing,
+        }
+        return {
+            'org': data['organization'],
+            'title': data['title'],
+            'number': data['number'],
+            'type': str(course_type_uuid),
+            'prices': pricing,
+            'course_run': course_run_creation_fields
+        }
+
+    def _update_course_api_request_data(self, data, course):
+        """
+        Create and return the request data for making a patch call to update the course.
+        """
+        collaborator_uuids = self.process_collaborators(data['collaborators'], course.key)
+        subjects = self.get_subject_slugs(
+            data.get('primary_subject'),
+            data.get('secondary_subject'),
+            data.get('tertiary_subject')
+        )
+
+        update_course_data = {
+            'draft': False,
+            'key': course.key,
+            'uuid': str(course.uuid),
+            'url_slug': course.url_slug,
+            'type': str(course.type.uuid),
+            'subjects': subjects,
+            'collaborators': collaborator_uuids,
+            'prices': self.get_pricing_representation(data['verified_price']),
+
+            'title': data['title'],
+            'syllabus_raw': data['syllabus'],
+            'level_type': data['course_level'],
+            'outcome': data['what_will_you_learn'],
+            'faq': data['frequently_asked_questions'],
+            'video': {'src': data['about_video_link']},
+            'prerequisites_raw': data['prerequisites'],
+            'full_description': data['long_description'],
+            'short_description': data['short_description'],
+            'learner_testimonials': data['learner_testimonials'],
+            'additional_information': data['additional_information'],
+        }
+        return update_course_data
+
+    def _update_course_run_request_data(self, data, course_run):
+        """
+        Create and return the request data for making a patch call to update the course run.
+        """
+        program_type = data['expected_program_type']
+        staff_uuids = self.process_staff_names(data['staff'], course_run.key)
+        content_language = self.verify_and_get_language_tags(data['content_language'])
+        transcript_language = self.verify_and_get_language_tags(data['transcript_language'])
+
+        update_course_run_data = {
+            'run_type': str(course_run.type.uuid),
+            'key': course_run.key,
+            'prices': self.get_pricing_representation(data['verified_price']),
+            'staff': staff_uuids,
+            'draft': False,
+
+            'weeks_to_complete': data['length'],
+            'min_effort': data['minimum_effort'],
+            'max_effort': data['maximum_effort'],
+            'content_language': content_language[0],
+            'expected_program_name': data['expected_program_name'],
+            'transcript_languages': transcript_language,
+            'go_live_date': self.get_formatted_datetime_string(data['publish_date']),
+            'expected_program_type': program_type if program_type in self.PROGRAM_TYPES else None,
+            'upgrade_deadline_override': self.get_formatted_datetime_string(
+                f"{data['upgrade_deadline_override_date']} {data['upgrade_deadline_override_time']}"
+            ),
+        }
+        return update_course_run_data
+
+    def get_formatted_datetime_string(self, date_string):
+        """
+        Return the datetime string into the desired format %Y-%m-%dT%H:%M:%SZ
+        """
+        return serialize_datetime(self.parse_date(date_string))
+
+    def get_pacing_type(self, pacing):
+        """
+        Return appropriate pacing selection against a provided pacing string.
+        """
+        if pacing:
+            pacing = pacing.lower()
+
+        if pacing == 'instructor-paced':
+            return CourseRunPacing.Instructor
+        elif pacing == 'self-paced':
+            return CourseRunPacing.Self
+        else:
+            return None
+
+    def verify_and_get_language_tags(self, language_str):
+        """
+        Given a string of language tags or names, verify their existence in the database
+        and return a list of language codes.
+        """
+        languages_codes_list = []
+        languages_list = language_str.split(',')
+        for language in languages_list:
+            language = language.strip()
+            language_obj = LanguageTag.objects.filter(
+                Q(name=language) | Q(code=language)
+            ).first()
+            if not language_obj:
+                raise Exception(
+                    'Language {} from provided string {} is either missing or an invalid ietf language'.format(
+                        language, language_str
+                    )
+                )
+            languages_codes_list.append(language_obj.code)
+        return languages_codes_list
+
+    def _call_course_api(self, method, url, data):
+        """
+        Helper method to make course and course run api calls.
+        """
+        response = self.api_client.request(
+            method,
+            url,
+            json=data,
+            headers={'content-type': 'application/json'}
+        )
+        response.raise_for_status()
+        return response
+
+    def _create_course(self, data, course_type_uuid, course_run_type_uuid):
+        """
+        Make a course entry through course api.
+        """
+        course_api_url = reverse('api:v1:course-list')
+        url = f"{settings.DISCOVERY_BASE_URL}{course_api_url}"
+
+        request_data = self._create_course_api_request_data(data, course_type_uuid, course_run_type_uuid)
+        response = self._call_course_api('POST', url, request_data)
+        if response.status_code not in (200, 201):
+            logger.info("Course creation response: {}".format(response.content))
+        return response.json()
+
+    def _update_course(self, data, course):
+        """
+        Update the course data.
+        """
+        course_api_url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})
+        url = f"{settings.DISCOVERY_BASE_URL}{course_api_url}?exclude_utm=1"
+        request_data = self._update_course_api_request_data(data, course)
+        response = self._call_course_api('PATCH', url, request_data)
+
+        if response.status_code not in (200, 201):
+            logger.info("Course update response: {}".format(response.content))
+        return response.json()
+
+    def _update_course_run(self, data, course_run):
+        """
+        Update the course run data.
+        """
+        course_run_api_url = reverse('api:v1:course_run-detail', kwargs={'key': course_run.key})
+        url = f"{settings.DISCOVERY_BASE_URL}{course_run_api_url}?exclude_utm=1"
+        request_data = self._update_course_run_request_data(data, course_run)
+        response = self._call_course_api('PATCH', url, request_data)
+        if response.status_code not in (200, 201):
+            logger.info("Course run update response: {}".format(response.content))
+        return response.json()
+
+    def _complete_run_review(self, data, course_run):
+        """
+        Complete the review phase of the course run and publish(internally by model save) if applicable.
+        """
+        has_ofac_restrictions = data['course_embargo_(ofac)_restriction_text_added_to_the_faq_section'].lower() in [
+            'yes', '1', 'true'
+        ]
+        ofac_comment = data.get('ofac_comment', '')
+        course_run.complete_review_phase(has_ofac_restrictions, ofac_comment)
+
+    def transform_dict_keys(self, data):
+        """
+        Given a data dictionary, return a new dict that has its keys transformed to
+        snake case. For example, Enrollment Track becomes enrollment_track.
+
+        Each key is stripped of whitespaces around the edges, converted to lower case,
+        and has internal spaces converted to _. This convention removes the dependency on CSV
+        headers format(Enrollment Track vs Enrollment track) and makes code flexible to ignore
+        any case sensitivity, among other things.
+        """
+        transformed_dict = {}
+        for key, value in data.items():
+            updated_key = key.strip().lower().replace(' ', '_')
+            transformed_dict[updated_key] = value
+        return transformed_dict
+
+    def get_course_key(self, organization_key, number):
+        """
+        Given organization key and course number, return course key.
+        """
+        return '{org}+{number}'.format(org=organization_key, number=number)
+
+    def get_pricing_representation(self, verified_price):
+        """
+        Return dict representation of prices.
+        """
+        return {
+            'verified': verified_price,  # TODO: temporary value to verified
+            # Actual value from course type -> entitlement_tracks -> slugs
+        }
+
+    def get_subject_slugs(self, *subjects):
+        """
+        Given a list of subject names, convert the subject names into their
+        slug representation.
+        """
+        subjects = [subject.lower().replace(' ', '-') for subject in subjects if subject]
+        return list(set(subjects))
+
+    def process_collaborators(self, collaborators, course_key):
+        """
+        Given a comma-separated string of collaborator names, return the list of collaborator
+        uuids after processing.
+
+        Processing involves the following
+            * Checking if the collaborator value is valid
+            * Checking for existence of collaborator in DB
+            * Create collaborator if not present
+        """
+        collaborators = collaborators.split(',')
+        collaborators = [collaborator.strip() for collaborator in collaborators if collaborator.strip()]
+        collaborator_uuids = []
+        for collaborator in collaborators:
+            collaborator_obj, created = Collaborator.objects.get_or_create(name=collaborator)
+            collaborator_uuids.append(str(collaborator_obj.uuid))
+            if created:
+                logger.info("Collaborator {} created for course {}".format(collaborator, course_key))
+        return collaborator_uuids
+
+    def process_staff_names(self, staff_names, course_run_key):
+        """
+        Given a comma-separated string of staff names, return the list of staff
+        uuids after processing.
+
+        Processing involves the following
+            * Checking if the staff value is valid
+            * Checking for existence of staff member in DB
+            * Create staff if not present
+        """
+
+        staff_names_list = staff_names.split(',')
+        staff_names_list = [staff_name for staff_name in staff_names_list if staff_name.strip()]
+        staff_uuids = []
+
+        # TODO: This is a fragile approach. It is possible for two people to have same name within a partner.
+        # TODO: CSV would need to provide more information to identify staff members from other than names
+        for staff_name in staff_names_list:
+            person, created = Person.objects.get_or_create(
+                partner=self.partner,
+                given_name=staff_name
+            )
+            staff_uuids.append(str(person.uuid))
+            if created:
+                logger.info("Staff with name {} has been created for course run {}".format(
+                    staff_name,
+                    course_run_key
+                ))
+        return staff_uuids

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -1,6 +1,6 @@
 """
-Data loader responsible for creating course and course runs entries in Database
-provided a csv containing the required information.
+Data loader responsible for creating course and course runs entries in discovery Database,
+creating and updating related objects in Studio, and ecommerce, provided a csv containing the required information.
 """
 import csv
 import logging

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -3,7 +3,12 @@ from unittest import mock
 import responses
 
 from course_discovery.apps.api.v1.tests.test_views.mixins import OAuth2Mixin
-from course_discovery.apps.course_metadata.tests.factories import PartnerFactory
+from course_discovery.apps.course_metadata.models import (
+    CourseEntitlement, CourseRunStatus, CourseRunType, CourseType, Seat
+)
+from course_discovery.apps.course_metadata.tests.factories import (
+    LevelTypeFactory, OrganizationFactory, PartnerFactory, SubjectFactory
+)
 
 
 # pylint: disable=not-callable
@@ -35,3 +40,193 @@ class DataLoaderTestMixin(OAuth2Mixin):
     def test_init(self):
         """ Verify the constructor sets the appropriate attributes. """
         assert self.loader.partner.short_code == self.partner.short_code
+
+
+class CSVLoaderMixin:
+    """
+    Mixin to contain various variables and methods used for CSVDataLoader testing.
+    """
+    COURSE_KEY = 'edx+csv_123'
+    COURSE_RUN_KEY = 'course-v1:edx+csv_123+1T2020'
+
+    # The list to define order of the header keys in csv. The order here is important to keep header->values in sync.
+    CSV_DATA_KEYS_ORDER = [
+        'organization', 'title', 'number', 'course_enrollment_track', 'image', 'short_description',
+        'long_description', 'what_will_you_learn', 'course_level', 'primary_subject', 'verified_price', 'collaborators',
+        'syllabus', 'prerequisites', 'learner_testimonials', 'frequently_asked_questions', 'additional_information',
+        'about_video_link', 'secondary_subject', 'tertiary_subject',
+        'course_embargo_(ofac)_restriction_text_added_to_the_faq_section', 'publish_date',
+        'start_date', 'start_time', 'end_date', 'end_time', 'course_run_enrollment_track', 'course_pacing', 'staff',
+        'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language',
+        'expected_program_type', 'expected_program_name', 'upgrade_deadline_override_date',
+        'upgrade_deadline_override_time'
+    ]
+    BASE_EXPECTED_COURSE_DATA = {
+        'draft': False,
+        'verified_price': 150,
+        'title': 'CSV Course',
+        'level_type': 'beginner',
+        'about_video_link': 'http://www.example.com',
+        'faq': '<p>Is day 19 really that tough?</p>',
+        'outcome': '<p>Outcomes</p>',
+        'syllabus': '<p>Introduction to Algorithms</p>',
+        'prerequisites_raw': '<p>Summer of Winter</p>',
+        'learner_testimonials': '<p>Very challenging</p>',
+        'subjects': ['computer-science', 'social-sciences'],
+        'collaborators': ['collab_1', 'collab_2', 'collab_3'],
+        'short_description': '<p>Very short description</p>',
+        'full_description': '<p>Organization,Title,Number,Course Enrollment track,Image,Short Description,Long '
+                            'Description,Organization,Title,Number,Course Enrollment track,Image,Short Description'
+                            ',Long Description,</p>',
+    }
+
+    BASE_EXPECTED_COURSE_RUN_DATA = {
+        'draft': False,
+        'status': CourseRunStatus.Published,
+        'length': 10,
+        'minimum_effort': 4,
+        'maximum_effort': 10,
+        'verified_price': 150,
+        'ofac_restrictions': False,
+        'ofac_comment': '',
+        'staff': ['staff_2', 'staff_1'],
+        'content_language': 'English - United States',
+        'transcript_language': ['English - Great Britain'],
+        'go_live_date': '2020-01-01T00:00:00+00:00',
+        'expected_program_type': 'professional-certificate',
+        'expected_program_name': 'New Program for all',
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.course_type = CourseType.objects.get(
+            slug=CourseType.VERIFIED_AUDIT)
+        self.course_run_type = CourseRunType.objects.get(
+            slug=CourseRunType.VERIFIED_AUDIT)
+
+    def _write_csv(self, csv, lines_dict_list):
+        """
+        Helper method to write given list of data dictionaries to csv, including the csv header.
+        """
+        header = ''
+        lines = ''
+        for key in self.CSV_DATA_KEYS_ORDER:
+            title_case_key = key.replace('_', ' ').title()
+            header = '{}{},'.format(header, title_case_key)
+        header = f"{header[:-1]}\n"
+
+        for line_dict in lines_dict_list:
+            for key in self.CSV_DATA_KEYS_ORDER:
+                lines = '{}"{}",'.format(lines, line_dict[key])
+            lines = f"{lines[:-1]}\n"
+
+        csv.write(header.encode())
+        csv.write(lines.encode())
+        csv.seek(0)
+        return csv
+
+    def _setup_organization(self, partner):
+        """
+        setup test-only organization.
+        """
+        OrganizationFactory(name='edx', key='edx', partner=partner)
+
+    def _setup_prerequisites(self, partner):
+        """
+        Setup pre-reqs for the course and course run api calls.
+        """
+        self._setup_organization(partner)
+
+        beginner = LevelTypeFactory()
+        beginner.set_current_language('en')
+        beginner.name_t = 'beginner'
+        beginner.save()
+
+        SubjectFactory(name='Computer Science')
+        SubjectFactory(name='Social Sciences')
+
+    def mock_ecommerce_publication(self, partner):
+        """
+        Mock ecommerce api calls.
+        """
+        url = f'{partner.ecommerce_api_url}publication/'
+        responses.add(responses.POST, url, json={}, status=200)
+
+    def mock_studio_calls(self, partner, run_key='course-v1:edx+csv_123+1T2020'):
+        """
+        Mock the studio api calls.
+        """
+        studio_url = '{root}/api/v1/course_runs/'.format(root=partner.studio_url.strip('/'))
+        responses.add(responses.POST, studio_url, status=200)
+        responses.add(responses.PATCH, f'{studio_url}{run_key}/', status=200)
+        responses.add(responses.POST, f'{studio_url}{run_key}/images/', status=200)
+
+    def mock_image_response(self, status=200, body=None, content_type='image/jpeg'):
+        """
+        Mock the image download call to return a pre-defined image.
+        """
+        # PNG. Single black pixel
+        body = body or b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00' \
+                       b'\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc```\x00\x00\x00\x04\x00\x01\xf6\x178U\x00\x00\x00\x00' \
+                       b'IEND\xaeB`\x82'
+        image_url = 'https://example.com/image.jpg'
+        responses.add(
+            responses.GET,
+            image_url,
+            body=body,
+            status=status,
+            content_type=content_type
+        )
+        return image_url, body
+
+    def _assert_course_data(self, course, expected_data):
+        """
+        Verify the course's data fields have same values as the expected data dict.
+        """
+        course_entitlement = CourseEntitlement.everything.get(
+            draft=expected_data['draft'], mode__slug='verified', course=course
+        )
+
+        assert course.draft is expected_data['draft']
+        assert course.title == expected_data['title']
+        assert course.faq == expected_data['faq']
+        assert course.outcome == expected_data['outcome']
+        assert course.syllabus_raw == expected_data['syllabus']
+        assert course.short_description == expected_data['short_description']
+        assert course.full_description == expected_data['full_description']
+        assert course.prerequisites_raw == expected_data['prerequisites_raw']
+        assert course.learner_testimonials == expected_data['learner_testimonials']
+        assert course.level_type.name_t == expected_data['level_type']
+        assert course.video.src == expected_data['about_video_link']
+        assert course.type == self.course_type
+        assert course_entitlement.price == expected_data['verified_price']
+        assert sorted([subject.slug for subject in course.subjects.all()]) == sorted(expected_data['subjects'])
+        assert sorted(
+            [collaborator.name for collaborator in course.collaborators.all()]
+        ) == sorted(expected_data['collaborators'])
+
+    def _assert_course_run_data(self, course_run, expected_data):
+        """
+        Verify the course run's data fields have same values as the expected data dict.
+        """
+        course_run_seat = Seat.everything.get(type__slug='verified', course_run=course_run)
+
+        assert course_run.draft is expected_data['draft']
+        assert course_run.status == expected_data['status']
+        assert course_run.weeks_to_complete == expected_data['length']
+        assert course_run.min_effort == expected_data['minimum_effort']
+        assert course_run.max_effort == expected_data['maximum_effort']
+        assert course_run_seat.price == expected_data['verified_price']
+        assert course_run.has_ofac_restrictions == expected_data['ofac_restrictions']
+        assert course_run.ofac_comment == expected_data['ofac_comment']
+        assert course_run.go_live_date.isoformat() == expected_data['go_live_date']
+        assert course_run.expected_program_type.slug == expected_data['expected_program_type']
+        assert course_run.expected_program_name == expected_data['expected_program_name']
+        assert course_run.language.name == expected_data['content_language']
+        assert course_run.type == self.course_run_type
+        assert sorted(
+            [staff.given_name for staff in course_run.staff.all()]
+        ) == sorted(expected_data['staff'])
+        assert sorted(
+            [language.name for language in course_run.transcript_languages.all()]
+        ) == sorted(expected_data['transcript_language'])

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -92,7 +92,7 @@ class CSVLoaderMixin:
         'staff': ['staff_2', 'staff_1'],
         'content_language': 'English - United States',
         'transcript_language': ['English - Great Britain'],
-        'go_live_date': '2020-01-01T00:00:00+00:00',
+        'go_live_date': '2020-01-25T00:00:00+00:00',
         'expected_program_type': 'professional-certificate',
         'expected_program_name': 'New Program for all',
     }

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3070,3 +3070,65 @@ DISCOVERY_CREATED_MARKETING_SITE_API_COURSE_BODY = {
     'uuid': '6b8b779f-f567-4e98-aa41-a265d6fa073a',
     'vuuid': 'e0f8c80a-b377-4546-b247-1c94ab3a218a'
 }
+
+VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
+    'organization': 'edx',
+    'title': 'CSV Course',
+    'number': 'csv_123',
+    'course_enrollment_track': 'Verified and Audit',
+    'image': 'https://example.com/image.jpg',
+    'short_description': 'Very short description',
+    'long_description': 'Organization,Title,Number,Course Enrollment track,Image,Short Description,Long Description,'
+                        'Organization,Title,Number,Course Enrollment track,Image,Short Description,Long Description,',
+    'what_will_you_learn': 'Outcomes',
+    'course_level': 'beginner',
+    'primary_subject': 'Computer Science',
+    'secondary_subject': 'Social Sciences',
+    'tertiary_subject': '',
+    'verified_price': 150,
+    'collaborators': 'collab_1,collab_2,collab_3',
+    'syllabus': 'Introduction to Algorithms',
+    'prerequisites': 'Summer of Winter',
+    'learner_testimonials': 'Very challenging',
+    'frequently_asked_questions': 'Is day 19 really that tough?',
+    'additional_information': '',
+    'about_video_link': 'http://www.example.com',
+    'course_embargo_(ofac)_restriction_text_added_to_the_faq_section': False,
+    'publish_date': '01/01/2020',
+    'start_date': '01/01/2020',
+    'start_time': '00:00',
+    'end_date': '01/01/2021',
+    'end_time': '00:00',
+    'course_pacing': 'self-paced',
+    'course_run_enrollment_track': 'Verified and Audit',
+    'staff': 'staff_1,staff_2',
+    'minimum_effort': 4,
+    'maximum_effort': 10,
+    'length': 10,
+    'content_language': 'English - United States',
+    'transcript_language': 'English - Great Britain',
+    'expected_program_type': 'professional-certificate',
+    'expected_program_name': 'New Program for all',
+    'upgrade_deadline_override_date': '02/01/2020',
+    'upgrade_deadline_override_time': '00:00'
+}
+
+INVALID_ORGANIZATION_DATA = {
+    **VALID_COURSE_AND_COURSE_RUN_CSV_DICT,
+    'organization': 'invalid-organization'
+}
+
+INVALID_COURSE_TYPE_DATA = {
+    **VALID_COURSE_AND_COURSE_RUN_CSV_DICT,
+    'course_enrollment_track': 'invalid track'
+}
+
+INVALID_COURSE_RUN_TYPE_DATA = {
+    **VALID_COURSE_AND_COURSE_RUN_CSV_DICT,
+    'course_run_enrollment_track': 'invalid track'
+}
+
+INVALID_LANGUAGE = {
+    **VALID_COURSE_AND_COURSE_RUN_CSV_DICT,
+    'content_language': 'gibberish-language',
+}

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3094,10 +3094,10 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'additional_information': '',
     'about_video_link': 'http://www.example.com',
     'course_embargo_(ofac)_restriction_text_added_to_the_faq_section': False,
-    'publish_date': '01/01/2020',
-    'start_date': '01/01/2020',
+    'publish_date': '01/25/2020',
+    'start_date': '01/25/2020',
     'start_time': '00:00',
-    'end_date': '01/01/2021',
+    'end_date': '02/25/2020',
     'end_time': '00:00',
     'course_pacing': 'self-paced',
     'course_run_enrollment_track': 'Verified and Audit',
@@ -3109,7 +3109,7 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'transcript_language': 'English - Great Britain',
     'expected_program_type': 'professional-certificate',
     'expected_program_name': 'New Program for all',
-    'upgrade_deadline_override_date': '02/01/2020',
+    'upgrade_deadline_override_date': '01/25/2020',
     'upgrade_deadline_override_time': '00:00'
 }
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -235,7 +235,12 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         self.mock_image_response()
 
         course = CourseFactory(key=self.COURSE_KEY, partner=self.partner, type=self.course_type, draft=True)
-        CourseRunFactory(course=course, key=self.COURSE_RUN_KEY, type=self.course_run_type, draft=True)
+        CourseRunFactory(
+            course=course,
+            key=self.COURSE_RUN_KEY,
+            type=self.course_run_type,
+            draft=True,
+        )
 
         with NamedTemporaryFile() as csv:
             csv = self._write_csv(csv, [mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT])

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -1,0 +1,317 @@
+"""
+Unit tests for CSV Data loader.
+"""
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+import responses
+from testfixtures import LogCapture
+
+from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from course_discovery.apps.course_metadata.data_loaders.csv_loader import CSVDataLoader
+from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
+from course_discovery.apps.course_metadata.data_loaders.tests.mixins import CSVLoaderMixin
+from course_discovery.apps.course_metadata.models import Course, CourseRun
+from course_discovery.apps.course_metadata.tests.factories import CourseFactory, CourseRunFactory
+
+LOGGER_PATH = 'course_discovery.apps.course_metadata.data_loaders.csv_loader'
+
+
+@mock.patch(
+    'course_discovery.apps.course_metadata.data_loaders.configured_jwt_decode_handler',
+    return_value={'preferred_username': 'test_username'}
+)
+class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
+    """
+    Test Suite for CSVDataLoader.
+    """
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_access_token()
+        self.user = UserFactory.create(username="test_user", password=USER_PASSWORD, is_staff=True)
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+
+    def mock_call_course_api(self, method, url, data):
+        """
+        Helper method to make api calls using test client.
+        """
+        response = None
+        if method == 'POST':
+            response = self.client.post(
+                url,
+                data=data,
+                format='json'
+            )
+        elif method == 'PATCH':
+            response = self.client.patch(
+                url,
+                data=data,
+                format='json'
+            )
+        return response
+
+    def _assert_default_logs(self, log_capture):
+        """
+        Assert the initiation and completion logs are present in the logger.
+        """
+        log_capture.check_present(
+            (
+                LOGGER_PATH,
+                'INFO',
+                'Initiating CSV data loader flow.'
+            ),
+            (
+                LOGGER_PATH,
+                'INFO',
+                'CSV loader ingest pipeline has completed.'
+            )
+
+        )
+
+    def test_missing_organization(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that no course and course run are created for a missing organization in the database.
+        """
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.INVALID_ORGANIZATION_DATA])
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = CSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        'Organization invalid-organization does not exist in database. Skipping CSV '
+                        'loader for course CSV Course'
+                    )
+                )
+                assert Course.objects.count() == 0
+                assert CourseRun.objects.count() == 0
+
+    def test_invalid_course_type(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that no course and course run are created for an invalid course track type.
+        """
+        self._setup_organization(self.partner)
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.INVALID_COURSE_TYPE_DATA])
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = CSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        'CourseType invalid track does not exist in the database.'
+                    )
+                )
+                assert Course.objects.count() == 0
+                assert CourseRun.objects.count() == 0
+
+    def test_invalid_course_run_type(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that no course and course run are created for an invalid course run track type.
+        """
+        self._setup_organization(self.partner)
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.INVALID_COURSE_RUN_TYPE_DATA])
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = CSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        'CourseRunType invalid track does not exist in the database.'
+                    )
+                )
+                assert Course.objects.count() == 0
+                assert CourseRun.objects.count() == 0
+
+    @responses.activate
+    def test_image_download_failure(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that if the course image download fails, the ingestion does not complete.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_studio_calls(self.partner)
+        self.mock_ecommerce_publication(self.partner)
+        responses.add(
+            responses.GET,
+            'https://example.com/image.jpg',
+            status=400,
+            body='Image unavailable',
+            content_type='image/jpeg',
+        )
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                with mock.patch.object(
+                        CSVDataLoader,
+                        '_call_course_api',
+                        self.mock_call_course_api
+                ):
+                    loader = CSVDataLoader(self.partner, csv_path=csv.name)
+                    loader.ingest()
+
+                    self._assert_default_logs(log_capture)
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            'Course key edx+csv_123 could not be found in database, creating the course.'
+                        )
+                    )
+
+                    # Creation call results in creating course and course run objects
+                    assert Course.everything.count() == 1
+                    assert CourseRun.everything.count() == 1
+
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'ERROR',
+                            'Unexpected error happened while downloading image for course edx+csv_123'
+                        )
+                    )
+
+    @responses.activate
+    def test_single_valid_row(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that for a single row of valid data, both official/non-draft versions
+        of course and course runs are created with correct data.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_studio_calls(self.partner)
+        self.mock_ecommerce_publication(self.partner)
+        _, image_content = self.mock_image_response()
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                with mock.patch.object(
+                        CSVDataLoader,
+                        '_call_course_api',
+                        self.mock_call_course_api
+                ):
+                    loader = CSVDataLoader(self.partner, csv_path=csv.name)
+                    loader.ingest()
+
+                    self._assert_default_logs(log_capture)
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            'Course key edx+csv_123 could not be found in database, creating the course.'
+                        )
+                    )
+
+                    assert Course.objects.count() == 1
+                    assert CourseRun.objects.count() == 1
+
+                    course = Course.objects.get(key=self.COURSE_KEY, partner=self.partner)
+                    course_run = CourseRun.objects.get(course=course)
+
+                    assert course.image.read() == image_content
+                    self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)
+                    self._assert_course_run_data(course_run, self.BASE_EXPECTED_COURSE_RUN_DATA)
+
+    @responses.activate
+    def test_ingest_flow_for_preexisting_course(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that the loader updates the existing draft versions of the course and its
+        associated course run.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_studio_calls(self.partner)
+        self.mock_ecommerce_publication(self.partner)
+        self.mock_image_response()
+
+        course = CourseFactory(key=self.COURSE_KEY, partner=self.partner, type=self.course_type, draft=True)
+        CourseRunFactory(course=course, key=self.COURSE_RUN_KEY, type=self.course_run_type, draft=True)
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                with mock.patch.object(
+                        CSVDataLoader,
+                        '_call_course_api',
+                        self.mock_call_course_api
+                ):
+                    loader = CSVDataLoader(self.partner, csv_path=csv.name)
+                    loader.ingest()
+
+                    self._assert_default_logs(log_capture)
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            'Course edx+csv_123 is located in the database.'
+                        )
+                    )
+
+                    course = Course.objects.get(key=self.COURSE_KEY, partner=self.partner)
+                    course_run = CourseRun.objects.get(course=course)
+
+                    self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)
+                    self._assert_course_run_data(course_run, self.BASE_EXPECTED_COURSE_RUN_DATA)
+
+    @responses.activate
+    def test_invalid_language(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that the course run update fails if an invalid language information is provided
+        in the data but the course information is updated properly.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_studio_calls(self.partner)
+        _, image_content = self.mock_image_response()
+
+        expected_course_response = {
+            **self.BASE_EXPECTED_COURSE_DATA,
+            'draft': True
+        }
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.INVALID_LANGUAGE])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                with mock.patch.object(
+                        CSVDataLoader,
+                        '_call_course_api',
+                        self.mock_call_course_api
+                ):
+                    loader = CSVDataLoader(self.partner, csv_path=csv.name)
+                    loader.ingest()
+
+                    self._assert_default_logs(log_capture)
+
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            'Course key edx+csv_123 could not be found in database, creating the course.'
+                        )
+                    )
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'ERROR',
+                            'An unknown error occurred while updating course run information'
+                        )
+                    )
+
+                    assert Course.everything.count() == 1
+                    assert CourseRun.everything.count() == 1
+
+                    course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
+
+                    assert course.image.read() == image_content
+                    self._assert_course_data(course, expected_course_response)

--- a/course_discovery/apps/course_metadata/management/commands/download_course_images.py
+++ b/course_discovery/apps/course_metadata/management/commands/download_course_images.py
@@ -1,17 +1,11 @@
 import logging
 
-import requests
-from django.core.files.base import ContentFile
 from django.core.management import BaseCommand
 
 from course_discovery.apps.course_metadata.models import Course
+from course_discovery.apps.course_metadata.utils import download_and_save_course_image
 
 logger = logging.getLogger(__name__)
-
-IMAGE_TYPES = {
-    'image/jpeg': 'jpg',
-    'image/png': 'png',
-}
 
 
 class Command(BaseCommand):
@@ -42,25 +36,4 @@ class Command(BaseCommand):
 
         for course in courses:
             logger.info('Retrieving image for course [%s] from [%s]...', course.key, course.card_image_url)
-
-            try:
-                response = requests.get(course.card_image_url)
-
-                if response.status_code == requests.codes.ok:  # pylint: disable=no-member
-                    content_type = response.headers['Content-Type'].lower()
-                    extension = IMAGE_TYPES.get(content_type)
-
-                    if extension:
-                        filename = '{uuid}.{extension}'.format(uuid=str(course.uuid), extension=extension)
-                        course.image.save(filename, ContentFile(response.content))
-                        logger.info('Image for course [%s] successfully updated.', course.key)
-                    else:
-                        # pylint: disable=line-too-long
-                        msg = 'Image retrieved for course [%s] from [%s] has an unknown content type [%s] and will not be saved.'
-                        logger.error(msg, course.key, course.card_image_url, content_type)
-
-                else:
-                    msg = 'Failed to download image for course [%s] from [%s]! Response was [%d]:\n%s'
-                    logger.error(msg, course.key, course.card_image_url, response.status_code, response.content)
-            except Exception:  # pylint: disable=broad-except
-                logger.exception('An unknown exception occurred while downloading image for course [%s]', course.key)
+            download_and_save_course_image(course, course.card_image_url)

--- a/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
@@ -1,0 +1,68 @@
+"""
+Management command to import, create, and/or update course and course run information for
+executive education courses.
+"""
+import logging
+
+from django.apps import apps
+from django.core.management import BaseCommand, CommandError
+from django.db.models.signals import post_delete, post_save
+
+from course_discovery.apps.api.cache import api_change_receiver, set_api_timestamp
+from course_discovery.apps.core.models import Partner
+from course_discovery.apps.course_metadata.data_loaders.csv_loader import CSVDataLoader
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Import course and course run information from a CSV available on a provided csv path.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--partner_code',
+            help='The short code for a specific partner to import courses to, defaults to "edx".',
+            default='edx',
+            type=str,
+        )
+        parser.add_argument(
+            '--csv_path',
+            help='Path to the CSV file',
+            type=str,
+            required=True
+        )
+
+    def handle(self, *args, **options):
+        """
+        Example usage: ./manage.py import_course_metadata --partner_code=edx --csv_path=test.csv
+        """
+
+        # The signal disconnect has been taken from refresh_course_metadata management command.
+        # We only want to invalidate the API response cache once data loading
+        # completes. Disconnecting the api_change_receiver function from post_save
+        # and post_delete signals prevents model changes during data loading from
+        # repeatedly invalidating the cache.
+        for model in apps.get_app_config('course_metadata').get_models():
+            for signal in (post_save, post_delete):
+                signal.disconnect(receiver=api_change_receiver, sender=model)
+
+        partner_short_code = options.get('partner_code')
+        csv_path = options.get('csv_path')
+        try:
+            partner = Partner.objects.get(short_code=partner_short_code)
+        except Partner.DoesNotExist:
+            raise CommandError(  # pylint: disable=raise-missing-from
+                "Unable to locate partner with code {}".format(partner_short_code)
+            )
+
+        try:
+            loader = CSVDataLoader(partner, csv_path=csv_path)
+            logger.info("Starting CSV loader import flow for partner {}".format(partner_short_code))
+            loader.ingest()
+        except Exception as exc:
+            raise CommandError(  # pylint: disable=raise-missing-from
+                "CSV loader import could not be completed due to unexpected errors.\n{}".format(exc)
+            )
+        else:
+            set_api_timestamp()
+            logger.info("CSV loader import flow completed.")

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_download_course_images.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_download_course_images.py
@@ -9,7 +9,7 @@ from course_discovery.apps.course_metadata.tests.factories import CourseFactory
 
 @pytest.mark.django_db
 class TestDownloadCourseImages:
-    LOGGER_PATH = 'course_discovery.apps.course_metadata.management.commands.download_course_images.logger'
+    LOGGER_PATH = 'course_discovery.apps.course_metadata.utils.logger'
 
     def mock_image_response(self, status=200, body=None, content_type='image/jpeg'):
         # PNG. Single black pixel
@@ -94,7 +94,9 @@ class TestDownloadCourseImages:
         self.assert_course_has_no_image(course)
 
     def test_download_without_courses(self):
-        with mock.patch(self.LOGGER_PATH) as mock_logger:
+        with mock.patch(
+                'course_discovery.apps.course_metadata.management.commands.download_course_images.logger'
+        ) as mock_logger:
             call_command('download_course_images')
             mock_logger.info.assert_called_with('All courses are up to date.')
 

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for import_course_metadata management command.
+"""
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+import responses
+from django.core.management import CommandError, call_command
+from testfixtures import LogCapture
+
+from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from course_discovery.apps.course_metadata.data_loaders.csv_loader import CSVDataLoader
+from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
+from course_discovery.apps.course_metadata.data_loaders.tests.mixins import CSVLoaderMixin
+from course_discovery.apps.course_metadata.models import Course, CourseRun
+
+LOGGER_PATH = 'course_discovery.apps.course_metadata.management.commands.import_course_metadata'
+
+
+@mock.patch(
+    'course_discovery.apps.course_metadata.data_loaders.configured_jwt_decode_handler',
+    return_value={'preferred_username': 'test_username'}
+)
+class TestImportCourseMetadata(CSVLoaderMixin, OAuth2Mixin, APITestCase):
+    """
+    Test suite for import_course_metadata management command.
+    """
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_access_token()
+        self.user = UserFactory.create(username="test_user", password=USER_PASSWORD, is_staff=True)
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+
+    def mock_call_course_api(self, method, url, data):
+        """
+        Helper method to make api calls using test client.
+        """
+        response = None
+        if method == 'POST':
+            response = self.client.post(
+                url,
+                data=data,
+                format='json'
+            )
+        elif method == 'PATCH':
+            response = self.client.patch(
+                url,
+                data=data,
+                format='json'
+            )
+        return response
+
+    def test_missing_partner(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Test that the command raises CommandError if no partner is present against the provided short code.
+        """
+        with self.assertRaisesMessage(CommandError, 'Unable to locate partner with code invalid-partner-code'):
+            call_command(
+                'import_course_metadata', '--partner_code', 'invalid-partner-code', '--csv_path', ''
+            )
+
+    def test_invalid_csv_path(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Test that the command raises CommandError if an invalid csv path is provided.
+        """
+        with self.assertRaisesMessage(
+                CommandError, 'CSV loader import could not be completed due to unexpected errors.'
+        ):
+            call_command(
+                'import_course_metadata', '--partner_code', self.partner.short_code, '--csv_path', 'no-path'
+            )
+
+    @responses.activate
+    def test_success_flow(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that for a single row of valid data, the command completes CSV loader ingestion flow successfully.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_studio_calls(self.partner)
+        self.mock_ecommerce_publication(self.partner)
+        _, image_content = self.mock_image_response()
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                with mock.patch.object(
+                        CSVDataLoader,
+                        '_call_course_api',
+                        self.mock_call_course_api
+                ):
+                    call_command(
+                        'import_course_metadata', '--csv_path', csv.name, '--partner_code', self.partner.short_code
+                    )
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            'Starting CSV loader import flow for partner {}'.format(self.partner.short_code)
+                        )
+                    )
+                    log_capture.check_present(
+                        (LOGGER_PATH, 'INFO', 'CSV loader import flow completed.')
+                    )
+
+                    assert Course.objects.count() == 1
+                    assert CourseRun.objects.count() == 1
+
+                    course = Course.objects.get(key=self.COURSE_KEY, partner=self.partner)
+                    course_run = CourseRun.objects.get(course=course)
+
+                    assert course.image.read() == image_content
+                    self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)
+                    self._assert_course_run_data(course_run, self.BASE_EXPECTED_COURSE_RUN_DATA)

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1975,6 +1975,16 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
         is_published = self.status == CourseRunStatus.Published
         return is_published and self.seats.exists() and bool(self.marketing_url)
 
+    def complete_review_phase(self, has_ofac_restrictions, ofac_comment):
+        """
+        Complete the review phase of the course run by marking status as reviewed and adding
+        ofac fields' values.
+        """
+        self.has_ofac_restrictions = has_ofac_restrictions
+        self.ofac_comment = ofac_comment
+        self.status = CourseRunStatus.Reviewed
+        self.save()
+
 
 class Seat(DraftModelMixin, TimeStampedModel):
     """ Seat model. """

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -10,6 +10,7 @@ import markdown
 import requests
 from bs4 import BeautifulSoup
 from django.conf import settings
+from django.core.files.base import ContentFile
 from django.db import models, transaction
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
@@ -19,6 +20,7 @@ from stdimage.models import StdImageFieldFile
 
 from course_discovery.apps.core.models import SalesforceConfiguration
 from course_discovery.apps.core.utils import serialize_datetime
+from course_discovery.apps.course_metadata.constants import IMAGE_TYPES
 from course_discovery.apps.course_metadata.exceptions import (
     EcommerceSiteAPIClientException, MarketingSiteAPIClientException
 )
@@ -682,3 +684,33 @@ def clean_html(content):
     cleaned = markdown.markdown(cleaned)
 
     return cleaned
+
+
+def download_and_save_course_image(course, image_url):
+    """
+    Helper method to download an image from a provided image url and save it
+    as course card image.
+    """
+    try:
+        response = requests.get(image_url)
+
+        if response.status_code == requests.codes.ok:  # pylint: disable=no-member
+            content_type = response.headers['Content-Type'].lower()
+            extension = IMAGE_TYPES.get(content_type)
+
+            if extension:
+                filename = '{uuid}.{extension}'.format(uuid=str(course.uuid), extension=extension)
+                course.image.save(filename, ContentFile(response.content))
+                logger.info('Image for course [%s] successfully updated.', course.key)
+                return True
+            else:
+                # pylint: disable=line-too-long
+                msg = 'Image retrieved for course [%s] from [%s] has an unknown content type [%s] and will not be saved.'
+                logger.error(msg, course.key, image_url, content_type)
+
+        else:
+            msg = 'Failed to download image for course [%s] from [%s]! Response was [%d]:\n%s'
+            logger.error(msg, course.key, image_url, response.status_code, response.content)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception('An unknown exception occurred while downloading image for course [%s]', course.key)
+    return False

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -631,3 +631,5 @@ FIRE_UPDATE_COURSE_SKILLS_SIGNAL = False
 # Learner Pathway
 # Disable learner pathway on all environment except devstack and testing.
 ENABLE_LEARNER_PATHWAY = False
+
+DISCOVERY_BASE_URL = "http://localhost:18381"

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -89,3 +89,6 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 # Learner Pathway
 # Disable learner pathway on all environment except devstack and testing.
 ENABLE_LEARNER_PATHWAY = True
+
+DISCOVERY_BASE_URL = "http://edx.devstack.discovery:18381"
+


### PR DESCRIPTION
### [PROD-2613](https://openedx.atlassian.net/browse/PROD-2613)

### Description

This PR adds a management command that uses CSVDataLoader, also added via this PR, to import course and course information from CSV into discovery. For a single row, the CSV loader works as follows:

- Check the existence of the course and course run in the database. They should be draft if already present
- If the course and course run are not present, create an initial entry
- Update course and course run through separate API calls with their respective fields. 
- Mark the run as reviewed. This essentially publishes the course if applicable.

The loader uses existing course and course run view sets to make API calls to create or update objects. The consumption of APIs as opposed to writing ORM queries is that the CSV loaded is mimicking the way courses and course runs are authored on the publisher. Eventually, all the course/course runs will be accessible and editable from the publisher, so the data representation of API will help achieve that. Also, the APIs already have certain data validation and status update procedures in place which will ensure no bad/missing information is being ingested into discovery.

### Assumptions

The csv loader works under some assumptions, at least at the time of creating this PR:
- Course and course run should be draft if already present before ingesting.
- LevelType and related subjects should be present in the database
- Collaborators(for the course) and Staff(for course runs) are created during ingestion if not located within DB. Staff's name is saved only
- The dates are in UTC as compared to EST. This might require a change in the near future if the provided dates in the sample are in EST
- If the content and/or transcript language are not in IETF language format, course run data is not updated
- Some CSV keys might need an update once there is a sample data set
- The default course editor of the imported course will be the user associated with OAuth application used for making API calls.
 

### Testing

You can use the management command to check the loader, replace csv path value with a valid csv path.
```
python manage.py import_course_metadata --csv_path='/edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/test.csv'
```

Make sure you have the following LevelType entries in the database:
- Introductory
- Advanced
- Intermediate

Also, add the following subjects to the DB, if not present:

- Mathematics
- Physics
- Computer Science
- Social Sciences

### Test CSVs
- [test.csv](https://github.com/openedx/course-discovery/files/7904309/test.csv)
- [test.csv](https://github.com/openedx/course-discovery/files/7904316/test.csv)

### Testing on Sandbox

dawoudsheraz.sandbox.edx.org/

- Download the CSV generator from ticket https://openedx.atlassian.net/browse/PROD-2613?focusedCommentId=589805
- Generate a new CSV
- Connect to VPN
- Copy the csv to sandbox via command `scp test.csv <github_user>@dawoudsheraz.sandbox.edx.org:/tmp`(Assuming command is run from directory where csv is present)
- SSh into sandbox `ssh <github_user>@dawoudsheraz.sandbox.edx.org:`. 
- cd `/edx/app/discovery/discovery`
- run `source ../venvs/discovery/bin/activate`
- Run `python manage.py import_course_metadata --csv_path='/tmp/test.csv'`
- Verify the data on https://discovery-dawoudsheraz.sandbox.edx.org/admin (email: admin@example.com, edx)
- Verify the data on LMS/Studio (admin@example.com, Hamilton)
- Verify data on ecommerce

### Todos
to be catered in follow-up PRs:

- Change price to proper enrollment track-type instead of hard-coding to verified
- Update how the staff/person ids are passed
- Update date parsing to EST once the time values are confirmed
- Add verified deadline override verification checks

Also, in the ticket, there is a script to generate CSV with dummy data. You should generate some other test csv using that script and verify the behavior.


