### PR TITLE
feat: add ingestion summary email for degree loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -62,6 +62,13 @@ class DegreeCSVDataLoader(AbstractDataLoader):
 
         self.error_logs = {}
         self.degree_uuids = {}  # to show the discovery degrees/program ids for each processed degree
+        self.ingestion_summary = {
+            'total_products_count': 0,
+            'success_count': 0,
+            'failure_count': 0,
+            'updated_products_count': 0,
+            'created_products': [],
+        }
 
         for error_log_key in DEGREE_LOADER_ERROR_LOG_SEQUENCE:
             self.error_logs.setdefault(error_log_key, [])
@@ -83,6 +90,9 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         except Exception:
             logger.exception("Error reading the input data source")
             raise  # re-raising exception to avoid moving the code flow
+        else:
+            self.reader = list(self.reader)
+            self.ingestion_summary['total_products_count'] = len(self.reader)
 
     def ingest(self):
         logger.info("Initiating Degree CSV data loader flow.")
@@ -99,7 +109,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
                     missing_data=missing_data
                 )
                 logger.error(error_message)
-                self.error_logs[DegreeCSVIngestionErrors.MISSING_REQUIRED_DATA].append(error_message)
+                self._register_ingestion_error(DegreeCSVIngestionErrors.MISSING_REQUIRED_DATA, error_message)
                 continue
 
             logger.info('Starting data import flow for {}'.format(degree_slug))    # lint-amnesty, pylint: disable=logging-format-interpolation
@@ -135,7 +145,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             ))
 
             try:
-                degree = self._update_or_create_degree(
+                degree, is_degree_created = self._update_or_create_degree(
                     row, program_type, primary_subject_override,
                     level_type_override, language_override
                 )
@@ -151,7 +161,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
                     exception_message=exc
                 )
                 logger.exception(error_message)
-                self.error_logs[error_type].append(error_message)
+                self._register_ingestion_error(error_type, error_message)
                 continue
 
             self._handle_organization_data(org, degree)
@@ -162,6 +172,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
 
             logger.info("Degree updated successfully for degree key {}".format(degree.uuid))    # lint-amnesty, pylint: disable=logging-format-interpolation
             self.degree_uuids[str(degree.uuid)] = degree.marketing_slug
+            self._register_successful_ingestion(str(degree.uuid), is_degree_created)
 
         logger.info("Degree CSV loader ingest pipeline has completed.")
 
@@ -198,6 +209,30 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             logger.info("Degree UUIDs:")
             for degree_uuid, marketing_slug in self.degree_uuids.items():
                 logger.info("{}:{}".format(degree_uuid, marketing_slug))  # lint-amnesty, pylint: disable=logging-format-interpolation
+
+    def _register_ingestion_error(self, error_key, error_message):
+        """
+        Helper method to register error log and increase count of ingestion errors.
+        """
+        self.ingestion_summary['failure_count'] += 1
+        self.error_logs[error_key].append(error_message)
+
+    def get_ingestion_stats(self):
+        return {
+            **self.ingestion_summary,
+            'created_products_count': len(self.ingestion_summary['created_products']),
+            'errors': self.error_logs
+        }
+
+    def _register_successful_ingestion(self, program_uuid, created):
+        """
+        Register the summary of a successful ingestion.
+        """
+        self.ingestion_summary['success_count'] += 1
+        if created:
+            self.ingestion_summary['created_products'].append(program_uuid)
+        else:
+            self.ingestion_summary['updated_products_count'] += 1
 
     def transform_dict_keys(self, data):
         """
@@ -244,7 +279,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             "created" if created else "updated",
         ))
 
-        return degree
+        return degree, created
 
     def _handle_organization_data(self, org, degree):
         """
@@ -272,7 +307,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
                 degree_slug=degree.marketing_slug
             )
             logger.error(error_message)
-            self.error_logs[DegreeCSVIngestionErrors.IMAGE_DOWNLOAD_FAILURE].append(error_message)
+            self._register_ingestion_error(DegreeCSVIngestionErrors.IMAGE_DOWNLOAD_FAILURE, error_message)
 
         if data.get('organization_logo_override'):
             is_downloaded = download_and_save_program_image(
@@ -289,7 +324,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
                     degree_slug=degree.marketing_slug
                 )
                 logger.error(error_message)
