### PR TITLE
fix: use list filter in degree admin search

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -716,7 +716,8 @@ class DegreeAdmin(admin.ModelAdmin):
     list_display = ('title', 'partner', 'status', 'hidden')
     ordering = ('title', 'status')
     readonly_fields = ('uuid', )
-    search_fields = ('title', 'partner', 'marketing_slug')
+    list_filter = ('partner',)
+    search_fields = ('title', 'marketing_slug',)
     inlines = (
         CurriculumAdminInline,
         DegreeDeadlineInlineAdmin,

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -717,7 +717,7 @@ class DegreeAdmin(admin.ModelAdmin):
     ordering = ('title', 'status')
     readonly_fields = ('uuid', )
     list_filter = ('partner',)
-    search_fields = ('title', 'marketing_slug',)
+    search_fields = ('uuid', 'title', 'marketing_slug',)
     inlines = (
         CurriculumAdminInline,
         DegreeDeadlineInlineAdmin,

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -713,10 +713,10 @@ class DegreeAdmin(admin.ModelAdmin):
     This is an inheritance model from Program
 
     """
-    list_display = ('title', 'partner', 'status', 'hidden')
+    list_display = ('uuid', 'title', 'marketing_slug', 'status', 'hidden')
     ordering = ('title', 'status')
     readonly_fields = ('uuid', )
-    list_filter = ('partner',)
+    list_filter = ('partner', 'status',)
     search_fields = ('uuid', 'title', 'marketing_slug',)
     inlines = (
         CurriculumAdminInline,


### PR DESCRIPTION
### Description:
This PR fixes 500 - Internal server error while searching degree via django admin

### Linked Ticket:
[PROD-2875](https://2u-internal.atlassian.net/browse/PROD-2875)

### Testing:
1. Open admin and search degree on master branch [expected: error]
2. Checkout this branch and search again [expected: display results]

### TODO:
- [x] Discuss and add more fields for searching  
- [x] Alternate approach like `partner__name` in search list 