### PR TITLE
feat: custom validations on location restriction serializer

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2915,6 +2915,82 @@ class LocationRestrictionSerializerTests(TestCase):
         }
         assert serializer.data['location_restriction'] == expected
 
+    def test_null_fields(self):
+        request = make_request()
+        location_restriction = CourseLocationRestrictionFactory()
+        course = CourseFactory(location_restriction=location_restriction)
+        data = {
+            'location_restriction': {
+                'restriction_type': None,
+                'countries': None,
+                'states': None,
+            },
+        }
+        serializer = CourseSerializer(course, context={'request': request}, data=data)
+        serializer.is_valid()
+        assert 'location_restriction' not in serializer.errors
+
+    def test_no_restriction_type(self):
+        request = make_request()
+        data = {
+            'location_restriction': {
+                'restriction_type': None,
+                'countries': ['CA'],
+                'states': ['MI'],
+            }
+        }
+        location_restriction = CourseLocationRestrictionFactory()
+        course = CourseFactory(location_restriction=location_restriction)
+        serializer = CourseSerializer(course, context={'request': request}, data=data)
+        serializer.is_valid()
+        assert 'location_restriction' in serializer.errors
+        assert 'Restriction Type' in serializer.errors['location_restriction']
+
+    def test_no_countries(self):
+        request = make_request()
+        data = {
+            'location_restriction': {
+                'restriction_type': 'allowlist',
+                'countries': None,
+                'states': ['MI'],
+            }
+        }
+        location_restriction = CourseLocationRestrictionFactory()
+        course = CourseFactory(location_restriction=location_restriction)
+        serializer = CourseSerializer(course, context={'request': request}, data=data)
+        serializer.is_valid()
+        assert 'location_restriction' not in serializer.errors
+
+    def test_no_states(self):
+        request = make_request()
+        data = {
+            'location_restriction': {
+                'restriction_type': 'allowlist',
+                'countries': ['CA'],
+                'states': None,
+            }
+        }
+        location_restriction = CourseLocationRestrictionFactory()
+        course = CourseFactory(location_restriction=location_restriction)
+        serializer = CourseSerializer(course, context={'request': request}, data=data)
+        serializer.is_valid()
+        assert 'location_restriction' not in serializer.errors
+
+    def test_no_countries_or_states(self):
+        request = make_request()
+        data = {
+            'location_restriction': {
+                'restriction_type': 'allowlist',
+                'countries': None,
+                'states': None,
+            }
+        }
+        location_restriction = CourseLocationRestrictionFactory()
+        course = CourseFactory(location_restriction=location_restriction)
+        serializer = CourseSerializer(course, context={'request': request}, data=data)
+        serializer.is_valid()
+        assert 'location_restriction' not in serializer.errors
+
     def test_invalid_codes(self):
         request = make_request()
         course = CourseFactory()

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1319,32 +1319,6 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         course = Course.everything.get(uuid=course.uuid, draft=True)
         self.assertDictEqual(self.serialize_course(course)['location_restriction'], location_restriction_data)
 
-    @responses.activate
-    def test_update_location_restriction_no_countries_or_states(self):
-        """
-        If countries and/or states fields are not included in the request, then existing data for those fields
-        should not be affected.
-        """
-        location_restriction_data = {
-            'restriction_type': AbstractLocationRestrictionModel.ALLOWLIST,
-            'countries': ['US'],
-            'states': ['MA']
-        }
-        location_restriction = CourseLocationRestrictionFactory(**location_restriction_data)
-        course = CourseFactory(location_restriction=location_restriction)
-
-        location_restriction_data['restriction_type'] = AbstractLocationRestrictionModel.BLOCKLIST
-
-        url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})
-        course_data = {
-            'location_restriction': {'restriction_type': location_restriction_data['restriction_type']}
-        }
-
-        response = self.client.patch(url, course_data, format='json')
-        assert response.status_code == 200
-        course = Course.everything.get(uuid=course.uuid, draft=True)
-        self.assertDictEqual(self.serialize_course(course)['location_restriction'], location_restriction_data)
-
     @ddt.data(False, True)
     @responses.activate
     def test_update_in_year_value(self, existing_in_year_value):


### PR DESCRIPTION
This is a part of [WS-3120](https://2u-internal.atlassian.net/browse/WS-3120)

This PR customizes the validations on the location restriction serializer to facilitate creating and editing course location restriction from Publisher.

The validations will handle the following cases:
1. If all fields on the location restriction are null, it is assumed that the user does not wish add location restriction.  No error will occur, and no location restriction object will be created. 
2. If `countries` or `states` is set but the `restriction_type` is null, the user will receive an error.
3. If `restriction_type` is set but both `countries` and `states` is null, the user will not receive an error. The assumption is that the user wants to remove the location restriction by setting restrictions to null.