### PR TITLE
feat: Add course override fields to algolia index

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -54,7 +54,8 @@ def delegate_attributes(cls):
     ranking_fields = ['availability_rank', 'product_recent_enrollment_count', 'promoted_in_spanish_index']
     result_fields = ['product_marketing_url', 'product_card_image_url', 'product_uuid', 'product_weeks_to_complete',
                      'product_max_effort', 'product_min_effort', 'active_run_key', 'active_run_start',
-                     'active_run_type', 'owners', 'program_types', 'course_titles', 'tags']
+                     'active_run_type', 'owners', 'program_types', 'course_titles', 'tags',
+                     'product_organization_short_code_override', 'product_organization_logo_override']
     object_id_field = ['custom_object_id', ]
     fields = product_type_fields + search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -215,6 +216,14 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
     @property
     def product_max_effort(self):
         return getattr(self.advertised_course_run, 'max_effort', None)
+
+    @property
+    def product_organization_short_code_override(self):
+        return self.organization_short_code_override
+
+    @property
+    def product_organization_logo_override(self):
+        return self.organization_logo_override
 
     @property
     def owners(self):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -72,7 +72,8 @@ class EnglishProductIndex(BaseProductIndex):
     result_fields = (('product_marketing_url', 'marketing_url'), ('product_card_image_url', 'card_image_url'),
                      ('product_uuid', 'uuid'), ('product_weeks_to_complete', 'weeks_to_complete'),
                      ('product_max_effort', 'max_effort'), ('product_min_effort', 'min_effort'), 'active_run_key',
-                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags')
+                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags',
+                     'product_organization_short_code_override', 'product_organization_logo_override')
     # Algolia needs this
     object_id_field = (('custom_object_id', 'objectID'), )
     fields = search_fields + facet_fields + ranking_fields + result_fields + object_id_field
@@ -106,7 +107,8 @@ class SpanishProductIndex(BaseProductIndex):
     result_fields = (('product_marketing_url', 'marketing_url'), ('product_card_image_url', 'card_image_url'),
                      ('product_uuid', 'uuid'), ('product_weeks_to_complete', 'weeks_to_complete'),
                      ('product_max_effort', 'max_effort'), ('product_min_effort', 'min_effort'), 'active_run_key',
-                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags')
+                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags',
+                     'product_organization_short_code_override', 'product_organization_logo_override')
     # Algolia uses objectID as unique identifier. Can't use straight uuids because a program and a course could
     # have the same one, so we add 'course' or 'program' as a prefix
     object_id_field = (('custom_object_id', 'objectID'), )


### PR DESCRIPTION
JIRA ticket: https://openedx.atlassian.net/browse/WS-2646

Two fields from the Course model (`organization_short_code_override` and `organization_logo_override`) have been added to the Algolia index model so that they are returned with search results. 

We need this to show these override values on course cards. 