### PR TITLE
fix: allow variant_id to be null in serializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -637,7 +637,7 @@ class AdditionalMetadataSerializer(BaseModelSerializer):
     certificate_info = CertificateInfoSerializer()
     start_date = serializers.DateTimeField()
     registration_deadline = serializers.DateTimeField()
-    variant_id = serializers.UUIDField()
+    variant_id = serializers.UUIDField(allow_null=True)
 
     @classmethod
     def prefetch_queryset(cls):


### PR DESCRIPTION
Publisher will POST a null value to discovery when saving variant_id, so we need to make the serializer accept null values.

Publisher PR is here: https://github.com/openedx/frontend-app-publisher/pull/769