-                self.error_logs[DegreeCSVIngestionErrors.LOGO_IMAGE_DOWNLOAD_FAILURE].append(error_message)
+                self._register_ingestion_error(DegreeCSVIngestionErrors.LOGO_IMAGE_DOWNLOAD_FAILURE, error_message)
 
     def _handle_courses(self, data, degree):
         """
@@ -351,7 +386,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             error_type = error_dict['error_type']
 
             logger.exception(error_message)
-            self.error_logs[error_type].append(error_message)
+            self._register_ingestion_error(error_type, error_message)
             return None
 
     def _handle_additional_metadata(self, data, degree):

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_degree_csv_loader.py
@@ -160,6 +160,15 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 assert degree.specializations.count() == 2
                 assert curriculam.marketing_text == self.marketing_text
                 self._assert_degree_data(degree, self.BASE_EXPECTED_DEGREE_DATA)
+                assert loader.get_ingestion_stats() == {
+                    'total_products_count': 1,
+                    'success_count': 1,
+                    'failure_count': 0,
+                    'updated_products_count': 0,
+                    'created_products_count': 1,
+                    'created_products': [str(degree.uuid)],
+                    'errors': loader.error_logs
+                }
 
     def test_ingest_flow_for_preexisting_degree(self, jwt_decode_patch):  # pylint: disable=unused-argument
         """
@@ -202,6 +211,15 @@ class TestDegreeCSVDataLoader(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 assert curriculam.marketing_text == self.marketing_text
                 assert degree.card_image.read() == image_content
                 self._assert_degree_data(degree, self.BASE_EXPECTED_DEGREE_DATA)
+                assert loader.get_ingestion_stats() == {
+                    'total_products_count': 1,
+                    'success_count': 1,
+                    'failure_count': 0,
+                    'updated_products_count': 1,
+                    'created_products_count': 0,
+                    'created_products': [],
+                    'errors': loader.error_logs
+                }
 
     def test_ingest_flow_for_minimal_degree_data(self, jwt_decode_patch):  # pylint: disable=unused-argument
         """

--- a/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
@@ -95,6 +95,7 @@ class Command(BaseCommand):
             connect_api_change_receiver()
 
         if product_type:
+            logger.info(f"Sending Ingestion stats email for product type {product_type}")
             email_subject = f"{product_type.replace('_', ' ').title()} Data Ingestion"
             to_users = settings.PRODUCT_METADATA_MAPPING[product_type]['EMAIL_NOTIFICATION_LIST']
             ingestion_details = {

--- a/course_discovery/apps/course_metadata/management/commands/import_degree_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_degree_data.py
@@ -2,14 +2,17 @@
 Management command to import, create, and/or update degrees' data.
 """
 import logging
+from datetime import datetime
 
 from django.apps import apps
+from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from django.db.models.signals import post_delete, post_save
 
 from course_discovery.apps.api.cache import api_change_receiver, set_api_timestamp
 from course_discovery.apps.core.models import Partner
 from course_discovery.apps.course_metadata.data_loaders.degrees_loader import DegreeCSVDataLoader
+from course_discovery.apps.course_metadata.emails import send_ingestion_email
 from course_discovery.apps.course_metadata.models import DegreeDataLoaderConfiguration
 from course_discovery.apps.course_metadata.signals import connect_api_change_receiver
 
@@ -78,6 +81,7 @@ class Command(BaseCommand):
                 args_from_env=args_from_env, product_type=product_type
             )
             logger.info("Starting CSV loader import flow for partner {}".format(partner_short_code))  # lint-amnesty, pylint: disable=logging-format-interpolation
+            ingestion_time = datetime.now()
             loader.ingest()
         except Exception as exc:
             raise CommandError(  # pylint: disable=raise-missing-from
@@ -89,3 +93,15 @@ class Command(BaseCommand):
         finally:
             # Re-connect back the api_change_receiver receiver to post_save and post_delete signals
             connect_api_change_receiver()
+
+        if product_type:
+            logger.info(f"Sending Ingestion stats email for product type {product_type}")
+            email_subject = f"{product_type.replace('_', ' ').title()} Data Ingestion"
+            to_users = settings.PRODUCT_METADATA_MAPPING[product_type]['EMAIL_NOTIFICATION_LIST']
+            ingestion_details = {
+                'ingestion_run_time': ingestion_time,
+                **loader.get_ingestion_stats()
+            }
+            send_ingestion_email(
+                partner, email_subject, to_users, product_type, ingestion_details,
+            )


### PR DESCRIPTION
### [PROD-2974](https://2u-internal.atlassian.net/browse/PROD-2974)

### Description

- Followup to https://github.com/openedx/course-discovery/pull/3641, adding ingestion summary logic in Degree loader
- Use email method in degree load management command to send Degree ingestion stats