### PR TITLE
fix: populate exec ed data csv mgt command fixups

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -54,7 +54,6 @@ class Command(BaseCommand):
             '--auth_token',
             dest='auth_token',
             type=str,
-            required=True,
             help='Bearer token for making API calls to Product API'
         )
         parser.add_argument(
@@ -84,6 +83,11 @@ class Command(BaseCommand):
         output_csv = options.get('output_csv')
         auth_token = options.get('auth_token')
         dev_input_json = options.get('dev_input_json')
+
+        if not (dev_input_json or auth_token):
+            raise CommandError(  # pylint: disable=raise-missing-from
+                "auth_token or dev_input_json should be provided to perform data transformation."
+            )
 
         # Error/Warning messages to be displayed at the end of population
         self.messages_list = []  # pylint: disable=attribute-defined-outside-init
@@ -167,8 +171,11 @@ class Command(BaseCommand):
         Method to get all products from provided product API.
         """
         url = settings.PRODUCT_API_URL
+        # TODO: Remove User-agent once product API's 403 error is resolved.
         headers = {
-            "Authorization": f"Bearer {auth_token}"
+            "Authorization": f"Bearer {auth_token}",
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+                          '(KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36'
         }
         params = {
             "detail": 1

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -252,6 +252,19 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 '--auth_token', self.AUTH_TOKEN
             )
 
+    def test_missing_json_and_auth_token(self):
+        """
+        Test that the command raises CommandError if both auth token and input JSON are missing.
+        """
+        with self.assertRaisesMessage(
+                CommandError, 'auth_token or dev_input_json should be provided to perform data transformation.'
+        ):
+            output_csv = NamedTemporaryFile()  # lint-amnesty, pylint: disable=consider-using-with
+            call_command(
+                'populate_executive_education_data_csv',
+                '--output_csv', output_csv.name,
+            )
+
     @responses.activate
     def test_product_api_call_failure(self):
         """


### PR DESCRIPTION
### [PROD-2926](https://2u-internal.atlassian.net/browse/PROD-2926)

### Description

- Do not require auth_token in management command. Raise error if both token and json file is missing
- Add temporary headers that allow API call to product API, which started returning 403 for some reason. This is expected to remove once there is more info from Product API owners on why the script API call is not allowed