### PR TITLE
feat: update base class for views

### DIFF
--- a/course_discovery/apps/learner_pathway/api/v1/views.py
+++ b/course_discovery/apps/learner_pathway/api/v1/views.py
@@ -1,7 +1,7 @@
 """
 API Views for learner_pathway app.
 """
-from rest_framework import viewsets
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.learner_pathway import models
@@ -9,7 +9,7 @@ from course_discovery.apps.learner_pathway.api import serializers
 from course_discovery.apps.learner_pathway.choices import PathwayStatus
 
 
-class LearnerPathwayViewSet(viewsets.ModelViewSet):
+class LearnerPathwayViewSet(ReadOnlyModelViewSet):
     """
     View-set for LearnerPathway model.
     """
@@ -23,7 +23,7 @@ class LearnerPathwayViewSet(viewsets.ModelViewSet):
     pagination_class = ProxiedPagination
 
 
-class LearnerPathwayStepViewSet(viewsets.ModelViewSet):
+class LearnerPathwayStepViewSet(ReadOnlyModelViewSet):
     """
     View-set for LearnerPathwayStep model.
     """
@@ -37,7 +37,7 @@ class LearnerPathwayStepViewSet(viewsets.ModelViewSet):
     pagination_class = ProxiedPagination
 
 
-class LearnerPathwayCourseViewSet(viewsets.ModelViewSet):
+class LearnerPathwayCourseViewSet(ReadOnlyModelViewSet):
     """
     View-set for LearnerPathwayCourse model.
     """
@@ -51,7 +51,7 @@ class LearnerPathwayCourseViewSet(viewsets.ModelViewSet):
     pagination_class = ProxiedPagination
 
 
-class LearnerPathwayProgramViewSet(viewsets.ModelViewSet):
+class LearnerPathwayProgramViewSet(ReadOnlyModelViewSet):
     """
     View-set for LearnerPathwayProgram model.
     """
@@ -65,7 +65,7 @@ class LearnerPathwayProgramViewSet(viewsets.ModelViewSet):
     pagination_class = ProxiedPagination
 
 
-class LearnerPathwayBlocViewSet(viewsets.ModelViewSet):
+class LearnerPathwayBlocViewSet(ReadOnlyModelViewSet):
     """
     View-set for LearnerPathwayBlock model.
     """


### PR DESCRIPTION
Switching to `ReadOnlyModelViewSet` for following views because we only need the 'read-only' actions, `.list()` and `.retrieve()` here.

- course_discovery/apps/learner_pathway/api/v1/views.py:12
- course_discovery/apps/learner_pathway/api/v1/views.py:26
- course_discovery/apps/learner_pathway/api/v1/views.py:40
- course_discovery/apps/learner_pathway/api/v1/views.py:54
- course_discovery/apps/learner_pathway/api/v1/views.py:68

Ticket: https://openedx.atlassian.net/browse/VAN-923