### PR TITLE
feat: upgrade openedx-events and event-bus-kafka

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -737,7 +737,6 @@ class TestCourseDataUpdateSignal(TestCase):
             course_key=self.course_key,
             name='Test Course',
             schedule_data=self.scheduling_data,
-            effort='a lot',
             hidden=False,
         )
         self.partner = PartnerFactory(id=settings.DEFAULT_PARTNER_ID)

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -370,7 +370,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==1.2.0
+edx-event-bus-kafka==1.3.0
     # via -r requirements/base.in
 edx-i18n-tools==0.9.1
     # via -r requirements/local.in
@@ -503,7 +503,7 @@ oauthlib==3.2.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==1.0.0
+openedx-events==3.0.0
     # via edx-event-bus-kafka
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -304,7 +304,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==1.2.0
+edx-event-bus-kafka==1.3.0
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -399,7 +399,7 @@ oauthlib==3.2.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==1.0.0
+openedx-events==3.0.0
     # via edx-event-bus-kafka
 oscrypto==1.3.0
     # via snowflake-connector-python


### PR DESCRIPTION
This will bring in a change to the COURSE_CATALOG_INFO_CHANGED event data schema. Specifically it removes the "effort" field, which is not being used anywhere.