### PR TITLE
feat: add management command to populate course_length

### DIFF
--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -20,3 +20,96 @@ class PathwayType(Enum):
     """ Allowed values for Pathway.pathway_type """
     CREDIT = 'credit'
     INDUSTRY = 'industry'
+
+
+SNOWFLAKE_POPULATE_COURSE_LENGTH_QUERY = '''
+    WITH completions as (
+
+    /* Get all completions, all time.
+    */
+
+    SELECT
+        ccu.user_id,
+        dc.course_uuid,
+        ccu.courserun_key,
+        DATE(ccu.passed_timestamp) as passed_date
+    FROM
+        business_intelligence.bi_course_completion as ccu
+    LEFT JOIN
+        core.dim_courseruns as dcr
+    on
+        ccu.courserun_key = dcr.courserun_key
+    LEFT JOIN
+        core.dim_courses as dc
+    ON
+        dcr.course_id = dc.course_id
+    LEFT JOIN
+        enterprise.ent_base_enterprise_enrollment as bee
+    ON
+        ccu.user_id = bee.lms_user_id AND ccu.courserun_key = bee.lms_courserun_key
+    WHERE
+        passed_timestamp IS NOT NULL
+
+    ),
+
+    time_to_pass as (
+
+    /* Calculate the amount of time it took
+       to pass the course for each completion.
+    */
+
+
+    SELECT
+        completions.course_uuid,
+        lt.user_id,
+        SUM(lt.learning_time_seconds/60/60) as hours_of_learning
+    FROM
+        business_intelligence.learning_time as lt
+    JOIN
+        completions
+    ON
+        lt.user_id = completions.user_id
+      AND
+        lt.courserun_key = completions.courserun_key
+      AND
+        lt.date <= completions.passed_date
+    JOIN
+        discovery.course_metadata_courserun as disc
+    ON
+        lt.courserun_key = disc.key
+    LEFT JOIN
+        core.dim_courseruns as dim
+    ON
+        disc.key = dim.courserun_key
+    WHERE
+        disc.draft = False
+    GROUP BY
+        1,2
+    ),
+
+    courses as (
+
+    /* Calculate the average amount
+       of time it takes to pass a course.
+        */
+
+    SELECT
+        course_uuid,
+        round(AVG(hours_of_learning),1) as avg_pass_time,
+        COUNT(*) as n_passed_learners
+    FROM
+        time_to_pass
+    GROUP BY
+        1
+    )
+
+    select
+        course_uuid,
+        avg_pass_time,
+        case when avg_pass_time <= 6.5 then 'short'
+        when avg_pass_time < 13 then 'medium'
+        when avg_pass_time >= 13 then 'long'
+        end as course_length_bin
+    from
+        courses
+'''

--- a/course_discovery/apps/course_metadata/management/commands/populate_course_length.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_course_length.py
@@ -1,0 +1,84 @@
+"""
+Django management command to populate course_length in Course model by fetching data from snowflake.
+"""
+import logging
+
+import snowflake.connector
+from django.conf import settings
+from django.core.management import BaseCommand
+
+from course_discovery.apps.course_metadata.constants import SNOWFLAKE_POPULATE_COURSE_LENGTH_QUERY
+from course_discovery.apps.course_metadata.models import Course
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Django management command to populate course length field in Course model by fetching data from snowflake.
+
+    Example usage:
+    ./manage.py populate_course_length
+    ./manage.py populate_course_length --no-commit
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--no-commit',
+            action='store_true',
+            dest='no_commit',
+            default=False,
+            help='Dry Run, print log messages without committing anything.',
+        )
+
+    def get_query_results_from_snowflake(self):
+        """
+        Get query results from Snowflake and yield each row.
+        """
+        ctx = snowflake.connector.connect(
+            user=settings.SNOWFLAKE_SERVICE_USER,
+            password=settings.SNOWFLAKE_SERVICE_USER_PASSWORD,
+            account='edx.us-east-1',
+            database='prod'
+        )
+        cs = ctx.cursor()
+        try:
+            cs.execute(SNOWFLAKE_POPULATE_COURSE_LENGTH_QUERY)
+            rows = cs.fetchall()
+            for row in rows:
+                yield row
+        finally:
+            cs.close()
+        ctx.close()
+
+    def handle(self, *args, **options):
+        should_commit = not options['no_commit']
+
+        update_failure_uuids = []
+        courses_updated = 0
+        LOGGER.info(f'[Populate Course Length]  Process started with option no_commit={should_commit}.')
+        for next_row in self.get_query_results_from_snowflake():
+            course_uuid = next_row[0]
+            course_length = next_row[2]
+            LOGGER.info(
+                f'[Populate Course Length] adding \'{course_length}\' as length to course with UUID {course_uuid}'
+            )
+
+            courses = Course.everything.filter(uuid=course_uuid)
+            if courses:
+                if should_commit:
+                    courses.update(course_length=course_length)
+                # if the course have draft and non draft version, updated count will still be incremented by 1 after
+                # updating both versions because they both are the version of same course.
+                courses_updated += 1
+            else:
+                update_failure_uuids.append(course_uuid)
+                LOGGER.info(f'[Populate Course Length] No course found with UUID {course_uuid}')
+
+        LOGGER.info(
+            f'''[Populate Course Length] Execution completed.
+            Courses Updated: {courses_updated}
+            Courses Update Failed: {len(update_failure_uuids)}
+            {f'UUIDs of courses with failures: {update_failure_uuids}' if update_failure_uuids else ''}
+            '''
+        )

