### PR TITLE
feat: add libcairo library in docker image to convert organization logo svg to png

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get install --yes \
 	libxml2-dev \
 	libxslt1-dev \
 	libjpeg-dev \
-	libssl-dev
+	libssl-dev \
+	libcairo2-dev
 
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Ticket link: [Use logos provided by the Exec Ed team in the GEAG API](https://2u-internal.atlassian.net/browse/PROD-2818)

## Description

In the scope of this ticket [Use logos provided by the Exec Ed team in the GEAG API](https://2u-internal.atlassian.net/browse/PROD-2818) we need to convert SVG format logo to PNG. So we need to use some third party library (libcairo) which will convert the image to PNG. So we need to install that library in Docker Image
