### PR TITLE
feat!: do not send course emails to editors for external courses

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1310,7 +1310,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
         if 'additional_metadata' in validated_data:
             # Handle additional metadata only for 2U courses else just pop
             additional_metadata_data = validated_data.pop('additional_metadata')
-            if instance.type.slug in [CourseType.BOOTCAMP_2U, CourseType.EXECUTIVE_EDUCATION_2U]:
+            if instance.is_external_course:
                 self.update_additional_metadata(instance, additional_metadata_data)
         if 'location_restriction' in validated_data:
             self.update_location_restriction(instance, validated_data.pop('location_restriction'))

--- a/course_discovery/apps/course_metadata/emails.py
+++ b/course_discovery/apps/course_metadata/emails.py
@@ -198,10 +198,10 @@ def send_email_to_editors(course_run, template_name, subject, context=None):
     from course_discovery.apps.course_metadata.models import CourseEditor  # pylint: disable=import-outside-toplevel
 
     if course_run.course.is_external_course:
-        logger.info("Skipping send email to the editors of external course: '{}' with type: '{}'".format(
-            course_run.course.title,
-            course_run.course.type.slug
-        ))
+        logger.info("Skipping send email to the editors of external course: '%s' with type: '%s'",
+                    course_run.course.title,
+                    course_run.course.type.slug
+                    )
         return
 
     editors = CourseEditor.course_editors(course_run.course)

--- a/course_discovery/apps/course_metadata/emails.py
+++ b/course_discovery/apps/course_metadata/emails.py
@@ -197,6 +197,13 @@ def send_email_to_editors(course_run, template_name, subject, context=None):
     # Model imports here to avoid a circular import
     from course_discovery.apps.course_metadata.models import CourseEditor  # pylint: disable=import-outside-toplevel
 
+    if course_run.course.is_external_course:
+        logger.info("Skipping send email to the editors of external course: '{}' with type: '{}'".format(
+            course_run.course.title,
+            course_run.course.type.slug
+        ))
+        return
+
     editors = CourseEditor.course_editors(course_run.course)
     send_email(template_name, subject, editors, _('course team'), context=context, course_run=course_run)
 

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1017,6 +1017,13 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
         return None
 
     @property
+    def is_external_course(self):
+        """
+        Property to check if the course is an external product type.
+        """
+        return self.type.slug in [CourseType.EXECUTIVE_EDUCATION_2U, CourseType.BOOTCAMP_2U]
+
+    @property
     def original_image_url(self):
         if self.image:
             return self.image.url


### PR DESCRIPTION
### [PROD-2793](https://2u-internal.atlassian.net/browse/PROD-2793)

### Description

- Do not send course emails to the editors of the course for external courses (Exec Ed and Bootcamps)