### PR TITLE
feat: add course type filtering in courses api

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -504,6 +504,7 @@ class CourseType(TimeStampedModel):
     CREDIT_VERIFIED_AUDIT = 'credit-verified-audit'
     EMPTY = 'empty'
     EXECUTIVE_EDUCATION_2U = 'executive-education-2u'
+    BOOTCAMP_2U = 'bootcamp-2u'
 
     uuid = models.UUIDField(default=uuid4, editable=False, verbose_name=_('UUID'), unique=True)
     name = models.CharField(max_length=64)


### PR DESCRIPTION
### [PROD-2771](https://openedx.atlassian.net/browse/PROD-2771)

### Description

- Add course_type filtering in course API to quickly filter the courses based on the course type
- The exception in course type slug is `open-courses`, where all the course type courses except Executive Education and Bootcamp are returned. [Figma Design Reference](https://www.figma.com/file/M4jkaKcn1kwbN1OcEVMiPr/Project-Board%3A-Publisher?node-id=0%3A1)
- If the slug is incorrect/missing, no validation is done. By default, the filter will be attempted and empty results will be returned if the slug is incorrect.

### Testing

- Use different course types on `http://localhost:18381/api/v1/courses/?course_type=executive-education-2u&editable=1` and verify the results

### Reference

- https://django-filter.readthedocs.io/en/main/ref/filters.html#keyword-only-arguments