### PR TITLE
feat: Added weeks_to_complete in MinimalCourseRunSerializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -868,7 +868,7 @@ class MinimalCourseRunSerializer(FlexFieldsSerializerMixin, TimestampModelSerial
     class Meta:
         model = CourseRun
         fields = ('key', 'uuid', 'title', 'external_key', 'image', 'short_description', 'marketing_url',
-                  'seats', 'start', 'end', 'go_live_date', 'enrollment_start', 'enrollment_end',
+                  'seats', 'start', 'end', 'go_live_date', 'enrollment_start', 'enrollment_end', 'weeks_to_complete',
                   'pacing_type', 'type', 'run_type', 'status', 'is_enrollable', 'is_marketable', 'term', 'availability')
 
     def get_marketing_url(self, obj):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -621,6 +621,7 @@ class MinimalCourseRunBaseTestSerializer(TestCase):
             'go_live_date': json_date_format(course_run.go_live_date),
             'enrollment_start': json_date_format(course_run.enrollment_start),
             'enrollment_end': json_date_format(course_run.enrollment_end),
+            'weeks_to_complete': course_run.weeks_to_complete,
             'pacing_type': course_run.pacing_type,
             'type': course_run.type_legacy,
             'run_type': course_run.type.uuid,


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/ENT-6407
Description:
We need the `weeks_to_complete` data for every course run in the program's API. I've added it to `MinimalCourseRunSerializer`
http://localhost:18381/api/v1/programs/{program_uuid}/