### PR TITLE
feat: add skills as attributes for algolia faceting

### DIFF
--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -94,8 +94,11 @@ class EnglishProductIndex(BaseProductIndex):
             'unordered(secondary_description)',
             'unordered(tertiary_description)',
         ],
-        'attributesForFaceting': ['partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
-                                  'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)'],
+        'attributesForFaceting': [
+            'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
+            'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)', 'skills.skill',
+            'skills.category', 'skills.subcategory',
+        ],
         'customRanking': ['asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
     index_name = 'product'
@@ -137,8 +140,11 @@ class SpanishProductIndex(BaseProductIndex):
             'unordered(secondary_description)',
             'unordered(tertiary_description)',
         ],
-        'attributesForFaceting': ['partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
-                                  'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)'],
+        'attributesForFaceting': [
+            'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
+            'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)',
+            'skills.skill', 'skills.category', 'skills.subcategory'
+        ],
         'customRanking': ['desc(promoted_in_spanish_index)', 'asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
     index_name = 'spanish_product'


### PR DESCRIPTION
### [PROD-2936](https://2u-internal.atlassian.net/browse/PROD-2936)

### Description

Add skills.skill, skills.category, and skills.subcategory as faceting attributes in Algolia. The skills field in Index is a list of dicts, in the following format:

``` 
[
            {
            'skill': 'Skill 1',
            'category': 'Category 1',
            'subcategory': 'Subcategory 1',
            },
            {
            'skill': 'Skill 2',
            'category': 'Category 1',
            'subcategory': 'Subcategory 1',
            }
 ]
```

### Local Testing

- Getting stage keys https://2u-internal.atlassian.net/wiki/spaces/WS/pages/8749500/Algolia+Indexing#How-to-test-the-indexing-locally
- Override `should_index` in algolia_models to return True for all the courses, for easy testing.
- Go to discovery shell
- Run `./manage.py ./manage.py algolia_reindex`. It should add your local products to index
- Open Djang shell `./manage.py shell`
- Run `from algoliasearch_django import raw_search`, `from course_discovery.apps.course_metadata.index import AlgoliaProxyProduct`
- Call raw_search with different query params `raw_search(AlgoliaProxyProduct, "Advanced", {"facets": ['*']})` and verify the results

### References
- https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/#declaring-attributes-for-faceting
- https://www.algolia.com/doc/api-reference/api-parameters/attributesForFaceting/
- https://www.algolia.com/blog/engineering/facets-data-model-of-json-records/
- https://www.algolia.com/doc/api-reference/api-parameters/facets/#examples
- https://www.algolia.com/doc/framework-integration/django/search/?client=python
- https://www.algolia.com/doc/api-reference/search-api-parameters/