### PR TITLE
feat: upgrade event bus dependencies

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -370,7 +370,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==1.4.1
+edx-event-bus-kafka==1.4.3
     # via -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via -r requirements/local.in
@@ -505,7 +505,7 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==3.0.0
+openedx-events==3.0.1
     # via edx-event-bus-kafka
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -304,7 +304,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==1.4.1
+edx-event-bus-kafka==1.4.3
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -399,7 +399,7 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==3.0.0
+openedx-events==3.0.1
     # via edx-event-bus-kafka
 oscrypto==1.3.0
     # via snowflake-connector-python


### PR DESCRIPTION
This will bring in a fix to event bus schema generation in the consumer. The fix will not be evident until https://github.com/openedx/edx-platform/pull/31237 is merged, so ideally this will be merged after but it's not a requirement.