### PR TITLE
feat: add external identifier in csv loader

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1175,7 +1175,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
             additional_metadata, _ = AdditionalMetadata.objects.get_or_create(external_url=external_url)
             if external_identifier:
                 additional_metadata.external_identifier = external_identifier
-            additional_metadata.save()
+                additional_metadata.save()
             instance.additional_metadata = additional_metadata
             instance.save()
 

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1175,6 +1175,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
             additional_metadata, _ = AdditionalMetadata.objects.get_or_create(external_url=external_url)
             if external_identifier:
                 additional_metadata.external_identifier = external_identifier
+            additional_metadata.save()
             instance.additional_metadata = additional_metadata
             instance.save()
 

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -175,7 +175,10 @@ class CSVDataLoader(AbstractDataLoader):
             'short_description': data['short_description'],
             'learner_testimonials': data['learner_testimonials'],
             'additional_information': data['additional_information'],
-            'additional_metadata': {'external_url': data['redirect_url']},
+            'additional_metadata': {
+                'external_url': data['redirect_url'],
+                'external_identifier': data['external_identifier'],
+            },
         }
         return update_course_data
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -59,7 +59,7 @@ class CSVLoaderMixin:
         'start_date', 'start_time', 'end_date', 'end_time', 'course_run_enrollment_track', 'course_pacing', 'staff',
         'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language',
         'expected_program_type', 'expected_program_name', 'upgrade_deadline_override_date',
-        'upgrade_deadline_override_time', 'redirect_url'
+        'upgrade_deadline_override_time', 'redirect_url', 'external_identifier',
     ]
     BASE_EXPECTED_COURSE_DATA = {
         'draft': False,
@@ -79,6 +79,7 @@ class CSVLoaderMixin:
                             'Description,Organization,Title,Number,Course Enrollment track,Image,Short Description'
                             ',Long Description,</p>',
         'external_url': 'http://www.example.com',
+        'external_identifier': '123456789',
     }
 
     BASE_EXPECTED_COURSE_RUN_DATA = {
@@ -202,6 +203,7 @@ class CSVLoaderMixin:
         assert course.type == self.course_type
         assert course_entitlement.price == expected_data['verified_price']
         assert course.additional_metadata.external_url == expected_data['external_url']
+        assert course.additional_metadata.external_identifier == expected_data['external_identifier']
         assert sorted([subject.slug for subject in course.subjects.all()]) == sorted(expected_data['subjects'])
         assert sorted(
             [collaborator.name for collaborator in course.collaborators.all()]

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3112,6 +3112,7 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'upgrade_deadline_override_date': '01/25/2020',
     'upgrade_deadline_override_time': '00:00',
     'redirect_url': 'http://www.example.com',
+    'external_identifier': '123456789',
 }
 
 INVALID_ORGANIZATION_DATA = {


### PR DESCRIPTION
### [PROD-2683](https://openedx.atlassian.net/browse/PROD-2683)

### Description
- Add external identifier in additional metadata payload in CSV Data loader
- Fix the additional metadata object not saving the updates to the external identifier by calling explicit save(though I am not sure if that is a best practice endorsed by DRF. Tried Google but could not find any helpful link)
- Updated the tests