### PR TITLE
fix: Updated course recommendation command with logging

### DIFF
--- a/course_discovery/apps/taxonomy_support/management/commands/update_course_recommendations.py
+++ b/course_discovery/apps/taxonomy_support/management/commands/update_course_recommendations.py
@@ -1,9 +1,13 @@
+import logging
+
 from django.core.management import BaseCommand, CommandError
 from django.utils.translation import gettext as _
 from taxonomy.models import CourseSkills
 
 from course_discovery.apps.course_metadata.models import Course
 from course_discovery.apps.taxonomy_support.models import CourseRecommendation, UpdateCourseRecommendationsConfig
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -84,8 +88,8 @@ class Command(BaseCommand):
 
         if failures:
             keys = sorted(f'{failure.key} ({failure.id})' for failure in failures)
-            raise CommandError(
-                _('Could not add recommendations for the following courses: {course_keys}').format(
+            logger.warning(
+                '[UPDATE_COURSE_RECOMMENDATIONS] Skipping the following courses: {course_keys}'.format(
                     course_keys=', '.join(keys)
                 )
             )


### PR DESCRIPTION
**Description:** The update course recommendation command throws a command error if a course does not have any skills or subjects associated with it. This PR logs this case instead of throwing an error.

**JIRA:** https://openedx.atlassian.net/browse/ENT-5554