### PR TITLE
feat: add stats and cert handling in csv loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -12,7 +12,8 @@ from django.urls import reverse
 from course_discovery.apps.core.utils import serialize_datetime
 from course_discovery.apps.course_metadata.data_loaders import AbstractDataLoader
 from course_discovery.apps.course_metadata.models import (
-    Collaborator, Course, CourseRun, CourseRunPacing, CourseRunType, CourseType, Organization, Person, ProgramType
+    Collaborator, Course, CourseRun, CourseRunPacing, CourseRunType, CourseType, Organization, Person, ProgramType,
+    Subject
 )
 from course_discovery.apps.course_metadata.utils import download_and_save_course_image
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
@@ -33,6 +34,7 @@ class CSVDataLoader(AbstractDataLoader):
     def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None, is_draft=False):
         super().__init__(partner, api_url, max_workers, is_threadsafe)
 
+        self.messages_list = []  # to show failure/skipped ingestion message at the end
         try:
             self.reader = csv.DictReader(open(csv_path, 'r'))
             self.is_draft = is_draft
@@ -54,6 +56,7 @@ class CSVDataLoader(AbstractDataLoader):
                     org_key,
                     course_title
                 ))
+                self.messages_list.append('[MISSING ORGANIZATION] org: {}, course: {}'.format(org_key, course_title))
                 continue
 
             try:
@@ -84,6 +87,7 @@ class CSVDataLoader(AbstractDataLoader):
                     logger.exception("Error occurred when attempting to create a new course against key {}".format(
                         course_key
                     ))
+                    self.messages_list.append('[COURSE CREATION ERROR] course {}'.format(course_title))
                     continue
                 course = Course.everything.get(key=course_key, partner=self.partner)
                 course_run = CourseRun.everything.filter(course=course).first()
@@ -93,12 +97,14 @@ class CSVDataLoader(AbstractDataLoader):
                 logger.error("Unexpected error happened while downloading image for course {}".format(
                     course_key
                 ))
+                self.messages_list.append('[IMAGE DOWNLOAD FAILURE] course {}'.format(course_title))
                 continue
 
             try:
                 self._update_course(row, course)
             except Exception:  # pylint: disable=broad-except
                 logger.exception("An unknown error occurred while updating course information")
+                self.messages_list.append('[COURSE UPDATE ERROR] course {}'.format(course_title))
                 continue
 
             # No need to update the course run if the run is already in the review
@@ -108,6 +114,7 @@ class CSVDataLoader(AbstractDataLoader):
                     course_run.refresh_from_db()
                 except Exception:  # pylint: disable=broad-except
                     logger.exception("An unknown error occurred while updating course run information")
+                    self.messages_list.append('[COURSE RUN UPDATE ERROR] course {}'.format(course_title))
                     continue
 
             if not self.is_draft:
@@ -118,6 +125,12 @@ class CSVDataLoader(AbstractDataLoader):
 
             logger.info("Course and course run updated successfully for course key {}".format(course_key))
         logger.info("CSV loader ingest pipeline has completed.")
+
+        # Log the summarized errors at the end for easy filtering of the courses whose ingestion failed
+        if self.messages_list:
+            logger.info("Summarized errors:")
+            for msg in self.messages_list:
+                logger.error(msg)
 
     def _create_course_api_request_data(self, data, course_type, course_run_type_uuid):
         """
@@ -178,7 +191,14 @@ class CSVDataLoader(AbstractDataLoader):
             'additional_metadata': {
                 'external_url': data['redirect_url'],
                 'external_identifier': data['external_identifier'],
-                'lead_capture_form_url': data['lead_capture_form_url']
+                'lead_capture_form_url': data['lead_capture_form_url'],
+                'certificate_info': self.process_heading_blurb(
+                    data['certificate_header'], data['certificate_text']
+                ),
+                'facts': self.process_stats(
+                    data['stat1'], data['stat1_text'],
+                    data['stat2'], data['stat2_text']
+                )
             },
         }
         return update_course_data
@@ -352,8 +372,16 @@ class CSVDataLoader(AbstractDataLoader):
         Given a list of subject names, convert the subject names into their
         slug representation.
         """
