### PR TITLE
Bpant/ent 5221 add fields to all programs

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1576,6 +1576,7 @@ class MinimalProgramSerializer(FlexFieldsSerializerMixin, BaseModelSerializer):
             'banner_image', 'hidden', 'courses', 'authoring_organizations', 'card_image_url',
             'is_program_eligible_for_one_click_purchase', 'degree', 'curricula', 'marketing_hook',
             'total_hours_of_effort', 'recent_enrollment_count',
+            'price_ranges', 'expected_learning_items',
         )
         read_only_fields = ('uuid', 'marketing_url', 'banner_image')
 
@@ -1731,9 +1732,9 @@ class ProgramSerializer(MinimalProgramSerializer):
         model = Program
         fields = MinimalProgramSerializer.Meta.fields + (
             'overview', 'weeks_to_complete', 'weeks_to_complete_min', 'weeks_to_complete_max',
-            'min_hours_effort_per_week', 'max_hours_effort_per_week', 'video', 'expected_learning_items',
+            'min_hours_effort_per_week', 'max_hours_effort_per_week', 'video',
             'faq', 'credit_backing_organizations', 'corporate_endorsements', 'job_outlook_items',
-            'individual_endorsements', 'languages', 'transcript_languages', 'subjects', 'price_ranges',
+            'individual_endorsements', 'languages', 'transcript_languages', 'subjects',
             'staff', 'credit_redemption_overview', 'applicable_seat_types', 'instructor_ordering',
             'enrollment_count', 'topics', 'credit_value',
         )

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1550,6 +1550,7 @@ class MinimalProgramSerializer(FlexFieldsSerializerMixin, BaseModelSerializer):
     degree = DegreeSerializer()
     curricula = CurriculumSerializer(many=True)
     card_image_url = serializers.SerializerMethodField()
+    expected_learning_items = serializers.SlugRelatedField(many=True, read_only=True, slug_field='value')
 
     @classmethod
     def prefetch_queryset(cls, partner, queryset=None):
@@ -1576,7 +1577,7 @@ class MinimalProgramSerializer(FlexFieldsSerializerMixin, BaseModelSerializer):
             'banner_image', 'hidden', 'courses', 'authoring_organizations', 'card_image_url',
             'is_program_eligible_for_one_click_purchase', 'degree', 'curricula', 'marketing_hook',
             'total_hours_of_effort', 'recent_enrollment_count',
-            'price_ranges', 'expected_learning_items',
+            'expected_learning_items', 'price_ranges',
         )
         read_only_fields = ('uuid', 'marketing_url', 'banner_image')
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1026,6 +1026,8 @@ class MinimalProgramSerializerTests(TestCase):
             'marketing_slug': program.marketing_slug,
             'marketing_url': program.marketing_url,
             'banner_image': image_field.to_representation(program.banner_image),
+            'expected_learning_items': [item.value for item in program.expected_learning_items.all()],
+            'price_ranges': program.price_ranges,
             'hidden': program.hidden,
             'courses': MinimalProgramCourseSerializer(
                 program.courses,

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -1,3 +1,4 @@
+from asyncio.log import logger
 import base64
 
 from django.core.files.base import ContentFile

--- a/course_discovery/apps/api/v1/views/programs.py
+++ b/course_discovery/apps/api/v1/views/programs.py
@@ -1,4 +1,3 @@
-from asyncio.log import logger
 import base64
 
 from django.core.files.base import ContentFile


### PR DESCRIPTION
The api/v1/programs/ endpoint currently does not list these fields

`price_ranges`
`expected_learning_items`

We would like to add these fields to the endpoint serializer so that we can index those in algolia for use in enterprise public catalog MFE

### This PR contains

A change to 'move' the fields from the programSerializer to the MinimalProgramSerializer. The former already utilizes all the fields in Meta from the latter so both endpoint should now report these fields

JIRA: ENT-5221

### Alternative considered: 
We could, from enterprise catalog, call the `api/v1/programs/<uuid>` for each program item, but that would hammer discovery a lot more, than this trade off of increased payload size for the list endpoint

### Testing notes
Locally visited 
http://localhost:18381/api/v1/programs/2199b158-eff7-4c16-b5a6-0f48570f1d0e/

and 

http://localhost:18381/api/v1/programs

and verified these fields exist in both responses 