### PR TITLE
feat: ingestion email and CSV loader updates

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -69,7 +69,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         try:
             if args_from_env:
                 # TODO: add unit tests
-                product_type_config = settings.PRODUCT_EXTERNAL_SHEET_MAPPING[product_type]
+                product_type_config = settings.PRODUCT_METADATA_MAPPING[product_type]
                 gspread_client = GspreadClient()
                 self.reader = gspread_client.read_data(product_type_config)
             else:

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -230,6 +230,16 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                     self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)
                     self._assert_course_run_data(course_run, self.BASE_EXPECTED_COURSE_RUN_DATA)
 
+                    assert loader.get_ingestion_stats() == {
+                        'total_products_count': 1,
+                        'success_count': 1,
+                        'failure_count': 0,
+                        'updated_products_count': 0,
+                        'created_products_count': 1,
+                        'created_products': [str(course.uuid)],
+                        'errors': loader.error_logs
+                    }
+
     @responses.activate
     def test_ingest_flow_for_preexisting_published_course(self, jwt_decode_patch):  # pylint: disable=unused-argument
         """
@@ -293,6 +303,16 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
 
                     self._assert_course_data(course, expected_course_data)
                     self._assert_course_run_data(course_run, expected_course_run_data)
+
+                    assert loader.get_ingestion_stats() == {
+                        'total_products_count': 1,
+                        'success_count': 1,
+                        'failure_count': 0,
+                        'updated_products_count': 1,
+                        'created_products_count': 0,
+                        'created_products': [],
+                        'errors': loader.error_logs
+                    }
 
     @responses.activate
     def test_invalid_language(self, jwt_decode_patch):  # pylint: disable=unused-argument

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
@@ -1,0 +1,73 @@
+{% extends "course_metadata/email/email_base.html" %}
+{% load django_markup %}
+{% block body %}
+
+<p>
+    The data ingestion has been run for product type <strong>{{ product_type }}</strong>. See below for the ingestion stats.
+</p>
+<div>
+    <table border="2" width="50%" style="padding: 5px;">
+        <tr>
+            <th colspan="2">
+                Ingestion Statistics
+            </th>
+        </tr>
+        <tr>
+            <th>Ingestion Time</th>
+            <td>{{ ingestion_run_time | date:"m/d/Y P" }}</td>
+        </tr>
+        <tr>
+            <th>Total data rows</th>
+            <td>{{ total_products_count }}</td>
+        </tr>
+        <tr>
+            <th>Successful Ingestion</th>
+            <td>{{ success_count }}</td>
+        </tr>
+        <tr>
+            <th>Ingestion with Errors </th>
+            <td>{{ failure_count }}</td>
+        </tr>
+        <tr>
+            <th>New Products</th>
+            <td>{{ created_products_count }}</td>
+        </tr>
+        <tr>
+            <th>Updated Products</th>
+            <td>{{ updated_products_count }}</td>
+        </tr>
+    </table>
+</div>
+
+{% if created_products_count > 0 %}
+<div>
+    <h3>New Products</h3>
+        <ul>
+            {% for new_product in created_products %}
+                {% if product_type != "DEGREES" %}
+                    <li><a href="{{publisher_url}}courses/{{new_product}}">{{ new_product }}</a></li>
+                {% else %}
+                    <li>{{ new_product }}</li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+</div>
+{% endif %}
+
+{% if failure_count > 0 %}
+<div>
+    <h3>Ingestion Failures</h3>
+        <ul>
+            {% for error_type, error_list in errors.items %}
+                {% for error_message in error_list %}
+                    <li> {{ error_message }} </li>
+                {% endfor %}
+            {% endfor %}
+        </ul>
+</div>
+{% endif %}
+
+<p>
+    Note: This email address is unable to receive replies. For questions or comments, please contact the relevant team.
+</p>
+{% endblock body %}

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.txt
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.txt
@@ -1,0 +1,23 @@
+The data ingestion has been run for product type <strong>{{ product_type }}</strong>. See below for the ingestion stats.
+
+Ingestion Statistics
+
+Ingestion Time: {{ ingestion_run_time | date:"m/d/Y P" }}
+Total data rows:  {{ total_products_count }}
+Successful Ingestion:{{ success_count }}
+Ingestion with Errors: {{ failure_count }}
+New Products: {{ created_products_count }}
+Updated Products: {{ updated_products_count }}
+{% if created_products_count > 0 %}
+New Products
+{% for new_product in created_products %}
+{{ new_product }}
+{% endfor %}
+{% endif %}
+{% if failure_count > 0 %}
+Ingestion Failures
+{% for error_type, error_list in errors.items %}{% for error_message in error_list %}
+{{ error_message }}
+{% endfor %}{% endfor %}
+{% endif %}
+Note: This email address is unable to receive replies. For questions or comments, please contact the relevant team.

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -653,20 +653,24 @@ GOOGLE_SERVICE_ACCOUNT_CREDENTIALS = {
   'CLIENT_X509_CERT_URL': ''
 }
 
-PRODUCT_EXTERNAL_SHEET_MAPPING = {
+PRODUCT_METADATA_MAPPING = {
     'EXECUTIVE_EDUCATION': {
         'SHEET_ID': '',
         'INPUT_TAB_ID': '',
-        'ERROR_TAB_ID': ''
+        'ERROR_TAB_ID': '',
+        'EMAIL_NOTIFICATION_LIST': []
     },
     'BOOTCAMPS': {
         'SHEET_ID': '',
         'INPUT_TAB_ID': '',
-        'ERROR_TAB_ID': ''
+        'ERROR_TAB_ID': '',
+        'EMAIL_NOTIFICATION_LIST': []
     },
     'DEGREES': {
         'SHEET_ID': '',
         'INPUT_TAB_ID': '',
-        'ERROR_TAB_ID': ''
+        'ERROR_TAB_ID': '',
+        'EMAIL_NOTIFICATION_LIST': []
     },
 }
+


### PR DESCRIPTION
### [PROD-2974](https://2u-internal.atlassian.net/browse/PROD-2974)

### Description

- Add email for sending ingestion summary (CSV loader in this PR, Degree loader will be added in a followup PR)
- Add email flow in import_course_metadata command

Related PR https://github.com/edx/edx-internal/pull/7227

**The email flow could not be tested locally due to botocore credentials. However, the output HTML of the email has been verified. See screenshots below**

<img width="1098" alt="image (1)" src="https://user-images.githubusercontent.com/40599381/195095035-59d87279-58c3-42ae-a146-f32ffe0c3b48.png">
<img width="930" alt="image (2)" src="https://user-images.githubusercontent.com/40599381/195095048-62c32a70-8baf-4f34-931d-a1e8260bf6e4.png">
