### PR TITLE
refactor: use slug instead of title

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -41,6 +41,9 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         for row in self.reader:
             row = self.transform_dict_keys(row)
 
+            degree_slug = row['slug']
+            program_type = row['product_type'].replace('\'', '').lower()
+
             message = self.validate_degree_data(row)
             if message:
                 logger.error("Data validation issue for degree {}, skipping ingestion".format(degree_slug))    # lint-amnesty, pylint: disable=logging-format-interpolation
@@ -48,9 +51,6 @@ class DegreeCSVDataLoader(AbstractDataLoader):
                     degree_slug, message
                 ))
                 continue
-
-            degree_slug = row['slug']
-            program_type = row['product_type'].replace('\'', '').lower()
 
             logger.info('Starting data import flow for {}'.format(degree_slug))    # lint-amnesty, pylint: disable=logging-format-interpolation
 

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -40,6 +40,15 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         logger.info("Initiating Degree CSV data loader flow.")
         for row in self.reader:
             row = self.transform_dict_keys(row)
+
+            message = self.validate_degree_data(row)
+            if message:
+                logger.error("Data validation issue for degree {}, skipping ingestion".format(degree_slug))    # lint-amnesty, pylint: disable=logging-format-interpolation
+                self.messages_list.append("[DATA VALIDATION ERROR] Degree {}. Missing data: {}".format(
+                    degree_slug, message
+                ))
+                continue
+
             degree_slug = row['slug']
             program_type = row['product_type'].replace('\'', '').lower()
 
@@ -61,14 +70,6 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             )
 
             if not (org and program_type and primary_subject_override and level_type_override and language_override):
-                continue
-
-            message = self.validate_degree_data(row)
-            if message:
-                logger.error("Data validation issue for degree {}, skipping ingestion".format(degree_slug))    # lint-amnesty, pylint: disable=logging-format-interpolation
-                self.messages_list.append("[DATA VALIDATION ERROR] Degree {}. Missing data: {}".format(
-                    degree_slug, message
-                ))
                 continue
 
             # get degree object from slug and external_identifier

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -41,7 +41,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         for row in self.reader:
             row = self.transform_dict_keys(row)
             degree_slug = row['slug']
-            program_type = row['product_type'].replace('\'', '')
+            program_type = row['product_type'].replace('\'', '').lower()
 
             logger.info('Starting data import flow for {}'.format(degree_slug))    # lint-amnesty, pylint: disable=logging-format-interpolation
 

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -174,7 +174,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             "partner": self.partner,
 
         }
-        degree, updated = Degree.objects.update_or_create(
+        degree, created = Degree.objects.update_or_create(
             marketing_slug=data['slug'],
             additional_metadata__external_identifier=data['identifier'],
             defaults=data_dict
@@ -182,7 +182,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
 
         logger.info("Degree with slug {} is {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
             degree.marketing_slug,
-            "updated" if updated else "created",
+            "created" if created else "updated",
         ))
 
         return degree
@@ -299,7 +299,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             defaults=additional_metadata_dict
         )
 
