### PR TITLE
feat: use blurb from GEAG api response

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -297,7 +297,7 @@ class Command(BaseCommand):
             'title': partially_filled_csv_dict.get('title') or product_dict['altName'] or product_dict['name'],
             '2u_title': product_dict['name'],
             'edx_title': product_dict['altName'],
-            'short_description': partially_filled_csv_dict.get('title') or product_dict['name'],
+            'short_description': product_dict.get('blurb') or product_dict.get('name'),
             'what_will_you_learn': product_dict['whatWillSetYouApart'] or partially_filled_csv_dict.get(
                 'what_will_you_learn'
             ),

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -31,6 +31,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 "altName": "Alternative CSV Course",
                 "abbreviation": "TC",
                 "altAbbreviation": "UCT",
+                "blurb": "A short description for CSV course",
                 "language": "Español",
                 "subjectMatter": "Marketing",
                 "altSubjectMatter": "Design and Marketing",
@@ -134,7 +135,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 assert data_row['Organization'] == 'altEdx'
                 assert data_row['External Identifier'] == '12345678'
                 assert data_row['Start Time'] == '00:00:00'
-                assert data_row['Short Description'] == 'CSV Course'
+                assert data_row['Short Description'] == 'A short description for CSV course'
                 assert data_row['Long Description'] == 'Very short description\n' \
                                                        'This is supposed to be a long description'
                 assert data_row['End Time'] == '23:59:59'
@@ -292,7 +293,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
         assert data_row['End Time'] == '23:59:59'
         assert data_row['End Date'] == '2022-05-06'
         assert data_row['Verified Price'] == '1998'
-        assert data_row['Short Description'] == 'CSV Course'
+        assert data_row['Short Description'] == 'A short description for CSV course'
         assert data_row['Long Description'] == 'Very short description\n' \
                                                'This is supposed to be a long description'
         assert data_row['Course Enrollment Track'] == 'Executive Education(2U)'


### PR DESCRIPTION
[PROD-2815](https://2u-internal.atlassian.net/browse/PROD-2815)

The current EE data loader didn't have any short description field and used to add title as short description. 
This PR uses `blurb` field to be mapped onto short description which is now being exposed through getsmarter GEAG api. 

Note: Currently, there's no validation being performed on the response of GEAG api so if there isn't any `blurb` field, the title will be used as the fallback `short_description`