### PR TITLE
fix: use unicodecsv to read s3 csv file

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -5,6 +5,7 @@ creating and updating related objects in Studio, and ecommerce, provided a csv c
 import csv
 import logging
 
+import unicodecsv
 from django.conf import settings
 from django.db.models import Q
 from django.urls import reverse
@@ -53,13 +54,15 @@ class CSVDataLoader(AbstractDataLoader):
         'redirect_url', 'organic_url', 'external_identifier',
     ]
 
-    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None):
+    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None, csv_file=None):
         super().__init__(partner, api_url, max_workers, is_threadsafe)
 
         self.messages_list = []  # to show failure/skipped ingestion message at the end
         self.course_uuids = {}  # to show the discovery course ids for each processed course
         try:
-            self.reader = csv.DictReader(open(csv_path, 'r'))  # lint-amnesty, pylint: disable=consider-using-with
+            # Read file from the path if given. Otherwise, read from the file received from CSVDataLoaderConfiguration.
+            self.reader = csv.DictReader(open(csv_path, 'r')) if csv_path \
+                else list(unicodecsv.DictReader(csv_file))  # lint-amnesty, pylint: disable=consider-using-with
         except FileNotFoundError:
             logger.exception("Error opening csv file at path {}".format(csv_path))  # lint-amnesty, pylint: disable=logging-format-interpolation
             raise  # re-raising exception to avoid moving the code flow

--- a/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
@@ -40,8 +40,8 @@ class Command(BaseCommand):
         """
         partner_short_code = options.get('partner_code')
         csv_loader_config = CSVDataLoaderConfiguration.current()
-        csv_path = options.get('csv_path') if options.get('csv_path') \
-            else csv_loader_config.csv_file.path if csv_loader_config.is_enabled() else ''
+        csv_path = options.get('csv_path', None)
+        csv_file = csv_loader_config.csv_file if csv_loader_config.is_enabled() else None
         try:
             partner = Partner.objects.get(short_code=partner_short_code)
         except Partner.DoesNotExist:
@@ -59,7 +59,7 @@ class Command(BaseCommand):
                 signal.disconnect(receiver=api_change_receiver, sender=model)
 
         try:
-            loader = CSVDataLoader(partner, csv_path=csv_path)
+            loader = CSVDataLoader(partner, csv_path=csv_path, csv_file=csv_file)
             logger.info("Starting CSV loader import flow for partner {}".format(partner_short_code))  # lint-amnesty, pylint: disable=logging-format-interpolation
             loader.ingest()
         except Exception as exc:

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
@@ -65,7 +65,7 @@ class TestImportCourseMetadata(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         Test that the command raises ValueError if no csv file is provided.
         """
         _ = CSVDataLoaderConfigurationFactory.create(enabled=True)
-        with self.assertRaisesMessage(ValueError, "The 'csv_file' attribute has no file associated with it."):
+        with self.assertRaisesMessage(CommandError, "The 'csv_file' attribute has no file associated with it."):
             call_command(
                 'import_course_metadata', '--partner_code', self.partner.short_code,
             )


### PR DESCRIPTION
[PROD-2814](https://2u-internal.atlassian.net/browse/PROD-2814)
Fixes the issue reading file from s3. Instead of reading the absolute path, we need to read the file directly through `unicodecsv`. 

### Common Questions:

- Did I try reading the file through `csv.DictReader(csv_file)`? Yes, but it doesn't work as it reads data through strings not bytes
- Did I try using `unicodecsv.DictReader(open(csv_path, 'r'))`? yes, it still doesn't work. Says `'str' object has no attribute 'decode'`