### PR TITLE
feat: add degrees data loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -7,7 +7,7 @@ import logging
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.data_loaders import AbstractDataLoader
 from course_discovery.apps.course_metadata.models import (
-    Degree, DegreeAdditionalMetadata, Organization, Program, ProgramType, Specialization, Curriculum
+    Curriculum, Degree, DegreeAdditionalMetadata, Organization, Program, ProgramType, Specialization
 )
 from course_discovery.apps.course_metadata.utils import download_and_save_program_image
 

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -1,0 +1,235 @@
+"""
+Data loader responsible for creating degree entries in discovery Database,
+"""
+import csv
+import logging
+
+from course_discovery.apps.course_metadata.choices import ProgramStatus
+from course_discovery.apps.course_metadata.data_loaders import AbstractDataLoader
+from course_discovery.apps.course_metadata.models import (
+    Degree, DegreeAdditionalMetadata, Organization, Program, ProgramType
+)
+from course_discovery.apps.course_metadata.utils import download_and_save_program_image
+
+logger = logging.getLogger(__name__)
+
+
+class DegreeCSVDataLoader(AbstractDataLoader):
+
+    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None):
+        super().__init__(partner, api_url, max_workers, is_threadsafe)
+
+        self.messages_list = []  # to show failure/skipped ingestion message at the end
+        self.degree_uuids = {}  # to show the discovery degrees/program ids for each processed degree
+        try:
+            self.reader = csv.DictReader(open(csv_path, 'r'))   # lint-amnesty, pylint: disable=consider-using-with
+        except FileNotFoundError:
+            logger.exception("Error opening csv file at path {}".format(csv_path))    # lint-amnesty, pylint: disable=logging-format-interpolation
+            raise  # re-raising exception to avoid moving the code flow
+
+    def ingest(self):  # pylint: disable=too-many-statements
+        logger.info("Initiating Degree CSV data loader flow.")
+        for row in self.reader:
+            # TODO: test and decide if need to make transaction atomic
+            # with transaction.atomic():
+
+            row = self.transform_dict_keys(row)
+            degree_title = row['title']
+            external_identifier = row['identifier']
+            org_key = row['organization_key']
+
+            logger.info('Starting data import flow for {}'.format(degree_title))    # lint-amnesty, pylint: disable=logging-format-interpolation
+
+            if not Organization.objects.filter(key=org_key).exists():
+                logger.error("Organization {} does not exist. Skipping CSV loader for degree {}".format(   # lint-amnesty, pylint: disable=logging-format-interpolation
+                    org_key,
+                    degree_title
+                ))
+                self.messages_list.append('[MISSING ORGANIZATION] org: {}, degree: {}'.format(
+                    org_key, degree_title
+                ))
+                continue
+
+            try:
+                program_type = ProgramType.objects.get(slug=row['product_type'])
+            except ProgramType.DoesNotExist:
+                logger.exception("ProgramType {} does not exist in the database.".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                    row['product_type']
+                ))
+                continue
+
+            message = self.validate_degree_data(program_type, row)
+            if message:
+                logger.error("Data validation issue for degree {}, skipping ingestion".format(degree_title))    # lint-amnesty, pylint: disable=logging-format-interpolation
+                self.messages_list.append("[DATA VALIDATION ERROR] Degree {}. Missing data: {}".format(
+                    degree_title, message
+                ))
+                continue
+
+            # TODO: handle org override
+            # simple field populate
+
+            # get degree object from title
+            degree = Degree.objects.filter(title=degree_title, partner=self.partner).first()
+
+            degree_title = degree.title if degree else degree_title
+
+            if degree:
+                logger.info("Degree {} is located in the database.".format(degree_title))    # lint-amnesty, pylint: disable=logging-format-interpolation
+
+                additional_metadata = DegreeAdditionalMetadata.objects.filter(degree=degree).first()
+
+                if not additional_metadata or \
+                        additional_metadata.external_identifier == external_identifier:
+                    try:
+                        self._update_degree(row, degree, program_type)
+                    except Exception:  # pylint: disable=broad-except
+                        logger.exception("An unknown error occurred while updating degree information")
+                        self.messages_list.append('[DEGREE UPDATE ERROR] degree {}'.format(degree_title))
+                        continue
+                else:
+                    logger.error("Skipping Degree {} Othrwise it will overwrite existing OCM degree data.".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                        degree_title
+                    ))
+                    self.messages_list.append('[DEGREE UPDATE ERROR] degree {}'.format(degree_title))
+                    continue
+            else:
+                logger.info("Degree Program {} could not be found in database, creating the degree.".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                    degree_title
+                ))
+                try:
+                    degree = self._create_degree(row, program_type)
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception("Error occurred when attempting to create a new degree against key {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                        degree_title
+                    ))
+                    self.messages_list.append('[DEGREE CREATION ERROR] degree {}'.format(degree_title))
+                    continue
+                degree = Degree.objects.get(uuid=degree.uuid, partner=self.partner)
+
+            program = Program.objects.get(degree=degree, partner=self.partner)
+            is_downloaded = download_and_save_program_image(program, row['card_image_url'])
+            if not is_downloaded:
+                logger.error("Unexpected error happened while downloading image for degree {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation
+                    degree_title
+                ))
+                self.messages_list.append('[IMAGE DOWNLOAD FAILURE] degree {}'.format(degree_title))
+                continue
+
+            logger.info("Degree updated successfully for degree key {}".format(degree.uuid))    # lint-amnesty, pylint: disable=logging-format-interpolation
+            self.degree_uuids[str(degree.uuid)] = degree_title
+
+        logger.info("Degree CSV loader ingest pipeline has completed.")
+
+        # Log the summarized errors at the end for easy filtering of the degrees whose ingestion failed
+        if self.messages_list:
+            logger.info("Summarized errors:")
+            for msg in self.messages_list:
+                logger.error(msg)
+
+        # log the processed degree uuids and their titles
+        if self.degree_uuids:
+            logger.info("Degree UUIDs:")
+            for degree_uuid, title in self.degree_uuids.items():
+                logger.info("{}:{}".format(degree_uuid, title))    # lint-amnesty, pylint: disable=logging-format-interpolation
+
+    def validate_degree_data(self, program_type, data):  # pylint: disable=unused-argument
+        """
+        Verify the required data key-values for a program type are present in the provided
+        data dictionary and return a comma separated string of missing data fields.
+        """
+        # TODO
+        return ''
+
+    def transform_dict_keys(self, data):
+        """
+        Given a data dictionary, return a new dict that has its keys transformed to
+        snake case. For example, Enrollment Track becomes enrollment_track.
+
+        Each key is stripped of whitespaces around the edges, converted to lower case,
+        and has internal spaces converted to _. This convention removes the dependency on CSV
+        headers format(Enrollment Track vs Enrollment track) and makes code flexible to ignore
+        any case sensitivity, among other things.
+        """
+        transformed_dict = {}
+        for key, value in data.items():
+            updated_key = key.strip().lower().replace(' ', '_')
+            transformed_dict[updated_key] = value
+        return transformed_dict
+
+    def _create_degree(self, data, program_type):
+        """
+        Make a degree object through ORM
+        """
+        org = Organization.objects.get(key=data['organization_key'])
+
+        degree = Degree.objects.create(
+            title=data['title'],
+            type=program_type,
+            status=ProgramStatus.Unpublished,
+            marketing_slug=data['slug'],
+            overview=data['overview'],
+            partner=self.partner,
+        )
+        if degree:
+            logger.info("Degree with title {} has been created".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                degree,
+            ))
+
+            degree.authoring_organizations.add(org)
+            additional_metadata = DegreeAdditionalMetadata.objects.create(
+                external_identifier=data['identifier'],
+                organic_url=data['organic_url'],
+                external_url=data['paid_landing_page_url'],
+                degree=degree
+            )
+
+            if additional_metadata:
+                logger.info("AdditionalMetdata {} has been created with Degree title {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                    additional_metadata,
+                    degree,
+                ))
+
+        return degree
+
+    def _update_degree(self, data, degree, program_type):
+        """
+        Update degree object through ORM
+        """
+        updated = Degree.objects.filter(title=degree.title).update(
+            type=program_type,
+            status=ProgramStatus.Unpublished,
+            marketing_slug=data['slug'],
+            overview=data['overview'],
+            partner=self.partner,
+        )
+        if updated:
+            logger.info("Degree with title {} is updated".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                degree,
+            ))
+        else:
+            logger.error("Degree with title {} has not been updated".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                degree,
+            ))
+            return
+
+        org = Organization.objects.get(key=data['organization_key'])
+        degree.authoring_organizations.clear()
+        degree.authoring_organizations.add(org)
+
+        additional_metadata_dict = {
+            "external_identifier": data['identifier'],
+            "organic_url": data['organic_url'],
+            "external_url": data['paid_landing_page_url'],
+        }
+
+        additional_metadata, created = DegreeAdditionalMetadata.objects.update_or_create(
+            degree=degree,
+            defaults=additional_metadata_dict
+        )
+
+        if created:
+            logger.info("AdditionalMetdata {} has been created with Degree title {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                additional_metadata,
+                degree,
+            ))

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -32,22 +32,23 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         for row in self.reader:
             row = self.transform_dict_keys(row)
             degree_title = row['title']
