### PR TITLE
refactor: make handling of optional fields flexible in CSV loader

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1118,7 +1118,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
     collaborators = SlugRelatedFieldWithReadSerializer(slug_field='uuid', required=False, many=True,
                                                        queryset=Collaborator.objects.all(),
                                                        read_serializer=CollaboratorSerializer())
-    organization_short_code_override = serializers.CharField(required=False)
+    organization_short_code_override = serializers.CharField(required=False, allow_blank=True)
     organization_logo_override_url = serializers.SerializerMethodField()
     skill_names = serializers.SerializerMethodField()
     skills = serializers.SerializerMethodField()

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -63,6 +63,14 @@ class CSVLoaderMixin:
         'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text',
         'organization_logo_override', 'organization_short_code_override'
     ]
+    # The list of minimal data headers
+    MINIMAL_CSV_DATA_KEYS_ORDER = [
+        'organization', 'title', 'number', 'course_enrollment_track', 'image', 'short_description',
+        'long_description', 'what_will_you_learn', 'course_level', 'primary_subject', 'verified_price', 'publish_date',
+        'start_date', 'start_time', 'end_date', 'end_time', 'course_run_enrollment_track', 'course_pacing',
+        'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language', 'redirect_url',
+        'external_identifier'
+    ]
     BASE_EXPECTED_COURSE_DATA = {
         'draft': False,
         'verified_price': 150,
@@ -115,19 +123,21 @@ class CSVLoaderMixin:
         self.course_run_type = CourseRunType.objects.get(
             slug=CourseRunType.VERIFIED_AUDIT)
 
-    def _write_csv(self, csv, lines_dict_list):
+    def _write_csv(self, csv, lines_dict_list, headers=None):
         """
         Helper method to write given list of data dictionaries to csv, including the csv header.
         """
+        if headers is None:
+            headers = self.CSV_DATA_KEYS_ORDER
         header = ''
         lines = ''
-        for key in self.CSV_DATA_KEYS_ORDER:
+        for key in headers:
             title_case_key = key.replace('_', ' ').title()
             header = '{}{},'.format(header, title_case_key)
         header = f"{header[:-1]}\n"
 
         for line_dict in lines_dict_list:
-            for key in self.CSV_DATA_KEYS_ORDER:
+            for key in headers:
                 lines = '{}"{}",'.format(lines, line_dict[key])
             lines = f"{lines[:-1]}\n"
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -69,7 +69,7 @@ class CSVLoaderMixin:
         'long_description', 'what_will_you_learn', 'course_level', 'primary_subject', 'verified_price', 'publish_date',
         'start_date', 'start_time', 'end_date', 'end_time', 'course_run_enrollment_track', 'course_pacing',
         'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language', 'redirect_url',
-        'external_identifier'
+        'external_identifier', 'syllabus'
     ]
     BASE_EXPECTED_COURSE_DATA = {
         'draft': False,

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3124,6 +3124,35 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'organization_logo_override': 'https://example.com/image.jpg'
 }
 
+VALID_MINIMAL_COURSE_AND_COURSE_RUN_CSV_DICT = {
+    'organization': 'edx',
+    'title': 'CSV Course',
+    'number': 'csv_123',
+    'course_enrollment_track': 'Verified and Audit',
+    'image': 'https://example.com/image.jpg',
+    'short_description': 'Very short description',
+    'long_description': 'Organization,Title,Number,Course Enrollment track,Image,Short Description,Long Description,'
+                        'Organization,Title,Number,Course Enrollment track,Image,Short Description,Long Description,',
+    'what_will_you_learn': 'Outcomes',
+    'course_level': 'beginner',
+    'primary_subject': 'Computer Science',
+    'verified_price': 150,
+    'publish_date': '01/25/2020',
+    'start_date': '01/25/2020',
+    'start_time': '00:00',
+    'end_date': '02/25/2020',
+    'end_time': '00:00',
+    'course_pacing': 'self-paced',
+    'course_run_enrollment_track': 'Verified and Audit',
+    'minimum_effort': 4,
+    'maximum_effort': 10,
+    'length': 10,
+    'content_language': 'English - United States',
+    'transcript_language': 'English - Great Britain',
+    'redirect_url': 'http://www.example.com',
+    'external_identifier': '123456789',
+}
+
 INVALID_ORGANIZATION_DATA = {
     **VALID_COURSE_AND_COURSE_RUN_CSV_DICT,
     'organization': 'invalid-organization'

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3139,6 +3139,7 @@ VALID_MINIMAL_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'verified_price': 150,
     'publish_date': '01/25/2020',
     'start_date': '01/25/2020',
+    'syllabus': 'Introduction to Algorithms',
     'start_time': '00:00',
     'end_date': '02/25/2020',
     'end_time': '00:00',

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -450,3 +450,57 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                             '{}:CSV Course'.format(course2.uuid)
                         )
                     )
+
+    @responses.activate
+    def test_ingest_flow_for_minimal_course_data(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that the loader runs as expected for minimal set of data.
+        """
+        self._setup_prerequisites(self.partner)
+        self.mock_studio_calls(self.partner)
+        self.mock_image_response()
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(
+                csv, [mock_data.VALID_MINIMAL_COURSE_AND_COURSE_RUN_CSV_DICT], self.MINIMAL_CSV_DATA_KEYS_ORDER
+            )
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                with mock.patch.object(
+                        CSVDataLoader,
+                        '_call_course_api',
+                        self.mock_call_course_api
+                ):
+                    loader = CSVDataLoader(self.partner, csv_path=csv.name, is_draft=True)
+                    loader.ingest()
+
+                    self._assert_default_logs(log_capture)
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            'Course key edx+csv_123 could not be found in database, creating the course.'
+                        )
+                    )
+
+                    assert Course.everything.count() == 1
+                    assert CourseRun.everything.count() == 1
+
+                    course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
+                    course_run = CourseRun.everything.get(course=course)
+
+                    # Asserting some required and optional values to verify the correctnesss
+                    assert course.title == 'CSV Course'
+                    assert course.short_description == '<p>Very short description</p>'
+                    assert course.full_description == (
+                        '<p>Organization,Title,Number,Course Enrollment track,Image,Short Description,Long Description,'
+                        'Organization,Title,Number,Course Enrollment track,Image,'
+                        'Short Description,Long Description,</p>'
+                    )
+                    assert course.subjects.first().slug == "computer-science"
+                    assert course.additional_metadata.external_url == 'http://www.example.com'
+                    assert course.additional_metadata.external_identifier == '123456789'
+                    assert course.additional_metadata.lead_capture_form_url == ''
+                    assert course.additional_metadata.certificate_info is None
+                    assert course.additional_metadata.facts.exists() is False
+                    assert course_run.staff.exists() is False

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -497,6 +497,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                         'Organization,Title,Number,Course Enrollment track,Image,'
                         'Short Description,Long Description,</p>'
                     )
+                    assert course.syllabus_raw == '<p>Introduction to Algorithms</p>'
                     assert course.subjects.first().slug == "computer-science"
                     assert course.additional_metadata.external_url == 'http://www.example.com'
                     assert course.additional_metadata.external_identifier == '123456789'


### PR DESCRIPTION
### [PROD-2751](https://openedx.atlassian.net/browse/PROD-2751)

### Description

- Handle optional fields for CSV loader in a flexible way as to not break the flow if the data dict or column is not present in CSV
- If the data is present for an optional field, it would work as before. 
- Allow the override code field to be blank in the serializer.