### PR TITLE
feat: Add program provider to use in taxonomy-connector app to get program fields

### DIFF
--- a/course_discovery/apps/taxonomy_support/providers.py
+++ b/course_discovery/apps/taxonomy_support/providers.py
@@ -14,9 +14,9 @@ For a more detailed explanation of the implementation and thinking behind this p
 https://openedx.atlassian.net/wiki/spaces/SOL/pages/1814922129/Platform+Agnostic+Implementation+of+Taxonomy+Application
 """
 from edx_django_utils.db import chunked_queryset
-from taxonomy.providers import CourseMetadataProvider
+from taxonomy.providers import CourseMetadataProvider, ProgramMetadataProvider
 
-from course_discovery.apps.course_metadata.models import Course
+from course_discovery.apps.course_metadata.models import Course, Program
 
 
 class DiscoveryCourseMetadataProvider(CourseMetadataProvider):
@@ -52,4 +52,38 @@ class DiscoveryCourseMetadataProvider(CourseMetadataProvider):
                     'title': course.title,
                     'short_description': course.short_description,
                     'full_description': course.full_description,
+                }
+
+
+class DiscoveryProgramMetadataProvider(ProgramMetadataProvider):
+    """
+    Discovery program provider.
+    """
+
+    @staticmethod
+    def get_programs(program_ids):  # lint-amnesty, pylint: disable=arguments-differ
+        """
+        Get list of programs matching the given program UUIDs and return then in the form of a dict.
+        """
+        programs = Program.objects.filter(uuid__in=program_ids).distinct()
+        return [{
+            'uuid': program.uuid,
+            'title': program.title,
+            'subtitle': program.subtitle,
+            'overview': program.overview,
+        } for program in programs]
+
+    @staticmethod
+    def get_all_programs():  # lint-amnesty, pylint: disable=arguments-differ
+        """
+        Get iterator for all the programs.
+        """
+        all_programs = Program.objects.all()
+        for chunked_programs in chunked_queryset(all_programs):
+            for program in chunked_programs:
+                yield {
+                    'uuid': program.uuid,
+                    'title': program.title,
+                    'subtitle': program.subtitle,
+                    'overview': program.overview,
                 }

--- a/course_discovery/apps/taxonomy_support/tests/test_providers.py
+++ b/course_discovery/apps/taxonomy_support/tests/test_providers.py
@@ -2,7 +2,8 @@
 Validate taxonomy integration.
 
 This file validates the following
-    1. Make sure the provider specified by `TAXONOMY_COURSE_METADATA_PROVIDER` implements all the abstract methods
+    1. Make sure the provider specified by `TAXONOMY_COURSE_METADATA_PROVIDER` and `TAXONOMY_PROGRAM_METADATA_PROVIDER`
+     implements all the abstract methods
     2. Make sure the signature of all the methods match with the interfaces of the abstract class
     3. Make sure the data returned and the structure of the data matches with the definitions inside the interface.
 
@@ -13,7 +14,9 @@ method.
 
 `validate` method will raise `AssertError` if any of the assertions do not pass.
 
-Note: Validator will use the provider pointed by the `TAXONOMY_COURSE_METADATA_PROVIDER` django setting.
+Note: Course Metadata validator will use the provider pointed by the `TAXONOMY_COURSE_METADATA_PROVIDER` django setting.
+Note: Program Metadata validator will use the provider pointed by the `TAXONOMY_PROGRAM_METADATA_PROVIDER` django
+setting.
 
 Reason behind keeping the validator a part of taxonomy-connector is to keep the provider and its validation logic in the
 same repository, so whenever a new dependency (e.g. a new method or a new field in the returned data) is added in the
@@ -22,9 +25,9 @@ discovery and its interface in taxonomy are always in sync.
 """
 
 from django.test import TestCase
-from taxonomy.validators import CourseMetadataProviderValidator
+from taxonomy.validators import CourseMetadataProviderValidator, ProgramMetadataProviderValidator
 
-from course_discovery.apps.course_metadata.tests.factories import CourseFactory
+from course_discovery.apps.course_metadata.tests.factories import CourseFactory, ProgramFactory
 
 
 class TaxonomyIntegrationTests(TestCase):
@@ -32,7 +35,7 @@ class TaxonomyIntegrationTests(TestCase):
     Validate integration of taxonomy_support and metadata providers.
     """
 
-    def test_validate(self):
+    def test_validate_course_metadata(self):
         """
         Validate that there are no integration issues.
         """
@@ -43,3 +46,15 @@ class TaxonomyIntegrationTests(TestCase):
 
         # Run all the validations, note that an assertion error will be raised if any of the validation fail.
         course_metadata_validator.validate()
+
+    def test_validate_program_metadata(self):
+        """
+        Validate that there are no integration issues.
+        """
+        programs = ProgramFactory.create_batch(3)
+        program_metadata_validator = ProgramMetadataProviderValidator(
+            [str(program.uuid) for program in programs]
+        )
+
+        # Run all the validations, note that an assertion error will be raised if any of the validation fail.
+        program_metadata_validator.validate()

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -590,6 +590,7 @@ MEDIA_STORAGE_BACKEND = {
 
 # Settings related to the taxonomy_support
 TAXONOMY_COURSE_METADATA_PROVIDER = 'course_discovery.apps.taxonomy_support.providers.DiscoveryCourseMetadataProvider'
+TAXONOMY_PROGRAM_METADATA_PROVIDER = 'course_discovery.apps.taxonomy_support.providers.DiscoveryProgramMetadataProvider'
 
 # Settings related to the EMSI client
 EMSI_API_ACCESS_TOKEN_URL = 'https://auth.emsicloud.com/connect/token'


### PR DESCRIPTION
Ticket link: [3/5 - Create provider and validators for Program/Degree](https://2u-internal.atlassian.net/browse/PROD-2901)

## Description:
After adding provider and validator in taxonomy-connector app in [this PR](https://github.com/openedx/taxonomy-connector/pull/98) . We need to override there methods in discovery app to return Discovery Program data