### PR TITLE
temp: fixed headers for downloading images from CDN

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -114,7 +114,14 @@ class CSVDataLoader(AbstractDataLoader):
                 course = Course.everything.get(key=course_key, partner=self.partner)
                 course_run = CourseRun.everything.filter(course=course).first()
 
-            is_downloaded = download_and_save_course_image(course, row['image'])
+            is_downloaded = download_and_save_course_image(
+                course,
+                row['image'],
+                # TODO: Temporary addition of User agent to allow access to data CDNs
+                headers={
+                        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+                                      '(KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36'
+                })
             if not is_downloaded:
                 logger.error("Unexpected error happened while downloading image for course {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation
                     course_key

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -119,8 +119,8 @@ class CSVDataLoader(AbstractDataLoader):
                 row['image'],
                 # TODO: Temporary addition of User agent to allow access to data CDNs
                 headers={
-                        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
-                                      '(KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36'
+                    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+                                  '(KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36'
                 })
             if not is_downloaded:
                 logger.error("Unexpected error happened while downloading image for course {}".format(  # lint-amnesty, pylint: disable=logging-format-interpolation


### PR DESCRIPTION
### [PROD-2819](https://2u-internal.atlassian.net/browse/PROD-2819)

### Description

- In CSV loader, add the fixed headers when attempting to download course images from a CDN to skip 403 errors.