+            program_type = row['product_type'].replace('\'', '')
 
             logger.info('Starting data import flow for {}'.format(degree_title))    # lint-amnesty, pylint: disable=logging-format-interpolation
 
             org = self._get_object(Organization, "key", row['organization_key'], degree_title)
-            program_type = self._get_object(ProgramType, "slug", row['product_type'], degree_title)
+            program_type = self._get_object(ProgramType, "slug", program_type, degree_title)
             # primary_subject_override = self._get_object(
             #     Subjetcs, "translations__name",
-            #     row['primary_subject_override'], degree_title
+            #     row['primary_subject'], degree_title
             # )
             # level_type_override = self._get_object(
             #     LevelType, "name_t",
-            #     row['level_type_override'], degree_title
+            #     row['course_level'], degree_title
             # )
             # language_override = self._get_object(
             #     LanguageTag, "code",
-            #     row['language_override'], degree_title
+            #     row['content_language'], degree_title
             # )
 
             if not (org and program_type):
@@ -187,7 +188,9 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         """
 
         program = Program.objects.get(degree=degree, partner=self.partner)
-        is_downloaded = download_and_save_program_image(program, data['card_image_url'])
+        is_downloaded = download_and_save_program_image(
+            program, data['card_image_url'],
+        )
         if not is_downloaded:
             logger.error("Unexpected error happened while downloading image for degree {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation
                 degree.title
@@ -197,7 +200,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         if data.get('organization_logo_override'):
             is_downloaded = download_and_save_program_image(
                 program, data['organization_logo_override'],
-                'organization_logo_override'
+                'organization_logo_override',
             )
             if not is_downloaded:
                 logger.error("Unexpected error happened while downloading image for degree {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -155,7 +155,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         level_type_override, language_override
     ):
         """