-        logger.info("AdditionalMetdata {} is {} with Degree slug {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
+        logger.info("AdditionalMetadata {} is {} with Degree slug {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
             additional_metadata,
             "created" if created else "updated",
             degree.marketing_slug,

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -53,7 +53,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
 
         )
 
-    @ddt.data('identifier', 'card_image_url', 'slug', 'paid_landing_page_url', 'organic_url', 'courses')
+    @ddt.data('identifier', 'card_image_url', 'title', 'paid_landing_page_url', 'organic_url', 'courses')
     def test_validation_failure(self, missing_key, jwt_decode_patch):  # pylint: disable=unused-argument
         """
         Verify that data validation fails given an invalid data.
@@ -73,13 +73,13 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        'Data validation issue for degree {}, skipping ingestion'.format(self.DEGREE_TITLE)
+                        'Data validation issue for degree {}, skipping ingestion'.format(self.DEGREE_SLUG)
                     ),
                     (
                         LOGGER_PATH,
                         'ERROR',
                         '[DATA VALIDATION ERROR] Degree {}. Missing data: {}'.format(
-                            self.DEGREE_TITLE, missing_key
+                            self.DEGREE_SLUG, missing_key
                         )
                     )
                 )

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -100,13 +100,13 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                         LOGGER_PATH,
                         'ERROR',
                         'Organization invalid-organization does not exist. Skipping CSV '
-                        'loader for degree {}'.format(self.DEGREE_TITLE)
+                        'loader for degree {}'.format(self.DEGREE_SLUG)
                     ),
                     (
                         LOGGER_PATH,
                         'ERROR',
                         '[MISSING ORGANIZATION] Organization: invalid-organization, degree: {}'.format(
-                            self.DEGREE_TITLE
+                            self.DEGREE_SLUG
                         )
                     )
                 )
@@ -128,7 +128,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                         LOGGER_PATH,
                         'ERROR',
                         'ProgramType invalid-program-type does not exist. Skipping CSV '
-                        'loader for degree {}'.format(self.DEGREE_TITLE)
+                        'loader for degree {}'.format(self.DEGREE_SLUG)
                     )
                 )
                 assert Degree.objects.count() == 0
@@ -153,7 +153,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'INFO',
-                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_TITLE)
+                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_SLUG)
                     )
                 )
 
@@ -161,7 +161,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 assert Program.objects.count() == 1
                 assert Curriculum.objects.count() == 1
 
-                degree = Degree.objects.get(title=self.DEGREE_TITLE, partner=self.partner)
+                degree = Degree.objects.get(marketing_slug=self.DEGREE_SLUG, partner=self.partner)
                 program = Program.objects.get(degree=degree, partner=self.partner)
                 curriculam = Curriculum.objects.get(program=program)
 
@@ -179,7 +179,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
         _, image_content = self.mock_image_response()
 
         degree = DegreeFactory(
-            title=self.DEGREE_TITLE, partner=self.partner,
+            marketing_slug=self.DEGREE_SLUG, partner=self.partner,
             type=self.program_type
         )
         _ = DegreeAdditionalMetadataFactory(degree=degree, external_identifier='123456')
@@ -196,14 +196,14 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'INFO',
-                        'Degree {} is located in the database. Updating existing degree.'.format(self.DEGREE_TITLE)
+                        'Degree {} is located in the database. Updating existing degree.'.format(self.DEGREE_SLUG)
                     )
                 )
                 assert Degree.objects.count() == 1
                 assert Program.objects.count() == 1
                 assert Curriculum.objects.count() == 1
 
-                degree = Degree.objects.get(title=self.DEGREE_TITLE, partner=self.partner)
+                degree = Degree.objects.get(marketing_slug=self.DEGREE_SLUG, partner=self.partner)
                 program = Program.objects.get(degree=degree, partner=self.partner)
                 curriculam = Curriculum.objects.get(program=program)
 
@@ -233,7 +233,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'INFO',
-                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_TITLE)
+                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_SLUG)
                     )
                 )
 
@@ -241,7 +241,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 assert Program.objects.count() == 1
                 assert Curriculum.objects.count() == 1
 
-                degree = Degree.objects.get(title=self.DEGREE_TITLE, partner=self.partner)
+                degree = Degree.objects.get(marketing_slug=self.DEGREE_SLUG, partner=self.partner)
                 program = Program.objects.get(degree=degree, partner=self.partner)
                 curriculam = Curriculum.objects.get(program=program)
 
@@ -285,7 +285,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'INFO',
-                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_TITLE)
+                        'Degree {} is not located in the database. Creating new degree.'.format(self.DEGREE_SLUG)
                     )
                 )
 
@@ -296,11 +296,11 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        'Unexpected error happened while downloading image for degree {}'.format(self.DEGREE_TITLE)
+                        'Unexpected error happened while downloading image for degree {}'.format(self.DEGREE_SLUG)
                     ),
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        '[DEGREE IMAGE DOWNLOAD FAILURE] degree {}'.format(self.DEGREE_TITLE)
+                        '[DEGREE IMAGE DOWNLOAD FAILURE] degree {}'.format(self.DEGREE_SLUG)
                     )
                 )


### PR DESCRIPTION
## Description:
This PR updates degree loader logic to use `marketing_slug` instead of `title` as unique key. 

## Linked Ticket:
[PROD-2852](https://2u-internal.atlassian.net/browse/PROD-2852)

## Checklist:
- [x] Merge after #3465 