### PR TITLE
fix: remove skip-review step from csv loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -134,7 +134,12 @@ class CSVDataLoader(AbstractDataLoader):
                 is_logo_downloaded = download_and_save_course_image(
                     course,
                     row['organization_logo_override'],
-                    'organization_logo_override'
+                    'organization_logo_override',
+                    # TODO: Temporary addition of User agent to allow access to data CDNs
+                    headers={
+                        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+                                      '(KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36'
+                    }
                 )
                 if not is_logo_downloaded:
                     logger.error("Unexpected error happened while downloading override logo image for course {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation
@@ -146,17 +151,10 @@ class CSVDataLoader(AbstractDataLoader):
             if not course_run.in_review:
                 try:
                     self._update_course_run(row, course_run, course_type)
-                    course_run.refresh_from_db()
                 except Exception:  # pylint: disable=broad-except
                     logger.exception("An unknown error occurred while updating course run information")
                     self.messages_list.append('[COURSE RUN UPDATE ERROR] course {}'.format(course_title))
                     continue
-
-            if not self.is_draft:
-                try:
-                    self._complete_run_review(row, course_run)
-                except Exception:  # pylint: disable=broad-except
-                    logger.exception("An unknown error occurred while completing course run review")
 
             logger.info("Course and course run updated successfully for course key {}".format(course_key))  # lint-amnesty, pylint: disable=logging-format-interpolation
             self.course_uuids[str(course.uuid)] = course_title

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -72,6 +72,8 @@ class CSVLoaderMixin:
         'external_identifier', 'syllabus', 'frequently_asked_questions'
     ]
     BASE_EXPECTED_COURSE_DATA = {
+        # Loader does not publish newly created course or a course that has not reached published status.
+        # That's why only the draft version of the course exists.
         'draft': True,
         'verified_price': 150,
         'title': 'CSV Course',
@@ -101,14 +103,14 @@ class CSVLoaderMixin:
     }
 
     BASE_EXPECTED_COURSE_RUN_DATA = {
+        # Loader does not publish newly created course or a course that has not reached published status.
+        # That's why only the draft version of the course run exists.
         'draft': True,
         'status': CourseRunStatus.LegalReview,
         'length': 10,
         'minimum_effort': 4,
         'maximum_effort': 10,
         'verified_price': 150,
-        'ofac_restrictions': False,
-        'ofac_comment': '',
         'staff': ['staff_2', 'staff_1'],
         'content_language': 'English - United States',
         'transcript_language': ['English - Great Britain'],

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -72,7 +72,7 @@ class CSVLoaderMixin:
         'external_identifier', 'syllabus', 'frequently_asked_questions'
     ]
     BASE_EXPECTED_COURSE_DATA = {
-        'draft': False,
+        'draft': True,
         'verified_price': 150,
         'title': 'CSV Course',
         'level_type': 'beginner',
@@ -101,8 +101,8 @@ class CSVLoaderMixin:
     }
 
     BASE_EXPECTED_COURSE_RUN_DATA = {
-        'draft': False,
-        'status': CourseRunStatus.Published,
+        'draft': True,
+        'status': CourseRunStatus.LegalReview,
         'length': 10,
         'minimum_effort': 4,
         'maximum_effort': 10,
@@ -250,8 +250,6 @@ class CSVLoaderMixin:
         assert course_run.min_effort == expected_data['minimum_effort']
         assert course_run.max_effort == expected_data['maximum_effort']
         assert course_run_seat.price == expected_data['verified_price']
-        assert course_run.has_ofac_restrictions == expected_data['ofac_restrictions']
-        assert course_run.ofac_comment == expected_data['ofac_comment']
         assert course_run.go_live_date.isoformat() == expected_data['go_live_date']
         assert course_run.expected_program_type.slug == expected_data['expected_program_type']
         assert course_run.expected_program_name == expected_data['expected_program_name']

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -227,11 +227,11 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                         )
                     )
 
-                    assert Course.objects.count() == 1
-                    assert CourseRun.objects.count() == 1
+                    assert Course.everything.count() == 1
+                    assert CourseRun.everything.count() == 1
 