--- a/course_discovery/apps/course_metadata/tests/management/test_populate_course_length.py
+++ b/course_discovery/apps/course_metadata/tests/management/test_populate_course_length.py
@@ -1,0 +1,119 @@
+"""
+Tests for the django management command `populate_course_length`.
+"""
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+from pytest import mark
+from testfixtures import LogCapture
+
+from course_discovery.apps.course_metadata.models import Course
+from course_discovery.apps.course_metadata.tests.factories import CourseFactory
+
+LOGGER_NAME = 'course_discovery.apps.course_metadata.management.commands.populate_course_length'
+
+
+@mark.django_db
+class PopulateCourseLengthCommandTests(TestCase):
+    """
+    Test command `populate_course_length`.
+    """
+
+    command = 'populate_course_length'
+
+    def setUp(self):
+        super().setUp()
+        self.course_a = CourseFactory()
+        self.course_b = CourseFactory()
+
+    @mock.patch(
+        'course_discovery.apps.course_metadata.management.'
+        'commands.populate_course_length.Command.get_query_results_from_snowflake'
+    )
+    def test_populate_course_length(
+            self,
+            mock_get_query_results,
+    ):
+        """
+        Test that populate_course_length works correctly and saves correct data.
+        """
+        mock_get_query_results.return_value = [[self.course_a.uuid, 5, 'short'], [self.course_b.uuid, 12, 'medium']]
+        with LogCapture(LOGGER_NAME) as log:
+            call_command(self.command)
+            log.check_present(
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    '[Populate Course Length]  Process started with option no_commit=True.'
+                ),
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    f'''[Populate Course Length] adding 'short' as length to course with UUID {self.course_a.uuid}'''
+                ),
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    f'''[Populate Course Length] adding 'medium' as length to course with UUID {self.course_b.uuid}'''
+                ),
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    '[Populate Course Length] Execution completed.\n'
+                    '            Courses Updated: 2\n'
+                    '            Courses Update Failed: 0\n'
+                    '            \n'
+                    '            ',
+                )
+            )
+
+            assert Course.objects.get(uuid=self.course_a.uuid).course_length == 'short'
+            assert Course.objects.get(uuid=self.course_b.uuid).course_length == 'medium'
+
+    @mock.patch(
+        'course_discovery.apps.course_metadata.management.'
+        'commands.populate_course_length.Command.get_query_results_from_snowflake'
+    )
+    def test_populate_course_length_logs_errors_for_failures(
+            self,
+            mock_get_query_results,
+    ):
+        """
+        Test that populate_course_length logs correct errors and stats for failures.
+        """
+        dummy_uuid = '00000000-0000-0000-0000-000000000000'
+        mock_get_query_results.return_value = [[self.course_a.uuid, 5, 'short'], [dummy_uuid, 12, 'medium']]
+        with LogCapture(LOGGER_NAME) as log:
+            call_command(self.command, '--no-commit')
+            log.check_present(
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    '[Populate Course Length]  Process started with option no_commit=False.'
+                ),
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    f'''[Populate Course Length] adding 'short' as length to course with UUID {self.course_a.uuid}'''
+                ),
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    f'''[Populate Course Length] adding 'medium' as length to course with UUID {dummy_uuid}'''
+                ),
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    f'''[Populate Course Length] No course found with UUID {dummy_uuid}'''
+                ),
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    '[Populate Course Length] Execution completed.\n'
+                    '            Courses Updated: 1\n'
+                    '            Courses Update Failed: 1\n'
+                    f'            UUIDs of courses with failures: [\'{dummy_uuid}\']\n'
+                    '            ',
+                )
+            )

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -69,3 +69,4 @@ python-slugify
 xss-utils
 taxonomy-connector
 importlib-metadata