-        Make a degree object through ORM
+        Create or Update a degree object through ORM
         """
         data_dict = {
             "type": program_type,
@@ -202,7 +202,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             logger.error("Unexpected error happened while downloading image for degree {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation
                 degree.title
             ))
-            self.messages_list.append('[OVERRIDE IMAGE DOWNLOAD FAILURE] degree {}'.format(degree.title))
+            self.messages_list.append('[DEGREE IMAGE DOWNLOAD FAILURE] degree {}'.format(degree.title))
 
         if data.get('organization_logo_override'):
             is_downloaded = download_and_save_program_image(

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class DegreeCSVDataLoader(AbstractDataLoader):
+    """ Loads the degrees from the csv file """
 
     def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None):
         super().__init__(partner, api_url, max_workers, is_threadsafe)
@@ -210,10 +211,12 @@ class DegreeCSVDataLoader(AbstractDataLoader):
                 'organization_logo_override',
             )
             if not is_downloaded:
-                logger.error("Unexpected error happened while downloading image for degree {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation
+                logger.error("Unexpected error happened while downloading org logo image for degree {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation
                     degree.title
                 ))
-                self.messages_list.append('[OVERRIDE IMAGE DOWNLOAD FAILURE] degree {}'.format(degree.title))
+                self.messages_list.append('[ORG LOGO OVERRIDE IMAGE DOWNLOAD FAILURE] degree {}'.format(  # lint-amnesty, pylint: disable=logging-format-interpolation
+                    degree.title
+                ))
 
     def _handle_courses(self, data, degree):
         """
@@ -227,15 +230,15 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             marketing_text = '<ul>{}</ul>'.format("".join(html_list))
 
             program = Program.objects.get(degree=degree, partner=self.partner)
-            curriculam, created = Curriculum.objects.update_or_create(
+            curriculum, created = Curriculum.objects.update_or_create(
                 program=program,
                 defaults={
                     'marketing_text': marketing_text,
                 }
             )
 
-            logger.info("Curriculam {} is {} for Degree title {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
-                curriculam,
+            logger.info("Curriculum {} is {} for Degree title {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+                curriculum,
                 "created" if created else "updated",
                 degree,
             ))

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -61,6 +61,7 @@ class DegreeCSVLoaderMixin:
         'paid_landing_page_url',
         'organic_url',
         'overview',
+        'specializations',
     ]
 
     # TODO: update it

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -55,19 +55,17 @@ class DegreeCSVLoaderMixin:
         'card_image_url',
         'product_type',
         'organization_key',
-        'organization_name',
-        'organization_logo',
         'slug',
         'paid_landing_page_url',
         'organic_url',
         'overview',
         'specializations',
         'courses',
-        # 'primary_subject',
-        # 'course_level',
-        # 'content_language',
-        # 'organization_logo_override',
-        # 'organization_short_code_override',
+        'course_level',
+        'primary_subject',
+        'content_language',
+        'organization_logo_override',
+        'organization_short_code_override',
     ]
 
     # TODO: update it
@@ -78,11 +76,14 @@ class DegreeCSVLoaderMixin:
         'title': 'Test Degree',
         'type': 'masters',
         'organization_key': 'edx',
-        'organization_name': 'edx',
         'marketing_slug': 'test-degree',
         'paid_landing_page_url': 'http://example.com/landing-page.html',
         'organic_url': 'http://example.com/organic-page.html',
         'overview': 'Test Degree Overview',
+        'level_type_override': 'Intermediate',
+        'primary_subject_override': 'computer-science',
+        'language_override': 'English - United States',
+        'organization_short_code_override': 'Org Override',
     }
 
     def setUp(self):
@@ -125,6 +126,13 @@ class DegreeCSVLoaderMixin:
         """
         self._setup_organization(partner)
 
+        intermediate = LevelTypeFactory(name='Intermediate')
+        intermediate.set_current_language('en')
+        intermediate.name_t = 'Intermediate'
+        intermediate.save()
+
+        SubjectFactory(name='Computer Science')
+
     def _assert_degree_data(self, degree, expected_data):
         """
         Verify the degree's data fields have same values as the expected data dict.
@@ -137,6 +145,10 @@ class DegreeCSVLoaderMixin:
         assert degree.additional_metadata.external_url == expected_data['paid_landing_page_url']
         assert degree.additional_metadata.external_identifier == expected_data['external_identifier']
         assert degree.additional_metadata.organic_url == expected_data['organic_url']
