### PR TITLE
feat: add lead capture form handling in CSv loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -178,6 +178,7 @@ class CSVDataLoader(AbstractDataLoader):
             'additional_metadata': {
                 'external_url': data['redirect_url'],
                 'external_identifier': data['external_identifier'],
+                'lead_capture_form_url': data['lead_capture_form_url']
             },
         }
         return update_course_data

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -59,7 +59,7 @@ class CSVLoaderMixin:
         'start_date', 'start_time', 'end_date', 'end_time', 'course_run_enrollment_track', 'course_pacing', 'staff',
         'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language',
         'expected_program_type', 'expected_program_name', 'upgrade_deadline_override_date',
-        'upgrade_deadline_override_time', 'redirect_url', 'external_identifier',
+        'upgrade_deadline_override_time', 'redirect_url', 'external_identifier', 'lead_capture_form_url',
     ]
     BASE_EXPECTED_COURSE_DATA = {
         'draft': False,
@@ -80,6 +80,7 @@ class CSVLoaderMixin:
                             ',Long Description,</p>',
         'external_url': 'http://www.example.com',
         'external_identifier': '123456789',
+        'lead_capture_form_url': 'http://www.interest-form.com?id=1234'
     }
 
     BASE_EXPECTED_COURSE_RUN_DATA = {
@@ -204,6 +205,7 @@ class CSVLoaderMixin:
         assert course_entitlement.price == expected_data['verified_price']
         assert course.additional_metadata.external_url == expected_data['external_url']
         assert course.additional_metadata.external_identifier == expected_data['external_identifier']
+        assert course.additional_metadata.lead_capture_form_url == expected_data['lead_capture_form_url']
         assert sorted([subject.slug for subject in course.subjects.all()]) == sorted(expected_data['subjects'])
         assert sorted(
             [collaborator.name for collaborator in course.collaborators.all()]

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3113,6 +3113,7 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'upgrade_deadline_override_time': '00:00',
     'redirect_url': 'http://www.example.com',
     'external_identifier': '123456789',
+    'lead_capture_form_url': 'http://www.interest-form.com?id=1234',
 }
 
 INVALID_ORGANIZATION_DATA = {


### PR DESCRIPTION
### [PROD-2718](https://openedx.atlassian.net/browse/PROD-2718)

### Description

Adding lead capture form handling in CSV Data loader. Needs changes from https://github.com/openedx/course-discovery/pull/3308 for the testing and CI tests to pass.