-                    course = Course.objects.get(key=self.COURSE_KEY, partner=self.partner)
-                    course_run = CourseRun.objects.get(course=course)
+                    course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
+                    course_run = CourseRun.everything.get(course=course)
 
                     assert course.image.read() == image_content
                     assert course.organization_logo_override.read() == image_content
@@ -254,6 +254,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             course=course,
             key=self.COURSE_RUN_KEY,
             type=self.course_run_type,
+            status='unpublished',
             draft=True,
         )
 
@@ -278,8 +279,8 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                         )
                     )
 
-                    course = Course.objects.get(key=self.COURSE_KEY, partner=self.partner)
-                    course_run = CourseRun.objects.get(course=course)
+                    course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
+                    course_run = CourseRun.everything.get(course=course)
 
                     self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)
                     self._assert_course_run_data(course_run, self.BASE_EXPECTED_COURSE_RUN_DATA)
@@ -370,9 +371,9 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                 assert course_run.status == 'unpublished'
 
     @responses.activate
-    def test_course_status_is_published_if_draft_disabled(self, jwt_decode_patch):  # pylint: disable=unused-argument
+    def test_course_status_is_legal_review_if_draft_disabled(self, jwt_decode_patch):  # pylint: disable=unused-argument
         """
-        Verify that the course run will be published if csv loader ingests data with draft disabled
+        Verify that the course run will be in legal review if csv loader ingests data with draft disabled
         """
         self._setup_prerequisites(self.partner)
         self.mock_studio_calls(self.partner)
@@ -394,7 +395,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                 course = Course.everything.filter(key=self.COURSE_KEY, partner=self.partner).first()
                 course_run = CourseRun.everything.filter(course=course).first()
 
-                assert course_run.status == 'published'
+                assert course_run.status == 'review_by_legal'
 
     @responses.activate
     def test_active_slug(self, jwt_decode_patch):  # pylint: disable=unused-argument

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
@@ -104,11 +104,11 @@ class TestImportCourseMetadata(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                         (LOGGER_PATH, 'INFO', 'CSV loader import flow completed.')
                     )
 
-                    assert Course.objects.count() == 1
-                    assert CourseRun.objects.count() == 1
+                    assert Course.everything.count() == 1
+                    assert CourseRun.everything.count() == 1
 
-                    course = Course.objects.get(key=self.COURSE_KEY, partner=self.partner)
-                    course_run = CourseRun.objects.get(course=course)
+                    course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
+                    course_run = CourseRun.everything.get(course=course)
 
                     assert course.image.read() == image_content
                     self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -671,13 +671,13 @@ def clean_html(content):
     return cleaned
 
 
-def download_and_save_course_image(course, image_url, data_field='image'):
+def download_and_save_course_image(course, image_url, data_field='image', headers=None):
     """
     Helper method to download an image from a provided image url and save it
     in the data field mentioned, defaulting to course card image.
     """
     try:
-        response = requests.get(image_url)
+        response = requests.get(image_url, headers=headers)
 
         if response.status_code == requests.codes.ok:  # pylint: disable=no-member
             content_type = response.headers['Content-Type'].lower()


### PR DESCRIPTION
### [PROD-2817](https://2u-internal.atlassian.net/browse/PROD-2817)

### Description

- Remove the step of setting course run status as reviewed if draft=False. This means that a course create from scratch via loader will move in legal view and only have draft versions of the course
    - This was added to move a course directly into published status, skipping internal and legal reviews. Not needed anymore
- Update course and course run query method in test to `everything` instead of `objects`. objects filter out draft versions of the course
- Adding a temporary, default User Agent for the org logo overrides download requests call, to avoid 403 from 2U CDNs.


### Notes
- If the course and course run are already published, running the loader with no draft flag will push the changes to both draft and non-draft versions of the course and course run.
- If the CSV contains an entry for a new course and the draft flag is not provided, the course and course run will be created, and the course run will move into the LegalReview phase.
    - In a follow-up PR, the draft flag will be removed from CSV loader. Instead, using course run status, the draft flag value will be determined for each row. If a course has any published course run, the draft will be False. Otherwise true. Reference: https://github.com/openedx/frontend-app-publisher/blob/master/src/components/EditCoursePage/index.jsx#L204-L213