+        assert degree.level_type_override.name == expected_data['level_type_override']
+        assert degree.primary_subject_override.slug == expected_data['primary_subject_override']
+        assert degree.language_override.name == expected_data['language_override']
+        assert degree.organization_short_code_override == expected_data['organization_short_code_override']
 
     def mock_image_response(self, status=200, body=None, content_type='image/jpeg'):
         """

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -63,6 +63,11 @@ class DegreeCSVLoaderMixin:
         'overview',
         'specializations',
         'courses',
+        # 'primary_subject',
+        # 'course_level',
+        # 'content_language',
+        # 'organization_logo_override',
+        # 'organization_short_code_override',
     ]
 
     # TODO: update it

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -62,6 +62,7 @@ class DegreeCSVLoaderMixin:
         'organic_url',
         'overview',
         'specializations',
+        'courses',
     ]
 
     # TODO: update it

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -4,7 +4,7 @@ import responses
 
 from course_discovery.apps.api.v1.tests.test_views.mixins import OAuth2Mixin
 from course_discovery.apps.course_metadata.models import (
-    CourseEntitlement, CourseRunStatus, CourseRunType, CourseType, Seat
+    CourseEntitlement, CourseRunStatus, CourseRunType, CourseType, ProgramType, Seat
 )
 from course_discovery.apps.course_metadata.tests.factories import (
     LevelTypeFactory, OrganizationFactory, PartnerFactory, SubjectFactory
@@ -40,6 +40,114 @@ class DataLoaderTestMixin(OAuth2Mixin):
     def test_init(self):
         """ Verify the constructor sets the appropriate attributes. """
         assert self.loader.partner.short_code == self.partner.short_code
+
+
+class DegreeCSVLoaderMixin:
+    """
+    Mixin to contain various variables and methods used for DegreeCSVDataLoader testing.
+    """
+    DEGREE_TITLE = 'Test Degree'
+    DEGREE_SLUG = 'test-degree'
+
+    CSV_DATA_KEYS_ORDER = [
+        'identifier',
+        'title',
+        'card_image_url',
+        'product_type',
+        'organization_key',
+        'organization_name',
+        'organization_logo',
+        'slug',
+        'paid_landing_page_url',
+        'organic_url',
+        'overview',
+    ]
+
+    # TODO: update it
+    MINIMAL_CSV_DATA_KEYS_ORDER = CSV_DATA_KEYS_ORDER
+
+    # TODO: handle card image url
+    BASE_EXPECTED_DEGREE_DATA = {
+        'external_identifier': '123456',
+        'title': 'Test Degree',
+        'type': 'masters',
+        'organization_key': 'edx',
+        'organization_name': 'edx',
+        'marketing_slug': 'test-degree',
+        'paid_landing_page_url': 'http://example.com/landing-page.html',
+        'organic_url': 'http://example.com/organic-page.html',
+        'overview': 'Test Degree Overview',
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.program_type = ProgramType.objects.get(slug=ProgramType.MASTERS)
+
+    def _write_csv(self, csv, lines_dict_list, headers=None):
+        """
+        Helper method to write given list of data dictionaries to csv, including the csv header.
+        """
+        if headers is None:
+            headers = self.CSV_DATA_KEYS_ORDER
+        header = ''
+        lines = ''
+        for key in headers:
+            title_case_key = key.replace('_', ' ').title()
+            header = '{}{},'.format(header, title_case_key)
+        header = f"{header[:-1]}\n"
+
+        for line_dict in lines_dict_list:
+            for key in headers:
+                lines = '{}"{}",'.format(lines, line_dict[key])
+            lines = f"{lines[:-1]}\n"
+
+        csv.write(header.encode())
+        csv.write(lines.encode())
+        csv.seek(0)
+        return csv
+
+    def _setup_organization(self, partner):
+        """
+        setup test-only organization.
+        """
+        OrganizationFactory(name='edx', key='edx', partner=partner)
+
+    def _setup_prerequisites(self, partner):
+        """
+        Setup pre-reqs for Degree Program.
+        """
+        self._setup_organization(partner)
+
+    def _assert_degree_data(self, degree, expected_data):
+        """
+        Verify the degree's data fields have same values as the expected data dict.
+        """
+
+        assert degree.title == expected_data['title']
+        assert degree.overview == expected_data['overview']
+        assert degree.type == self.program_type
+        assert degree.marketing_slug == expected_data['marketing_slug']
+        assert degree.additional_metadata.external_url == expected_data['paid_landing_page_url']
+        assert degree.additional_metadata.external_identifier == expected_data['external_identifier']
+        assert degree.additional_metadata.organic_url == expected_data['organic_url']
+
+    def mock_image_response(self, status=200, body=None, content_type='image/jpeg'):
+        """
+        Mock the image download call to return a pre-defined image.
+        """
+        # PNG. Single black pixel
+        body = body or b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00' \
+                       b'\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc```\x00\x00\x00\x04\x00\x01\xf6\x178U\x00\x00\x00\x00' \
+                       b'IEND\xaeB`\x82'
+        image_url = 'https://example.com/image.jpg'
+        responses.add(
+            responses.GET,
+            image_url,
+            body=body,
+            status=status,
+            content_type=content_type
+        )
+        return image_url, body
 
 
 class CSVLoaderMixin:

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -68,7 +68,6 @@ class DegreeCSVLoaderMixin:
     # TODO: update it
     MINIMAL_CSV_DATA_KEYS_ORDER = CSV_DATA_KEYS_ORDER
 
-    # TODO: handle card image url
     BASE_EXPECTED_DEGREE_DATA = {
         'external_identifier': '123456',
         'title': 'Test Degree',
@@ -84,6 +83,7 @@ class DegreeCSVLoaderMixin:
     def setUp(self):
         super().setUp()
         self.program_type = ProgramType.objects.get(slug=ProgramType.MASTERS)
+        self.marketing_text = "<ul><li>ABC</li><li>D&E</li><li>Harvard CS50</li></ul>"
 
     def _write_csv(self, csv, lines_dict_list, headers=None):
         """

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3077,14 +3077,17 @@ VALID_DEGREE_CSV_DICT = {
     'card_image_url': 'https://example.com/image.jpg',
     'product_type': 'masters',
     'organization_key': 'edx',
-    'organization_name': 'edx',
-    'organization_logo': 'https://example.com/image.jpg',
     'slug': 'test-degree',
     'paid_landing_page_url': 'http://example.com/landing-page.html',
     'organic_url': 'http://example.com/organic-page.html',
     'overview': 'Test Degree Overview',
     'specializations': 'Marketing | Finance',
     'courses': 'ABC|D&E|Harvard CS50',
+    'course_level': 'Intermediate',
+    'primary_subject': 'Computer Science',
+    'content_language': 'English - United States',
+    'organization_logo_override': 'https://example.com/image.jpg',
+    'organization_short_code_override': 'Org Override',
 }
 
 VALID_MINIMAL_DEGREE_CSV_DICT = VALID_DEGREE_CSV_DICT

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3084,6 +3084,7 @@ VALID_DEGREE_CSV_DICT = {
     'organic_url': 'http://example.com/organic-page.html',
     'overview': 'Test Degree Overview',
     'specializations': 'Marketing | Finance',
+    'courses': 'ABC|D&E|Harvard CS50',
 }
 
 VALID_MINIMAL_DEGREE_CSV_DICT = VALID_DEGREE_CSV_DICT

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3083,6 +3083,7 @@ VALID_DEGREE_CSV_DICT = {
     'paid_landing_page_url': 'http://example.com/landing-page.html',
     'organic_url': 'http://example.com/organic-page.html',
     'overview': 'Test Degree Overview',
+    'specializations': 'Marketing | Finance',
 }
 
 VALID_MINIMAL_DEGREE_CSV_DICT = VALID_DEGREE_CSV_DICT

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3071,6 +3071,34 @@ DISCOVERY_CREATED_MARKETING_SITE_API_COURSE_BODY = {
     'vuuid': 'e0f8c80a-b377-4546-b247-1c94ab3a218a'
 }
 
