### PR TITLE
fix: course run key was overflowing after 'z'

### DIFF
--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -144,6 +144,29 @@ def decode_image_data(image_data):
     return image_data.name, image_data
 
 
+def increment_str(input_str):
+    """
+    Given a string, it will return its next combination by incrementing the last alphabet and handle all boundary cases
+    ref link: https://gist.github.com/jlp78/f306afc919dc06c8ce156475fc9320bf
+    example:
+    1. given a string 'a' and it will return 'b'
+    2. given a string 'z' and it will return 'aa'
+    3. given a string 'az' and it will return 'ba'
+    """
+    lpart = input_str.rstrip('z')
+    num_replacements = len(input_str) - len(lpart)
+    new_str = lpart[:-1] + increment_character(lpart[-1]) if lpart else 'a'
+    new_str += 'a' * num_replacements
+    return new_str
+
+
+def increment_character(character):
+    """
+    Given a character and it will return its next character using ASCII code
+    """
+    return chr(ord(character) + 1) if character != 'z' else 'a'
+
+
 class StudioAPI:
     """
     A convenience class for talking to the Studio API - designed to allow subclassing by the publisher django app,
@@ -163,7 +186,7 @@ class StudioAPI:
         if candidate in existing_runs:
             # If our candidate is an existing run, use the next letter in the alphabet as the
             # run suffix (e.g. 1T2017, 1T2017a, 1T2017b, ...).
-            suffix = chr(ord(suffix) + 1) if suffix else 'a'
+            suffix = increment_str(suffix)
             return cls._get_next_run(root, suffix, existing_runs)
 
         return candidate


### PR DESCRIPTION
[Investigate and fix why the bootcamp ingestion for a set of courses is failing on production](https://2u-internal.atlassian.net/browse/PROD-2869)


## Issue:
We are increasing Course Run if course run already exist for any course_num.

For example if we have course run = `course-v1:TestX+Testing101x+1T2017`
the new course run will `course-v1:TestX+Testing101x+1T2017a` 
append `a` at the last. And if we have `course-v1:TestX+Testing101x+1T2017a` then it will replace `a` with `b` to make it unique like `course-v1:TestX+Testing101x+1T2017b`, So each time course run is increasing it will change alphabet. And we are not handling boundary case, like if we get `z` at the end then after increment it was replaced with `{` which is not acceptable.

## Fix:
We need to update logic to handle boundary case that if we get `z` at the last then new course run will `course-v1:TestX+Testing101x+1T2017aa`
