### PR TITLE
feat: add frontend-app-admin-portal to discovery CORS

### DIFF
--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -15,6 +15,7 @@ INTERNAL_IPS = ('127.0.0.1',)
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:8734',  # frontend-app-learner-portal-enterprise
+    'http://localhost:1991',  # frontend-app-admin-portal
     'http://localhost:18400',  # frontend-app-publisher
     'http://localhost:18450',  # frontend-app-support-tools
     'http://localhost:2000',  # frontend-app-learning


### PR DESCRIPTION
`frontend-app-admin-portal` now calls the discovery.edx.org API, so it needs to be added to CORS locally as well as to remote config (already done).