### PR TITLE
feat: suppress 2u products in catalog

### DIFF
--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -11,6 +11,7 @@ from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import HTTPError
 from sortedm2m.fields import SortedManyToManyField
 
+from course_discovery.apps.core.api_client.lms import LMSAPIClient
 from course_discovery.apps.core.utils import serialize_datetime
 from course_discovery.apps.course_metadata.models import CourseRun
 
@@ -142,6 +143,37 @@ def decode_image_data(image_data):
     ext = file_format.split('/')[-1]  # guess file extension
     image_data = ContentFile(base64.b64decode(img_str), name=f'tmp.{ext}')
     return image_data.name, image_data
+
+
+def check_catalog_api_access(partner, user):
+    """
+    Uses LMSAPIClient to check the catalog api access for a
+    given user
+
+    Arguments:
+        user (User): Django User.
+
+    Returns:
+        (dict): ApiAccessRequests for the given user.
+
+    Example:
+        {
+            "id": 1,
+            "created": "2017-09-25T08:37:05.872566Z",
+            "modified": "2017-09-25T08:37:47.412496Z",
+            "user": 5,
+            "status": "approved",
+            "website": "https://example.com/",
+            "reason": "Example Reason",
+            "company_name": "Example Inc",
+            "company_address": "Example Address",
+            "site": 1,
+            "contacted": True
+        }
+    """
+    lms_client = LMSAPIClient(partner)
+    api_access_response = lms_client.get_api_access_request(user)
+    return api_access_response
 
 
 class StudioAPI:


### PR DESCRIPTION
## Description:
Exclude 2u products in course data returned from catalogs. This way 2u products will not appear on edX pages.

## Linked Ticket:
for more details please visit: [PROD-2835](https://2u-internal.atlassian.net/browse/PROD-2835)