### PR TITLE
fix: geotargeting country code capitalization

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/geotargeting_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/geotargeting_loader.py
@@ -158,7 +158,7 @@ class GeotargetingCSVDataLoader(AbstractDataLoader):
         for key, value in data.items():
             updated_key = key.strip().lower().replace(' ', '_')
             if updated_key == 'countries':
-                transformed_dict[updated_key] = value.strip().lower().replace(";", ",") if value else ''
+                transformed_dict[updated_key] = value.strip().upper().replace(";", ",") if value else ''
             else:
                 transformed_dict[updated_key] = value.strip().lower()
         return transformed_dict


### PR DESCRIPTION
When we initially created the data loader, we were creating the country codes in lowercase. While this doesn't effect performance in prospectus, it does make it so that the location restrictions do not show up in discovery's django admin. The checkbox for the country codes will only show as checked if the country code is capitalized. This PR makes it so that those country codes are entered into the database capitalized.