### PR TITLE
feat: add new program/degree types

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_affiliate_window.py
@@ -94,7 +94,7 @@ class ProgramsAffiliateWindowViewSetTests(SerializationMixin, APITestCase):
         assert response.status_code == status.HTTP_200_OK
         root = ET.fromstring(response.content)
 
-        # Assert that there is only on Program in the returned data even though 5
+        # Assert that there is only one Program in the returned data even though 5
         # are created in setup
         assert len(root.findall('product')) == 1
         self._assert_product_xml(

--- a/course_discovery/apps/api/v1/views/affiliates.py
+++ b/course_discovery/apps/api/v1/views/affiliates.py
@@ -67,10 +67,15 @@ class ProgramsAffiliateWindowViewSet(viewsets.ViewSet):
             raise PermissionDenied
 
         try:
-            exclude_type = ProgramType.objects.get(slug=ProgramType.MASTERS)
+            exclude_types = [
+                ProgramType.objects.get(slug=ProgramType.MASTERS),
+                ProgramType.objects.get(slug=ProgramType.BACHELORS),
+                ProgramType.objects.get(slug=ProgramType.DOCTORATE),
+                ProgramType.objects.get(slug=ProgramType.LICENSE),
+            ]
         except ProgramType.DoesNotExist:
-            exclude_type = ''
-        programs = catalog.programs().marketable().exclude(type=exclude_type).select_related(
+            exclude_types = []
+        programs = catalog.programs().marketable().exclude(type__in=exclude_types).select_related(
             'type',
             'partner',
         ).prefetch_related(

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -376,10 +376,15 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     @property
     def availability_level(self):
-        # Master's programs don't have courses in the same way that our other programs do.
+        # Master's and 2U programs don't have courses in the same way that our other programs do.
         # We got confirmation from masters POs that we should make masters Programs always
         # 'Available now'
-        if self.type and self.type.slug == ProgramType.MASTERS:
+        if self.type and self.type.slug in [
+            ProgramType.MASTERS,
+            ProgramType.BACHELORS,
+            ProgramType.DOCTORATE,
+            ProgramType.LICENSE,
+        ]:
             return _('Available now')
 
         all_courses = self.courses.all()

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -27,6 +27,9 @@ class CSVDataLoader(AbstractDataLoader):
     PROGRAM_TYPES = [
         ProgramType.XSERIES,
         ProgramType.MASTERS,
+        ProgramType.BACHELORS,
+        ProgramType.DOCTORATE,
+        ProgramType.LICENSE,
         ProgramType.MICROMASTERS,
         ProgramType.MICROBACHELORS,
         ProgramType.PROFESSIONAL_PROGRAM_WL,

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -335,6 +335,9 @@ class ProgramType(TranslatableModel, TimeStampedModel):
     PROFESSIONAL_CERTIFICATE = 'professional-certificate'
     PROFESSIONAL_PROGRAM_WL = 'professional-program-wl'
     MASTERS = 'masters'
+    BACHELORS = 'bachelors'
+    DOCTORATE = 'doctorate'
+    LICENSE = 'license'
     MICROBACHELORS = 'microbachelors'
 
     name = models.CharField(max_length=32, blank=False)

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -1,6 +1,7 @@
 import datetime
 from collections import ChainMap
 
+import ddt
 import pytest
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -320,6 +321,7 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         assert not english_course.promoted_in_spanish_index
 
 
+@ddt.ddt
 @pytest.mark.django_db
 class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
 
@@ -382,30 +384,10 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         assert 'Upcoming' in program.availability_level
         assert 'Archived' in program.availability_level
 
-    def test_program_available_now_if_program_type_is_masters(self):
+    @ddt.data('masters', 'bachelors', 'doctorate', 'license')
+    def test_program_available_now(self, program_type_slug):
         program_type = ProgramTypeFactory()
-        program_type.slug = 'masters'
-        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
-
-        assert program.availability_level == 'Available now'
-
-    def test_program_available_now_if_program_type_is_bachelors(self):
-        program_type = ProgramTypeFactory()
-        program_type.slug = 'bachelors'
-        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
-
-        assert program.availability_level == 'Available now'
-
-    def test_program_available_now_if_program_type_is_doctorate(self):
-        program_type = ProgramTypeFactory()
-        program_type.slug = 'doctorate'
-        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
-
-        assert program.availability_level == 'Available now'
-
-    def test_program_available_now_if_program_type_is_license(self):
-        program_type = ProgramTypeFactory()
-        program_type.slug = 'license'
+        program_type.slug = program_type_slug
         program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
 
         assert program.availability_level == 'Available now'

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -389,6 +389,27 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
 
         assert program.availability_level == 'Available now'
 
+    def test_program_available_now_if_program_type_is_bachelors(self):
+        program_type = ProgramTypeFactory()
+        program_type.slug = 'bachelors'
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
+
+        assert program.availability_level == 'Available now'
+
+    def test_program_available_now_if_program_type_is_doctorate(self):
+        program_type = ProgramTypeFactory()
+        program_type.slug = 'doctorate'
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
+
+        assert program.availability_level == 'Available now'
+
+    def test_program_available_now_if_program_type_is_license(self):
+        program_type = ProgramTypeFactory()
+        program_type.slug = 'license'
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
+
+        assert program.availability_level == 'Available now'
+
     def test_program_not_available_if_no_published_runs(self):
         program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
         course = AlgoliaProxyCourseFactory(partner=self.__class__.edxPartner)


### PR DESCRIPTION
## Description:
This PR adds `bachelors, doctorate, license` ProgramType slug in models and excludes them from affiliate endpoints. 

## Linked Ticket:
[PROD-2804](https://2u-internal.atlassian.net/browse/PROD-2804)

## Checklist:
- [x] fix (any) failings tests
- [x] check if we need to add doctorate program or not
- [x] communicated `Available Now` change with WS team
- [ ] double check what else needs to be updated
- [ ] create admin entries in stage/prod
- [ ] research if any seat related changes are needed or not
