### PR TITLE
feat: ws-3228 Restore Spanish EE post query

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -332,7 +332,6 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
     @property
     def should_index_spanish(self):
         return (self.should_index and
-                self.type.slug != CourseType.EXECUTIVE_EDUCATION_2U and
                 self.type.slug != CourseType.BOOTCAMP_2U)
 
     @property


### PR DESCRIPTION
Description:
Restore Executive Education to Spanish post-query search, and show English courses.
JIRA:
[WS-3228](https://2u-internal.atlassian.net/browse/WS-3228)