### PR TITLE
chore: add organic url handling in populate_exed_data mgt command

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/utils.py
+++ b/course_discovery/apps/course_metadata/data_loaders/utils.py
@@ -64,7 +64,7 @@ def format_curriculum(data):
     if 'modules' in data:
         for modules in data['modules']:
             heading = modules['heading']
-            description = modules['description']
+            description = modules['description'].strip()
             formatted_html += p_tag(f"<b>{heading}: </b>{description}")
 
     return cleaner.clean_html(formatted_html) if formatted_html else formatted_html

--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
         'staff', 'minimum_effort', 'maximum_effort', 'length', 'content_language', 'transcript_language',
         'expected_program_type', 'expected_program_name', 'upgrade_deadline_override_date',
         'upgrade_deadline_override_time', 'redirect_url', 'external_identifier', 'lead_capture_form_url',
-        'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text'
+        'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text', 'organic_url'
     ]
 
     # Mapping English and Spanish languages to IETF equivalent variants
@@ -292,6 +292,7 @@ class Command(BaseCommand):
             'stat1_text': stats['stat1Blurb'],
             'stat2': stats['stat2'],
             'stat2_text': stats['stat2Blurb'],
+            'organic_url': utils.format_base64_strings(product_dict.get('edxPlpUrl', '')),
 
             'title': partially_filled_csv_dict.get('title') or product_dict['altName'] or product_dict['name'],
             '2u_title': product_dict['name'],

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -39,6 +39,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 "altUniversityAbbreviation": "altEdx",
                 "cardUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS9pbWFnZS5qcGc=",
                 "edxRedirectUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS8=",
+                "edxPlpUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS8=",
                 "durationWeeks": 10,
                 "effort": "7–10 hours per week",
                 'introduction': 'Very short description\n',
@@ -142,6 +143,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 assert data_row['Length'] == '10'
                 assert data_row['Number'] == 'TC'
                 assert data_row['Redirect Url'] == 'https://example.com/'
+                assert data_row['Organic Url'] == 'https://example.com/'
                 assert data_row['Image'] == 'https://example.com/image.jpg'
                 assert data_row['Course Level'] == 'Introductory'
                 assert data_row['Course Pacing'] == 'Instructor-Paced'
@@ -304,6 +306,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
         assert data_row['Stat2 Text'] == '<p>VC fund</p>'
         assert data_row['Length'] == '10'
         assert data_row['Redirect Url'] == 'https://example.com/'
+        assert data_row['Organic Url'] == 'https://example.com/'
         assert data_row['Image'] == 'https://example.com/image.jpg'
         assert data_row['Course Level'] == 'Introductory'
         assert data_row['Course Pacing'] == 'Instructor-Paced'


### PR DESCRIPTION
### [PROD-2772](https://openedx.atlassian.net/browse/PROD-2772)

### Description

- organic url will be available in Product API under edxPlpUrl. The populate mgt command handles the field to add organic url in output csv
- strip syllabus description items. This caused CSV formatting issues in a few cases when downloading from Google sheet. 