+snowflake-connector-python

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -35,3 +35,6 @@ semgrep==0.102.0
 
 # Version 8.3.0 introduced changes that caused users to see User Disabled error
 edx-drf-extensions < 8.3.0
+
+# pinning because of 'cryptography' dependency conflict while installing snowflake-connector-python
+pyopenssl==22.0.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -19,6 +19,10 @@ amqp==5.1.1
     # via kombu
 asgiref==3.5.2
     # via django
+asn1crypto==1.5.1
+    # via
+    #   oscrypto
+    #   snowflake-connector-python
 astroid==2.12.11
     # via
     #   pylint
@@ -85,13 +89,17 @@ certifi==2022.9.24
     #   elasticsearch
     #   requests
     #   selenium
+    #   snowflake-connector-python
 cffi==1.15.1
     # via
     #   cairocffi
     #   cryptography
     #   pynacl
+    #   snowflake-connector-python
 charset-normalizer==2.1.1
-    # via requests
+    # via
+    #   requests
+    #   snowflake-connector-python
 click==8.1.3
     # via
     #   celery
@@ -130,11 +138,13 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==38.0.1
+cryptography==36.0.2
     # via
     #   authlib
     #   paramiko
     #   pyjwt
+    #   pyopenssl
+    #   snowflake-connector-python
     #   social-auth-core
 cssselect2==0.7.0
     # via cairosvg
@@ -407,6 +417,7 @@ fastavro==1.6.1
     # via openedx-events
 filelock==3.8.0
     # via
+    #   snowflake-connector-python
     #   tox
     #   virtualenv
 freezegun==1.2.2
@@ -430,6 +441,7 @@ html2text==2020.1.16
 idna==3.4
     # via
     #   requests
+    #   snowflake-connector-python
     #   trio
 imagesize==1.4.1
     # via sphinx
@@ -493,6 +505,8 @@ oauthlib==3.2.1
     #   social-auth-core
 openedx-events==1.0.0
     # via edx-event-bus-kafka
+oscrypto==1.3.0
+    # via snowflake-connector-python
 outcome==1.2.0
     # via trio
 packaging==21.3
@@ -550,7 +564,9 @@ pycountry==22.3.5
 pycparser==2.21
     # via cffi
 pycryptodomex==3.15.0
-    # via pyjwkest
+    # via
+    #   pyjwkest
+    #   snowflake-connector-python
 pygments==2.13.0
     # via sphinx
 pyjwkest==1.4.2
@@ -561,6 +577,7 @@ pyjwt[crypto]==2.5.0
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   snowflake-connector-python
     #   social-auth-core
 pylint==2.15.4
     # via
@@ -582,6 +599,10 @@ pynacl==1.5.0
     # via
     #   edx-django-utils
     #   paramiko
+pyopenssl==22.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   snowflake-connector-python
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.18.1
@@ -642,6 +663,7 @@ pytz==2022.4
     #   django-ses
     #   djangorestframework
     #   drf-yasg
+    #   snowflake-connector-python
     #   taxonomy-connector
     #   zeep
 pywatchman==1.4.1
@@ -674,6 +696,7 @@ requests==2.28.1
     #   semgrep
     #   simple-salesforce
     #   slumber
+    #   snowflake-connector-python
     #   social-auth-core
     #   sphinx
     #   zeep
@@ -745,6 +768,8 @@ sniffio==1.3.0
     # via trio
 snowballstemmer==2.2.0
     # via sphinx
+snowflake-connector-python==2.8.0
+    # via -r requirements/base.in
 social-auth-app-django==5.0.0
     # via
     #   -r requirements/base.in
@@ -824,6 +849,7 @@ typing-extensions==4.4.0
     #   django-countries
     #   pylint
     #   semgrep
+    #   snowflake-connector-python
 ujson==5.5.0
     # via python-lsp-jsonrpc
 unicodecsv==0.14.1
