### PR TITLE
fix: Url Slug Update

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1275,6 +1275,58 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         new_course = Course.everything.last()
         assert new_course.active_url_slug == 'unpublished'
 
+    def test_update_url_slug(self):
+        self.mock_ecommerce_publication()
+        self.create_course_and_course_run()
+        draft_course = Course.everything.last()
+        draft_course_run = CourseRun.everything.last()
+        draft_course_run.status = CourseRunStatus.Reviewed  # Triggers creation of official versions
+        draft_course_run.save()
+
+        official_course = Course.everything.get(uuid=draft_course.uuid, draft=False)
+        draft_course = official_course.draft_version
+
+        assert official_course.active_url_slug == 'course-title'
+
+        # url slug will only update for draft course when the course run is in unpublished state
+        draft_course_run.status = CourseRunStatus.Unpublished
+        draft_course_run.save()
+
+        url = reverse('api:v1:course-detail', kwargs={'key': draft_course.uuid})
+        response = self.client.patch(url, {'url_slug': 'unpublished-url-slug', 'draft': True}, format='json')
+        assert response.status_code == 200
+
+        draft_course.refresh_from_db()
+        official_course.refresh_from_db()
+        assert draft_course.active_url_slug == 'unpublished-url-slug'
+        assert official_course.active_url_slug == 'course-title'
+
+        # url slug will update for both draft and official course when the course run is in reviewed state
+        draft_course_run.status = CourseRunStatus.Reviewed
+        draft_course_run.save()
+
+        response = self.client.patch(url, {'url_slug': 'reviewed-url-slug', 'draft': True}, format='json')
+        assert response.status_code == 200
+
+        draft_course.refresh_from_db()
+        official_course.refresh_from_db()
+        assert draft_course.active_url_slug == 'reviewed-url-slug'
+        assert official_course.active_url_slug == 'reviewed-url-slug'
+
+        # url slug will update for both draft and official course when the course run is in published state
+        draft_course_run.status = CourseRunStatus.Reviewed
+        draft_course_run.save()
+        draft_course_run.status = CourseRunStatus.Published
+        draft_course_run.save()
+
+        response = self.client.patch(url, {'url_slug': 'published-url-slug', 'draft': False}, format='json')
+        assert response.status_code == 200
+
+        draft_course.refresh_from_db()
+        official_course.refresh_from_db()
+        assert draft_course.active_url_slug == 'published-url-slug'
+        assert official_course.active_url_slug == 'published-url-slug'
+
     @responses.activate
     def test_patch_published_switch_audit_to_verified(self):
         """

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1314,8 +1314,6 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         assert official_course.active_url_slug == 'reviewed-url-slug'
 
         # url slug will update for both draft and official course when the course run is in published state
-        draft_course_run.status = CourseRunStatus.Reviewed
-        draft_course_run.save()
         draft_course_run.status = CourseRunStatus.Published
         draft_course_run.save()
 

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -399,10 +399,6 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
                         if any(field in COURSE_FIELDS_FOR_SKILLS for field in changed_fields):
                             logger.info('Signal fired to update course skills. Course: [%s]', course.uuid)
                             UPDATE_COURSE_SKILLS.send(self.__class__, course_uuid=course.uuid)
-                elif course.official_version:
-                    # If there is an official version available but no active or published
-                    # course run, update the slug for official version
-                    course.official_version.set_active_url_slug(url_slug)
 
         # Revert any Reviewed course runs back to Unpublished
         if changed:
@@ -418,10 +414,8 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         return Response(return_dict)
 
     def _is_course_run_reviewed(self, course):
-        """ Checks if any course run for a course is being reviewed """
-        if course.course_runs.filter(status=CourseRunStatus.Reviewed).exists():
-            return True
-        return False
+        """ Checks if any course run for a course is in reviewed state """
+        return course.course_runs.filter(status=CourseRunStatus.Reviewed).exists()
 
     def update(self, request, *_args, **_kwargs):
         """ Update details for a course. """

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -383,6 +383,8 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         course = serializer.save()
         if url_slug:
             course.set_active_url_slug(url_slug)
+            if course.official_version and (not draft or self._is_course_run_reviewed(course)):
+                course.official_version.set_active_url_slug(url_slug)
 
         if not draft:
             for course_run in course.active_course_runs:
@@ -414,6 +416,12 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         return_dict = {'url_slug': course.active_url_slug}
         return_dict.update(serializer.data)
         return Response(return_dict)
+
+    def _is_course_run_reviewed(self, course):
+        """ Checks if any course run for a course is being reviewed """
+        if course.course_runs.filter(status=CourseRunStatus.Reviewed).exists():
+            return True
+        return False
 
     def update(self, request, *_args, **_kwargs):
         """ Update details for a course. """


### PR DESCRIPTION
Url slug will now update for both official and draft
version if the course is in reviewed or published state

[DISCO-1774](https://openedx.atlassian.net/browse/DISCO-1774)