### PR TITLE
fix: prevent making additional metadata object for non 2U courses

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1260,7 +1260,11 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
     def update(self, instance, validated_data):
         # Handle writing nested additional_metadata separately
         if 'additional_metadata' in validated_data:
-            self.update_additional_metadata(instance, validated_data.pop('additional_metadata'))
+            # Handle additional metadata only for 2U courses else just pop
+            additional_metadata_data = validated_data.pop('additional_metadata')
+            if instance.type.slug in [CourseType.BOOTCAMP_2U, CourseType.EXECUTIVE_EDUCATION_2U]:
+                self.update_additional_metadata(instance, additional_metadata_data)
+
         return super().update(instance, validated_data)
 
 

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -273,7 +273,7 @@ class CSVDataLoader(AbstractDataLoader):
             'prerequisites_raw': data.get('prerequisites', ''),
             'full_description': data['long_description'],
             'short_description': data['short_description'],
-            'additional_metadata': self.get_additional_metadata_dict(data),
+            'additional_metadata': self.get_additional_metadata_dict(data, course.type.slug),
             'learner_testimonials': data.get('learner_testimonials', ''),
             'additional_information': data.get('additional_information', ''),
             'organization_short_code_override': data.get('organization_short_code_override', ''),
@@ -542,11 +542,14 @@ class CSVDataLoader(AbstractDataLoader):
             stats.append(stat2_dict)
         return stats
 
-    def get_additional_metadata_dict(self, data):
+    def get_additional_metadata_dict(self, data, type_slug):
         """
         Return the appropriate additional metadata dict representation, skipping the keys that are not
         present in the input data dict.
         """
