### PR TITLE
build: manual usage of semgrep instead of github-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: returntocorp/semgrep-action@v1
-        name: django rules
-        with:
-          config: p/django
+      - run: make requirements.python
+      - name: Run semgrep Django rules
+        run: semgrep ci --config p/django

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -287,9 +287,9 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
     def _login(self):
         """ Log into Django admin. """
         self.browser.get(self._build_url(reverse('admin:login')))
-        self.browser.find_element_by_id('id_username').send_keys(self.user.username)
-        self.browser.find_element_by_id('id_password').send_keys(USER_PASSWORD)
-        self.browser.find_element_by_css_selector('input[type=submit]').click()
+        self.browser.find_element(By.ID, 'id_username').send_keys(self.user.username)
+        self.browser.find_element(By.ID, 'id_password').send_keys(USER_PASSWORD)
+        self.browser.find_element(By.CSS_SELECTOR, 'input[type=submit]').click()
         self._wait_for_page_load('dashboard')
 
     def _wait_for_add_edit_page_to_load(self):
@@ -304,18 +304,18 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
         self._wait_for_add_edit_page_to_load()
 
     def _select_option(self, select_id, option_value):
-        select = Select(self.browser.find_element_by_id(select_id))
+        select = Select(self.browser.find_element(By.ID, select_id))
         select.select_by_value(option_value)
 
     def _submit_program_form(self):
-        self.browser.find_element_by_css_selector('input[type=submit][name=_save]').click()
+        self.browser.find_element(By.CSS_SELECTOR, 'input[type=submit][name=_save]').click()
         self._wait_for_excluded_course_runs_page_to_load()
 
     def assert_form_fields_present(self):
         """ Asserts the correct fields are rendered on the form. """
         # Check the model fields
         actual = []
-        for element in self.browser.find_elements_by_class_name('form-row'):
+        for element in self.browser.find_elements(By.CLASS_NAME, 'form-row'):
             actual += [_class for _class in element.get_attribute('class').split(' ') if _class.startswith('field-')]
 
         expected = [
@@ -346,9 +346,9 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
             type=ProgramType.objects.first(),
             marketing_slug='foo'
         )
-        self.browser.find_element_by_id('id_title').send_keys(program.title)
-        self.browser.find_element_by_id('id_subtitle').send_keys(program.subtitle)
-        self.browser.find_element_by_id('id_marketing_slug').send_keys(program.marketing_slug)
+        self.browser.find_element(By.ID, 'id_title').send_keys(program.title)
+        self.browser.find_element(By.ID, 'id_subtitle').send_keys(program.subtitle)
+        self.browser.find_element(By.ID, 'id_marketing_slug').send_keys(program.marketing_slug)
         self._select_option('id_status', program.status)
         self._select_option('id_type', str(program.type.id))
         self._select_option('id_partner', str(program.partner.id))
@@ -376,7 +376,7 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
         )
 
         for field, value in data:
-            element = self.browser.find_element_by_id('id_' + field)
+            element = self.browser.find_element(By.ID, 'id_' + field)
             element.clear()
             element.send_keys(value)
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,7 +12,7 @@ certifi==2022.6.15
     # via
     #   elasticsearch
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 django-elasticsearch-dsl @ git+https://github.com/django-es/django-elasticsearch-dsl.git@0e92e01c6ef74d2fe329965deee5f4b25da7ec87
     # via -r requirements/github.in
@@ -31,9 +31,9 @@ elasticsearch-dsl==7.4.0
     #   django-elasticsearch-dsl
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.0
     # via sphinx
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
@@ -49,7 +49,7 @@ python-dateutil==2.8.2
     # via elasticsearch-dsl
 pytz==2022.1
     # via babel
-requests==2.28.0
+requests==2.28.1
     # via sphinx
 six==1.16.0
     # via

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -31,9 +31,11 @@ async-timeout==4.0.2
     # via redis
 attrs==21.4.0
     # via
+    #   glom
     #   jsonschema
     #   outcome
     #   pytest
+    #   semgrep
     #   trio
     #   zeep
 authlib==1.0.0rc1
@@ -52,12 +54,19 @@ beautifulsoup4==4.11.1
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.24.14
+boltons==21.0.0
+    # via
+    #   face
+    #   glom
+    #   semgrep
+boto3==1.24.21
     # via django-ses
-botocore==1.27.14
+botocore==1.27.21
     # via
     #   boto3
     #   s3transfer
