### PR TITLE
feat: update refresh_course_metadata command

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -43,6 +43,8 @@ def _fatal_code(ex):
 class CoursesApiDataLoader(AbstractDataLoader):
     """ Loads course runs from the Courses API. """
 
+    PAGE_SIZE = 25
+
     def ingest(self):
         logger.info('Refreshing Courses and CourseRuns from %s...', self.partner.courses_api_url)
 


### PR DESCRIPTION
Added option to run the dependant stages separately. This can unblock other stages if one fails. Also will reduce time to run the command.

Currently we can run parallelised execution of the data loading pipeline. The pipeline is structured so that stages that can run independently of others are interleaved using separate processes. However the management command runs as one and takes a lot of time to finish.

This argument is not required and we can ignore it to run the command as it runs today.

[VAN-941](https://2u-internal.atlassian.net/browse/VAN-941)