### PR TITLE
feat: read data from gspread client

### DIFF
--- a/course_discovery/apps/course_metadata/gspread_client.py
+++ b/course_discovery/apps/course_metadata/gspread_client.py
@@ -18,18 +18,29 @@ class GspreadClient:
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception(f'[Connection Failed]: Failed to connect with google service account error_message: {ex}')
 
-    def get_spread_sheet_by_url(self, url):
+    def get_spread_sheet_by_key(self, key):
         try:
-            spread_sheet = self.client.open_by_url(url)
+            spread_sheet = self.client.open_by_key(key)
             logger.info('[Spread Sheet Found]: Opening google sheet')
             return spread_sheet
         except Exception as ex:  # pylint: disable=broad-except
-            logger.exception(f'[Spread Sheet Not Found]: No spreadsheet found for url: {url} error_message: {ex}')
+            logger.exception(f'[Spread Sheet Not Found]: No spreadsheet found for key: {key} error_message: {ex}')
+        return None
+
+    def read_data(self, config):
+        # TODO: add unit tests
+        try:
+            spread_sheet = self.get_spread_sheet_by_key(config['SHEET_ID'])
+            input_tab = self.get_worksheet_data_by_tab_id(spread_sheet, config['INPUT_TAB_ID'])
+            return input_tab
+        except Exception:  # pylint: disable=broad-except
+            logger.exception('[Spread Sheet Read Error]: Exception occurred while reading sheet data')
         return None
 
     @staticmethod
     def get_worksheet_data_by_tab_id(spread_sheet, tab_id):
         try:
+            tab_id = int(tab_id)
             worksheet_title = [ws.title for ws in spread_sheet.worksheets() if ws.id == tab_id]
             if not worksheet_title:
                 logger.error(f'[Worksheet Not Found]: No worksheet found with id: {tab_id}')

--- a/course_discovery/apps/course_metadata/management/commands/import_degree_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_degree_data.py
@@ -4,14 +4,12 @@ Management command to import, create, and/or update degrees' data.
 import logging
 
 from django.apps import apps
-from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from django.db.models.signals import post_delete, post_save
 
 from course_discovery.apps.api.cache import api_change_receiver, set_api_timestamp
 from course_discovery.apps.core.models import Partner
 from course_discovery.apps.course_metadata.data_loaders.degrees_loader import DegreeCSVDataLoader
-from course_discovery.apps.course_metadata.gspread_client import GspreadClient
 from course_discovery.apps.course_metadata.models import DegreeDataLoaderConfiguration
 from course_discovery.apps.course_metadata.signals import connect_api_change_receiver
 
@@ -34,6 +32,18 @@ class Command(BaseCommand):
             help='Path to the CSV file',
             type=str,
         )
+        parser.add_argument(
+            '--product_type',
+            help='Product Type to ingest',
+            type=str,
+            default='DEGREES',
+            choices=['DEGREES']
+        )
+        parser.add_argument(
+            '--args_from_env',
+            help='Link to the Data Spreadsheet',
+            type=bool,
+        )
 
     def handle(self, *args, **options):
         """
@@ -43,6 +53,9 @@ class Command(BaseCommand):
         degree_loader_config = DegreeDataLoaderConfiguration.current()
         csv_path = options.get('csv_path', None)
         csv_file = degree_loader_config.csv_file if degree_loader_config.is_enabled() else None
+        product_type = options.get('product_type', None)
+        args_from_env = options.get('args_from_env', None)
+
         try:
             partner = Partner.objects.get(short_code=partner_short_code)
         except Partner.DoesNotExist:
@@ -60,13 +73,10 @@ class Command(BaseCommand):
                 signal.disconnect(receiver=api_change_receiver, sender=model)
 
         try:
-            # Temporary code to check Gspread client connection in Jenkins job
-            google_link = settings.EXTERNAL_DEGREE_SHEET_LINK
-            if google_link:
-                gspread_client = GspreadClient()
-                gspread_client.get_spread_sheet_by_url(google_link)
-
-            loader = DegreeCSVDataLoader(partner, csv_path=csv_path, csv_file=csv_file)
+            loader = DegreeCSVDataLoader(
+                partner, csv_path=csv_path, csv_file=csv_file,
+                args_from_env=args_from_env, product_type=product_type
+            )
             logger.info("Starting CSV loader import flow for partner {}".format(partner_short_code))  # lint-amnesty, pylint: disable=logging-format-interpolation
             loader.ingest()
         except Exception as exc:

--- a/course_discovery/apps/course_metadata/tests/test_gspread.py
+++ b/course_discovery/apps/course_metadata/tests/test_gspread.py
@@ -16,9 +16,9 @@ class GspreadClientTests(TestCase):
 
     @mock.patch('course_discovery.apps.course_metadata.gspread_client.logger')
     @mock.patch('course_discovery.apps.course_metadata.gspread_client.gspread.service_account_from_dict')
-    def test_get_spread_sheet_by_url(self, _mock_gspread_connection, mock_logger):
+    def test_get_spread_sheet_by_key(self, _mock_gspread_connection, mock_logger):
         client = GspreadClient()
-        client.get_spread_sheet_by_url('https://www.testsheet.com')
+        client.get_spread_sheet_by_key('abc123Id')
         mock_logger.info.assert_called_with('[Spread Sheet Found]: Opening google sheet')
 
     @mock.patch('course_discovery.apps.course_metadata.gspread_client.logger')

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -652,4 +652,21 @@ GOOGLE_SERVICE_ACCOUNT_CREDENTIALS = {
   'AUTH_PROVIDER_X509_CERT_URL': '',
   'CLIENT_X509_CERT_URL': ''
 }
-EXTERNAL_DEGREE_SHEET_LINK = "https://docs.google.com/spreadsheets/random-key"
+
+PRODUCT_EXTERNAL_SHEET_MAPPING = {
+    'EXECUTIVE_EDUCATION': {
+        'SHEET_ID': '',
+        'INPUT_TAB_ID': '',
+        'ERROR_TAB_ID': ''
+    },
+    'BOOTCAMPS': {
+        'SHEET_ID': '',
+        'INPUT_TAB_ID': '',
+        'ERROR_TAB_ID': ''
+    },
+    'DEGREES': {
+        'SHEET_ID': '',
+        'INPUT_TAB_ID': '',
+        'ERROR_TAB_ID': ''
+    },
+}


### PR DESCRIPTION
### Description
We're attempting to read data form Google Sheets using gspread client and pass it to data loaders w/out affecting their existing behavior or run sequence. The client returns the data as list of dict where each dict is a row from sheet/csv and in same format as `ingest` method wanted.

### Related Ticket
[PROD-2924](https://2u-internal.atlassian.net/browse/PROD-2924)
[PROD-2928](https://2u-internal.atlassian.net/browse/PROD-2928)


### Linked PR:
https://github.com/edx/edx-internal/pull/7156

### TODOs
- [x] Jenkins not accepting url as an arg 
- [x] We need a better way to specify sheet link and tab id
- [x] How and what to test