### PR TITLE
feat: add course title and short_description field text for skill tagging

### DIFF
--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -40,7 +40,7 @@ from course_discovery.apps.publisher.utils import is_publisher_user
 
 logger = logging.getLogger(__name__)
 
-COURSE_FIELDS_FOR_SKILLS = ['full_description']
+COURSE_FIELDS_FOR_SKILLS = ['title', 'short_description', 'full_description']
 
 
 def writable_request_wrapper(method):

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -781,7 +781,7 @@ stevedore==4.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.22.5
+taxonomy-connector==1.23.0
     # via -r requirements/base.in
 testfixtures==7.0.0
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -547,7 +547,7 @@ stevedore==4.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.22.5
+taxonomy-connector==1.23.0
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
**JIRA:** https://2u-internal.atlassian.net/browse/ENT-6293

**Description:** We currently only use full_description field of a course for skill tagging but we believe that including course `title` and `short_description` fields can generate and improve course skill tagging and cover more use cases.