### PR TITLE
feat: add cascade toggle logic to enterprise sub inclusion boolean

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2075,6 +2075,8 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         course_run = CourseRunFactory(course=course)
         course.course_runs.add(course_run)
         course.save()
+        course.refresh_from_db()
+        course_run.refresh_from_db()
         seat = SeatFactory(course_run=course_run)
         course_skill = CourseSkillsFactory(
             course_key=course.key
@@ -2105,6 +2107,8 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         )
         course.course_runs.add(course_run, course_run_expired)
         course.save()
+        course.refresh_from_db()
+        course_run.refresh_from_db()
         seat = SeatFactory(course_run=course_run)
         course_skill = CourseSkillsFactory(
             course_key=course.key
@@ -2186,6 +2190,8 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         course_run = CourseRunFactory(course=course)
         course.course_runs.add(course_run)
         course.save()
+        course.refresh_from_db()
+        course_run.refresh_from_db()
         seat = SeatFactory(course_run=course_run)
         course_skill = CourseSkillsFactory(
             course_key=course.key
@@ -2333,6 +2339,7 @@ class CourseSearchModelSerializerTests(ElasticsearchTestMixin, TestCase, CourseS
 
     @classmethod
     def get_expected_data(cls, course, course_skill, request):
+        course.refresh_from_db()
         expected_data = CourseWithProgramsSerializerTests.get_expected_data(course, course_skill, request)
         expected_data.update({'content_type': 'course'})
         return expected_data

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_backfill_enterprise_inclusion.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_backfill_enterprise_inclusion.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from course_discovery.apps.course_metadata.management.commands.backfill_enterprise_inclusion import Command
-from course_discovery.apps.course_metadata.models import Course, Organization
+from course_discovery.apps.course_metadata.models import Course, CourseType, Organization
 from course_discovery.apps.course_metadata.tests.factories import CourseFactory, OrganizationFactory
 
 
@@ -11,17 +11,13 @@ class BackfillEnterpriseInclusion(TestCase):
     def setUp(self):
         super().setUp()
         self.org_1, self.org_2 = OrganizationFactory.create_batch(2)
-        self.course_1 = CourseFactory(authoring_organizations=[self.org_1])
-        self.course_2 = CourseFactory(authoring_organizations=[self.org_1])
-        self.course_3 = CourseFactory(authoring_organizations=[self.org_2])
-        self.course_4 = CourseFactory(
-            authoring_organizations=[
-                self.org_1, self.org_2])
+        course_type = CourseType.objects.filter(slug=CourseType.VERIFIED_AUDIT).first()
+        self.course_1 = CourseFactory(authoring_organizations=[self.org_1], type=course_type)
+        self.course_2 = CourseFactory(authoring_organizations=[self.org_1], type=course_type)
+        self.course_3 = CourseFactory(authoring_organizations=[self.org_2], type=course_type)
+        self.course_4 = CourseFactory(authoring_organizations=[self.org_1, self.org_2], type=course_type)
         self.org_test_data = [str(self.org_1.uuid)]
-        self.course_test_data = [
-            self.course_1.key,
-            self.course_3.key,
-            self.course_4.key]
+        self.course_test_data = [self.course_1.key, self.course_3.key, self.course_4.key]
 
     def test_normal_run(self):
         uuid_path = 'course_discovery.apps.course_metadata.management.commands.backfill_enterprise_inclusion.org_uuids'

--- a/course_discovery/apps/course_metadata/tasks.py
+++ b/course_discovery/apps/course_metadata/tasks.py
@@ -1,0 +1,49 @@
+"""
+Celery tasks for course metadata.
+"""
+import logging
+
+from celery import shared_task
+
+from course_discovery.apps.course_metadata.models import Course, CourseType, Program, ProgramType
+
+LOGGER = logging.getLogger(__name__)
+
+
+@shared_task()
+def update_org_program_and_courses_ent_sub_inclusion(org_pk, org_sub_inclusion):
+    """
+    Task to update an organization's child courses' and programs' enterprise subscription inclusion status upon saving
+    the org object.
+    Arguments:
+        org_pk (int): primary key of the organization
+        org_sub_inclusion (bool): whether or not the org is included in enterprise subscriptions
+    """
+    courses = Course.objects.filter(
+        authoring_organizations__pk=org_pk,
+        enterprise_subscription_inclusion__in=[None, True],
+        type__slug__in=[
+            CourseType.AUDIT,
+            CourseType.VERIFIED_AUDIT,
+            CourseType.PROFESSIONAL,
+            CourseType.CREDIT_VERIFIED_AUDIT,
+            CourseType.EMPTY
+        ]
+    )
+    course_ids = []
+    for course in courses:
+        course.enterprise_subscription_inclusion = org_sub_inclusion
+        course.save()
+        course_ids.append(course.id)
+    programs = Program.objects.filter(
+        courses__in=course_ids,
+        type__slug__in=[
+            ProgramType.XSERIES,
+            ProgramType.MICROMASTERS,
+            ProgramType.PROFESSIONAL_CERTIFICATE,
+            ProgramType.PROFESSIONAL_PROGRAM_WL,
+            ProgramType.MICROBACHELORS
+        ]
+    )
+    for program in programs:
+        program.save()

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -31,9 +31,9 @@ from course_discovery.apps.core.utils import SearchQuerySetWrapper
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import (
     FAQ, AbstractHeadingBlurbModel, AbstractMediaModel, AbstractNamedModel, AbstractTitleDescriptionModel,
-    AbstractValueModel, CorporateEndorsement, Course, CourseEditor, CourseRun, Curriculum, CurriculumCourseMembership,
-    CurriculumCourseRunExclusion, CurriculumProgramMembership, DegreeCost, DegreeDeadline, Endorsement, Organization,
-    Program, ProgramType, Ranking, Seat, SeatType, Subject, Topic
+    AbstractValueModel, CorporateEndorsement, Course, CourseEditor, CourseRun, CourseType, Curriculum,
+    CurriculumCourseMembership, CurriculumCourseRunExclusion, CurriculumProgramMembership, DegreeCost, DegreeDeadline,
+    Endorsement, Organization, Program, ProgramType, Ranking, Seat, SeatType, Subject, Topic
 )
 from course_discovery.apps.course_metadata.publishers import (
     CourseRunMarketingSitePublisher, ProgramMarketingSitePublisher
@@ -211,12 +211,17 @@ class TestCourse(TestCase):
         org1 = factories.OrganizationFactory(enterprise_subscription_inclusion=True)
         org2 = factories.OrganizationFactory(enterprise_subscription_inclusion=True)
         org_list = [org1, org2]
-        course = factories.CourseFactory(authoring_organizations=org_list, enterprise_subscription_inclusion=None)
+        course_type = CourseType.objects.filter(slug=CourseType.VERIFIED_AUDIT).first()
+        course = factories.CourseFactory(
+            authoring_organizations=org_list, enterprise_subscription_inclusion=None, type=course_type,
+        )
         assert course.enterprise_subscription_inclusion is True
 
         org3 = factories.OrganizationFactory(enterprise_subscription_inclusion=False)
         org_list = [org2, org3]
-        course1 = factories.CourseFactory(authoring_organizations=org_list, enterprise_subscription_inclusion=None)
+        course1 = factories.CourseFactory(
+            authoring_organizations=org_list, enterprise_subscription_inclusion=None, type=course_type,
+        )
         assert course1.enterprise_subscription_inclusion is False
 
 
@@ -627,12 +632,13 @@ class CourseRunTests(OAuth2Mixin, TestCase):
 
     def test_enterprise_subscription_inclusion(self):
         """ Verify the enterprise inclusion boolean is calculated as expected. """
-        course1 = factories.CourseFactory(enterprise_subscription_inclusion=False)
+        course_type = CourseType.objects.filter(slug=CourseType.VERIFIED_AUDIT).first()
+        course1 = factories.CourseFactory(enterprise_subscription_inclusion=False, type=course_type)
         course_run1 = factories.CourseRunFactory(course=course1, pacing_type='self_paced')
         course_run1.save()
         assert course_run1.enterprise_subscription_inclusion is False
 
-        course2 = factories.CourseFactory(enterprise_subscription_inclusion=True)
+        course2 = factories.CourseFactory(enterprise_subscription_inclusion=True, type=course_type)
         course_run2 = factories.CourseRunFactory(course=course2, pacing_type='self_paced')
         course_run2.save()
         assert course_run2.enterprise_subscription_inclusion is True
@@ -1178,6 +1184,7 @@ class CourseRunTestsThatNeedSetUp(OAuth2Mixin, TestCase):
 
 
 @ddt.ddt
+@pytest.mark.django_db
 class OrganizationTests(TestCase):
     """ Tests for the `Organization` model. """
 
@@ -1238,6 +1245,91 @@ class OrganizationTests(TestCase):
         user.groups.add(org_ext.group)
 
         assert len(Organization.user_organizations(user)) == 1
+
+    def test_org_enterprise_subscription_inclusion_toggle_course(self):
+        """Test that toggling an org's enterprise_subscription_inclusion value will turn courses in the org on"""
+        org = factories.OrganizationFactory(enterprise_subscription_inclusion=True)
+        course_type = CourseType.objects.filter(slug=CourseType.VERIFIED_AUDIT).first()
+        course = factories.CourseFactory(enterprise_subscription_inclusion=True, type=course_type)
+        course.authoring_organizations.add(org)
+        course.save()
+
+        org.enterprise_subscription_inclusion = False
+        org.save()
+
+        course.refresh_from_db()
+        assert course.enterprise_subscription_inclusion is False
+
+    def test_org_enterprise_subscription_inclusion_toggle_with_multiple_orgs(self):
+        """
+        Test that toggling an org's enterprise_subscription_inclusion value on will not turn the course, course run or
+        program on if there is another org that is still off, with that course, course run and program
+        """
+        org = factories.OrganizationFactory(enterprise_subscription_inclusion=False)
+        org2 = factories.OrganizationFactory(enterprise_subscription_inclusion=False)
+        course = factories.CourseFactory(enterprise_subscription_inclusion=False)
+        course_run = factories.CourseRunFactory(
+            course=course,
+            pacing_type='self_paced',
+            enterprise_subscription_inclusion=False
+        )
+        program = factories.ProgramFactory(enterprise_subscription_inclusion=False)
+        program.courses.add(course)
+        program.save()
+
+        course.authoring_organizations.add(org)
+        course.authoring_organizations.add(org2)
+        course.save()
+
+        # Toggle one of the orgs to true
+        org.enterprise_subscription_inclusion = True
+        org.save()
+
+        # Confirm that the course is still False
+        course.refresh_from_db()
+        assert course.enterprise_subscription_inclusion is False
+        assert course_run.enterprise_subscription_inclusion is False
+        assert program.enterprise_subscription_inclusion is False
+
+    def test_org_enterprise_subscription_inclusion_toggle_courserun(self):
+        """Test that toggling an org's enterprise_subscription_inclusion value will toggle the course run"""
+        org = factories.OrganizationFactory(enterprise_subscription_inclusion=True)
+        course_type = CourseType.objects.filter(slug=CourseType.VERIFIED_AUDIT).first()
+        course = factories.CourseFactory(enterprise_subscription_inclusion=True, type=course_type)
+        course_run = factories.CourseRunFactory(
+            course=course,
+            pacing_type='self_paced',
+            enterprise_subscription_inclusion=True
+        )
+
+        course.authoring_organizations.add(org)
+        course.save()
+
+        org.enterprise_subscription_inclusion = False
+        org.save()
+
+        course_run.refresh_from_db()
+        assert course_run.enterprise_subscription_inclusion is False
+
+    def test_org_enterprise_subscription_inclusion_toggle_program(self):
+        """Test that toggling an org's enterprise_subscription_inclusion value will toggle the program"""
+        org = factories.OrganizationFactory(enterprise_subscription_inclusion=True)
+        course_type = CourseType.objects.filter(slug=CourseType.VERIFIED_AUDIT).first()
+        course = factories.CourseFactory(enterprise_subscription_inclusion=True, type=course_type)
+        course.save()
+        course.authoring_organizations.add(org)
+        course.save()
+
+        program_type = ProgramType.objects.get(translations__name_t='XSeries')
+        program = factories.ProgramFactory(enterprise_subscription_inclusion=True, type=program_type)
+        program.courses.add(course)
+        program.save()
+
+        org.enterprise_subscription_inclusion = False
+        org.save()
+
+        program.refresh_from_db()
+        assert program.enterprise_subscription_inclusion is False
 
 
 @ddt.ddt
@@ -1401,6 +1493,7 @@ class AbstractHeadingBlurbModelTests(TestCase):
 
 
 @ddt.ddt
+@pytest.mark.django_db
 class ProgramTests(TestCase):
     """Tests of the Program model."""
 
@@ -2034,19 +2127,30 @@ class ProgramTests(TestCase):
 
     def test_enterprise_subscription_inclusion(self):
         """ Verify the enterprise inclusion boolean is calculated as expected. """
-
-        course1 = factories.CourseFactory(enterprise_subscription_inclusion=False)
-        course2 = factories.CourseFactory(enterprise_subscription_inclusion=True)
+        course_type = CourseType.objects.filter(slug=CourseType.VERIFIED_AUDIT).first()
+        course1 = factories.CourseFactory(enterprise_subscription_inclusion=False, type=course_type)
+        course2 = factories.CourseFactory(enterprise_subscription_inclusion=True, type=course_type)
         course_list = [course1, course2]
-        type1 = ProgramType.objects.get(translations__name_t='XSeries')
-        program1 = factories.ProgramFactory(type=type1, courses=course_list)
+        program_type = ProgramType.objects.get(translations__name_t='XSeries')
+        program1 = factories.ProgramFactory(type=program_type, courses=course_list)
         assert program1.enterprise_subscription_inclusion is False
-
-        course3 = factories.CourseFactory(enterprise_subscription_inclusion=True)
-        course4 = factories.CourseFactory(enterprise_subscription_inclusion=True)
+        course3 = factories.CourseFactory(enterprise_subscription_inclusion=True, type=course_type)
+        course4 = factories.CourseFactory(enterprise_subscription_inclusion=True, type=course_type)
         course_list2 = [course3, course4]
-        program2 = factories.ProgramFactory(type=type1, courses=course_list2)
+        program2 = factories.ProgramFactory(courses=course_list2, type=program_type)
         assert program2.enterprise_subscription_inclusion is True
+
+    def test_enterprise_subscription_exclusion(self):
+        """
+        Verify the enterprise inclusion boolean will default to false if the program is not included in the
+        is_enterprise_catalog_program_type list.
+        """
+        # Create a program with a program type that is not included in the subscription tagging logic
+        program_type = ProgramType.objects.get(translations__name_t='Masters')
+        # Attempt to set the subscription inclusion to True when generating the program
+        program1 = factories.ProgramFactory(type=program_type, enterprise_subscription_inclusion=True)
+        # Assert that the sub tagging has defaulted to false.
+        assert not program1.enterprise_subscription_inclusion
 
     def test_banner_image(self):
         self.program.banner_image = make_image_file('test_banner.jpg')

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -72,7 +72,8 @@ CELERY_TASK_ALWAYS_EAGER = True
 
 CELERY_TASK_IGNORE_RESULT = True
 
-CELERY_RESULT_BACKEND = f'file://{tempfile.TemporaryDirectory()}'
+results_dir = tempfile.TemporaryDirectory()
+CELERY_RESULT_BACKEND = f'file://{results_dir.name}'
 
 CELERY_BROKER_URL = 'memory://localhost/'
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/jira/software/c/projects/ENT/boards/630?modal=detail&selectedIssue=ENT-5840

When an org subscription inclusion is toggled, all courses, course runs and programs included in the org should check if they should be toggled.

accounts for course/program types as well. 