### PR TITLE
feat: add edx-event-bus-kafka to requirements and update settings

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/consume_events.py
+++ b/course_discovery/apps/course_metadata/management/commands/consume_events.py
@@ -59,14 +59,14 @@ class Command(BaseCommand):
             logger.info("Cannot consume events because the events libraries are not available.")
             return
 
-        # .. toggle_name: KAFKA_CONSUMERS_ENABLED
+        # .. toggle_name: EVENT_BUS_KAFKA_CONSUMERS_ENABLED
         # .. toggle_implementation: SettingToggle
         # .. toggle_default: False
         # .. toggle_description: Enables the ability to listen and process events from the Kafka event bus
         # .. toggle_use_cases: opt_in
         # .. toggle_creation_date: 2022-01-31
         # .. toggle_tickets: https://openedx.atlassian.net/browse/ARCHBOM-1992
-        KAFKA_CONSUMERS_ENABLED = SettingToggle('KAFKA_CONSUMERS_ENABLED', default=False)
+        KAFKA_CONSUMERS_ENABLED = SettingToggle('EVENT_BUS_KAFKA_CONSUMERS_ENABLED', default=False)
 
         if not KAFKA_CONSUMERS_ENABLED.is_enabled():
             logger.info("Kafka consumers not enabled")

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -46,6 +46,7 @@ edx-django-release-util
 edx-django-sites-extensions
 edx-django-utils
 edx-drf-extensions
+edx-event-bus-kafka
 edx-opaque-keys
 edx-rest-api-client
 elasticsearch

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -33,6 +33,7 @@ attrs==21.4.0
     # via
     #   glom
     #   jsonschema
+    #   openedx-events
     #   outcome
     #   pytest
     #   semgrep
@@ -108,7 +109,9 @@ click-plugins==1.1.1
 click-repl==0.2.0
     # via celery
 code-annotations==1.3.0
-    # via edx-lint
+    # via
+    #   edx-lint
+    #   edx-toggles
 colorama==0.4.5
     # via semgrep
 coreapi==2.3.3
@@ -179,8 +182,11 @@ distro==1.7.0
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
+    #   edx-toggles
     #   jsonfield
+    #   openedx-events
     #   taxonomy-connector
     #   xss-utils
 django-admin-sortable2==1.0.4
@@ -206,7 +212,9 @@ django-cors-headers==3.13.0
 django-countries==7.3.2
     # via -r requirements/base.in
 django-crum==0.7.9
-    # via edx-django-utils
+    # via
+    #   edx-django-utils
+    #   edx-toggles
 django-debug-toolbar==3.6.0
     # via -r requirements/local.in
 django-dry-rest-permissions==1.2.0
@@ -275,6 +283,7 @@ django-waffle==2.6.0
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django-webpack-loader==1.6.0
     # via -r requirements/base.in
 djangorestframework==3.13.1
@@ -330,25 +339,32 @@ edx-django-utils==5.0.0
     #   -r requirements/base.in
     #   django-config-models
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   taxonomy-connector
 edx-drf-extensions==8.0.1
+    # via -r requirements/base.in
+edx-event-bus-kafka==0.4.1
     # via -r requirements/base.in
 edx-i18n-tools==0.9.1
     # via -r requirements/local.in
 edx-lint==5.2.4
     # via -r requirements/test.in
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
 edx-sphinx-theme==3.0.0
     # via -r requirements/docs.in
+edx-toggles==5.0.0
+    # via edx-event-bus-kafka
 elasticsearch==7.13.4
     # via
     #   -c requirements/common_constraints.txt
@@ -370,6 +386,8 @@ factory-boy==3.2.1
     # via -r requirements/test.in
 faker==14.1.0
     # via factory-boy
+fastavro==1.6.0
+    # via openedx-events
 filelock==3.8.0
     # via
     #   tox
@@ -448,6 +466,8 @@ oauthlib==3.2.0
     # via
     #   requests-oauthlib
     #   social-auth-core
