### PR TITLE
fix: slug handling in request

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -13,7 +13,7 @@ from course_discovery.apps.course_metadata.data_loaders.csv_loader import CSVDat
 from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
 from course_discovery.apps.course_metadata.data_loaders.tests.mixins import CSVLoaderMixin
 from course_discovery.apps.course_metadata.models import Course, CourseRun
-from course_discovery.apps.course_metadata.tests.factories import CourseFactory, CourseRunFactory
+from course_discovery.apps.course_metadata.tests.factories import CourseFactory, CourseRunFactory, OrganizationFactory
 
 LOGGER_PATH = 'course_discovery.apps.course_metadata.data_loaders.csv_loader'
 
@@ -389,3 +389,62 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                 course_run = CourseRun.everything.filter(course=course).first()
 
                 assert course_run.status == 'published'
+
+    @responses.activate
+    def test_active_slug(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that the correct slug is created for two courses with same title in different organizations.
+        """
+        test_org = OrganizationFactory(name='testOrg', key='testOrg', partner=self.partner)
+        self._setup_prerequisites(self.partner)
+        self.mock_studio_calls(self.partner)
+        _, image_content = self.mock_image_response()
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(
+                csv, [
+                    mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT,
+                    {**mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT, 'organization': test_org.key}
+                ]
+            )
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                with mock.patch.object(
+                        CSVDataLoader,
+                        '_call_course_api',
+                        self.mock_call_course_api
+                ):
+                    loader = CSVDataLoader(self.partner, csv_path=csv.name)
+                    loader.ingest()
+
+                    self._assert_default_logs(log_capture)
+
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            'Course key edx+csv_123 could not be found in database, creating the course.'
+                        )
+                    )
+
+                    assert Course.everything.count() == 2
+                    assert CourseRun.everything.count() == 2
+
+                    course1 = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
+                    course2 = Course.everything.get(key='testOrg+csv_123', partner=self.partner)
+
+                    assert course1.active_url_slug == 'csv-course'
+                    assert course2.active_url_slug == 'csv-course-2'
+
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            '{}:CSV Course'.format(course1.uuid)
+                        ),
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            '{}:CSV Course'.format(course2.uuid)
+                        )
+                    )

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -398,7 +398,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         test_org = OrganizationFactory(name='testOrg', key='testOrg', partner=self.partner)
         self._setup_prerequisites(self.partner)
         self.mock_studio_calls(self.partner)
-        _, image_content = self.mock_image_response()
+        self.mock_image_response()
 
         with NamedTemporaryFile() as csv:
             csv = self._write_csv(


### PR DESCRIPTION
### [PROD-2746](https://openedx.atlassian.net/browse/PROD-2746)

### Description

- Update the active slug get in loader(https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/course_metadata/models.py#L935-L944)
- update error logs to log response in case of failure
- Log course title and uuids at the end of ingestion