+        if type_slug not in [CourseType.EXECUTIVE_EDUCATION_2U, CourseType.BOOTCAMP_2U]:
+            return {}
+
         additional_metadata = {
             'external_url': data['redirect_url'],
             'external_identifier': data['external_identifier'],

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -7,7 +7,8 @@ from course_discovery.apps.course_metadata.models import (
     CourseEntitlement, CourseRunStatus, CourseRunType, CourseType, ProgramType, Seat
 )
 from course_discovery.apps.course_metadata.tests.factories import (
-    LevelTypeFactory, OrganizationFactory, PartnerFactory, SubjectFactory
+    CourseRunTypeFactory, CourseTypeFactory, LevelTypeFactory, ModeFactory, OrganizationFactory, PartnerFactory,
+    SeatTypeFactory, SubjectFactory, TrackFactory
 )
 
 
@@ -188,7 +189,7 @@ class CSVLoaderMixin:
         'length', 'content_language', 'transcript_language', 'expected_program_type', 'expected_program_name',
         'upgrade_deadline_override_date', 'upgrade_deadline_override_time', 'redirect_url', 'external_identifier',
         'lead_capture_form_url', 'organic_url', 'certificate_header', 'certificate_text', 'stat1', 'stat1_text',
-        'stat2', 'stat2_text', 'organization_logo_override', 'organization_short_code_override'
+        'stat2', 'stat2_text', 'organization_logo_override', 'organization_short_code_override',
     ]
     # The list of minimal data headers
     MINIMAL_CSV_DATA_KEYS_ORDER = [
@@ -196,8 +197,7 @@ class CSVLoaderMixin:
         'long_description', 'what_will_you_learn', 'course_level', 'primary_subject', 'verified_price', 'publish_date',
         'start_date', 'start_time', 'end_date', 'end_time', 'reg_close_date', 'reg_close_time',
         'course_run_enrollment_track', 'course_pacing', 'minimum_effort', 'maximum_effort', 'length',
-        'content_language', 'transcript_language', 'redirect_url', 'external_identifier', 'syllabus',
-        'frequently_asked_questions'
+        'content_language', 'transcript_language', 'syllabus', 'frequently_asked_questions',
     ]
     BASE_EXPECTED_COURSE_DATA = {
         # Loader does not publish newly created course or a course that has not reached published status.
@@ -251,10 +251,20 @@ class CSVLoaderMixin:
 
     def setUp(self):
         super().setUp()
-        self.course_type = CourseType.objects.get(
-            slug=CourseType.VERIFIED_AUDIT)
-        self.course_run_type = CourseRunType.objects.get(
-            slug=CourseRunType.VERIFIED_AUDIT)
+        paid_exec_ed_name = 'Paid Executive Education'
+        self.paid_exec_ed_slug = CourseRunType.PAID_EXECUTIVE_EDUCATION
+
+        seat_type = SeatTypeFactory(name=paid_exec_ed_name)
+        mode = ModeFactory(name=paid_exec_ed_name, slug=self.paid_exec_ed_slug)
+        track = TrackFactory(mode=mode, seat_type=seat_type)
+        self.course_run_type = CourseRunTypeFactory(
+            name=paid_exec_ed_name, slug=self.paid_exec_ed_slug, tracks=[track]
+        )
+        self.course_type = CourseTypeFactory(
+            name='Executive Education(2U)', slug=CourseType.EXECUTIVE_EDUCATION_2U,
+            course_run_types=[self.course_run_type],
+            entitlement_types=[seat_type]
+        )
 
     def _write_csv(self, csv, lines_dict_list, headers=None):
         """
@@ -338,7 +348,7 @@ class CSVLoaderMixin:
         Verify the course's data fields have same values as the expected data dict.
         """
         course_entitlement = CourseEntitlement.everything.get(
-            draft=expected_data['draft'], mode__slug='verified', course=course
+            draft=expected_data['draft'], mode__slug=self.paid_exec_ed_slug, course=course
         )
 
         assert course.draft is expected_data['draft']
@@ -378,7 +388,7 @@ class CSVLoaderMixin:
         """
         # No need to add draft in the filter here. Based on the draft status of the course run,
         # the appropriate Seat object is returned.
-        course_run_seat = Seat.everything.get(type__slug='verified', course_run=course_run)
+        course_run_seat = Seat.everything.get(type__slug=self.paid_exec_ed_slug, course_run=course_run)
 
         assert course_run.draft is expected_data['draft']
         assert course_run_seat.draft is expected_data['draft']

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3108,7 +3108,7 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'organization': 'edx',
     'title': 'CSV Course',
     'number': 'csv_123',
-    'course_enrollment_track': 'Verified and Audit',
+    'course_enrollment_track': 'Executive Education(2U)',
     'image': 'https://example.com/image.jpg',
     'short_description': 'Very short description',
     'long_description': 'Organization,Title,Number,Course Enrollment track,Image,Short Description,Long Description,'
@@ -3135,7 +3135,7 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'reg_close_date': '01/25/2020',
     'reg_close_time': '00:00',
     'course_pacing': 'self-paced',
-    'course_run_enrollment_track': 'Verified and Audit',
+    'course_run_enrollment_track': 'Paid Executive Education',
     'staff': 'staff_1,staff_2',
     'minimum_effort': 4,
     'maximum_effort': 10,
@@ -3189,8 +3189,6 @@ VALID_MINIMAL_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'length': 10,
     'content_language': 'English - United States',
     'transcript_language': 'English - Great Britain',
-    'redirect_url': 'http://www.example.com',
-    'external_identifier': '123456789',
 }
 
 INVALID_ORGANIZATION_DATA = {

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -13,7 +13,7 @@ from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactor
 from course_discovery.apps.course_metadata.data_loaders.csv_loader import CSVDataLoader
 from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
 from course_discovery.apps.course_metadata.data_loaders.tests.mixins import CSVLoaderMixin
-from course_discovery.apps.course_metadata.models import Course, CourseRun
+from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseType
 from course_discovery.apps.course_metadata.tests.factories import (
     CourseFactory, CourseRunFactory, CourseTypeFactory, OrganizationFactory
 )
@@ -486,7 +486,6 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         self._setup_prerequisites(self.partner)
         self.mock_studio_calls(self.partner)
         self.mock_image_response()
-
         with NamedTemporaryFile() as csv:
             csv = self._write_csv(
                 csv, [mock_data.VALID_MINIMAL_COURSE_AND_COURSE_RUN_CSV_DICT], self.MINIMAL_CSV_DATA_KEYS_ORDER
@@ -531,13 +530,6 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                     )
                     assert course.syllabus_raw == '<p>Introduction to Algorithms</p>'
                     assert course.subjects.first().slug == "computer-science"
-                    assert course.additional_metadata.external_url == 'http://www.example.com'
-                    assert course.additional_metadata.external_identifier == '123456789'
-                    assert course.additional_metadata.start_date.isoformat() == '2020-01-25T00:00:00+00:00'
-                    assert course.additional_metadata.registration_deadline.isoformat() == '2020-01-25T00:00:00+00:00'
-                    assert course.additional_metadata.lead_capture_form_url == ''
-                    assert course.additional_metadata.certificate_info is None
-                    assert course.additional_metadata.facts.exists() is False
                     assert course_run.staff.exists() is False
 
     @data(
@@ -570,7 +562,8 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         Verify that if any of the required field is missing in data, the ingestion is not done.
         """
         self._setup_prerequisites(self.partner)
-        _ = CourseTypeFactory(name=course_type[0], slug=course_type[1])
+        if not CourseType.objects.filter(name=course_type[0], slug=course_type[1]).exists():
+            _ = CourseTypeFactory(name=course_type[0], slug=course_type[1])
 
         csv_data = {
             **mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT,

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -480,6 +480,10 @@ class CourseRunType(TimeStampedModel):
     VERIFIED_HONOR = 'verified-honor'
     VERIFIED_AUDIT_HONOR = 'verified-audit-honor'
     EMPTY = 'empty'
+    PAID_EXECUTIVE_EDUCATION = 'paid-executive-education'
+    UNPAID_EXECUTIVE_EDUCATION = 'unpaid-executive-education'
+    PAID_BOOTCAMP = 'paid-bootcamp'
+    UNPAID_BOOTCAMP = 'unpaid-bootcamp'
 
     uuid = models.UUIDField(default=uuid4, editable=False, verbose_name=_('UUID'), unique=True)
     name = models.CharField(max_length=64)


### PR DESCRIPTION
### Description:
This PR adds a check to create additional metadata object only if the course type is of 2U. 

### Linked Ticket:
[PROD-2855](https://2u-internal.atlassian.net/browse/PROD-2855)

### Testing:
1. Run unit tests
2. Send additional metadata via api where courses type is not 2U, it shouldn't create additional metadata object in db. It will just ignore. 