### PR TITLE
chore: taxonomy-version-upgrade-1.14.5

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -617,7 +617,7 @@ stevedore==3.5.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.14.3
+taxonomy-connector==1.14.5
     # via -r requirements/base.in
 testfixtures==6.18.3
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -426,7 +426,7 @@ stevedore==3.5.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.14.3
+taxonomy-connector==1.14.5
     # via -r requirements/base.in
 unicode-slugify==0.1.5
     # via -r requirements/base.in


### PR DESCRIPTION
This PR upgrades the version of taxonomy-connector to 1.14.5. The following changes are included in this release: https://github.com/openedx/taxonomy-connector/pull/78
https://github.com/openedx/taxonomy-connector/pull/75