+VALID_DEGREE_CSV_DICT = {
+    'identifier': '123456',
+    'title': 'Test Degree',
+    'card_image_url': 'https://example.com/image.jpg',
+    'product_type': 'masters',
+    'organization_key': 'edx',
+    'organization_name': 'edx',
+    'organization_logo': 'https://example.com/image.jpg',
+    'slug': 'test-degree',
+    'paid_landing_page_url': 'http://example.com/landing-page.html',
+    'organic_url': 'http://example.com/organic-page.html',
+    'overview': 'Test Degree Overview',
+}
+
+VALID_MINIMAL_DEGREE_CSV_DICT = VALID_DEGREE_CSV_DICT
+
+
+INVALID_DEGREE_ORGANIZATION_DATA = {
+    **VALID_DEGREE_CSV_DICT,
+    'organization_key': 'invalid-organization'
+}
+
+INVALID_PROGRAM_TYPE_DATA = {
+    **VALID_DEGREE_CSV_DICT,
+    'product_type': 'invalid-program-type'
+}
+
+
 VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'organization': 'edx',
     'title': 'CSV Course',

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -230,7 +230,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
     @responses.activate
     def test_image_download_failure(self, jwt_decode_patch):  # pylint: disable=unused-argument
         """
-        Verify that if the course image download fails, the ingestion does not complete.
+        Verify that if the degree image download fails, the ingestion does not complete.
         """
         self._setup_prerequisites(self.partner)
         responses.add(
@@ -269,6 +269,6 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        '[OVERRIDE IMAGE DOWNLOAD FAILURE] degree {}'.format(self.DEGREE_TITLE)
+                        '[DEGREE IMAGE DOWNLOAD FAILURE] degree {}'.format(self.DEGREE_TITLE)
                     )
                 )

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -13,7 +13,7 @@ from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactor
 from course_discovery.apps.course_metadata.data_loaders.degrees_loader import DegreeCSVDataLoader
 from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
 from course_discovery.apps.course_metadata.data_loaders.tests.mixins import DegreeCSVLoaderMixin
-from course_discovery.apps.course_metadata.models import Degree, Program, Curriculum
+from course_discovery.apps.course_metadata.models import Curriculum, Degree, Program
 from course_discovery.apps.course_metadata.tests.factories import DegreeAdditionalMetadataFactory, DegreeFactory
 
 LOGGER_PATH = 'course_discovery.apps.course_metadata.data_loaders.degrees_loader'

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -130,6 +130,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 degree = Degree.objects.get(title=self.DEGREE_TITLE, partner=self.partner)
 
                 assert degree.card_image.read() == image_content
+                assert degree.specializations.count() == 2
                 self._assert_degree_data(degree, self.BASE_EXPECTED_DEGREE_DATA)
 
     def test_ingest_flow_for_preexisting_course(self, jwt_decode_patch):  # pylint: disable=unused-argument
@@ -202,6 +203,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 assert degree.additional_metadata.external_url == 'http://example.com/landing-page.html'
                 assert degree.additional_metadata.external_identifier == '123456'
                 assert degree.additional_metadata.organic_url == 'http://example.com/organic-page.html'
+                assert degree.specializations.count() == 2
 
     @responses.activate
     def test_image_download_failure(self, jwt_decode_patch):  # pylint: disable=unused-argument

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -214,6 +214,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 curriculam = Curriculum.objects.get(program=program)
 
                 assert degree.card_image.read() == image_content
+                assert program.organization_logo_override.read() == image_content
                 assert degree.specializations.count() == 2
                 assert curriculam.marketing_text == self.marketing_text
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -68,12 +68,14 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                         LOGGER_PATH,
                         'ERROR',
                         'Organization invalid-organization does not exist. Skipping CSV '
-                        'loader for degree Test Degree'
+                        'loader for degree {}'.format(self.DEGREE_TITLE)
                     ),
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        '[MISSING ORGANIZATION] org: invalid-organization, degree: Test Degree'
+                        '[MISSING ORGANIZATION] Organization: invalid-organization, degree: {}'.format(
+                            self.DEGREE_TITLE
+                        )
                     )
                 )
                 assert Degree.objects.count() == 0
@@ -93,7 +95,8 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        'ProgramType invalid-program-type does not exist in the database.'
+                        'ProgramType invalid-program-type does not exist. Skipping CSV '
+                        'loader for degree {}'.format(self.DEGREE_TITLE)
                     )
                 )
                 assert Degree.objects.count() == 0
@@ -118,7 +121,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'INFO',
-                        'Degree Program Test Degree could not be found in database, creating the degree.'
+                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_TITLE)
                     )
                 )
 
@@ -155,7 +158,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'INFO',
-                        'Degree {} is located in the database.'.format(self.DEGREE_TITLE)
+                        'Degree {} is located in the database. Updating existing degree.'.format(self.DEGREE_TITLE)
                     )
                 )
 
@@ -184,7 +187,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'INFO',
-                        'Degree Program Test Degree could not be found in database, creating the degree.'
+                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_TITLE)
                     )
                 )
 