+bracex==2.3.post1
+    # via wcmatch
 cached-property==1.5.2
     # via zeep
 celery==5.2.7
@@ -69,33 +78,39 @@ certifi==2022.6.15
     #   elasticsearch
     #   requests
     #   urllib3
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
     #   celery
     #   click-didyoumean
     #   click-log
+    #   click-option-group
     #   click-plugins
     #   click-repl
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
+    #   semgrep
 click-didyoumean==0.3.0
     # via celery
 click-log==0.4.0
     # via edx-lint
+click-option-group==0.5.3
+    # via semgrep
 click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
 code-annotations==1.3.0
     # via edx-lint
+colorama==0.4.5
+    # via semgrep
 coreapi==2.3.3
     # via drf-yasg
 coreschema==0.0.4
@@ -120,6 +135,7 @@ defusedxml==0.7.1
     # via
     #   djangorestframework-xml
     #   python3-openid
+    #   semgrep
     #   social-auth-core
 deprecated==1.2.13
     # via redis
@@ -129,7 +145,6 @@ distlib==0.3.4
     # via virtualenv
 distro==1.7.0
     # via docker-compose
-django==3.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
@@ -194,7 +209,7 @@ django-countries==7.3.2
     # via -r requirements/base.in
 django-crum==0.7.9
     # via edx-django-utils
-django-debug-toolbar==3.4.0
+django-debug-toolbar==3.5.0
     # via -r requirements/local.in
 django-dry-rest-permissions==1.2.0
     # via -r requirements/base.in
@@ -351,9 +366,11 @@ elasticsearch-dsl==7.4.0
     #   django-elasticsearch-dsl-drf
 execnet==1.9.0
     # via pytest-xdist
+face==20.1.1
+    # via glom
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==13.13.0
+faker==13.14.0
     # via factory-boy
 filelock==3.7.1
     # via
@@ -363,6 +380,8 @@ freezegun==1.2.1
     # via -r requirements/test.in
 future==0.18.2
     # via pyjwkest
+glom==22.1.0
+    # via semgrep
 h11==0.13.0
     # via wsproto
 html2text==2020.1.16
@@ -372,9 +391,9 @@ idna==3.3
     #   requests
     #   trio
     #   urllib3
-imagesize==1.3.0
+imagesize==1.4.0
     # via sphinx
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   -r requirements/base.in
     #   markdown
@@ -403,7 +422,9 @@ jmespath==1.0.1
 jsonfield==3.1.0
     # via -r requirements/base.in
 jsonschema==3.2.0
-    # via docker-compose
+    # via
+    #   docker-compose
+    #   semgrep
 kombu==5.2.4
     # via celery
 lazy-object-proxy==1.7.1
@@ -422,9 +443,9 @@ mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.in
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via -r requirements/test.in
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via edx-django-utils
 oauthlib==3.2.0
     # via
@@ -437,6 +458,7 @@ packaging==21.3
     #   drf-yasg
     #   pytest
     #   redis
+    #   semgrep
     #   sphinx
     #   tox
 paramiko==2.11.0
@@ -445,6 +467,8 @@ path==16.4.0
     # via edx-i18n-tools
 pbr==5.9.0
     # via stevedore
+peewee==3.15.0
+    # via semgrep
 pillow==9.1.1
     # via
     #   -r requirements/base.in
@@ -460,7 +484,7 @@ pluggy==1.0.0
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via click-repl
 psutil==5.9.1
     # via edx-django-utils
@@ -475,7 +499,7 @@ pycountry==22.3.5
     # via -r requirements/base.in
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via pyjwkest
 pygments==2.12.0
     # via sphinx
@@ -488,7 +512,7 @@ pyjwt[crypto]==2.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.14.3
+pylint==2.14.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -547,6 +571,8 @@ python-dateutil==2.8.2
     #   freezegun
 python-dotenv==0.20.0
     # via docker-compose
+python-lsp-jsonrpc==1.0.0
+    # via semgrep
 python-memcached==1.59
     # via -r requirements/test.in
 python-monkey-business==1.0.0
@@ -579,9 +605,9 @@ pyyaml==5.4.1
     #   edx-i18n-tools
 rcssmin==1.1.0
     # via django-compressor
-redis==4.3.3
+redis==4.3.4
     # via -r requirements/base.in
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/base.in
     #   algoliasearch
@@ -596,6 +622,7 @@ requests==2.28.0
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
+    #   semgrep
     #   simple-salesforce
     #   slumber
     #   social-auth-core
