### PR TITLE
fix: convert google drive link image url to downloadable url

### DIFF
--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -677,6 +677,7 @@ def download_and_save_course_image(course, image_url, data_field='image', header
     in the data field mentioned, defaulting to course card image.
     """
     try:
+        image_url = get_downloadable_url_from_drive_link(image_url)
         response = requests.get(image_url, headers=headers)
 
         if response.status_code == requests.codes.ok:  # pylint: disable=no-member


### PR DESCRIPTION
# Description:
We are getting some google drive url for course images during ingestion. So we need to convert that google drive url to a downloadable url and then download the file to save course image