### PR TITLE
chore: adding loggin to org ent sub inclusion update cascade task

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -9,6 +9,7 @@ import pytz
 import responses
 from django.contrib.auth.models import Group
 from django.db.models.functions import Lower
+from freezegun import freeze_time
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory
 
@@ -130,6 +131,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         assert response.data == \
             self.serialize_course_run(self.course_run, extra_context={'include_unpublished_programs': True})
 
+    @freeze_time("2022-01-14 12:00:01")
     @responses.activate
     def test_create_minimum(self):
         """ Verify the endpoint supports creating a course_run with the least info. """
@@ -267,6 +269,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         assert new_course_run.language == self.draft_course_run.language
         assert list(new_course_run.transcript_languages.all()) == list(self.draft_course_run.transcript_languages.all())
 
+    @freeze_time("2022-01-14 12:00:01")
     @ddt.data(True, False, "bogus")
     @responses.activate
     def test_create_draft_ignored(self, draft):
@@ -290,6 +293,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         self.assertDictEqual(response.data, self.serialize_course_run(new_course_run))
         assert new_course_run.draft
 
+    @freeze_time("2022-01-14 12:00:01")
     @responses.activate
     def test_create_using_type_with_price(self):
         """ Verify the endpoint supports creating a course_run and sets the seats price to the given price """
@@ -316,6 +320,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         assert float(new_seat.price) == 77.32
         assert new_seat.draft
 
+    @freeze_time("2022-01-14 12:00:01")
     @responses.activate
     def test_create_using_type_with_no_track_seat_types(self):
         """
@@ -342,6 +347,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
 
         assert Seat.everything.filter(course_run=new_course_run).count() == 0
 
+    @freeze_time("2022-01-14 12:00:01")
     @responses.activate
     def test_create_with_term(self):
         """ Verify the endpoint supports creating a course_run when specifying a key (if allowed). """

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1076,7 +1076,7 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
 
         # Course runs calculate enterprise subscription inclusion based off of their parent's status, so we need to
         # force a recalculation
-        course_runs = CourseRun.objects.filter(course=self)
+        course_runs = self.course_runs.all()
         for course_run in course_runs:
             course_run.save()
 

--- a/course_discovery/apps/course_metadata/tasks.py
+++ b/course_discovery/apps/course_metadata/tasks.py
@@ -19,7 +19,7 @@ def update_org_program_and_courses_ent_sub_inclusion(org_pk, org_sub_inclusion):
         org_pk (int): primary key of the organization
         org_sub_inclusion (bool): whether or not the org is included in enterprise subscriptions
     """
-    courses = Course.objects.filter(
+    courses = Course.everything.filter(
         authoring_organizations__pk=org_pk,
         enterprise_subscription_inclusion__in=[None, True],
         type__slug__in=[
@@ -30,6 +30,8 @@ def update_org_program_and_courses_ent_sub_inclusion(org_pk, org_sub_inclusion):
             CourseType.EMPTY
         ]
     )
+    sub_tag_log = "Org: %s has been saved. Updating enterprise sub tagging logic for %s %s"
+    LOGGER.info(sub_tag_log, org_pk, len(courses), 'courses')
     course_ids = []
     for course in courses:
         course.enterprise_subscription_inclusion = org_sub_inclusion
@@ -45,5 +47,6 @@ def update_org_program_and_courses_ent_sub_inclusion(org_pk, org_sub_inclusion):
             ProgramType.MICROBACHELORS
         ]
     )
+    LOGGER.info(sub_tag_log, org_pk, len(programs), 'programs')
     for program in programs:
         program.save()


### PR DESCRIPTION
related ticket: https://2u-internal.atlassian.net/browse/ENT-6205

Context: 
We are noticing that when organizations are saved, the signal/task that are responsible for re-saving all the org's courses (in order to update the courses' subscription tagging to match the org's if the org's value has changed) are only affecting published courses under the org, while draft courses are never changed when an org is saved. To bring clarity to the situation, I've added logs to the task to see the number of courses fetched by the task. This should let us know if it is the task that is not fetching the draft courses or if there is an issue further down when saving said draft courses.  