@@ -614,15 +641,19 @@ responses==0.21.0
 rjsmin==1.2.0
     # via django-compressor
 ruamel-yaml==0.17.21
-    # via drf-yasg
+    # via
+    #   drf-yasg
+    #   semgrep
 ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 s3transfer==0.6.0
     # via boto3
-selenium==4.2.0
+selenium==4.3.0
     # via -r requirements/test.in
 semantic-version==2.10.0
     # via edx-drf-extensions
+semgrep==0.102.0
+    # via -r requirements/test.in
 simple-salesforce==1.11.6
     # via -r requirements/base.in
 six==1.16.0
@@ -714,8 +745,10 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.11.0
     # via pylint
-tox==3.25.0
+tox==3.25.1
     # via -r requirements/test.in
+tqdm==4.64.0
+    # via semgrep
 trio==0.21.0
     # via
     #   selenium
@@ -727,6 +760,9 @@ typing-extensions==4.2.0
     #   astroid
     #   django-countries
     #   pylint
+    #   semgrep
+ujson==5.3.0
+    # via python-lsp-jsonrpc
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1
@@ -740,13 +776,16 @@ urllib3[secure,socks]==1.26.9
     #   requests
     #   responses
     #   selenium
+    #   semgrep
 vine==5.0.0
     # via
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.14.1
+virtualenv==20.15.1
     # via tox
+wcmatch==8.4
+    # via semgrep
 wcwidth==0.2.5
     # via prompt-toolkit
 websocket-client==0.59.0

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,14 +4,22 @@
 #
 #    pip-compile --output-file=requirements/pip_tools.txt requirements/pip_tools.in
 #
+build==0.8.0
+    # via pip-tools
 click==8.1.3
     # via pip-tools
+packaging==21.3
+    # via build
 pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
+    # via build
+pip-tools==6.8.0
     # via -r requirements/pip_tools.in
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.1
-    # via pep517
+    # via
+    #   build
+    #   pep517
 wheel==0.37.1
     # via pip-tools
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -33,9 +33,9 @@ beautifulsoup4==4.11.1
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.24.14
+boto3==1.24.21
     # via django-ses
-botocore==1.27.14
+botocore==1.27.21
     # via
     #   boto3
     #   s3transfer
@@ -50,11 +50,11 @@ certifi==2022.6.15
     #   -r requirements/production.in
     #   elasticsearch
     #   requests
-cffi==1.15.0
+cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
@@ -298,7 +298,7 @@ html2text==2020.1.16
     # via -r requirements/base.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   -r requirements/base.in
     #   markdown
@@ -328,9 +328,9 @@ markdown==3.3.7
     # via -r requirements/base.in
 markupsafe==2.1.1
     # via jinja2
-mysqlclient==2.1.0
+mysqlclient==2.1.1
     # via -r requirements/production.in
-newrelic==7.12.0.176
+newrelic==7.14.0.177
     # via
     #   -r requirements/production.in
     #   edx-django-utils
@@ -350,7 +350,7 @@ pillow==9.1.1
     #   django-stdimage
 platformdirs==2.5.2
     # via zeep
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
     # via click-repl
 psutil==5.9.1
     # via edx-django-utils
@@ -358,7 +358,7 @@ pycountry==22.3.5
     # via -r requirements/base.in
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.1
+pycryptodomex==3.15.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -406,9 +406,9 @@ pyyaml==6.0
     #   edx-django-release-util
 rcssmin==1.1.0
     # via django-compressor
-redis==4.3.3
+redis==4.3.4
     # via -r requirements/base.in
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/base.in
     #   algoliasearch

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -16,6 +16,7 @@ pytest-django
 pytest-responses
 pytest-xdist
 responses
+semgrep
 selenium
 testfixtures
 tox


### PR DESCRIPTION
### [PROD-2876](https://2u-internal.atlassian.net/browse/PROD-2876)

### Description
- Use semgrep manually instead of GitHub action. This allows using the latest version of semgrep that will potentially fix semgrep issues on various PRs. Base PR: https://github.com/openedx/course-discovery/pull/3505

- With selenium 4.3.0, find_elements_by_* methods have been removed. https://github.com/SeleniumHQ/selenium/pull/10712.  The correct method to use is find_element/find_elements where the first argument is search criteria (id, xpath, css selector, etc.). https://selenium-python.readthedocs.io/locating-elements.html