### PR TITLE
fix: use different logging settings for k8s deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,3 +66,9 @@ CMD gunicorn --bind=0.0.0.0:8381 --workers 2 --max-requests=1000 -c course_disco
 FROM app as newrelic
 RUN pip install newrelic
 CMD newrelic-admin run-program gunicorn --bind=0.0.0.0:8381 --workers 2 --max-requests=1000 -c course_discovery/docker_gunicorn_configuration.py course_discovery.wsgi:application
+
+###########################################################
+# Define k8s target
+FROM app as kubernetes
+ENV DISCOVERY_SETTINGS='kubernetes'
+ENV DJANGO_SETTINGS_MODULE="course_discovery.settings.$DISCOVERY_SETTINGS"

--- a/course_discovery/settings/kubernetes.py
+++ b/course_discovery/settings/kubernetes.py
@@ -1,0 +1,72 @@
+"""
+Specific overrides to the base prod settings for a docker production deployment.
+"""
+
+import platform
+import sys
+from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+
+def get_docker_logger_config():
+    """
+    Return the appropriate logging config dictionary. You should assign the
+    result of this to the LOGGING var in your settings.
+    """
+
+    hostname = platform.node().split(".")[0]
+    syslog_format = '[service_variant=discovery][%(name)s] %(levelname)s [{hostname}  %(process)d] ' \
+                    '[%(pathname)s:%(lineno)d] - %(message)s'.format(hostname=hostname)
+
+    handlers = ['console']
+
+    logger_config = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'standard': {
+                'format': '%(asctime)s %(levelname)s %(process)d '
+                          '[%(name)s] %(filename)s:%(lineno)d - %(message)s',
+            },
+            'syslog_format': {'format': syslog_format},
+            'raw': {'format': '%(message)s'},
+        },
+        'handlers': {
+            'console': {
+                'level': 'INFO',
+                'class': 'logging.StreamHandler',
+                'formatter': 'standard',
+                'stream': sys.stdout,
+            },
+        },
+        'loggers': {
+            'django': {
+                'handlers': handlers,
+                'propagate': True,
+                'level': 'INFO'
+            },
+            'requests': {
+                'handlers': handlers,
+                'propagate': True,
+                'level': 'WARNING'
+            },
+            'factory': {
+                'handlers': handlers,
+                'propagate': True,
+                'level': 'WARNING'
+            },
+            'django.request': {
+                'handlers': handlers,
+                'propagate': True,
+                'level': 'WARNING'
+            },
+            '': {
+                'handlers': handlers,
+                'level': 'DEBUG',
+                'propagate': False
+            },
+        }
+    }
+
+    return logger_config
+
+LOGGING = get_docker_logger_config()

--- a/course_discovery/settings/kubernetes.py
+++ b/course_discovery/settings/kubernetes.py
@@ -1,5 +1,5 @@
 """
-Specific overrides to the base prod settings for a docker production deployment.
+Specific overrides to the base prod settings for a kubernetes production deployment.
 """
 
 import platform

--- a/course_discovery/settings/kubernetes.py
+++ b/course_discovery/settings/kubernetes.py
@@ -4,6 +4,7 @@ Specific overrides to the base prod settings for a kubernetes production deploym
 
 import platform
 import sys
+
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 


### PR DESCRIPTION
Creates a different environment file for use with a kubernetes deployment of course-discovery, and a new target in the Dockerfile that uses this new environment. The environment file uses different logging settings to account for a kubernetes deployment of course-discovery. In particular, this removes the local syslog handler, which the container does not have access to.