### PR TITLE
chore: enhance logging in Degree CSV loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/constants.py
+++ b/course_discovery/apps/course_metadata/data_loaders/constants.py
@@ -56,3 +56,63 @@ CSV_LOADER_ERROR_LOG_SEQUENCE = [
     CSVIngestionErrors.IMAGE_DOWNLOAD_FAILURE, CSVIngestionErrors.COURSE_CREATE_ERROR,
     CSVIngestionErrors.COURSE_UPDATE_ERROR, CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR
 ]
+
+
+class DegreeCSVIngestionErrors:
+    """
+    Possible errors that will raise during Degree CSV Loader ingestion flow.
+    """
+    MISSING_REQUIRED_DATA = 'MISSING_REQUIRED_DATA'
+    MISSING_ORGANIZATION = 'MISSING_ORGANIZATION'
+    MISSING_PROGRAM_TYPE = 'MISSING_PROGRAM_TYPE'
+    MISSING_SUBJECT_DATA = 'MISSING_SUBJECT_DATA'
+    MISSING_LEVEL_TYPE_DATA = 'MISSING_LEVEL_TYPE_DATA'
+    MISSING_LANGUAGE_TAG_DATA = 'MISSING_LANGUAGE_TAG_DATA'
+    DEGREE_CREATE_ERROR = 'DEGREE_CREATE_ERROR'
+    DEGREE_UPDATE_ERROR = 'DEGREE_UPDATE_ERROR'
+    IMAGE_DOWNLOAD_FAILURE = 'IMAGE_DOWNLOAD_FAILURE'
+    LOGO_IMAGE_DOWNLOAD_FAILURE = 'LOGO_IMAGE_DOWNLOAD_FAILURE'
+
+
+class DegreeCSVIngestionErrorMessages:
+    """
+    String templates for various CSV ingestion error messages.
+    """
+    MISSING_ORGANIZATION = '[MISSING_ORGANIZATION] Unable to locate partner organization with key {} ' \
+                           'for the degree {degree_slug}.'
+
+    MISSING_PROGRAM_TYPE = '[MISSING_PROGRAM_TYPE] Unable to find the program type "{}" ' \
+                           'for the degree {degree_slug}'
+
+    MISSING_REQUIRED_DATA = '[MISSING_REQUIRED_DATA] Degree {degree_slug} is missing the required data for ' \
+                            'ingestion. The missing data elements are "{missing_data}"'
+
+    MISSING_SUBJECT_DATA = '[MISSING_SUBJECT_DATA] Unable to find the subject "{}" ' \
+                           'for the degree {degree_slug}'
+
+    MISSING_LEVEL_TYPE_DATA = '[MISSING_LEVEL_TYPE_DATA] Unable to find the level type "{}" ' \
+                              'for the degree {degree_slug}'
+
+    MISSING_LANGUAGE_TAG_DATA = '[MISSING_LANGUAGE_TAG_DATA] Unable to find the language "{}" ' \
+                                'for the degree {degree_slug}'
+
+    DEGREE_CREATE_ERROR = '[DEGREE_CREATE_ERROR] Unable to create degree {degree_slug} in the system. The ingestion' \
+                          'failed with the exception: {exception_message}'
+
+    DEGREE_UPDATE_ERROR = '[DEGREE_UPDATE_ERROR] Unable to update degree {degree_slug} in the system. The update' \
+                          'failed with the exception: {exception_message}'
+
+    IMAGE_DOWNLOAD_FAILURE = '[IMAGE_DOWNLOAD_FAILURE] The degree image download failed for the degree' \
+                             ' {degree_slug}.'
+
+    LOGO_IMAGE_DOWNLOAD_FAILURE = '[LOGO_IMAGE_DOWNLOAD_FAILURE] The logo image download failed for the degree ' \
+                                  '{degree_slug}.'
+
+
+DEGREE_LOADER_ERROR_LOG_SEQUENCE = [
+    DegreeCSVIngestionErrors.MISSING_REQUIRED_DATA, DegreeCSVIngestionErrors.MISSING_ORGANIZATION,
+    DegreeCSVIngestionErrors.MISSING_PROGRAM_TYPE, DegreeCSVIngestionErrors.MISSING_SUBJECT_DATA,
+    DegreeCSVIngestionErrors.MISSING_LEVEL_TYPE_DATA, DegreeCSVIngestionErrors.MISSING_LANGUAGE_TAG_DATA,
+    DegreeCSVIngestionErrors.DEGREE_CREATE_ERROR, DegreeCSVIngestionErrors.DEGREE_UPDATE_ERROR,
+    DegreeCSVIngestionErrors.IMAGE_DOWNLOAD_FAILURE, DegreeCSVIngestionErrors.LOGO_IMAGE_DOWNLOAD_FAILURE
+]

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -183,8 +183,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         if self.degree_uuids:
             logger.info("Degree UUIDs:")
             for degree_uuid, marketing_slug in self.degree_uuids.items():
