### PR TITLE
WS-2734: temporarily preventing EE courses from indexing into search

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -8,7 +8,7 @@ from django.utils.translation import override
 from sortedm2m.fields import SortedManyToManyField
 
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
-from course_discovery.apps.course_metadata.models import Course, Program, ProgramType
+from course_discovery.apps.course_metadata.models import Course, CourseType, Program, ProgramType
 
 
 # Utility methods used by both courses and programs
@@ -384,7 +384,8 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
                 self.status == ProgramStatus.Active and
                 self.availability_level and
                 self.partner.name == 'edX' and
-                not self.hidden)
+                not self.hidden and
+                self.course_type.slug != CourseType.EXECUTIVE_EDUCATION_2U)
 
 
 class SearchDefaultResultsConfiguration(models.Model):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -503,6 +503,7 @@ class CourseType(TimeStampedModel):
     PROFESSIONAL = 'professional'
     CREDIT_VERIFIED_AUDIT = 'credit-verified-audit'
     EMPTY = 'empty'
+    EXECUTIVE_EDUCATION_2U = 'executive-education-2u'
 
     uuid = models.UUIDField(default=uuid4, editable=False, verbose_name=_('UUID'), unique=True)
     name = models.CharField(max_length=64)


### PR DESCRIPTION
Prevent Executive Education courses from indexing into search so that they can be published but not show up yet in the frontend experience