### PR TITLE
fix: fix path for person typeahead view

### DIFF
--- a/course_discovery/apps/api/v1/urls.py
+++ b/course_discovery/apps/api/v1/urls.py
@@ -36,7 +36,7 @@ partners_router.register(
 urlpatterns = [
     path('partners/', include((partners_router.urls, 'partners'))),
     path('search/typeahead', search_views.TypeaheadSearchView.as_view(), name='search-typeahead'),
-    path('search/person_typeahead', search_views.PersonTypeaheadSearchView.as_view(), name='person-search-typeahead'),
+    path('search/person_typeahead/', search_views.PersonTypeaheadSearchView.as_view(), name='person-search-typeahead'),
     path('currency', CurrencyView.as_view(), name='currency'),
     re_path(r'^catalog/query_contains/?', CatalogQueryContainsViewSet.as_view(), name='catalog-query_contains'),
     path('replace_usernames/', UsernameReplacementView.as_view(), name="replace_usernames"),


### PR DESCRIPTION
##### Context
On publisher authors are unable to add staff because the following path gives 404 error:
`/api/v1/search/person_typeahead/?q=sean&org=AlaskaX`

The path above has started giving an error because we recently moved from `url()` (which is an alias for re_path()) to `path()` which checks for paths without regex.

Adding the trailing slash solves the issue. If a user misses adding trailing slash then django middleware automatically appends one based on the `APPEND_SLASH` settings which is `True` by default. 

##### Ticket
https://openedx.atlassian.net/browse/DISCO-1812