### PR TITLE
fix: add debug logging for event bus caching

### DIFF
--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -5,6 +5,8 @@ import zlib
 from django.conf import settings
 from django.core.cache import cache
 from django.http.response import HttpResponse
+from edx_django_utils.monitoring import set_custom_attribute
+from edx_toggles.toggles import SettingToggle
 from rest_framework.renderers import JSONRenderer
 from rest_framework_extensions.cache.decorators import CacheResponse
 from rest_framework_extensions.key_constructor.bits import KeyBitBase, QueryParamsKeyBit
@@ -62,6 +64,14 @@ def api_change_receiver(sender, **kwargs):  # pylint: disable=unused-argument
     """
     set_api_timestamp()
 
+    # 2022-11: Temporary logging to help debug a caching issue related to the new event bus event.
+    #   If this code hasn't been cleaned up by 2023, feel free to remove it.
+    #   This code uses/exposes a toggle that was only intended for the consumer code in:
+    #      course_discovery/apps/course_metadata/management/commands/consume_events.py
+    KAFKA_CONSUMERS_ENABLED = SettingToggle('EVENT_BUS_KAFKA_CONSUMERS_ENABLED', default=False)
+    if KAFKA_CONSUMERS_ENABLED.is_enabled():
+        logger.info("Updating api timestamp in api_change_receiver.")
+
 
 class CompressedCacheResponse(CacheResponse):
     """
@@ -88,6 +98,8 @@ class CompressedCacheResponse(CacheResponse):
                 kwargs=kwargs
             )
             response_triple = self.cache.get(key)
+            set_custom_attribute('api_cache_key', key)
+            set_custom_attribute('api_cache_hit', bool(response_triple))
         else:
             logger.info("Skipping page caching for %s", flag_name)
             response_triple = None
@@ -116,6 +128,7 @@ class CompressedCacheResponse(CacheResponse):
                     headers
                 )
                 self.cache.set(key, response_triple, self.timeout)
+                set_custom_attribute('api_cache_set', True)
         else:
             # If we get data from the cache, we reassemble the data to build a response
             # We reassemble the pieces from the cache because we can't actually set rendered_content


### PR DESCRIPTION
Add debug logging and monitoring for api caching

In order to help understand why caching is not being busted
properly for the event consumer, we are temporarily add
logging and monitoring to gather more information.