### PR TITLE
feat: decode organization logo override to save in image field

### DIFF
--- a/course_discovery/apps/api/tests/test_utils.py
+++ b/course_discovery/apps/api/tests/test_utils.py
@@ -5,13 +5,14 @@ from unittest import mock
 import ddt
 import pytest
 import responses
+from django.core.files.base import ContentFile
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 from rest_framework.views import APIView
 
-from course_discovery.apps.api.utils import StudioAPI, cast2int, get_query_param
+from course_discovery.apps.api.utils import StudioAPI, cast2int, decode_image_data, get_query_param
 from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
 from course_discovery.apps.core.tests.factories import UserFactory
 from course_discovery.apps.core.utils import serialize_datetime
@@ -58,6 +59,16 @@ class Cast2IntTests(TestCase):
                 cast2int(value, self.name)
 
         assert mock_logger.called
+
+
+class TestDecodeImageData(TestCase):
+    def test_decode_image_data(self):
+        test_image = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk' \
+                     '+A8AAQUBAScY42YAAAAASUVORK5CYII='
+        img_name, img_data = decode_image_data(test_image)
+        assert img_name == 'tmp.png'
+        assert img_data is not None
+        assert isinstance(img_data, ContentFile)
 
 
 class TestGetQueryParam:

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -1,8 +1,10 @@
+import base64
 import functools
 import logging
 import math
 from urllib.parse import parse_qsl, urlencode, urljoin
 
+from django.core.files.base import ContentFile
 from django.db.models.fields.related import ManyToManyField
 from django.utils.translation import gettext as _
 from opaque_keys.edx.keys import CourseKey
@@ -129,6 +131,17 @@ def conditional_decorator(condition, decorator):
     Util decorator that allows for only using the given decorator arg if the condition passes
     """
     return decorator if condition else lambda x: x
+
+
+def decode_image_data(image_data):
+    """
+    Given a encoded base64 image, it will decode encoded image and
+    return image name and decoded image_data
+    """
+    file_format, img_str = image_data.split(';base64,')  # format ~= data:image/X;base64,/xxxyyyzzz/
+    ext = file_format.split('/')[-1]  # guess file extension
+    image_data = ContentFile(base64.b64decode(img_str), name=f'tmp.{ext}')
+    return image_data.name, image_data
 
 
 class StudioAPI:

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1010,6 +1010,8 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
             # The API is expecting the image to be base64 encoded. We are simulating that here.
             'image': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY'
                      '42YAAAAASUVORK5CYII=',
+            'organization_logo_override': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0l'
+                                          'EQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
             'video': {'src': 'https://link.to.video.for.testing/watch?t_s=5'},
         }
 
@@ -1019,6 +1021,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         course = Course.everything.get(uuid=self.course.uuid, draft=True)
         assert course.title == 'Course title'
         assert course.active_url_slug == 'manual'
+        assert course.organization_logo_override.url is not None
         self.assertDictEqual(response.data, self.serialize_course(course))
 
     @responses.activate


### PR DESCRIPTION
[Add Organization short code and logo overrides on Publisher](https://2u-internal.atlassian.net/browse/PROD-2838)

## Description
We are sending image as encoded data to API. So we need to decode that image into required format to save in Image field

## Publisher PR
https://github.com/openedx/frontend-app-publisher/pull/731

## Testing
To test it, we need to send image data to Course API. We can also test this using publisher UI. 
1. Checkout to [this branch](https://github.com/openedx/frontend-app-publisher/pull/731)
2. Open course edit page
3. Go to Organization Logo Override field
4. Upload any png format picture and save course
5. You will see updated image for organization logo override