### PR TITLE
fix: send signal when overview is updated

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -2820,9 +2820,9 @@ class Program(PkSearchableMixin, TimeStampedModel):
                 kwargs['force_update'] = True
                 super().save(**kwargs)
                 publisher.publish_obj(self, previous_obj=previous_obj)
-            if settings.FIRE_UPDATE_PROGRAM_SKILLS_SIGNAL and self.is_active and \
-                    previous_obj and not previous_obj.is_active:
-                # If a Program is published then fire signal
+            if settings.FIRE_UPDATE_PROGRAM_SKILLS_SIGNAL and previous_obj and \
+                    ((not previous_obj.is_active and self.is_active) or self.overview != previous_obj.overview):
+                # If a Program is published or overview field is changed then fire signal
                 # so that a background task in taxonomy update the program skills.
                 logger.info('Signal fired to update program skills. Program: [%s]', self.uuid)
                 UPDATE_PROGRAM_SKILLS.send(self.__class__, program_uuid=self.uuid)

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2212,13 +2212,18 @@ class ProgramTests(TestCase):
 
     @override_switch('publish_program_to_marketing_site', True)
     @override_settings(FIRE_UPDATE_PROGRAM_SKILLS_SIGNAL=True)
+    @ddt.data(
+        {'status': ProgramStatus.Active, 'overview': 'test1'},
+        {'status': ProgramStatus.Unpublished, 'overview': 'test2'}
+    )
     @patch('course_discovery.apps.course_metadata.models.UPDATE_PROGRAM_SKILLS.send')
-    def test_send_program_skills_signal(self, mock_signal_send):
+    def test_send_program_skills_signal(self, test_data, mock_signal_send):
         """
-        Verify that publishing the program fires UPDATE_PROGRAM_SKILLS signal.
+        Verify that publishing the program or updating overview fires UPDATE_PROGRAM_SKILLS signal.
         """
-        program = factories.ProgramFactory(status=ProgramStatus.Unpublished)
-        program.status = ProgramStatus.Active
+        program = factories.ProgramFactory(overview='test1', status=ProgramStatus.Unpublished)
+        program.overview = test_data['overview']
+        program.status = test_data['status']
         with mock.patch.object(ProgramMarketingSitePublisher, 'publish_obj', return_value=None) as mock_publish_obj:
             program.save()
             assert mock_publish_obj.called


### PR DESCRIPTION
[PROD-2902](https://2u-internal.atlassian.net/browse/PROD-2902)
Sends signal whenever overview field changes instead of when the program is published.