### PR TITLE
feat: use logoUrl from GEAG for ExecEd

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         'expected_program_type', 'expected_program_name', 'upgrade_deadline_override_date',
         'upgrade_deadline_override_time', 'redirect_url', 'external_identifier', 'lead_capture_form_url',
         'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text', 'organic_url',
-        'organization_short_code_override',
+        'organization_short_code_override', 'logo_url',
     ]
 
     # Mapping English and Spanish languages to IETF equivalent variants
@@ -310,4 +310,5 @@ class Command(BaseCommand):
             'start_date': partially_filled_csv_dict.get('start_date') or product_dict['variant']['startDate'],
             'minimum_effort': minimum_effort,
             'maximum_effort': maximum_effort,
+            'logo_url': product_dict['logoUrl'],
         }

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -47,6 +47,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 'isThisCourseForYou': 'This is supposed to be a long description',
                 'whatWillSetYouApart': "New ways to learn",
                 "videoURL": "",
+                "logoUrl": "https://example.com/",
                 "lcfURL": "www.example.com/lead-capture?id=123",
                 "variant": {
                     "id": "test_id",
@@ -156,6 +157,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                                                '</p><p><b>Module 1: </b>Welcome to Module 1</p></div>'
                 assert data_row['Learner Testimonials'] == '<div><p><i>" This is a good course"</i></p><p>-Lorem ' \
                                                            'Ipsum (Gibberish)</p></div>'
+                assert data_row['Logo Url'] == 'https://example.com/'
                 assert str(date.today().year) in data_row['Publish Date']
 
                 log_capture.check_present(
@@ -318,4 +320,5 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                                        '</p><p><b>Module 1: </b>Welcome to Module 1</p></div>'
         assert data_row['Learner Testimonials'] == '<div><p><i>" This is a good course"</i></p><p>-Lorem ' \
                                                    'Ipsum (Gibberish)</p></div>'
+        assert data_row['Logo Url'] == 'https://example.com/'
         assert str(date.today().year) in data_row['Publish Date']


### PR DESCRIPTION
[PROD-2818](https://2u-internal.atlassian.net/browse/PROD-2818)
Uses `logoUrl` from GEAG api to use the correct logo in ExecEd data.