### PR TITLE
chore: making program and course run sub tagging readonly

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -248,7 +248,9 @@ class CourseRunAdmin(admin.ModelAdmin):
     )
     ordering = ('key',)
     raw_id_fields = ('course', 'draft_version',)
-    readonly_fields = ('enrollment_count', 'recent_enrollment_count', 'hidden', 'key')
+    readonly_fields = (
+        'enrollment_count', 'recent_enrollment_count', 'hidden', 'key', 'enterprise_subscription_inclusion'
+    )
     search_fields = ('uuid', 'key', 'title_override', 'course__title', 'slug', 'external_key')
     save_error = False
     form = CourseRunAdminForm
@@ -321,8 +323,10 @@ class ProgramAdmin(admin.ModelAdmin):
     list_display = ('id', 'uuid', 'title', 'type', 'partner', 'status', 'hidden')
     list_filter = ('partner', 'type', 'status', ProgramEligibilityFilter, 'hidden')
     ordering = ('uuid', 'title', 'status')
-    readonly_fields = ('uuid', 'custom_course_runs_display', 'excluded_course_runs', 'enrollment_count',
-                       'recent_enrollment_count',)
+    readonly_fields = (
+        'uuid', 'custom_course_runs_display', 'excluded_course_runs', 'enrollment_count', 'recent_enrollment_count',
+        'enterprise_subscription_inclusion'
+    )
     raw_id_fields = ('video',)
     search_fields = ('uuid', 'title', 'marketing_slug')
     exclude = ('card_image_url',)
@@ -337,6 +341,7 @@ class ProgramAdmin(admin.ModelAdmin):
         'individual_endorsements', 'job_outlook_items', 'expected_learning_items', 'instructor_ordering',
         'enrollment_count', 'recent_enrollment_count', 'credit_value', 'organization_short_code_override',
         'organization_logo_override', 'primary_subject_override', 'level_type_override', 'language_override',
+        'enterprise_subscription_inclusion',
     )
 
     save_error = False

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -331,6 +331,7 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
             'field-enrollment_count', 'field-recent_enrollment_count', 'field-credit_value',
             'field-organization_short_code_override', 'field-organization_logo_override',
             'field-primary_subject_override', 'field-level_type_override', 'field-language_override',
+            'field-enterprise_subscription_inclusion',
         ]
         assert actual == expected
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/jira/software/c/projects/ENT/boards/630?modal=detail&selectedIssue=ENT-5899

Ensure course and org admin forms can view and toggle ent subscription tag
Ensure program and course run admin forms can view and _**not**_ toggle ent subscription tag

course:
![image](https://user-images.githubusercontent.com/67655836/180092145-988e7f7d-ad49-4e72-b76d-226601fcbc46.png)

course run: 
![image](https://user-images.githubusercontent.com/67655836/180092174-194d686f-7115-4aad-a483-663b4ea239f5.png)

org:
![image](https://user-images.githubusercontent.com/67655836/180092218-3ea03e4f-4754-477f-93fa-f7f336200128.png)

Program:
![image](https://user-images.githubusercontent.com/67655836/181023661-9d750376-6ec5-4dca-a202-856bd433e718.png)
