### PR TITLE
feat: Added learner_pathway index in Search/All endpoint.

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -12,8 +12,6 @@ from django.utils.text import slugify
 from elasticsearch_dsl.query import Q as ESDSLQ
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
-from rest_framework.test import APIRequestFactory
-from rest_framework.views import APIView
 from taggit.models import Tag
 from waffle.testutils import override_switch
 
@@ -33,6 +31,7 @@ from course_discovery.apps.api.serializers import (
     TypeaheadProgramSearchSerializer, VideoSerializer, get_lms_course_url_for_archived, get_utm_source_for_user
 )
 from course_discovery.apps.api.tests.mixins import SiteMixin
+from course_discovery.apps.api.tests.test_utils import make_request
 from course_discovery.apps.catalogs.tests.factories import CatalogFactory
 from course_discovery.apps.core.models import User
 from course_discovery.apps.core.tests.factories import PartnerFactory, UserFactory
@@ -41,12 +40,13 @@ from course_discovery.apps.core.tests.mixins import ElasticsearchTestMixin, LMSA
 from course_discovery.apps.core.utils import serialize_datetime
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.search_indexes.documents import (
-    CourseDocument, CourseRunDocument, PersonDocument, ProgramDocument
+    CourseDocument, CourseRunDocument, LearnerPathwayDocument, PersonDocument, ProgramDocument
 )
 from course_discovery.apps.course_metadata.search_indexes.serializers import (
     CourseRunSearchDocumentSerializer, CourseRunSearchModelSerializer, CourseSearchDocumentSerializer,
-    CourseSearchModelSerializer, PersonSearchDocumentSerializer, PersonSearchModelSerializer,
-    ProgramSearchDocumentSerializer, ProgramSearchModelSerializer
+    CourseSearchModelSerializer, LearnerPathwaySearchDocumentSerializer, LearnerPathwaySearchModelSerializer,
+    PersonSearchDocumentSerializer, PersonSearchModelSerializer, ProgramSearchDocumentSerializer,
+    ProgramSearchModelSerializer
 )
 from course_discovery.apps.course_metadata.tests.factories import (
     AdditionalMetadataFactory, AdditionalPromoAreaFactory, CollaboratorFactory, CorporateEndorsementFactory,
@@ -59,28 +59,15 @@ from course_discovery.apps.course_metadata.tests.factories import (
 )
 from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
+from course_discovery.apps.learner_pathway.api.serializers import LearnerPathwayStepSerializer
+from course_discovery.apps.learner_pathway.tests.factories import (
+    LearnerPathwayCourseFactory, LearnerPathwayFactory, LearnerPathwayProgramFactory, LearnerPathwayStepFactory
+)
+from course_discovery.apps.learner_pathway.tests.test_serializer import TestLearnerPathwaySerializer
 
 
 def json_date_format(datetime_obj):
     return datetime_obj and datetime.datetime.strftime(datetime_obj, "%Y-%m-%dT%H:%M:%S.%fZ")
-
-
-def make_request(query_param=None):
-    user = UserFactory()
-    if query_param:
-        request = APIRequestFactory().get('/', query_param)
-    else:
-        request = APIRequestFactory().get('/')
-    request.user = user
-
-    # Convert a Django HTTPResponse object into a rest_framework.request
-    # using a generic API view. This is necessary because the drf-flex-fields
-    # library relies on the `.query_params` property of the request. DRF requests
-    # always have the `query_params` parameter unless the request is created using
-    # `APIRequestFactory`, which yelds Django's standard `HttpRequest`.
-    # Documentation: https://www.django-rest-framework.org/api-guide/testing/#forcing-authentication
-    # DRF issue: https://github.com/encode/django-rest-framework/issues/6488
-    return APIView().initialize_request(request)
 
 
 def serialize_language(language):
@@ -2466,6 +2453,63 @@ class ProgramSearchModelSerializerTest(TestProgramSearchDocumentSerializer):
         expected = ProgramSerializerTests.get_expected_data(program, request)
         expected.update({'content_type': 'program'})
         expected.update({'marketing_hook': program.marketing_hook})
+        return expected
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('elasticsearch_dsl_default_connection')
+class TestLearnerPathwaySearchDocumentSerializer(TestCase):
+    serializer_class = LearnerPathwaySearchDocumentSerializer
+
+    def setUp(self):
+        super().setUp()
+        self.request = make_request()
+
+    @classmethod
+    def get_expected_data(cls, learner_pathway, request):
+        image_field = StdImageSerializerField()
+        image_field._context = {'request': request}  # pylint: disable=protected-access
+        return {
+            'uuid': str(learner_pathway.uuid),
+            'name': learner_pathway.name,
+            'aggregation_key': f'learnerpathway:{learner_pathway.uuid}',
+            'content_type': 'learnerpathway',
+            'status': learner_pathway.status,
+            'banner_image': image_field.to_representation(learner_pathway.banner_image),
+            'overview': learner_pathway.overview,
+            'published': learner_pathway.status == ProgramStatus.Active,
+            'skill_names': [skill['name'] for skill in learner_pathway.skills],
+            'skills': learner_pathway.skills,
+            'partner': learner_pathway.partner.short_code,
+            'steps': LearnerPathwayStepSerializer(
+                learner_pathway.steps.all(),
+                many=True
+            ).data,
+        }
+
+    def serialize_learner_pathway(self, learner_pathway, request):
+        """ Serializes the given `Program` as a search result. """
+        result = LearnerPathwayDocument.search().filter('term', uuid=learner_pathway.uuid).execute()[0]
+        serializer = self.serializer_class(result, context={'request': request})
+        return serializer
+
+    def test_data(self):
+        learner_pathway = LearnerPathwayFactory()
+        step = LearnerPathwayStepFactory(pathway=learner_pathway)
+        LearnerPathwayCourseFactory(step=step)
+        LearnerPathwayProgramFactory(step=step)
+        serializer = self.serialize_learner_pathway(learner_pathway, self.request)
+        expected = self.get_expected_data(learner_pathway, self.request)
+        assert serializer.data == expected
+
+
+class LearnerPathwaySearchModelSerializerTest(TestLearnerPathwaySearchDocumentSerializer):
+    serializer_class = LearnerPathwaySearchModelSerializer
+
+    @classmethod
+    def get_expected_data(cls, learner_pathway, request):
+        expected = TestLearnerPathwaySerializer.get_expected_data(learner_pathway, request)
+        expected.update({'content_type': 'learnerpathway'})
         return expected
 
 

--- a/course_discovery/apps/api/tests/test_utils.py
+++ b/course_discovery/apps/api/tests/test_utils.py
@@ -9,13 +9,33 @@ from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
 
 from course_discovery.apps.api.utils import StudioAPI, cast2int, get_query_param
 from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
+from course_discovery.apps.core.tests.factories import UserFactory
 from course_discovery.apps.core.utils import serialize_datetime
 from course_discovery.apps.course_metadata.tests.factories import CourseEditorFactory, CourseRunFactory
 
 LOGGER_PATH = 'course_discovery.apps.api.utils.logger.exception'
+
+
+def make_request(query_param=None):
+    user = UserFactory()
+    if query_param:
+        request = APIRequestFactory().get('/', query_param)
+    else:
+        request = APIRequestFactory().get('/')
+    request.user = user
+
+    # Convert a Django HTTPResponse object into a rest_framework.request
+    # using a generic API view. This is necessary because the drf-flex-fields
+    # library relies on the `.query_params` property of the request. DRF requests
+    # always have the `query_params` parameter unless the request is created using
+    # `APIRequestFactory`, which yelds Django's standard `HttpRequest`.
+    # Documentation: https://www.django-rest-framework.org/api-guide/testing/#forcing-authentication
+    # DRF issue: https://github.com/encode/django-rest-framework/issues/6488
+    return APIView().initialize_request(request)
 
 
 @ddt.ddt

--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -12,10 +12,11 @@ from course_discovery.apps.api import serializers
 from course_discovery.apps.api.tests.mixins import SiteMixin
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from course_discovery.apps.course_metadata.search_indexes.documents import (
-    CourseDocument, CourseRunDocument, ProgramDocument
+    CourseDocument, CourseRunDocument, LearnerPathwayDocument, ProgramDocument
 )
 from course_discovery.apps.course_metadata.search_indexes.serializers import (
-    CourseRunSearchDocumentSerializer, CourseSearchDocumentSerializer, ProgramSearchDocumentSerializer
+    CourseRunSearchDocumentSerializer, CourseSearchDocumentSerializer, LearnerPathwaySearchDocumentSerializer,
+    ProgramSearchDocumentSerializer
 )
 from course_discovery.apps.course_metadata.tests import factories
 
@@ -84,6 +85,10 @@ class SerializationMixin:
     def serialize_program_search(self, program, serializer=None):
         obj = self._get_search_result(ProgramDocument, uuid=program.uuid)
         return self._serialize_object(serializer or ProgramSearchDocumentSerializer, obj)
+
+    def serialize_learner_pathway_search(self, learner_pathway, serializer=None):
+        obj = self._get_search_result(LearnerPathwayDocument, uuid=learner_pathway.uuid)
+        return self._serialize_object(serializer or LearnerPathwaySearchDocumentSerializer, obj)
 
     def serialize_program_type(self, program_type, many=False, format=None, extra_context=None):
         return self._serialize_object(serializers.ProgramTypeSerializer, program_type, many, format, extra_context)

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -24,6 +24,8 @@ from course_discovery.apps.course_metadata.search_indexes.serializers import (
 from course_discovery.apps.course_metadata.tests.factories import (
     CourseFactory, CourseRunFactory, OrganizationFactory, PersonFactory, PositionFactory, ProgramFactory
 )
+from course_discovery.apps.learner_pathway.models import LearnerPathway
+from course_discovery.apps.learner_pathway.tests.factories import LearnerPathwayStepFactory
 from course_discovery.apps.publisher.tests import factories as publisher_factories
 
 
@@ -559,6 +561,29 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
             [obj.get('aggregation_key') for obj in response_data['objects']['results']]
         )
         assert expected == actual
+
+    @ddt.data(True, False)
+    def test_learner_pathway_feature_flag(self, include_learner_pathways):
+        """ Verify the include_learner_pathways feature flag works as expected."""
+        LearnerPathwayStepFactory(pathway__partner=self.partner)
+        pathways = LearnerPathway.objects.all()
+        assert pathways.count() == 1
+        query = {
+            'include_learner_pathways': include_learner_pathways,
+        }
+
+        response = self.get_response(
+            query,
+            self.list_path
+        )
+        assert response.status_code == 200
+        response_data = response.json()
+
+        if include_learner_pathways:
+            assert response_data['count'] == 1
+            assert response_data['results'][0] == self.serialize_learner_pathway_search(pathways[0])
+        else:
+            assert response_data['count'] == 0
 
 
 class LimitedAggregateSearchViewSetTests(

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -21,6 +21,7 @@ from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import Person
 from course_discovery.apps.course_metadata.search_indexes import documents as search_documents
 from course_discovery.apps.course_metadata.search_indexes import serializers as search_indexes_serializers
+from course_discovery.apps.course_metadata.search_indexes.constants import LEARNER_PATHWAY_FEATURE_PARAM
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.backends import (
     AggregateDataFilterBackend, CatalogDataFilterBackend, MultiMatchSearchFilterBackend
 )
@@ -28,6 +29,7 @@ from course_discovery.apps.edx_elasticsearch_dsl_extensions.constants import LOO
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.viewsets import (
     BaseElasticsearchDocumentViewSet, MultiDocumentsWrapper
 )
+from course_discovery.apps.learner_pathway.models import LearnerPathway
 
 
 class FacetQueryFieldsMixin:
@@ -243,6 +245,7 @@ class AggregateSearchViewSet(BaseAggregateSearchViewSet):
     serializer_class = search_indexes_serializers.AggregateSearchSerializer
     document = MultiDocumentsWrapper(
         search_documents.CourseRunDocument,
+        search_documents.LearnerPathwayDocument,
         search_documents.PersonDocument,
         search_documents.ProgramDocument,
         search_documents.CourseDocument,
@@ -253,6 +256,20 @@ class AggregateSearchViewSet(BaseAggregateSearchViewSet):
         OrderingFilterBackend,
         DefaultOrderingFilterBackend,
     ]
+
+    def get_queryset(self):
+        """Get queryset."""
+        queryset = super().get_queryset()
+
+        # `learnerpathway` data will be visible only when we will pass LEARNER_PATHWAY_FEATURE_PARAM feature param.
+        # Example: GET http://discovery.edx.org/api/v1/search/all/?include_learner_pathways=True
+        # OR GET http://discovery.edx.org/api/v1/search/all/?content_type=learnerpathway&include_learner_pathways=true
+
+        query_params = self.request.query_params
+        if not query_params.get(LEARNER_PATHWAY_FEATURE_PARAM, 'false').lower() == 'true':
+            queryset = queryset.exclude('term', content_type=LearnerPathway.__name__.lower())
+
+        return queryset
 
     @update_query_params_with_body_data
     def create(self, request):

--- a/course_discovery/apps/course_metadata/search_indexes/constants.py
+++ b/course_discovery/apps/course_metadata/search_indexes/constants.py
@@ -15,3 +15,5 @@ BASE_PROGRAM_FIELDS = (
 )
 
 COMMON_IGNORED_FIELDS = ('text',)
+
+LEARNER_PATHWAY_FEATURE_PARAM = 'include_learner_pathways'

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/__init__.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/__init__.py
@@ -5,6 +5,7 @@ from .aggregation import (
 from .common import DocumentDSLSerializerMixin, ModelObjectDocumentSerializerMixin
 from .course import CourseFacetSerializer, CourseSearchDocumentSerializer, CourseSearchModelSerializer
 from .course_run import CourseRunFacetSerializer, CourseRunSearchDocumentSerializer, CourseRunSearchModelSerializer
+from .learner_pathway import LearnerPathwaySearchDocumentSerializer, LearnerPathwaySearchModelSerializer
 from .person import PersonFacetSerializer, PersonSearchDocumentSerializer, PersonSearchModelSerializer
 from .program import ProgramFacetSerializer, ProgramSearchDocumentSerializer, ProgramSearchModelSerializer
 
@@ -21,6 +22,8 @@ __all__ = (
     'CourseRunSearchModelSerializer',
     'DocumentDSLSerializerMixin',
     'ModelObjectDocumentSerializerMixin',
+    'LearnerPathwaySearchDocumentSerializer',
+    'LearnerPathwaySearchModelSerializer',
     'PersonSearchDocumentSerializer',
     'PersonFacetSerializer',
     'PersonSearchModelSerializer',

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/aggregation.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/aggregation.py
@@ -8,6 +8,7 @@ from course_discovery.apps.edx_elasticsearch_dsl_extensions.serializers import (
 
 from .course import CourseSearchDocumentSerializer, CourseSearchModelSerializer
 from .course_run import CourseRunSearchDocumentSerializer, CourseRunSearchModelSerializer
+from .learner_pathway import LearnerPathwaySearchDocumentSerializer, LearnerPathwaySearchModelSerializer
 from .person import PersonSearchDocumentSerializer
 from .program import ProgramSearchDocumentSerializer, ProgramSearchModelSerializer
 
@@ -26,6 +27,7 @@ class AggregateSearchModelSerializer(MultiDocumentSerializerMixin, DocumentSeria
         serializers = {
             documents.CourseRunDocument: CourseRunSearchModelSerializer,
             documents.CourseDocument: CourseSearchModelSerializer,
+            documents.LearnerPathwayDocument: LearnerPathwaySearchModelSerializer,
             documents.ProgramDocument: ProgramSearchModelSerializer,
         }
 
@@ -88,5 +90,6 @@ class AggregateSearchSerializer(MultiDocumentSerializerMixin, DocumentSerializer
             documents.CourseRunDocument: CourseRunSearchDocumentSerializer,
             documents.CourseDocument: CourseSearchDocumentSerializer,
             documents.ProgramDocument: ProgramSearchDocumentSerializer,
+            documents.LearnerPathwayDocument: LearnerPathwaySearchDocumentSerializer,
             documents.PersonDocument: PersonSearchDocumentSerializer,
         }

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/learner_pathway.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/learner_pathway.py
@@ -1,0 +1,53 @@
+from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
+
+from course_discovery.apps.api.fields import StdImageSerializerField
+from course_discovery.apps.api.serializers import ContentTypeSerializer
+from course_discovery.apps.learner_pathway.api.serializers import LearnerPathwaySerializer, LearnerPathwayStepSerializer
+
+from ..constants import BASE_SEARCH_INDEX_FIELDS, COMMON_IGNORED_FIELDS
+from ..documents import LearnerPathwayDocument
+from .common import DocumentDSLSerializerMixin, ModelObjectDocumentSerializerMixin
+
+__all__ = ('LearnerPathwaySearchDocumentSerializer',)
+
+
+class LearnerPathwaySearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DocumentSerializer):
+    """
+    Serializer for LearnerPathway elasticsearch document.
+    """
+
+    steps = LearnerPathwayStepSerializer(many=True, source='object.steps')
+    banner_image = StdImageSerializerField(source='object.banner_image')
+
+    class Meta:
+        """
+        Meta options.
+        """
+
+        document = LearnerPathwayDocument
+        ignore_fields = COMMON_IGNORED_FIELDS
+        fields = (
+            BASE_SEARCH_INDEX_FIELDS + (
+                'uuid', 'name', 'status', 'banner_image', 'overview', 'published', 'skills', 'skill_names', 'partner',
+                'steps',
+            )
+        )
+
+    def to_representation(self, instance):
+        _object = self.get_model_object_by_instance(instance)
+        setattr(instance, 'object', _object)  # pylint: disable=literal-used-as-attribute
+        return super().to_representation(instance)
+
+
+class LearnerPathwaySearchModelSerializer(DocumentDSLSerializerMixin, ContentTypeSerializer, LearnerPathwaySerializer):
+    """
+    Serializer for LearnerPathway model elasticsearch document.
+    """
+
+    class Meta(LearnerPathwaySerializer.Meta):
+        """
+        Meta options.
+        """
+
+        document = LearnerPathwayDocument
+        fields = ContentTypeSerializer.Meta.fields + LearnerPathwaySerializer.Meta.fields

--- a/course_discovery/apps/learner_pathway/tests/test_serializer.py
+++ b/course_discovery/apps/learner_pathway/tests/test_serializer.py
@@ -1,0 +1,58 @@
+from django.test import TestCase
+
+from course_discovery.apps.api.tests.test_utils import make_request
+from course_discovery.apps.learner_pathway.api.serializers import LearnerPathwaySerializer
+from course_discovery.apps.learner_pathway.tests.factories import (
+    LearnerPathwayCourseFactory, LearnerPathwayFactory, LearnerPathwayProgramFactory, LearnerPathwayStepFactory
+)
+
+
+class TestLearnerPathwaySerializer(TestCase):
+    serializer_class = LearnerPathwaySerializer
+
+    def create_pathway(self):
+        learner_pathway = LearnerPathwayFactory()
+        step = LearnerPathwayStepFactory(pathway=learner_pathway)
+        LearnerPathwayCourseFactory(step=step)
+        LearnerPathwayProgramFactory(step=step)
+        return learner_pathway
+
+    @classmethod
+    def get_expected_data(cls, learner_pathway, request):
+        return {
+            'id': learner_pathway.id,
+            'uuid': str(learner_pathway.uuid),
+            'name': learner_pathway.name,
+            'status': learner_pathway.status,
+            'banner_image': request.build_absolute_uri(learner_pathway.banner_image.url),
+            'overview': learner_pathway.overview,
+            'steps': [{
+                'uuid': str(step.uuid),
+                'min_requirement': step.min_requirement,
+                'courses': [
+                    {
+                        'key': learner_pathway_course.course.key,
+                        'title': learner_pathway_course.course.title,
+                        'short_description': learner_pathway_course.course.short_description,
+                        'card_image_url': learner_pathway_course.course.image_url,
+                        'content_type': 'course',
+                    } for learner_pathway_course in step.learnerpathwaycourse_set.all()
+                ],
+                'programs': [
+                    {
+                        'uuid': str(learner_pathway_program.program.uuid),
+                        'title': learner_pathway_program.program.title,
+                        'short_description': learner_pathway_program.program.subtitle,
+                        'card_image_url': learner_pathway_program.program.card_image_url,
+                        'content_type': 'program'
+                    } for learner_pathway_program in step.learnerpathwayprogram_set.all()
+                ]
+            } for step in learner_pathway.steps.all()],
+        }
+
+    def test_data(self):
+        request = make_request()
+        pathway = self.create_pathway()
+        serializer = self.serializer_class(pathway, context={'request': request})
+        expected = self.get_expected_data(pathway, request)
+        self.assertDictEqual(serializer.data, expected)


### PR DESCRIPTION
1. Crated LearnerPathwaySearchDocumentSerializer and LearnerPathwaySearchModelSerializer.
2. Added new serializers in AggregateSearchSerializer.
3. Added tests for new serializers
4. Added tests for existing LearnerPathwaySerializer.
5. Updated AggregateSearchViewSet to return pathways data on demand only
6. Added tests for a new flag.

Here is part 1 :https://github.com/openedx/course-discovery/pull/3296