### PR TITLE
fix: serializer to make pathway snapshot data consistent ENT-6280

### DIFF
--- a/course_discovery/apps/learner_pathway/api/v1/tests/test_views.py
+++ b/course_discovery/apps/learner_pathway/api/v1/tests/test_views.py
@@ -55,32 +55,6 @@ LEARNER_PATHWAY_COURSE_KEY = LEARNER_PATHWAY_DATA['steps'][0]['courses'][0]['key
 LEARNER_PATHWAY_COURSE_RUN_KEY = LEARNER_PATHWAY_DATA['steps'][0]['courses'][0]['course_runs'][0]['key']
 LEARNER_PATHWAY_PROGRAM_UUID = LEARNER_PATHWAY_DATA['steps'][0]['programs'][0]['uuid']
 
-LEARNER_PATHWAY_SNAPSHOT_DATA = {
-    "uuid": "6b8742ce-f294-4674-aacb-34fbf75249de",
-    "status": "active",
-    "steps": [
-        {
-            "uuid": "9d91b42a-f3e4-461a-b9e1-e53a4fc927ed",
-            "min_requirement": 2,
-            "courses": [
-                {
-                    "key": "AA+AA101",
-                    "course_runs": [
-                        {
-                            "key": "course-v1:AA+AA101+1T2022"
-                        }
-                    ]
-                }
-            ],
-            "programs": [
-                {
-                    "uuid": "1f301a72-f344-4a31-9e9a-e0b04d8d86b2"
-                }
-            ]
-        }
-    ]
-}
-
 
 @mark.django_db
 @ddt.ddt
@@ -136,7 +110,10 @@ class TestLearnerPathwayViewSet(TestCase):
         """
         Verify that learner pathway api response matches the expected data.
         """
-        data = api_response.json()
+        if not isinstance(api_response, dict):
+            data = api_response.json()
+        else:
+            data = api_response
 
         # verify pathway data
         assert data['uuid'] == expected_data['uuid']
@@ -212,7 +189,7 @@ class TestLearnerPathwayViewSet(TestCase):
         data = api_response.json()
         # remove id/pk of the object, we don't need to compare it
         data.pop('id')
-        assert data == LEARNER_PATHWAY_SNAPSHOT_DATA
+        self._verify_learner_pathway_data(data, LEARNER_PATHWAY_DATA)
 
     @ddt.data(
         {

--- a/course_discovery/apps/learner_pathway/api/v1/views.py
+++ b/course_discovery/apps/learner_pathway/api/v1/views.py
@@ -34,7 +34,7 @@ class LearnerPathwayViewSet(ReadOnlyModelViewSet):
     @action(detail=True)
     def snapshot(self, request, uuid):
         pathway = get_object_or_404(self.queryset, uuid=uuid, status=PathwayStatus.Active)
-        serializer = serializers.LearnerPathwayMinimalSerializer(pathway, many=False)
+        serializer = serializers.LearnerPathwaySerializer(pathway, many=False)
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=False)


### PR DESCRIPTION
Changed snapshot API serializer for `learner-pathway` endpoint. This would make data consistent in the LearnerPathway model in the `learner-pathway-progress` plugin of LMS. 

Jira: [ENT-6280](https://2u-internal.atlassian.net/browse/ENT-6280)