@@ -226,7 +229,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'INFO',
-                        'Degree Program Test Degree could not be found in database, creating the degree.'
+                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_TITLE)
                     )
                 )
 
@@ -237,11 +240,11 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        'Unexpected error happened while downloading image for degree Test Degree'
+                        'Unexpected error happened while downloading image for degree {}'.format(self.DEGREE_TITLE)
                     ),
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        '[IMAGE DOWNLOAD FAILURE] degree Test Degree'
+                        '[IMAGE DOWNLOAD FAILURE] degree {}'.format(self.DEGREE_TITLE)
                     )
                 )

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -1,0 +1,247 @@
+"""
+Unit tests for Degree CSV Data loader.
+"""
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+import responses
+from ddt import ddt
+from testfixtures import LogCapture
+
+from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from course_discovery.apps.course_metadata.data_loaders.degrees_loader import DegreeCSVDataLoader
+from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
+from course_discovery.apps.course_metadata.data_loaders.tests.mixins import DegreeCSVLoaderMixin
+from course_discovery.apps.course_metadata.models import Degree
+from course_discovery.apps.course_metadata.tests.factories import DegreeAdditionalMetadataFactory, DegreeFactory
+
+LOGGER_PATH = 'course_discovery.apps.course_metadata.data_loaders.degrees_loader'
+
+
+@ddt
+@mock.patch(
+    'course_discovery.apps.course_metadata.data_loaders.configured_jwt_decode_handler',
+    return_value={'preferred_username': 'test_username'}
+)
+class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
+    """
+    Test Suite for DegreeCSVLoader.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_access_token()
+        self.user = UserFactory.create(username="test_user", password=USER_PASSWORD, is_staff=True)
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+
+    def _assert_default_logs(self, log_capture):
+        """
+        Assert the initiation and completion logs are present in the logger.
+        """
+        log_capture.check_present(
+            (
+                LOGGER_PATH,
+                'INFO',
+                'Initiating Degree CSV data loader flow.'
+            ),
+            (
+                LOGGER_PATH,
+                'INFO',
+                'Degree CSV loader ingest pipeline has completed.'
+            )
+
+        )
+
+    def test_missing_organization(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that no degree is created for a missing organization in the database.
+        """
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.INVALID_DEGREE_ORGANIZATION_DATA])
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = DegreeCSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        'Organization invalid-organization does not exist. Skipping CSV '
+                        'loader for degree Test Degree'
+                    ),
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        '[MISSING ORGANIZATION] org: invalid-organization, degree: Test Degree'
+                    )
+                )
+                assert Degree.objects.count() == 0
+
+    def test_invalid_program_type(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that no degree is created for an invalid program type.
+        """
+        self._setup_organization(self.partner)
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.INVALID_PROGRAM_TYPE_DATA])
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = DegreeCSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        'ProgramType invalid-program-type does not exist in the database.'
+                    )
+                )
+                assert Degree.objects.count() == 0
+
+    @responses.activate
+    def test_single_valid_row(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that for a single row of valid data, degree is created.
+        """
+        self._setup_prerequisites(self.partner)
+        _, image_content = self.mock_image_response()
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.VALID_DEGREE_CSV_DICT])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = DegreeCSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'INFO',
+                        'Degree Program Test Degree could not be found in database, creating the degree.'
+                    )
+                )
+
+                assert Degree.objects.count() == 1
+
+                degree = Degree.objects.get(title=self.DEGREE_TITLE, partner=self.partner)
+
+                assert degree.card_image.read() == image_content
+                self._assert_degree_data(degree, self.BASE_EXPECTED_DEGREE_DATA)
+
+    def test_ingest_flow_for_preexisting_course(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that the loader updates the existing degree in database.
+        """
+
+        self._setup_prerequisites(self.partner)
+        _, image_content = self.mock_image_response()
+
+        degree = DegreeFactory(
+            title=self.DEGREE_TITLE, partner=self.partner,
+            type=self.program_type
+        )
+        _ = DegreeAdditionalMetadataFactory(degree=degree, external_identifier='123456')
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.VALID_DEGREE_CSV_DICT])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = DegreeCSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'INFO',
+                        'Degree {} is located in the database.'.format(self.DEGREE_TITLE)
+                    )
+                )
+
+                degree = Degree.objects.get(title=self.DEGREE_TITLE, partner=self.partner)
+
+                assert degree.card_image.read() == image_content
+                self._assert_degree_data(degree, self.BASE_EXPECTED_DEGREE_DATA)
+
+    def test_ingest_flow_for_minimal_course_data(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that the loader runs as expected for minimal set of data.
+        """
+        self._setup_prerequisites(self.partner)
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(
+                csv, [mock_data.VALID_DEGREE_CSV_DICT], self.MINIMAL_CSV_DATA_KEYS_ORDER
+            )
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = DegreeCSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'INFO',
+                        'Degree Program Test Degree could not be found in database, creating the degree.'
+                    )
+                )
+
+                assert Degree.objects.count() == 1
+
+                degree = Degree.objects.get(title=self.DEGREE_TITLE, partner=self.partner)
+
+                assert degree.title == 'Test Degree'
+                assert degree.overview == 'Test Degree Overview'
+                assert degree.type == self.program_type
+                assert degree.marketing_slug == 'test-degree'
+                assert degree.additional_metadata.external_url == 'http://example.com/landing-page.html'
+                assert degree.additional_metadata.external_identifier == '123456'
+                assert degree.additional_metadata.organic_url == 'http://example.com/organic-page.html'
+
+    @responses.activate
+    def test_image_download_failure(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that if the course image download fails, the ingestion does not complete.
+        """
+        self._setup_prerequisites(self.partner)
+        responses.add(
+            responses.GET,
+            'https://example.com/image.jpg',
+            status=400,
+            body='Image unavailable',
+            content_type='image/jpeg',
+        )
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.VALID_DEGREE_CSV_DICT])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                loader = DegreeCSVDataLoader(self.partner, csv_path=csv.name)
+                loader.ingest()
+
+                self._assert_default_logs(log_capture)
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'INFO',
+                        'Degree Program Test Degree could not be found in database, creating the degree.'
+                    )
+                )
+
+                # Creation call results in creating degree
+                assert Degree.objects.count() == 1
+
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        'Unexpected error happened while downloading image for degree Test Degree'
+                    ),
+                    (
+                        LOGGER_PATH,
+                        'ERROR',
+                        '[IMAGE DOWNLOAD FAILURE] degree Test Degree'
+                    )
+                )

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -135,10 +135,10 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
 
                 assert degree.card_image.read() == image_content
                 assert degree.specializations.count() == 2
-                assert curriculam.marketing_text == "ABC\nD&E\nHarvard CS50"
+                assert curriculam.marketing_text == self.marketing_text
                 self._assert_degree_data(degree, self.BASE_EXPECTED_DEGREE_DATA)
 
-    def test_ingest_flow_for_preexisting_course(self, jwt_decode_patch):  # pylint: disable=unused-argument
+    def test_ingest_flow_for_preexisting_degree(self, jwt_decode_patch):  # pylint: disable=unused-argument
         """
         Verify that the loader updates the existing degree in database.
         """
@@ -176,11 +176,11 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 curriculam = Curriculum.objects.get(program=program)
 
                 assert degree.specializations.count() == 2
-                assert curriculam.marketing_text == "ABC\nD&E\nHarvard CS50"
+                assert curriculam.marketing_text == self.marketing_text
                 assert degree.card_image.read() == image_content
                 self._assert_degree_data(degree, self.BASE_EXPECTED_DEGREE_DATA)
 
-    def test_ingest_flow_for_minimal_course_data(self, jwt_decode_patch):  # pylint: disable=unused-argument
+    def test_ingest_flow_for_minimal_degree_data(self, jwt_decode_patch):  # pylint: disable=unused-argument
         """
         Verify that the loader runs as expected for minimal set of data.
         """
@@ -215,7 +215,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
 
                 assert degree.card_image.read() == image_content
                 assert degree.specializations.count() == 2
-                assert curriculam.marketing_text == "ABC\nD&E\nHarvard CS50"
+                assert curriculam.marketing_text == self.marketing_text
 
                 assert degree.title == 'Test Degree'
                 assert degree.overview == 'Test Degree Overview'
@@ -268,6 +268,6 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        '[IMAGE DOWNLOAD FAILURE] degree {}'.format(self.DEGREE_TITLE)
+                        '[OVERRIDE IMAGE DOWNLOAD FAILURE] degree {}'.format(self.DEGREE_TITLE)
                     )
                 )

--- a/course_discovery/apps/course_metadata/management/commands/import_degree_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_degree_data.py
@@ -1,0 +1,70 @@
+"""
+Management command to import, create, and/or update degrees' data.
+"""
+import logging
+
+from django.apps import apps
+from django.core.management import BaseCommand, CommandError
+from django.db.models.signals import post_delete, post_save
+
+from course_discovery.apps.api.cache import api_change_receiver, set_api_timestamp
+from course_discovery.apps.core.models import Partner
+from course_discovery.apps.course_metadata.data_loaders.degrees_loader import DegreeCSVDataLoader
+from course_discovery.apps.course_metadata.signals import connect_api_change_receiver
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Import degree information from a CSV available on a provided csv path.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--partner_code',
+            help='The short code for a specific partner to import degree to, defaults to "edx".',
+            default='edx',
+            type=str,
+        )
+        parser.add_argument(
+            '--csv_path',
+            help='Path to the CSV file',
+            type=str,
+            required=True
+        )
+
+    def handle(self, *args, **options):
+        """
+        Example usage: ./manage.py import_degree_data --partner_code=edx --csv_path=test.csv
+        """
+        partner_short_code = options.get('partner_code')
+        csv_path = options.get('csv_path')
+        try:
+            partner = Partner.objects.get(short_code=partner_short_code)
+        except Partner.DoesNotExist:
+            raise CommandError(  # pylint: disable=raise-missing-from
+                "Unable to locate partner with code {}".format(partner_short_code)
+            )
+
+        # The signal disconnect has been taken from refresh_course_metadata management command.
+        # We only want to invalidate the API response cache once data loading
+        # completes. Disconnecting the api_change_receiver function from post_save
+        # and post_delete signals prevents model changes during data loading from
+        # repeatedly invalidating the cache.
+        for model in apps.get_app_config('course_metadata').get_models():
+            for signal in (post_save, post_delete):
+                signal.disconnect(receiver=api_change_receiver, sender=model)
+
+        try:
+            loader = DegreeCSVDataLoader(partner, csv_path=csv_path)
+            logger.info("Starting CSV loader import flow for partner {}".format(partner_short_code))  # lint-amnesty, pylint: disable=logging-format-interpolation
+            loader.ingest()
+        except Exception as exc:
+            raise CommandError(  # pylint: disable=raise-missing-from
+                "CSV loader import could not be completed due to unexpected errors.\n{}".format(exc)
+            )
+        else:
+            set_api_timestamp()
+            logger.info("CSV loader import flow completed.")
+        finally:
+            # Re-connect back the api_change_receiver receiver to post_save and post_delete signals
+            connect_api_change_receiver()

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_import_degree_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_import_degree_data.py
@@ -1,0 +1,91 @@
+"""
+Unit tests for import_degree_data management command.
+"""
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+import responses
+from django.core.management import CommandError, call_command
+from testfixtures import LogCapture
+
+from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
+from course_discovery.apps.course_metadata.data_loaders.tests.mixins import DegreeCSVLoaderMixin
+from course_discovery.apps.course_metadata.models import Curriculum, Degree, Program
+
+LOGGER_PATH = 'course_discovery.apps.course_metadata.management.commands.import_degree_data'
+
+
+@mock.patch(
+    'course_discovery.apps.course_metadata.data_loaders.configured_jwt_decode_handler',
+    return_value={'preferred_username': 'test_username'}
+)
+class TestImportDegreeData(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
+    """
+    Test suite for import_degree_data management command.
+    """
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_access_token()
+        self.user = UserFactory.create(username="test_user", password=USER_PASSWORD, is_staff=True)
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+
+    def test_missing_partner(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Test that the command raises CommandError if no partner is present against the provided short code.
+        """
+        with self.assertRaisesMessage(CommandError, 'Unable to locate partner with code invalid-partner-code'):
+            call_command(
+                'import_degree_data', '--partner_code', 'invalid-partner-code', '--csv_path', ''
+            )
+
+    def test_invalid_csv_path(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Test that the command raises CommandError if an invalid csv path is provided.
+        """
+        with self.assertRaisesMessage(
+                CommandError, 'CSV loader import could not be completed due to unexpected errors.'
+        ):
+            call_command(
+                'import_degree_data', '--partner_code', self.partner.short_code, '--csv_path', 'no-path'
+            )
+
+    @responses.activate
+    def test_success_flow(self, jwt_decode_patch):  # pylint: disable=unused-argument
+        """
+        Verify that for a single row of valid data, the command completes CSV loader ingestion flow successfully.
+        """
+        self._setup_prerequisites(self.partner)
+        _, image_content = self.mock_image_response()
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [mock_data.VALID_DEGREE_CSV_DICT])
+
+            with LogCapture(LOGGER_PATH) as log_capture:
+                call_command(
+                    'import_degree_data', '--csv_path', csv.name, '--partner_code', self.partner.short_code
+                )
+                log_capture.check_present(
+                    (
+                        LOGGER_PATH,
+                        'INFO',
+                        'Starting CSV loader import flow for partner {}'.format(self.partner.short_code)
+                    )
+                )
+                log_capture.check_present(
+                    (LOGGER_PATH, 'INFO', 'CSV loader import flow completed.')
+                )
+
+                assert Degree.objects.count() == 1
+                assert Program.objects.count() == 1
+                assert Curriculum.objects.count() == 1
+
+                degree = Degree.objects.get(title=self.DEGREE_TITLE, partner=self.partner)
+                program = Program.objects.get(degree=degree, partner=self.partner)
+                curriculam = Curriculum.objects.get(program=program)
+
+                assert degree.specializations.count() == 2
+                assert curriculam.marketing_text == self.marketing_text
+                assert degree.card_image.read() == image_content
+                self._assert_degree_data(degree, self.BASE_EXPECTED_DEGREE_DATA)

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -3,7 +3,7 @@ import logging
 import random
 import string
 import uuid
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import html2text
 import markdown
@@ -705,6 +705,16 @@ def download_and_save_course_image(course, image_url, data_field='image', header
         logger.exception('An unknown exception occurred while downloading image for course [%s]', course.key)
     return False
 
+def get_downloadable_url_from_drive_link(file_path):
+    """
+    Helper method to get the downloadable url from a drive link
+    """
+    URL = 'https://docs.google.com/uc?id={file_id}'
+    parsed_url = urlparse(file_path)
+    if parsed_url.hostname == 'drive.google.com':
+        file_id = parsed_url.path.split('/')[3]
+        return URL.format(file_id=file_id)
+    return file_path
 
 def download_and_save_program_image(program, image_url, data_field='image', headers=None):
     """
@@ -713,6 +723,7 @@ def download_and_save_program_image(program, image_url, data_field='image', head
     """
     # TODO: refactor and merge program image download to use the same code as course image download
     try:
+        image_url = get_downloadable_url_from_drive_link(image_url)
         response = requests.get(image_url, headers=headers)
 
         if response.status_code == requests.codes.ok:  # pylint: disable=no-member

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -705,6 +705,7 @@ def download_and_save_course_image(course, image_url, data_field='image', header
         logger.exception('An unknown exception occurred while downloading image for course [%s]', course.key)
     return False
 
+
 def get_downloadable_url_from_drive_link(file_path):
     """
     Helper method to get the downloadable url from a drive link
@@ -715,6 +716,7 @@ def get_downloadable_url_from_drive_link(file_path):
         file_id = parsed_url.path.split('/')[3]
         return URL.format(file_id=file_id)
     return file_path
+
 
 def download_and_save_program_image(program, image_url, data_field='image', headers=None):
     """


### PR DESCRIPTION
## Description:
This PR adds Degrees CSV loader to populate incoming degrees' data in `course_metadata` app.

## Linked Ticket:
[PROD-2807](https://2u-internal.atlassian.net/browse/PROD-2807)

## Testing Instructions
- Checkout masters, run migrations.
- Checkout this branch
- Run tests `pytest course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py --ds=course_discovery.settings.test_local --reuse-db`
- Run loader ` ./manage.py import_degree_data --csv_path=./degrees.csv`
- Test file: [degrees.csv](https://github.com/openedx/course-discovery/files/8814774/degrees.csv)
- Setup Subject, LevelType (and its translation) in django admin



## TODO:
- [x] refactor
- [x] update and rebase after #3428 
- [x] update and rebase after #3444 
- [x] update and rebase after #3441
- [x] fix existing degree update test failure
- [x] Write pending method 
- [x] Move loader to separate file
- [x] Write unit tests
- [x] complete TODO's in PR
- [ ] decide unique key after title discussion
- [ ] Write validator
