### PR TITLE
feat: [VAN-874] update Algolia index

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -51,8 +51,9 @@ def delegate_attributes(cls):
                      'tertiary_description']
     facet_fields = ['availability_level', 'subject_names', 'levels', 'active_languages', 'staff_slugs']
     ranking_fields = ['availability_rank', 'product_recent_enrollment_count', 'promoted_in_spanish_index']
-    result_fields = ['product_marketing_url', 'product_card_image_url', 'product_uuid', 'active_run_key',
-                     'active_run_start', 'active_run_type', 'owners', 'program_types', 'course_titles', 'tags']
+    result_fields = ['product_marketing_url', 'product_card_image_url', 'product_uuid', 'product_weeks_to_complete',
+                     'product_max_effort', 'product_min_effort', 'active_run_key', 'active_run_start',
+                     'active_run_type', 'owners', 'program_types', 'course_titles', 'tags']
     object_id_field = ['custom_object_id', ]
     fields = search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -199,6 +200,18 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
         return None
 
     @property
+    def product_weeks_to_complete(self):
+        return getattr(self.advertised_course_run, 'weeks_to_complete', None)
+
+    @property
+    def product_min_effort(self):
+        return getattr(self.advertised_course_run, 'min_effort', None)
+
+    @property
+    def product_max_effort(self):
+        return getattr(self.advertised_course_run, 'max_effort', None)
+
+    @property
     def owners(self):
         return get_owners(self)
 
@@ -278,6 +291,19 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
             return self.card_image.url
         # legacy field for programs with images hosted outside of discovery
         return self.card_image_url
+
+    @property
+    def product_weeks_to_complete(self):
+        # The field `weeks_to_complete` for Programs is now deprecated.
+        return None
+
+    @property
+    def product_min_effort(self):
+        return self.min_hours_effort_per_week
+
+    @property
+    def product_max_effort(self):
+        return self.max_hours_effort_per_week
 
     @property
     def subject_names(self):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -69,8 +69,9 @@ class EnglishProductIndex(BaseProductIndex):
                     ('staff_slugs', 'staff'))
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'))
     result_fields = (('product_marketing_url', 'marketing_url'), ('product_card_image_url', 'card_image_url'),
-                     ('product_uuid', 'uuid'), 'active_run_key', 'active_run_start', 'active_run_type', 'owners',
-                     'course_titles', 'tags')
+                     ('product_uuid', 'uuid'), ('product_weeks_to_complete', 'weeks_to_complete'),
+                     ('product_max_effort', 'max_effort'), ('product_min_effort', 'min_effort'), 'active_run_key',
+                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags')
     # Algolia needs this
     object_id_field = (('custom_object_id', 'objectID'), )
     fields = search_fields + facet_fields + ranking_fields + result_fields + object_id_field
@@ -102,8 +103,9 @@ class SpanishProductIndex(BaseProductIndex):
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'),
                       'promoted_in_spanish_index')
     result_fields = (('product_marketing_url', 'marketing_url'), ('product_card_image_url', 'card_image_url'),
-                     ('product_uuid', 'uuid'), 'active_run_key', 'active_run_start', 'active_run_type', 'owners',
-                     'course_titles', 'tags')
+                     ('product_uuid', 'uuid'), ('product_weeks_to_complete', 'weeks_to_complete'),
+                     ('product_max_effort', 'max_effort'), ('product_min_effort', 'min_effort'), 'active_run_key',
+                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags')
     # Algolia uses objectID as unique identifier. Can't use straight uuids because a program and a course could
     # have the same one, so we add 'course' or 'program' as a prefix
     object_id_field = (('custom_object_id', 'objectID'), )


### PR DESCRIPTION
Added three new fields
- weeks_to_complete
- max_effort
- min_effort

as a property on both `ProxyCourses` and `ProxyPrograms`. This is needed to make these field available for discovery cards on search page. 

Ticket: https://openedx.atlassian.net/browse/VAN-874