-        subjects = [subject.lower().replace(' ', '-') for subject in subjects if subject]
-        return list(set(subjects))
+        subject_slugs = []
+        subjects = [subject for subject in subjects if subject]
+        for subject in subjects:
+            try:
+                sub_obj = Subject.objects.get(translations__name=subject, translations__language_code='en')
+                subject_slugs.append(sub_obj.slug)
+            except Subject.DoesNotExist:
+                logger.exception("Unable to locate subject {} in the database. Skipping subject association")
+
+        return subject_slugs
 
     def process_collaborators(self, collaborators, course_key):
         """
@@ -404,3 +432,29 @@ class CSVDataLoader(AbstractDataLoader):
                     course_run_key
                 ))
         return staff_uuids
+
+    def process_heading_blurb(self, heading, blurb):
+        """
+        Process and return a representation of dict object, if applicable, for header and blurb fields.
+        """
+        if not (heading or blurb):
+            return None
+        else:
+            return {
+                'heading': heading,
+                'blurb': blurb
+            }
+
+    def process_stats(self, stat1, stat1_text, stat2, stat2_text):
+        """
+        Return a list of stat/fact dicts if valid input values are provided.
+        """
+        stats = []
+        stat1_dict = self.process_heading_blurb(stat1, stat1_text)
+        stat2_dict = self.process_heading_blurb(stat2, stat2_text)
+
+        if stat1_dict:
+            stats.append(stat1_dict)
+        if stat2_dict:
+            stats.append(stat2_dict)
+        return stats

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -60,6 +60,7 @@ class CSVLoaderMixin:
         'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language',
         'expected_program_type', 'expected_program_name', 'upgrade_deadline_override_date',
         'upgrade_deadline_override_time', 'redirect_url', 'external_identifier', 'lead_capture_form_url',
+        'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text'
     ]
     BASE_EXPECTED_COURSE_DATA = {
         'draft': False,
@@ -80,7 +81,12 @@ class CSVLoaderMixin:
                             ',Long Description,</p>',
         'external_url': 'http://www.example.com',
         'external_identifier': '123456789',
-        'lead_capture_form_url': 'http://www.interest-form.com?id=1234'
+        'lead_capture_form_url': 'http://www.interest-form.com?id=1234',
+        'certificate_info': {
+            'heading': 'About the certificate',
+            'blurb': 'For special people'
+        },
+        'facts_data': ['90 million', '<p>Bacterias cottage cost</p>', 'Diamond mine', '<p>Worth it</p>']
     }
 
     BASE_EXPECTED_COURSE_RUN_DATA = {
@@ -206,10 +212,16 @@ class CSVLoaderMixin:
         assert course.additional_metadata.external_url == expected_data['external_url']
         assert course.additional_metadata.external_identifier == expected_data['external_identifier']
         assert course.additional_metadata.lead_capture_form_url == expected_data['lead_capture_form_url']
+        assert course.additional_metadata.certificate_info.heading == expected_data['certificate_info']['heading']
+        assert expected_data['certificate_info']['blurb'] in course.additional_metadata.certificate_info.blurb
         assert sorted([subject.slug for subject in course.subjects.all()]) == sorted(expected_data['subjects'])
         assert sorted(
             [collaborator.name for collaborator in course.collaborators.all()]
         ) == sorted(expected_data['collaborators'])
+
+        for fact in course.additional_metadata.facts.all():
+            assert fact.heading in expected_data['facts_data']
+            assert fact.blurb in expected_data['facts_data']
 
     def _assert_course_run_data(self, course_run, expected_data):
         """

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3114,6 +3114,12 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'redirect_url': 'http://www.example.com',
     'external_identifier': '123456789',
     'lead_capture_form_url': 'http://www.interest-form.com?id=1234',
+    'certificate_header': 'About the certificate',
+    'certificate_text': 'For special people',
+    'stat1': '90 million',
+    'stat1_text': 'Bacterias cottage cost',
+    'stat2': 'Diamond mine',
+    'stat2_text': 'Worth it'
 }
 
 INVALID_ORGANIZATION_DATA = {

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -85,6 +85,11 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                         'ERROR',
                         'Organization invalid-organization does not exist in database. Skipping CSV '
                         'loader for course CSV Course'
+                    ),
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        '[MISSING ORGANIZATION] org: invalid-organization, course: CSV Course'
                     )
                 )
                 assert Course.objects.count() == 0
@@ -178,6 +183,11 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                             LOGGER_PATH,
                             'ERROR',
                             'Unexpected error happened while downloading image for course edx+csv_123'
+                        ),
+                        (
+                            LOGGER_PATH,
+                            'ERROR',
+                            '[IMAGE DOWNLOAD FAILURE] course CSV Course'
                         )
                     )
 
@@ -310,6 +320,11 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                             LOGGER_PATH,
                             'ERROR',
                             'An unknown error occurred while updating course run information'
+                        ),
+                        (
+                            LOGGER_PATH,
+                            'ERROR',
+                            '[COURSE RUN UPDATE ERROR] course CSV Course'
                         )
                     )
 


### PR DESCRIPTION
### [PROD-2718](https://openedx.atlassian.net/browse/PROD-2718)

### Description
**Note: depends upon https://github.com/openedx/course-discovery/pull/3320 for CI tests to be green.**

- Add certificate_info and facts_fields handling based on the changes to be added in https://github.com/openedx/course-discovery/pull/3320
- Update subject slug handling by getting subject from DB instead of creating an incorrect slug
- Add a message list to display summarized error messages at the end of ingestion, mainly to identify the courses whose ingestion could not take place