### PR TITLE
fix: exclude course runs from retired programs

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1848,7 +1848,6 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
             suppress_publication (bool): if True, we won't push the run data to the marketing site
             send_emails (bool): whether to send email notifications for status changes from this save
         """
-        is_new_course_run = not self.id
         push_to_marketing = (not suppress_publication and
                              self.course.partner.has_marketing_site and
                              waffle.switch_is_active('publish_course_runs_to_marketing_site') and
@@ -1864,7 +1863,7 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
             if push_to_marketing:
                 self.push_to_marketing_site(previous_obj)
 
-        if is_new_course_run:
+        if self.status == CourseRunStatus.Reviewed and not self.draft:
             retired_programs = self.programs.filter(status=ProgramStatus.Retired)
             for program in retired_programs:
                 program.excluded_course_runs.add(self)

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -582,7 +582,7 @@ class CourseRunTests(OAuth2Mixin, TestCase):
         assert self.course_run.program_types == [active_program.type.name]
 
     def test_new_course_run_excluded_in_retired_programs(self):
-        """ Verify the newly created course run must be excluded in associated retired programs"""
+        """ Verify the newly reviewed course run must be excluded in associated retired programs"""
         course = factories.CourseFactory()
         course_run = factories.CourseRunFactory(course=course)
         program = factories.ProgramFactory(
@@ -590,7 +590,7 @@ class CourseRunTests(OAuth2Mixin, TestCase):
         )
         course_run.weeks_to_complete = 2
         course_run.save()
-        new_course_run = factories.CourseRunFactory(course=course)
+        new_course_run = factories.CourseRunFactory(course=course, status=CourseRunStatus.Reviewed, draft=False)
         new_course_run.save()
         assert program.excluded_course_runs.count() == 1
         assert len(list(program.course_runs)) == 1


### PR DESCRIPTION
Once a course run is reviewed check to see if it is part of a retired program. If it is, then move this newly reviewed course run to excluded course run of the retired program.

[VAN-748](https://openedx.atlassian.net/browse/VAN-748)