### PR TITLE
fix: respect program overrides in algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -175,6 +175,16 @@ class AlgoliaBasicModelFieldsMixin(models.Model):
             return self.in_year_value.per_lead_international
         return None
 
+    @property
+    def product_organization_short_code_override(self):
+        return self.organization_short_code_override
+
+    @property
+    def product_organization_logo_override(self):
+        if self.organization_logo_override:
+            return getattr(self.organization_logo_override, 'url', None)
+        return None
+
 
 class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
 
@@ -268,16 +278,6 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
     @property
     def product_max_effort(self):
         return getattr(self.advertised_course_run, 'max_effort', None)
-
-    @property
-    def product_organization_short_code_override(self):
-        return self.organization_short_code_override
-
-    @property
-    def product_organization_logo_override(self):
-        if self.organization_logo_override:
-            return getattr(self.organization_logo_override, 'url', None)
-        return None
 
     @property
     def owners(self):
@@ -410,6 +410,8 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     @property
     def subject_names(self):
+        if self.primary_subject_override:
+            return [self.primary_subject_override.name]
         return [subject.name for subject in self.subjects]
 
     @property
@@ -422,10 +424,14 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     @property
     def levels(self):
+        if self.level_type_override:
+            return [getattr(self.level_type_override, 'name_t', None)]
         return list(dict.fromkeys([getattr(course.level_type, 'name_t', None) for course in self.courses.all()]))
 
     @property
     def active_languages(self):
+        if self.language_override:
+            return [self.language_override.get_search_facet_display(translate=True)]
         return list(dict.fromkeys([get_active_language(course) for course in self.courses.all()]))
 
     @property
@@ -497,6 +503,8 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     @property
     def promoted_in_spanish_index(self):
+        if self.language_override and self.language_override.code.startswith('es'):
+            return True
         all_course_languages = [get_active_language_tag(course) for course in self.courses.all()]
         all_course_languages = [tag for tag in all_course_languages if tag is not None]
         return any(tag.code.startswith('es') for tag in all_course_languages)


### PR DESCRIPTION
- Subject, level, and language fields in Algolia should respect program overrides.
- `organization_short_code_override` and `organization_logo_override` are passed into Algolia for both courses and programs now, not just courses. There is code on the Prospectus side to handle these overrides.

Tested against stage Algolia environment.

Internal ticket: https://2u-internal.atlassian.net/browse/WS-3113