### PR TITLE
feat: add uuid filtering on learner pathway API

### DIFF
--- a/course_discovery/apps/learner_pathway/api/filters.py
+++ b/course_discovery/apps/learner_pathway/api/filters.py
@@ -1,0 +1,22 @@
+"""
+Filters for the Learner Pathway APIs.
+"""
+
+from django_filters import rest_framework as filters
+
+from course_discovery.apps.learner_pathway.models import LearnerPathway
+
+
+class PathwayUUIDFilter(filters.FilterSet):
+    """
+    Filter pathways by uuid. Supports filtering by comma-delimited list of uuids.
+    """
+    uuid = filters.CharFilter(method='filter_by_uuid')
+
+    class Meta:
+        model = LearnerPathway
+        fields = ['uuid']
+
+    def filter_by_uuid(self, queryset, name, value):  # pylint: disable=unused-argument
+        uuid_values = value.strip().split(',')
+        return queryset.filter(uuid__in=uuid_values)

--- a/course_discovery/apps/learner_pathway/api/v1/tests/test_views.py
+++ b/course_discovery/apps/learner_pathway/api/v1/tests/test_views.py
@@ -176,6 +176,23 @@ class TestLearnerPathwayViewSet(TestCase):
         api_response = self.client.get(self.view_url)
         self._verify_learner_pathway_data(api_response, LEARNER_PATHWAY_DATA)
 
+    def test_learner_pathway_api_filtering(self):
+        """
+        Verify that comma-delimited filtering on pathway uuids is enabled for learner pathway api .
+        """
+        another_learner_pathway = LearnerPathwayFactory(
+            uuid='aaa7c03d-d2cf-420c-b109-aa227f770655',
+            title='Test Pathway 2',
+            status=PathwayStatus.Active,
+            overview='Test overview for Test Pathway 2',
+        )
+        url = f'/api/v1/learner-pathway/?uuid={self.learner_pathway.uuid},{another_learner_pathway.uuid}'
+        api_response = self.client.get(url)
+        data = api_response.json()
+        assert data['count'] == 2
+        assert data['results'][0]['uuid'] == self.learner_pathway.uuid
+        assert data['results'][1]['uuid'] == another_learner_pathway.uuid
+
     def test_learner_pathway_api_returns_active_pathway_only(self):
         """
         Verify that learner pathway api returns active pathway only.

--- a/course_discovery/apps/learner_pathway/api/v1/views.py
+++ b/course_discovery/apps/learner_pathway/api/v1/views.py
@@ -2,6 +2,7 @@
 API Views for learner_pathway app.
 """
 from django.db.models import Q
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -11,6 +12,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.learner_pathway import models
 from course_discovery.apps.learner_pathway.api import serializers
+from course_discovery.apps.learner_pathway.api.filters import PathwayUUIDFilter
 from course_discovery.apps.learner_pathway.choices import PathwayStatus
 
 
@@ -21,7 +23,9 @@ class LearnerPathwayViewSet(ReadOnlyModelViewSet):
 
     lookup_field = 'uuid'
     serializer_class = serializers.LearnerPathwaySerializer
+    filter_backends = (DjangoFilterBackend,)
     queryset = models.LearnerPathway.objects.prefetch_related('steps').filter(status=PathwayStatus.Active)
+    filterset_class = PathwayUUIDFilter
 
     # Explicitly support PageNumberPagination and LimitOffsetPagination. Future
     # versions of this API should only support the system default, PageNumberPagination.


### PR DESCRIPTION
Allows filtering via uuid on learner-pathway list endpoint. Also supports comma-delimited uuids list for filtering. 

JIRA: https://2u-internal.atlassian.net/browse/ENT-6069