### PR TITLE
chore: update ExecEd data transformation command to use detail=2 and map meta Fields

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -237,6 +237,7 @@ class CSVLoaderMixin:
         'upgrade_deadline_override_date', 'upgrade_deadline_override_time', 'redirect_url', 'external_identifier',
         'lead_capture_form_url', 'organic_url', 'certificate_header', 'certificate_text', 'stat1', 'stat1_text',
         'stat2', 'stat2_text', 'organization_logo_override', 'organization_short_code_override', 'variant_id',
+        'meta_title', 'meta_description', 'meta_keywords',
     ]
     # The list of minimal data headers
     MINIMAL_CSV_DATA_KEYS_ORDER = [
@@ -278,6 +279,9 @@ class CSVLoaderMixin:
         'start_date': '2020-01-25T00:00:00+00:00',
         'registration_deadline': '2020-01-25T00:00:00+00:00',
         'variant_id': "00000000-0000-0000-0000-000000000000",
+        "meta_title": "SEO Title",
+        "meta_description": "SEO Description",
+        "meta_keywords": "Keyword 1, Keyword 2",
     }
 
     BASE_EXPECTED_COURSE_RUN_DATA = {

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3159,6 +3159,9 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     'organization_short_code_override': 'Org Override',
     'organization_logo_override': 'https://example.com/image.jpg',
     'variant_id': "00000000-0000-0000-0000-000000000000",
+    "meta_title": "SEO Title",
+    "meta_description": "SEO Description",
+    "meta_keywords": "Keyword 1, Keyword 2",
 }
 
 VALID_MINIMAL_COURSE_AND_COURSE_RUN_CSV_DICT = {

--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -38,6 +38,7 @@ class Command(BaseCommand):
         'upgrade_deadline_override_date', 'upgrade_deadline_override_time', 'redirect_url', 'external_identifier',
         'lead_capture_form_url', 'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2',
         'stat2_text', 'organic_url', 'organization_short_code_override', 'organization_logo_override', 'variant_id',
+        'meta_title', 'meta_description', 'meta_keywords',
     ]
 
     # Mapping English and Spanish languages to IETF equivalent variants
@@ -178,7 +179,7 @@ class Command(BaseCommand):
                           '(KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36'
         }
         params = {
-            "detail": 1
+            "detail": 2
         }
 
         try:
@@ -302,6 +303,9 @@ class Command(BaseCommand):
             'stat2': stats['stat2'],
             'stat2_text': stats['stat2Blurb'],
             'organic_url': utils.format_base64_strings(product_dict.get('edxRedirectUrl', '')),
+            'meta_title': product_dict.get('metaTitle', ''),
+            'meta_description': product_dict.get('metaDescription', ''),
+            'meta_keywords': product_dict.get('metaKeywords', ''),
 
             'title': partially_filled_csv_dict.get('title') or product_dict['altName'] or product_dict['name'],
             '2u_title': product_dict['name'],

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -49,6 +49,9 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 "videoURL": "",
                 "lcfURL": "d3d3LmV4YW1wbGUuY29tL2xlYWQtY2FwdHVyZT9pZD0xMjM=",
                 "logoUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS9pbWFnZS5qcGc=g",
+                "metaTitle": "SEO Title",
+                "metaDescription": "SEO Description",
+                "metaKeywords": "Keyword 1, Keyword 2",
                 "variant": {
                     "id": "00000000-0000-0000-0000-000000000000",
                     "endDate": "2022-05-06",
@@ -105,7 +108,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
         """
         responses.add(
             responses.GET,
-            settings.PRODUCT_API_URL + '/?detail=1',
+            settings.PRODUCT_API_URL + '/?detail=2',
             body=json.dumps(self.SUCCESS_API_RESPONSE),
             status=200,
         )
@@ -274,7 +277,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
         """
         responses.add(
             responses.GET,
-            settings.PRODUCT_API_URL + '/?detail=1',
+            settings.PRODUCT_API_URL + '/?detail=2',
             status=400,
         )
         with self.assertRaisesMessage(
@@ -336,3 +339,6 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                                                    'Ipsum (Gibberish)</p></div>'
         assert str(date.today().year) in data_row['Publish Date']
         assert data_row['Variant Id'] == '00000000-0000-0000-0000-000000000000'
+        assert data_row['Meta Title'] == 'SEO Title'
+        assert data_row['Meta Description'] == 'SEO Description'
+        assert data_row['Meta Keywords'] =='Keyword 1, Keyword 2'

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -341,4 +341,4 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
         assert data_row['Variant Id'] == '00000000-0000-0000-0000-000000000000'
         assert data_row['Meta Title'] == 'SEO Title'
         assert data_row['Meta Description'] == 'SEO Description'
-        assert data_row['Meta Keywords'] =='Keyword 1, Keyword 2'
+        assert data_row['Meta Keywords'] == 'Keyword 1, Keyword 2'


### PR DESCRIPTION
### [PROD-3006](https://2u-internal.atlassian.net/browse/PROD-3006)

### Description

In populate_executive_education_data_csv management command:

- Update product api call to use detail=2
- Map Meta fields to CSV headers