+openedx-events==0.12.0
+    # via edx-event-bus-kafka
 outcome==1.2.0
     # via trio
 packaging==21.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,7 +20,9 @@ asgiref==3.5.2
 async-timeout==4.0.2
     # via redis
 attrs==22.1.0
-    # via zeep
+    # via
+    #   openedx-events
+    #   zeep
 authlib==1.0.0rc1
     # via
     #   -c requirements/constraints.txt
@@ -62,6 +64,7 @@ click==8.1.3
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   code-annotations
     #   edx-django-utils
 click-didyoumean==0.3.0
     # via celery
@@ -69,6 +72,8 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
+code-annotations==1.3.0
+    # via edx-toggles
 coreapi==2.3.3
     # via drf-yasg
 coreschema==0.0.4
@@ -123,7 +128,10 @@ django==3.2.15
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
+    #   edx-toggles
     #   jsonfield
+    #   openedx-events
     #   taxonomy-connector
     #   xss-utils
 django-admin-sortable2==1.0.4
@@ -149,7 +157,9 @@ django-cors-headers==3.13.0
 django-countries==7.3.2
     # via -r requirements/base.in
 django-crum==0.7.9
-    # via edx-django-utils
+    # via
+    #   edx-django-utils
+    #   edx-toggles
 django-dry-rest-permissions==1.2.0
     # via -r requirements/base.in
 django-dynamic-filenames==1.3.0
@@ -216,6 +226,7 @@ django-waffle==2.6.0
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-toggles
 django-webpack-loader==1.6.0
     # via -r requirements/base.in
 djangorestframework==3.13.1
@@ -261,19 +272,26 @@ edx-django-utils==5.0.0
     #   -r requirements/base.in
     #   django-config-models
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
+    #   edx-toggles
     #   taxonomy-connector
 edx-drf-extensions==8.0.1
     # via -r requirements/base.in
-edx-opaque-keys==2.3.0
+edx-event-bus-kafka==0.4.1
+    # via -r requirements/base.in
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
+edx-toggles==5.0.0
+    # via edx-event-bus-kafka
 elasticsearch==7.13.4
     # via
     #   -c requirements/common_constraints.txt
@@ -287,6 +305,8 @@ elasticsearch-dsl==7.4.0
     #   -r requirements/base.in
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
+fastavro==1.6.0
+    # via openedx-events
 future==0.18.2
     # via pyjwkest
 gevent==21.12.0
@@ -310,7 +330,9 @@ isodate==0.6.1
 itypes==1.2.0
     # via coreapi
 jinja2==3.1.2
-    # via coreschema
+    # via
+    #   code-annotations
+    #   coreschema
 jmespath==1.0.1
     # via
     #   boto3
@@ -339,6 +361,8 @@ oauthlib==3.2.0
     # via
     #   requests-oauthlib
     #   social-auth-core
+openedx-events==0.12.0
+    # via edx-event-bus-kafka
 packaging==21.3
     # via
     #   drf-yasg
@@ -387,7 +411,9 @@ python-memcached==1.59
 python-monkey-business==1.0.0
     # via django-nested-admin
 python-slugify==6.1.2
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   code-annotations
 python-stdnum==1.17
     # via django-localflavor
 python3-openid==3.2.0
@@ -405,6 +431,7 @@ pytz==2022.2.1
 pyyaml==6.0
     # via
     #   -r requirements/production.in
+    #   code-annotations
     #   edx-django-release-util
 rcssmin==1.1.0
     # via django-compressor
@@ -481,6 +508,7 @@ sqlparse==0.4.2
     # via django
 stevedore==4.0.0
     # via
+    #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 taxonomy-connector==1.20.0


### PR DESCRIPTION
Add edx-event-bus-kafka to the base requirements to ensure we can keep the library updates in sync with the necessary changes. This will still require a separate installation of confluent-kafka. See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst for why this is.