### PR TITLE
feat: update csv loader draft behavior to match publisher

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -224,7 +224,7 @@ class CSVDataLoader(AbstractDataLoader):
         No 1 is not applicable at the moment. For 2, CSV loader right now only expects
         one course run for each course, hence the status of the single fetched course run is checked.
         """
-        return not (course_run.status == CourseRunStatus.Published)
+        return not course_run.status == CourseRunStatus.Published
 
     def _update_course_api_request_data(self, data, course, is_draft):
         """

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -10,6 +10,7 @@ from django.db.models import Q
 from django.urls import reverse
 
 from course_discovery.apps.core.utils import serialize_datetime
+from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.data_loaders import AbstractDataLoader
 from course_discovery.apps.course_metadata.models import (
     Collaborator, Course, CourseRun, CourseRunPacing, CourseRunType, CourseType, Organization, Person, ProgramType,
@@ -44,14 +45,13 @@ class CSVDataLoader(AbstractDataLoader):
         'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text',
     ]
 
-    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None, is_draft=False):
+    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None):
         super().__init__(partner, api_url, max_workers, is_threadsafe)
 
         self.messages_list = []  # to show failure/skipped ingestion message at the end
         self.course_uuids = {}  # to show the discovery course ids for each processed course
         try:
             self.reader = csv.DictReader(open(csv_path, 'r'))  # lint-amnesty, pylint: disable=consider-using-with
-            self.is_draft = is_draft
         except FileNotFoundError:
             logger.exception("Error opening csv file at path {}".format(csv_path))  # lint-amnesty, pylint: disable=logging-format-interpolation
             raise  # re-raising exception to avoid moving the code flow
@@ -122,8 +122,11 @@ class CSVDataLoader(AbstractDataLoader):
                 self.messages_list.append('[IMAGE DOWNLOAD FAILURE] course {}'.format(course_title))
                 continue
 
+            is_draft = self.get_draft_flag(course_run)
+            logger.info(f"Draft flag is set to {is_draft} for the course {course_title}")
+
             try:
-                self._update_course(row, course)
+                self._update_course(row, course, is_draft)
             except Exception:  # pylint: disable=broad-except
                 logger.exception("An unknown error occurred while updating course information")
                 self.messages_list.append('[COURSE UPDATE ERROR] course {}'.format(course_title))
@@ -150,7 +153,7 @@ class CSVDataLoader(AbstractDataLoader):
             # No need to update the course run if the run is already in the review
             if not course_run.in_review:
                 try:
-                    self._update_course_run(row, course_run, course_type)
+                    self._update_course_run(row, course_run, course_type, is_draft)
                 except Exception:  # pylint: disable=broad-except
                     logger.exception("An unknown error occurred while updating course run information")
                     self.messages_list.append('[COURSE RUN UPDATE ERROR] course {}'.format(course_title))
@@ -213,7 +216,17 @@ class CSVDataLoader(AbstractDataLoader):
             'course_run': course_run_creation_fields
         }
 
-    def _update_course_api_request_data(self, data, course):
+    def get_draft_flag(self, course_run):
+        """
+        To keep behavior of CSV loader consistent with publisher, draft flag is false only when:
+            1. Course run is moved from Unpublished -> Review State
+            2. Any of the Course run is in published state
+        No 1 is not applicable at the moment. For 2, CSV loader right now only expects
+        one course run for each course, hence the status of the single fetched course run is checked.
+        """
+        return not (course_run.status == CourseRunStatus.Published)
+
+    def _update_course_api_request_data(self, data, course, is_draft):
         """
         Create and return the request data for making a patch call to update the course.
         """
@@ -225,7 +238,7 @@ class CSVDataLoader(AbstractDataLoader):
         )
 
         update_course_data = {
-            'draft': self.is_draft,
+            'draft': is_draft,
             'key': course.key,
             'uuid': str(course.uuid),
             'url_slug': course.active_url_slug,
@@ -250,7 +263,7 @@ class CSVDataLoader(AbstractDataLoader):
         }
         return update_course_data
 
-    def _update_course_run_request_data(self, data, course_run, course_type):
+    def _update_course_run_request_data(self, data, course_run, course_type, is_draft):
         """
         Create and return the request data for making a patch call to update the course run.
         """
@@ -264,7 +277,7 @@ class CSVDataLoader(AbstractDataLoader):
             'key': course_run.key,
             'prices': self.get_pricing_representation(data['verified_price'], course_type),
             'staff': staff_uuids,
-            'draft': self.is_draft,
+            'draft': is_draft,
 
             'weeks_to_complete': data['length'],
             'min_effort': data['minimum_effort'],
@@ -350,26 +363,26 @@ class CSVDataLoader(AbstractDataLoader):
             logger.info("Course creation response: {}".format(response.content))  # lint-amnesty, pylint: disable=logging-format-interpolation
         return response.json()
 
-    def _update_course(self, data, course):
+    def _update_course(self, data, course, is_draft):
         """
         Update the course data.
         """
         course_api_url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})
         url = f"{settings.DISCOVERY_BASE_URL}{course_api_url}?exclude_utm=1"
