### PR TITLE
chore: bump version of taxonomy-connector to 1.22.3

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -19,7 +19,7 @@ amqp==5.1.1
     # via kombu
 asgiref==3.5.2
     # via django
-astroid==2.12.8
+astroid==2.12.9
     # via
     #   pylint
     #   pylint-celery
@@ -60,9 +60,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.24.67
+boto3==1.24.68
     # via django-ses
-botocore==1.27.67
+botocore==1.27.68
     # via
     #   boto3
     #   s3transfer
@@ -123,7 +123,7 @@ coverage[toml]==6.4.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==38.0.0
+cryptography==38.0.1
     # via
     #   authlib
     #   paramiko
@@ -346,7 +346,7 @@ edx-django-utils==5.0.0
     #   edx-rest-api-client
     #   edx-toggles
     #   taxonomy-connector
-edx-drf-extensions==8.2.0
+edx-drf-extensions==8.3.0
     # via -r requirements/base.in
 edx-event-bus-kafka==0.6.1
     # via -r requirements/base.in
@@ -533,7 +533,7 @@ pyjwt[crypto]==2.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.0
+pylint==2.15.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -749,7 +749,7 @@ stevedore==4.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.22.2
+taxonomy-connector==1.22.3
     # via -r requirements/base.in
 testfixtures==7.0.0
     # via -r requirements/test.in
@@ -757,16 +757,15 @@ text-unidecode==1.3
     # via python-slugify
 texttable==1.6.4
     # via docker-compose
-toml==0.10.2
-    # via tox
 tomli==2.0.1
     # via
     #   coverage
     #   pylint
     #   pytest
+    #   tox
 tomlkit==0.11.4
     # via pylint
-tox==3.25.1
+tox==3.26.0
     # via -r requirements/test.in
 tqdm==4.64.1
     # via semgrep
@@ -804,7 +803,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.16.4
+virtualenv==20.16.5
     # via tox
 wcmatch==8.4
     # via semgrep

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -35,9 +35,9 @@ beautifulsoup4==4.11.1
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.24.67
+boto3==1.24.68
     # via django-ses
-botocore==1.27.67
+botocore==1.27.68
     # via
     #   boto3
     #   s3transfer
@@ -80,7 +80,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==38.0.0
+cryptography==38.0.1
     # via
     #   authlib
     #   pyjwt
@@ -280,7 +280,7 @@ edx-django-utils==5.0.0
     #   edx-rest-api-client
     #   edx-toggles
     #   taxonomy-connector
-edx-drf-extensions==8.2.0
+edx-drf-extensions==8.3.0
     # via -r requirements/base.in
 edx-event-bus-kafka==0.6.1
     # via -r requirements/base.in
@@ -515,7 +515,7 @@ stevedore==4.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.22.2
+taxonomy-connector==1.22.3
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
Upgrades the version of taxonomy-connector from 1.22.2 -> 1.22.3 which adds ability to filters skills on the basis of skill names.