### PR TITLE
feat: adding organization patch endpoint

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
@@ -189,3 +189,14 @@ class OrganizationViewSetTests(SerializationMixin, APITestCase):
 
         response = self.client.get(url)
         assert response.data.get('enterprise_subscription_inclusion') is True
+
+    def test_bad_partial_update(self):
+        organization = OrganizationFactory.create(partner=self.partner)
+        url = reverse('api:v1:organization-detail', kwargs={'uuid': organization.uuid})
+        response = self.client.get(url)
+
+        payload = {
+            'enterprise_subscription_inclusion': 'stringThatShouldBeBool'
+        }
+        response = self.client.patch(url, payload, format='json')
+        assert response.status_code == 400

--- a/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_organizations.py
@@ -174,3 +174,18 @@ class OrganizationViewSetTests(SerializationMixin, APITestCase):
 
         response = self.client.get(url)
         assert response.status_code == 404
+
+    def test_partial_update(self):
+        organization = OrganizationFactory.create(partner=self.partner)
+        url = reverse('api:v1:organization-detail', kwargs={'uuid': organization.uuid})
+        response = self.client.get(url)
+
+        assert response.data.get('enterprise_subscription_inclusion') is False
+        payload = {
+            'enterprise_subscription_inclusion': True
+        }
+        response = self.client.patch(url, payload, format='json')
+        assert response.status_code == 200
+
+        response = self.client.get(url)
+        assert response.data.get('enterprise_subscription_inclusion') is True

--- a/course_discovery/apps/api/v1/views/organizations.py
+++ b/course_discovery/apps/api/v1/views/organizations.py
@@ -10,7 +10,7 @@ from course_discovery.apps.publisher.models import OrganizationExtension
 
 
 # pylint: disable=useless-super-delegation
-class OrganizationViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+class OrganizationViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
     """ Organization resource. """
 
     filter_backends = (DjangoFilterBackend,)
@@ -50,3 +50,7 @@ class OrganizationViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelVi
     def retrieve(self, request, *args, **kwargs):
         """ Retrieve details for an organization. """
         return super().retrieve(request, *args, **kwargs)
+
+    def partial_update(self, request, *args, **kwargs):
+        """ Update one or more fields for an organization. """
+        return super().partial_update(request, *args, **kwargs)


### PR DESCRIPTION
My team needs to update over 100 organization's enterprise_subscription_inclusion variables, and since there is no way to do this through the current API, here's a PR to add a partial_update functionality to the Organization view. 

NOTE: If any additional security measures are needed, please describe them below and I will add them to this PR. 