### PR TITLE
fix: use `name_t` for `program_types` in algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -259,7 +259,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
 
     @property
     def program_types(self):
-        return [program.type.name for program in self.programs.all()]
+        return [program.type.name_t for program in self.programs.all()]
 
     @property
     def product_card_image_url(self):
@@ -453,7 +453,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
     @property
     def program_types(self):
         if self.type:
-            return [self.type.name]
+            return [self.type.name_t]
         return None
 
     @property


### PR DESCRIPTION
We're using the incorrect name field for `program_types` in Algolia models - the `name` field has been deprecated, we swapped to `name_t` a while ago to support translations.

Internal ticket: https://2u-internal.atlassian.net/browse/WS-3357