### PR TITLE
fix: return filterable value for empty location restriction lists

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -12,6 +12,9 @@ from course_discovery.apps.course_metadata.models import (
     AbstractLocationRestrictionModel, Course, CourseType, Program, ProgramType
 )
 
+# Algolia can't filter on an empty list, provide a value we can still filter on
+EMPTY_LOCATION_RESTRICTION_LIST = ['null']
+
 
 # Utility methods used by both courses and programs
 def get_active_language_tag(course):
@@ -90,6 +93,9 @@ def get_course_availability(course):
 
 
 def get_location_restriction(location_restriction):
+    if (len(location_restriction.countries) == 0 and len(location_restriction.states) == 0):
+        return EMPTY_LOCATION_RESTRICTION_LIST
+
     # Combine list of country and state codes in order to make filtering in Algolia easier
     states = ['US-' + state for state in location_restriction.states]
     return location_restriction.countries + states
@@ -266,7 +272,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
             self.location_restriction.restriction_type == AbstractLocationRestrictionModel.ALLOWLIST
         ):
             return get_location_restriction(self.location_restriction)
-        return []
+        return EMPTY_LOCATION_RESTRICTION_LIST
 
     @property
     def product_blocked_in(self):
@@ -275,7 +281,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
             self.location_restriction.restriction_type == AbstractLocationRestrictionModel.BLOCKLIST
         ):
             return get_location_restriction(self.location_restriction)
-        return []
+        return EMPTY_LOCATION_RESTRICTION_LIST
 
     @property
     def should_index(self):
@@ -411,7 +417,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
             self.location_restriction.restriction_type == AbstractLocationRestrictionModel.ALLOWLIST
         ):
             return get_location_restriction(self.location_restriction)
-        return []
+        return EMPTY_LOCATION_RESTRICTION_LIST
 
     @property
     def product_blocked_in(self):
@@ -420,7 +426,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
             self.location_restriction.restriction_type == AbstractLocationRestrictionModel.BLOCKLIST
         ):
             return get_location_restriction(self.location_restriction)
-        return []
+        return EMPTY_LOCATION_RESTRICTION_LIST
 
     @property
     def availability_level(self):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -90,7 +90,7 @@ class EnglishProductIndex(BaseProductIndex):
             'unordered(tertiary_description)',
         ],
         'attributesForFaceting': ['partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
-                                  'filterOnly(staff)'],
+                                  'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)'],
         'customRanking': ['asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
     index_name = 'product'
@@ -129,7 +129,7 @@ class SpanishProductIndex(BaseProductIndex):
             'unordered(tertiary_description)',
         ],
         'attributesForFaceting': ['partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
-                                  'filterOnly(staff)'],
+                                  'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)'],
         'customRanking': ['desc(promoted_in_spanish_index)', 'asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
     index_name = 'spanish_product'


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/WS-2861

Algolia can't filter on empty lists. For `allowed_in` and `blocked_in`, if the value is an empty list, index it as `['null']`. (the string can be any value here as long as it's consistent)