-                logger.info("{}:{}".format(degree_uuid,
-                                           marketing_slug))  # lint-amnesty, pylint: disable=logging-format-interpolation
+                logger.info("{}:{}".format(degree_uuid, marketing_slug))  # lint-amnesty, pylint: disable=logging-format-interpolation
 
     def transform_dict_keys(self, data):
         """

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -74,13 +74,10 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        'Data validation issue for degree {}, skipping ingestion'.format(self.DEGREE_SLUG)
-                    ),
-                    (
-                        LOGGER_PATH,
-                        'ERROR',
-                        '[DATA VALIDATION ERROR] Degree {}. Missing data: {}'.format(
-                            self.DEGREE_SLUG, missing_key
+                        '[MISSING_REQUIRED_DATA] Degree {degree_slug} is missing the required data for '
+                        'ingestion. The missing data elements are "{missing_data}"'.format(
+                            degree_slug=self.DEGREE_SLUG,
+                            missing_data=missing_key
                         )
                     )
                 )
@@ -100,16 +97,9 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        'Organization invalid-organization does not exist. Skipping CSV '
-                        'loader for degree {}'.format(self.DEGREE_SLUG)
+                        '[MISSING_ORGANIZATION] Unable to locate partner organization with key invalid-organization '
+                        'for the degree {degree_slug}.'.format(degree_slug=self.DEGREE_SLUG)
                     ),
-                    (
-                        LOGGER_PATH,
-                        'ERROR',
-                        '[MISSING ORGANIZATION] Organization: invalid-organization, degree: {}'.format(
-                            self.DEGREE_SLUG
-                        )
-                    )
                 )
                 assert Degree.objects.count() == 0
 
@@ -128,8 +118,8 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        'ProgramType invalid-program-type does not exist. Skipping CSV '
-                        'loader for degree {}'.format(self.DEGREE_SLUG)
+                        '[MISSING_PROGRAM_TYPE] Unable to find the program type "invalid-program-type" '
+                        'for the degree {degree_slug}'.format(degree_slug=self.DEGREE_SLUG)
                     )
                 )
                 assert Degree.objects.count() == 0
@@ -298,11 +288,7 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                     (
                         LOGGER_PATH,
                         'ERROR',
-                        'Unexpected error happened while downloading image for degree {}'.format(self.DEGREE_SLUG)
-                    ),
-                    (
-                        LOGGER_PATH,
-                        'ERROR',
-                        '[DEGREE IMAGE DOWNLOAD FAILURE] degree {}'.format(self.DEGREE_SLUG)
+                        '[IMAGE_DOWNLOAD_FAILURE] The degree image download failed for the degree'
+                        ' {degree_slug}.'.format(degree_slug=self.DEGREE_SLUG)
                     )
                 )


### PR DESCRIPTION
### [PROD-2931](https://2u-internal.atlassian.net/browse/PROD-2931)

### Description
This is part 2 for PROD-2931 and focuses on enhancing the logging information in Degree CSV loader. See part 1 https://github.com/openedx/course-discovery/pull/3601 for CSV loader logging updates. The updates in the PR are:

- Add enumerations for Ingestion errors and the errors messages to log
- Remove 2 variants of error logs for each error type. Now, there will be one error message/error that will be logged twice. Once during the ingestion and 2nd when the ingestion has been completed and the summarized errors are displayed

The reason for having enumeration for errors is that it will be easy to get the relevant error message from error_logs dict of Degree CSV loader when the appropriate logging information is to be shared with external parties.