### PR TITLE
fix: program admin fields validation

### DIFF
--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -51,6 +51,9 @@ class ProgramAdminForm(forms.ModelForm):
         self.fields['courses'].required = False
 
     def clean(self):
+
+        super().clean()
+
         status = self.cleaned_data.get('status')
         banner_image = self.cleaned_data.get('banner_image')
 


### PR DESCRIPTION
Backport of https://github.com/openedx/course-discovery/pull/3280

STR:
- go to `/admin/course_metadata/program/` and click "Add Program"
- use an existing program title for the new one
- click save and observe the result

ER:
- 500 error
(`django.db.utils.IntegrityError: (1062, "Duplicate entry '<title_you_use>' for key 'title'")`)

AR:
- Validation message "Program with this Title already exists."
is appeared if to try to save a program with the same title.