@@ -841,6 +867,7 @@ urllib3[socks]==1.26.12
     #   responses
     #   selenium
     #   semgrep
+    #   snowflake-connector-python
 vine==5.0.0
     # via
     #   amqp

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -17,6 +17,10 @@ amqp==5.1.1
     # via kombu
 asgiref==3.5.2
     # via django
+asn1crypto==1.5.1
+    # via
+    #   oscrypto
+    #   snowflake-connector-python
 async-timeout==4.0.2
     # via redis
 attrs==22.1.0
@@ -58,13 +62,17 @@ certifi==2022.9.24
     #   -r requirements/production.in
     #   elasticsearch
     #   requests
+    #   snowflake-connector-python
 cffi==1.15.1
     # via
     #   cairocffi
     #   cryptography
     #   pynacl
+    #   snowflake-connector-python
 charset-normalizer==2.1.1
-    # via requests
+    # via
+    #   requests
+    #   snowflake-connector-python
 click==8.1.3
     # via
     #   celery
@@ -87,10 +95,12 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==38.0.1
+cryptography==36.0.2
     # via
     #   authlib
     #   pyjwt
+    #   pyopenssl
+    #   snowflake-connector-python
     #   social-auth-core
 cssselect2==0.7.0
     # via cairosvg
@@ -323,6 +333,8 @@ elasticsearch-dsl==7.4.0
     #   django-elasticsearch-dsl-drf
 fastavro==1.6.1
     # via openedx-events
+filelock==3.8.0
+    # via snowflake-connector-python
 future==0.18.2
     # via pyjwkest
 gevent==22.10.1
@@ -342,7 +354,9 @@ gunicorn==20.1.0
 html2text==2020.1.16
     # via -r requirements/base.in
 idna==3.4
-    # via requests
+    # via
+    #   requests
+    #   snowflake-connector-python
 importlib-metadata==5.0.0
     # via
     #   -r requirements/base.in
@@ -387,6 +401,8 @@ oauthlib==3.2.1
     #   social-auth-core
 openedx-events==1.0.0
     # via edx-event-bus-kafka
+oscrypto==1.3.0
+    # via snowflake-connector-python
 packaging==21.3
     # via
     #   drf-yasg
@@ -415,7 +431,9 @@ pycountry==22.3.5
 pycparser==2.21
     # via cffi
 pycryptodomex==3.15.0
-    # via pyjwkest
+    # via
+    #   pyjwkest
+    #   snowflake-connector-python
 pyjwkest==1.4.2
     # via edx-drf-extensions
 pyjwt[crypto]==2.5.0
@@ -424,11 +442,16 @@ pyjwt[crypto]==2.5.0
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   snowflake-connector-python
     #   social-auth-core
 pymongo==3.12.3
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
+pyopenssl==22.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   snowflake-connector-python
 pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2
@@ -457,6 +480,7 @@ pytz==2022.4
     #   django-ses
     #   djangorestframework
     #   drf-yasg
+    #   snowflake-connector-python
     #   taxonomy-connector
     #   zeep
 pyyaml==6.0
@@ -482,6 +506,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   simple-salesforce
     #   slumber
+    #   snowflake-connector-python
     #   social-auth-core
     #   zeep
 requests-file==1.5.1
@@ -529,6 +554,8 @@ six==1.16.0
     #   requests-file
 slumber==0.7.1
     # via edx-rest-api-client
+snowflake-connector-python==2.8.0
+    # via -r requirements/base.in
 social-auth-app-django==5.0.0
     # via
     #   -r requirements/base.in
@@ -557,7 +584,9 @@ tinycss2==1.1.1
 types-cryptography==3.3.23.1
     # via pyjwt
 typing-extensions==4.4.0
-    # via django-countries
+    # via
+    #   django-countries
+    #   snowflake-connector-python
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1
@@ -569,6 +598,7 @@ urllib3==1.26.12
     #   botocore
     #   elasticsearch
     #   requests
+    #   snowflake-connector-python
 vine==5.0.0
     # via
     #   amqp


### PR DESCRIPTION
Implements a management command to fetch data from snowflake and populate field being added in https://github.com/openedx/course-discovery/pull/3631

Ticket: [ENT-6267](https://2u-internal.atlassian.net/browse/ENT-6267)

Sample snowflake response for query in management command
<img width="825" alt="image" src="https://user-images.githubusercontent.com/49611774/195285052-0e2012b2-7aad-48c5-91a2-e2a1370a664e.png">
