### PR TITLE
ENT-5896: chore: Updated taxonomy-connector version to 1.16.3

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -681,7 +681,7 @@ stevedore==3.5.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.16.2
+taxonomy-connector==1.16.3
     # via -r requirements/base.in
 testfixtures==6.18.5
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -465,7 +465,7 @@ stevedore==3.5.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.16.2
+taxonomy-connector==1.16.3
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
__Jira Ticket:__ [ENT-5896](https://2u-internal.atlassian.net/browse/ENT-5896)

__Description:__
New version of the taxonomy-connector contains [these](https://github.com/openedx/taxonomy-connector/pull/92/files) changes. Short description of the changes is that it contains fixes caused by EMSI API returning NULL values for non-null fields.