### PR TITLE
feat: add org short code and logo override handling in csv loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -108,6 +108,19 @@ class CSVDataLoader(AbstractDataLoader):
                 self.messages_list.append('[COURSE UPDATE ERROR] course {}'.format(course_title))
                 continue
 
+            if row.get('organization_logo_override'):
+                course.refresh_from_db()
+                is_logo_downloaded = download_and_save_course_image(
+                    course,
+                    row['organization_logo_override'],
+                    'organization_logo_override'
+                )
+                if not is_logo_downloaded:
+                    logger.error("Unexpected error happened while downloading override logo image for course {}".format(
+                        course_key
+                    ))
+                    self.messages_list.append('[OVERRIDE IMAGE DOWNLOAD FAILURE] course {}'.format(course_title))
+
             # No need to update the course run if the run is already in the review
             if not course_run.in_review:
                 try:
@@ -196,6 +209,7 @@ class CSVDataLoader(AbstractDataLoader):
             'short_description': data['short_description'],
             'learner_testimonials': data['learner_testimonials'],
             'additional_information': data['additional_information'],
+            'organization_short_code_override': data.get('organization_short_code_override', ''),
             'additional_metadata': {
                 'external_url': data['redirect_url'],
                 'external_identifier': data['external_identifier'],

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -60,7 +60,8 @@ class CSVLoaderMixin:
         'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language',
         'expected_program_type', 'expected_program_name', 'upgrade_deadline_override_date',
         'upgrade_deadline_override_time', 'redirect_url', 'external_identifier', 'lead_capture_form_url',
-        'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text'
+        'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text',
+        'organization_logo_override', 'organization_short_code_override'
     ]
     BASE_EXPECTED_COURSE_DATA = {
         'draft': False,
@@ -82,6 +83,7 @@ class CSVLoaderMixin:
         'external_url': 'http://www.example.com',
         'external_identifier': '123456789',
         'lead_capture_form_url': 'http://www.interest-form.com?id=1234',
+        'organization_short_code_override': 'Org Override',
         'certificate_info': {
             'heading': 'About the certificate',
             'blurb': 'For special people'
@@ -208,6 +210,7 @@ class CSVLoaderMixin:
         assert course.level_type.name_t == expected_data['level_type']
         assert course.video.src == expected_data['about_video_link']
         assert course.type == self.course_type
+        assert course.organization_short_code_override == 'Org Override'
         assert course_entitlement.price == expected_data['verified_price']
         assert course.additional_metadata.external_url == expected_data['external_url']
         assert course.additional_metadata.external_identifier == expected_data['external_identifier']

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3119,7 +3119,9 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'stat1': '90 million',
     'stat1_text': 'Bacterias cottage cost',
     'stat2': 'Diamond mine',
-    'stat2_text': 'Worth it'
+    'stat2_text': 'Worth it',
+    'organization_short_code_override': 'Org Override',
+    'organization_logo_override': 'https://example.com/image.jpg'
 }
 
 INVALID_ORGANIZATION_DATA = {

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -230,6 +230,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                     course_run = CourseRun.objects.get(course=course)
 
                     assert course.image.read() == image_content
+                    assert course.organization_logo_override.read() == image_content
                     self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)
                     self._assert_course_run_data(course_run, self.BASE_EXPECTED_COURSE_RUN_DATA)
 
@@ -334,6 +335,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                     course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
 
                     assert course.image.read() == image_content
+                    assert course.organization_logo_override.read() == image_content
                     self._assert_course_data(course, expected_course_response)
 
     @responses.activate
@@ -371,7 +373,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         self._setup_prerequisites(self.partner)
         self.mock_studio_calls(self.partner)
         self.mock_ecommerce_publication(self.partner)
-        _, image_content = self.mock_image_response()  # pylint: disable=unused-variable
+        self.mock_image_response()  # pylint: disable=unused-variable
 
         with NamedTemporaryFile() as csv:
             csv = self._write_csv(csv, [mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT])

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -686,10 +686,10 @@ def clean_html(content):
     return cleaned
 
 
-def download_and_save_course_image(course, image_url):
+def download_and_save_course_image(course, image_url, data_field='image'):
     """
     Helper method to download an image from a provided image url and save it
-    as course card image.
+    in the data field mentioned, defaulting to course card image.
     """
     try:
         response = requests.get(image_url)
@@ -700,7 +700,12 @@ def download_and_save_course_image(course, image_url):
 
             if extension:
                 filename = '{uuid}.{extension}'.format(uuid=str(course.uuid), extension=extension)
-                course.image.save(filename, ContentFile(response.content))
+                # TODO: Get field from _meta.get_field. Tried that approach initially but was getting
+                # field save errors for some reasons.
+                if data_field == 'image':
+                    course.image.save(filename, ContentFile(response.content))
+                elif data_field == 'organization_logo_override':
+                    course.organization_logo_override.save(filename, ContentFile(response.content))
                 logger.info('Image for course [%s] successfully updated.', course.key)
                 return True
             else:


### PR DESCRIPTION
### [PROD-2744](https://openedx.atlassian.net/browse/PROD-2744)

### Description

- Building on top of https://github.com/openedx/course-discovery/pull/3318/files to add org logo and shortcode override handling in CSV loader