### PR TITLE
Small bug fix for course discovery 

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -979,7 +979,7 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
         if self.enterprise_subscription_inclusion is False:
             return False
         for org in self.authoring_organizations.all():
-            if org.enterprise_subscription_inclusion is False:
+            if not org.enterprise_subscription_inclusion:
                 return False
         return True
 
@@ -2008,7 +2008,7 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
             email_method(self)
 
     def _check_enterprise_subscription_inclusion(self):
-        if self.course.enterprise_subscription_inclusion is False:
+        if not self.course.enterprise_subscription_inclusion:
             return False
         if self.pacing_type == 'instructor_paced':
             return False
@@ -2734,7 +2734,7 @@ class Program(PkSearchableMixin, TimeStampedModel):
         if self.type == 'micromasters':
             return False
         for course in self.courses.all():
-            if course.enterprise_subscription_inclusion is False:
+            if not course.enterprise_subscription_inclusion:
                 return False
         return True
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -636,6 +636,11 @@ class CourseRunTests(OAuth2Mixin, TestCase):
         course_run2.save()
         assert course_run2.enterprise_subscription_inclusion is True
 
+        course3 = factories.CourseFactory(enterprise_subscription_inclusion=True)
+        course_run3 = factories.CourseRunFactory(course=course3, pacing_type='instructor_paced')
+        course_run3.save()
+        assert course_run3.enterprise_subscription_inclusion is False
+
     @ddt.data(
         # Case 1: Return False when there are no paid Seats.
         ([('audit', 0)], False),


### PR DESCRIPTION
I made an error where I was checking is a value was False, but not accounting for the fact that all of these booleans have null=True in their model definition. To combat this, I changed the logic to instead be `not boolean` because None is falsy in python. 