-        request_data = self._update_course_api_request_data(data, course)
+        request_data = self._update_course_api_request_data(data, course, is_draft)
         response = self._call_course_api('PATCH', url, request_data)
 
         if response.status_code not in (200, 201):
             logger.info("Course update response: {}".format(response.content))  # lint-amnesty, pylint: disable=logging-format-interpolation
         return response.json()
 
-    def _update_course_run(self, data, course_run, course_type):
+    def _update_course_run(self, data, course_run, course_type, is_draft):
         """
         Update the course run data.
         """
         course_run_api_url = reverse('api:v1:course_run-detail', kwargs={'key': course_run.key})
         url = f"{settings.DISCOVERY_BASE_URL}{course_run_api_url}?exclude_utm=1"
-        request_data = self._update_course_run_request_data(data, course_run, course_type)
+        request_data = self._update_course_run_request_data(data, course_run, course_type, is_draft)
         response = self._call_course_api('PATCH', url, request_data)
         if response.status_code not in (200, 201):
             logger.info("Course run update response: {}".format(response.content))  # lint-amnesty, pylint: disable=logging-format-interpolation

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -106,7 +106,7 @@ class CSVLoaderMixin:
         # Loader does not publish newly created course or a course that has not reached published status.
         # That's why only the draft version of the course run exists.
         'draft': True,
-        'status': CourseRunStatus.LegalReview,
+        'status': CourseRunStatus.Unpublished,
         'length': 10,
         'minimum_effort': 4,
         'maximum_effort': 10,
@@ -244,9 +244,12 @@ class CSVLoaderMixin:
         """
         Verify the course run's data fields have same values as the expected data dict.
         """
+        # No need to add draft in the filter here. Based on the draft status of the course run,
+        # the appropriate Seat object is returned.
         course_run_seat = Seat.everything.get(type__slug='verified', course_run=course_run)
 
         assert course_run.draft is expected_data['draft']
+        assert course_run_seat.draft is expected_data['draft']
         assert course_run.status == expected_data['status']
         assert course_run.weeks_to_complete == expected_data['length']
         assert course_run.min_effort == expected_data['minimum_effort']

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -263,6 +263,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         expected_course_run_data = {
             **self.BASE_EXPECTED_COURSE_RUN_DATA,
             'draft': False,
+            'status': 'published'
         }
 
         with NamedTemporaryFile() as csv:

--- a/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
@@ -32,12 +32,6 @@ class Command(BaseCommand):
             type=str,
             required=True
         )
-        parser.add_argument(
-            '--is_draft',
-            help='The boolean value which is used to toggle draft courses',
-            type=bool,
-            default=False
-        )
 
     def handle(self, *args, **options):
         """
@@ -45,8 +39,6 @@ class Command(BaseCommand):
         """
         partner_short_code = options.get('partner_code')
         csv_path = options.get('csv_path')
-        # its default value is False, it will be treated as True if passed by any value via command-line
-        is_draft = options.get('is_draft')
         try:
             partner = Partner.objects.get(short_code=partner_short_code)
         except Partner.DoesNotExist:
@@ -64,7 +56,7 @@ class Command(BaseCommand):
                 signal.disconnect(receiver=api_change_receiver, sender=model)
 
         try:
-            loader = CSVDataLoader(partner, csv_path=csv_path, is_draft=is_draft)
+            loader = CSVDataLoader(partner, csv_path=csv_path)
             logger.info("Starting CSV loader import flow for partner {}".format(partner_short_code))  # lint-amnesty, pylint: disable=logging-format-interpolation
             loader.ingest()
         except Exception as exc:


### PR DESCRIPTION
### [PROD-2824](https://2u-internal.atlassian.net/browse/PROD-2824)

### Description

- Update CSV loader draft behavior to be course and course run specific. This makes the loader behavior consistent with publisher. The publisher's behavior for draft flag is:
    - Course: If any of the course run is in published state, the draft is false, else true ([Reference](https://github.com/openedx/frontend-app-publisher/blob/master/src/components/EditCoursePage/index.jsx#L204-L213)).
    - Course Run: If target run or status is published. CSV Loader expects only one run/course, so the status of the fetched course run is checked (https://github.com/openedx/frontend-app-publisher/blob/master/src/components/EditCoursePage/index.jsx#L117-L124)


### Testing
- Make sure you have Executive education course type setup https://2u-internal.atlassian.net/wiki/spaces/IM/pages/18974245/Executive+Education+Course+Type#Unpaid-and-Paid-Track%2FEnrollment-Type-Variants
- Create the subjects "Economics & Finance" and "Design" from admin
- Create "Introductory" level type from admin
- Use the file: [dt.csv](https://github.com/openedx/course-discovery/files/8787129/dt.csv)
- Run the loader inside discovery shell `./manage.py import_course_metadata --csv_path=dt.csv`
- Both courses will be in an Unpublished state.
- ~~Now, publish one from Published, make edits to draft version from admin, and re-run the loader~~
- ~~You would see the draft False for the published course in the logs and the admin changes would be present in non-draft version too.~~
- Now, publish one from Published, make edits to CSV against a few fields, and re-run the loader
- The CSV updates will be present for both draft and non-draft versions of the course (Check via admin)
 