### PR TITLE
fix: Upgrade Node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /edx/app/discovery
 # Copy just JS requirements and install them.
 COPY package.json package.json
 COPY package-lock.json package-lock.json
-RUN nodeenv /edx/app/nodeenv --node=12.11.1 --prebuilt
+RUN nodeenv /edx/app/nodeenv --node=16.14.2 --npm=8.5.x --prebuilt
 ENV PATH /edx/app/nodeenv/bin:${PATH}
 RUN npm install --production
 COPY bower.json bower.json


### PR DESCRIPTION
As we are moving course-discovery to Node 16, we need to update Dockerfile accordingly.