### PR TITLE
chore: taxonomy-version-upgrade-1.15.2

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -617,7 +617,7 @@ stevedore==3.5.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.14.5
+taxonomy-connector==1.15.2
     # via -r requirements/base.in
 testfixtures==6.18.3
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -426,7 +426,7 @@ stevedore==3.5.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.14.5
+taxonomy-connector==1.15.2
     # via -r requirements/base.in
 unicode-slugify==0.1.5
     # via -r requirements/base.in


### PR DESCRIPTION
@aht007 @saleem-latif I'm upgrading the taxonomy-version to **1.15.2**. I think **1.15.1** is not upgraded here and your changes are showing in that version. is it ok to upgrade this?