### PR TITLE
fix: Course recommendations updated if course skills are changed

### DIFF
--- a/course_discovery/apps/taxonomy_support/admin.py
+++ b/course_discovery/apps/taxonomy_support/admin.py
@@ -3,7 +3,7 @@ Admin definitions for models defined in `taxonomy-support`.
 """
 from django.contrib import admin
 
-from course_discovery.apps.taxonomy_support.models import CourseRecommendation
+from course_discovery.apps.taxonomy_support.models import CourseRecommendation, UpdateCourseRecommendationsConfig
 
 
 @admin.register(CourseRecommendation)
@@ -14,3 +14,9 @@ class CourseRecommendationAdmin(admin.ModelAdmin):
     )
     readonly_fields = ('created', 'modified', )
     search_fields = ('id', 'course', 'recommended_course', )
+
+
+@admin.register(UpdateCourseRecommendationsConfig)
+class UpdateCourseRecommendationsConfigAdmin(admin.ModelAdmin):
+    fields = ('uuids', 'num_past_days', 'all_courses')
+    list_display = ('id',)

--- a/course_discovery/apps/taxonomy_support/management/commands/update_course_recommendations.py
+++ b/course_discovery/apps/taxonomy_support/management/commands/update_course_recommendations.py
@@ -94,7 +94,9 @@ class Command(BaseCommand):
         else:
             num_past_days = kwargs['num_past_days'] or 10
             from_date = tz.now() - datetime.timedelta(days=num_past_days)
-            courses = all_courses.filter(Q(created__gt=from_date) | Q(modified__gt=from_date))
+            courses_with_modified_skills = CourseSkills.objects.filter(
+                modified__gt=from_date).values_list('course_key', flat=True)
+            courses = all_courses.filter(Q(created__gt=from_date) | Q(key__in=list(courses_with_modified_skills)))
         logger.info(
             '[UPDATE_COURSE_RECOMMENDATIONS] Updating {course_count} courses'.format(
                 course_count=courses.count()

--- a/course_discovery/apps/taxonomy_support/models.py
+++ b/course_discovery/apps/taxonomy_support/models.py
@@ -59,4 +59,4 @@ class UpdateCourseRecommendationsConfig(SingletonModel):
     )
 
     def __str__(self):
-        return f'All Courses:{self.all_courses}, UUIDs: {self.uuids}'
+        return 'Configuration for the update_course_recommendations management command'


### PR DESCRIPTION
**Description:** This PR fixes an issue with selection of courses for updating course recommendations. The modified filter has been removed since it was picking up all the courses. Instead, the course skills modified filter has been applied.

**JIRA:** [ENT-5554](https://openedx.atlassian.net/browse/ENT-5554)