### PR TITLE
feat: add tags in searchable fields in Algolia

### DIFF
--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -64,7 +64,7 @@ class EnglishProductIndex(BaseProductIndex):
     language = 'en'
 
     search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys',
-                     'primary_description', 'secondary_description', 'tertiary_description')
+                     'primary_description', 'secondary_description', 'tertiary_description', 'tags')
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
@@ -94,6 +94,7 @@ class EnglishProductIndex(BaseProductIndex):
             'unordered(primary_description)',
             'unordered(secondary_description)',
             'unordered(tertiary_description)',
+            'tags'
         ],
         'attributesForFaceting': [
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
@@ -110,7 +111,7 @@ class SpanishProductIndex(BaseProductIndex):
     language = 'es_419'
 
     search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys',
-                     'primary_description', 'secondary_description', 'tertiary_description')
+                     'primary_description', 'secondary_description', 'tertiary_description', 'tags')
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
@@ -141,6 +142,7 @@ class SpanishProductIndex(BaseProductIndex):
             'unordered(primary_description)',
             'unordered(secondary_description)',
             'unordered(tertiary_description)',
+            'tags'
         ],
         'attributesForFaceting': [
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',


### PR DESCRIPTION
## Description:
In the scope of [this epic](https://2u-internal.atlassian.net/browse/PROD-2906) we need to search on the basis of tags in Algolia. So in this PR tags are added in searchable attributes