### PR TITLE
feat: add program labels in algolia tag fields

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -458,7 +458,9 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
     @property
     def tags(self):
-        return [topic.name for topic in self.topics]
+        topics = [topic.name for topic in self.topics]
+        labels = [label.name for label in self.labels.all()]
+        return list(set(topics + labels))
 
     @property
     def product_allowed_in(self):

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -525,3 +525,17 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
             assert program.active_languages == ['English']
             assert program.levels == ['Introductory']
             assert program.subject_names == ['Computer Science']
+
+    def test_program_tags(self):
+        program = AlgoliaProxyProgramFactory()
+        course1 = AlgoliaProxyCourseFactory()
+        course2 = AlgoliaProxyCourseFactory()
+        course1.topics.add('course1_topic1', 'course1_topic2', 'generic')
+        course2.topics.add('course2_topic1', 'course2_topic2', 'generic')
+        program.labels.add('program_label1', 'program_label2', 'generic')
+        program.courses.add(course1, course2)
+        expected_tags = [
+            'generic', 'course1_topic1', 'program_label2', 'course1_topic2',
+            'course2_topic1', 'course2_topic2', 'program_label1'
+        ]
+        assert sorted(program.tags) == sorted(expected_tags)


### PR DESCRIPTION
Ticket: [Concat existing `labels` field data under program module with newly created "tags" field](https://2u-internal.atlassian.net/browse/PROD-2963)

## Description
We have added labels field in Program model to save tags of the program for Subcategory pages. So we need to expose those labels in Algolia. In this PR all labels will be appended with course topics of that program and will be saved in Algolia.