### PR TITLE
feat: expose course skill information in algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -15,7 +15,7 @@ from course_discovery.apps.course_metadata.models import (
 from course_discovery.apps.course_metadata.utils import transform_skills_data
 
 # Algolia can't filter on an empty list, provide a value we can still filter on
-EMPTY_LOCATION_RESTRICTION_LIST = ['null']
+ALGOLIA_EMPTY_LIST = ['null']
 
 
 # Utility methods used by both courses and programs
@@ -96,7 +96,7 @@ def get_course_availability(course):
 
 def get_location_restriction(location_restriction):
     if (len(location_restriction.countries) == 0 and len(location_restriction.states) == 0):
-        return EMPTY_LOCATION_RESTRICTION_LIST
+        return ALGOLIA_EMPTY_LIST
 
     # Combine list of country and state codes in order to make filtering in Algolia easier
     states = ['US-' + state for state in location_restriction.states]
@@ -274,7 +274,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
             self.location_restriction.restriction_type == AbstractLocationRestrictionModel.ALLOWLIST
         ):
             return get_location_restriction(self.location_restriction)
-        return EMPTY_LOCATION_RESTRICTION_LIST
+        return ALGOLIA_EMPTY_LIST
 
     @property
     def product_blocked_in(self):
@@ -283,7 +283,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
             self.location_restriction.restriction_type == AbstractLocationRestrictionModel.BLOCKLIST
         ):
             return get_location_restriction(self.location_restriction)
-        return EMPTY_LOCATION_RESTRICTION_LIST
+        return ALGOLIA_EMPTY_LIST
 
     @property
     def should_index(self):
@@ -305,6 +305,8 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
     @property
     def skills(self):
         skills_data = get_whitelisted_serialized_skills(self.key)
+        if not skills_data:
+            return ALGOLIA_EMPTY_LIST
         return transform_skills_data(skills_data)
 
     @property
@@ -426,7 +428,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
             self.location_restriction.restriction_type == AbstractLocationRestrictionModel.ALLOWLIST
         ):
             return get_location_restriction(self.location_restriction)
-        return EMPTY_LOCATION_RESTRICTION_LIST
+        return ALGOLIA_EMPTY_LIST
 
     @property
     def product_blocked_in(self):
@@ -435,7 +437,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
             self.location_restriction.restriction_type == AbstractLocationRestrictionModel.BLOCKLIST
         ):
             return get_location_restriction(self.location_restriction)
-        return EMPTY_LOCATION_RESTRICTION_LIST
+        return ALGOLIA_EMPTY_LIST
 
     @property
     def availability_level(self):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -75,7 +75,8 @@ class EnglishProductIndex(BaseProductIndex):
                      ('product_max_effort', 'max_effort'), ('product_min_effort', 'min_effort'),
                      ('product_organization_short_code_override', 'organization_short_code_override'),
                      ('product_organization_logo_override', 'organization_logo_override'),
-                     'active_run_key', 'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags')
+                     'active_run_key', 'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags',
+                     'skills')
 
     # Algolia needs this
     object_id_field = (('custom_object_id', 'objectID'), )
@@ -113,7 +114,7 @@ class SpanishProductIndex(BaseProductIndex):
                      ('product_max_effort', 'max_effort'), ('product_min_effort', 'min_effort'), 'active_run_key',
                      ('product_organization_short_code_override', 'organization_short_code_override'),
                      ('product_organization_logo_override', 'organization_logo_override'),
-                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags')
+                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags', 'skills')
 
     # Algolia uses objectID as unique identifier. Can't use straight uuids because a program and a course could
     # have the same one, so we add 'course' or 'program' as a prefix

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -754,3 +754,62 @@ def download_and_save_program_image(program, image_url, data_field='image', head
     except Exception:  # pylint: disable=broad-except
         logger.exception('An unknown exception occurred while downloading image for program [%s]', program.title)
     return False
+
+
+def transform_skills_data(skills_data):
+    """
+    Utility method to transform the representation of skills data coming-in from Taxonomy-connector.
+
+    * FROM:
+         [
+            {
+                'name': 'Skill 1',
+                'description': 'Skill 1',
+                'category': {
+                'name': 'Category 1'
+                },
+                'subcategory': {
+                    'name': 'Subcategory 1',
+                    'category': {
+                        'name': 'Category 1'
+                    },
+                }
+            },
+            {
+                'name': 'Skill 2',
+                'description': 'Skill 2',
+                'category': {
+                'name': 'Category 1'
+                    },
+                'subcategory': {
+                    'name': 'Subcategory 1',
+                    'category': {
+                        'name': 'Category 1'
+                    },
+                }
+            }
+        ]
+
+    * TO:
+        [
+            {
+            'skill': 'Skill 1',
+            'category': 'Category 1',
+            'subcategory': 'Subcategory 1',
+            },
+            {
+            'skill': 'Skill 2',
+            'category': 'Category 1',
+            'subcategory': 'Subcategory 1',
+            }
+        ]
+    """
+    skills = []
+    for skill in skills_data:
+        skill_dict = {
+            'skill': skill['name'],
+            'category': skill['category']['name'] if skill['category'] is not None else '',
+            'subcategory': skill['subcategory']['name'] if skill['subcategory'] is not None else ''
+        }
+        skills.append(skill_dict)
+    return skills


### PR DESCRIPTION
### [PROD-2890](https://2u-internal.atlassian.net/browse/PROD-2890)

### Description

- Expose transformed skill data in Algolia
- Dependent on PR https://github.com/openedx/taxonomy-connector/pull/96

I intentionally did not add unit tests for Algolia models because the property is just a wrapper on transformation on data coming from taxonomy. There are some prior algolia model tests but they are mostly related to fields where a complex decision is taken to determine the result.