### PR TITLE
feat: add course_length in CourseDocument for Elasticsearch

### DIFF
--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -53,6 +53,7 @@ class CourseDocument(BaseCourseDocument):
     start = fields.DateField(multi=True)
     course_type = fields.KeywordField(multi=True)
     enterprise_subscription_inclusion = fields.BooleanField()
+    course_length = fields.KeywordField()
 
     def prepare_aggregation_key(self, obj):
         return 'course:{}'.format(obj.key)
@@ -124,6 +125,9 @@ class CourseDocument(BaseCourseDocument):
 
     def prepare_course_type(self, obj):
         return obj.type.slug
+
+    def prepare_course_length(self, obj):
+        return obj.course_length
 
     def prepare_enterprise_subscription_inclusion(self, obj):
         return obj.enterprise_subscription_inclusion


### PR DESCRIPTION
This PR is to add the newly [added field](https://github.com/openedx/course-discovery/commit/ad05ca6456709f2f666d0a2b81d73ab466146b2a) which got populated through [management command,](https://github.com/openedx/course-discovery/commit/f5645cb5e03685ccc0a1f46e705f55672bebb0da) to the search all endpoint. 
The use case is that we want this field in our algolia index for learner portal enterprise, for that it has to be in enterprise catalog through jobs [update_content_metadata, update_full_content_metadata] which uses the search all endpoint to fetch details of courses. So this is being added to the endpoint. 

The work will be completed in two PRs, one will add in the document(this one), when the job to index elastic search runs, a new PR will be created to add the field in serializers for search all endpoint, such to avoid the errors which might happen when field is in serializer but not present in elastic search.

[Ticket](https://2u-internal.atlassian.net/browse/ENT-6372)