### PR TITLE
feat: add redirect url in course request payload in csv loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -173,6 +173,7 @@ class CSVDataLoader(AbstractDataLoader):
             'short_description': data['short_description'],
             'learner_testimonials': data['learner_testimonials'],
             'additional_information': data['additional_information'],
+            'additional_metadata': {'external_url': data['redirect_url']},
         }
         return update_course_data
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -59,7 +59,7 @@ class CSVLoaderMixin:
         'start_date', 'start_time', 'end_date', 'end_time', 'course_run_enrollment_track', 'course_pacing', 'staff',
         'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language',
         'expected_program_type', 'expected_program_name', 'upgrade_deadline_override_date',
-        'upgrade_deadline_override_time'
+        'upgrade_deadline_override_time', 'redirect_url'
     ]
     BASE_EXPECTED_COURSE_DATA = {
         'draft': False,
@@ -78,6 +78,7 @@ class CSVLoaderMixin:
         'full_description': '<p>Organization,Title,Number,Course Enrollment track,Image,Short Description,Long '
                             'Description,Organization,Title,Number,Course Enrollment track,Image,Short Description'
                             ',Long Description,</p>',
+        'external_url': 'http://www.example.com',
     }
 
     BASE_EXPECTED_COURSE_RUN_DATA = {
@@ -200,6 +201,7 @@ class CSVLoaderMixin:
         assert course.video.src == expected_data['about_video_link']
         assert course.type == self.course_type
         assert course_entitlement.price == expected_data['verified_price']
+        assert course.additional_metadata.external_url == expected_data['external_url']
         assert sorted([subject.slug for subject in course.subjects.all()]) == sorted(expected_data['subjects'])
         assert sorted(
             [collaborator.name for collaborator in course.collaborators.all()]

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3110,7 +3110,8 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'expected_program_type': 'professional-certificate',
     'expected_program_name': 'New Program for all',
     'upgrade_deadline_override_date': '01/25/2020',
-    'upgrade_deadline_override_time': '00:00'
+    'upgrade_deadline_override_time': '00:00',
+    'redirect_url': 'http://www.example.com',
 }
 
 INVALID_ORGANIZATION_DATA = {


### PR DESCRIPTION
### [PROD-2653](https://openedx.atlassian.net/browse/PROD-2653)

### Description

- Add the handling of redirect url from csv
- Pass redirect url as additional metadata when updating the course

Tested with Executive Education course type on local using csv: [test.csv](https://github.com/openedx/course-discovery/files/7958361/test.csv)
