### PR TITLE
[DO NOT MERGE] [POC] Index Contentful data in Algolia Spike

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -116,9 +116,9 @@ class AlgoliaProxyProduct(Program):
         self.product = product
         self.product.language = language
         product_uuid = str(product.uuid)
-        contentful_product = contentful_data[product_uuid] if contentful_data else None
-        if not contentful_product:
+        if not contentful_data or product_uuid not in contentful_data:
             return
+        contentful_product = contentful_data[product_uuid]
         self.product.product_taxi_form_title = contentful_product['taxi_form_title'] if 'taxi_form_title' in contentful_product else None;
 
     @property

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -59,7 +59,7 @@ def delegate_attributes(cls):
     search_fields = ['partner_names', 'partner_keys', 'product_title', 'primary_description', 'secondary_description',
                      'tertiary_description']
     facet_fields = ['availability_level', 'subject_names', 'levels', 'active_languages', 'staff_slugs',
-                    'product_allowed_in', 'product_blocked_in']
+                    'product_allowed_in', 'product_blocked_in', 'product_taxi_form_title']
     ranking_fields = ['availability_rank', 'product_recent_enrollment_count', 'promoted_in_spanish_index',
                       'product_value_per_click_usa', 'product_value_per_click_international',
                       'product_value_per_lead_usa', 'product_value_per_lead_international']
@@ -111,10 +111,15 @@ class AlgoliaProxyProduct(Program):
     class Meta:
         proxy = True
 
-    def __init__(self, product, language='en'):
+    def __init__(self, product, language='en', contentful_data=None):
         super().__init__()
         self.product = product
         self.product.language = language
+        product_uuid = str(product.uuid)
+        contentful_product = contentful_data[product_uuid] if contentful_data else None
+        if not contentful_product:
+            return
+        self.product.product_taxi_form_title = contentful_product['taxi_form_title'] if 'taxi_form_title' in contentful_product else None;
 
     @property
     def coordinates(self):
@@ -125,10 +130,12 @@ class AlgoliaProxyProduct(Program):
 
     # should_index is called differently from algoliasearch_django, can't use the delegate_attributes trick
     def should_index(self):
-        return getattr(self.product, 'should_index', True)
+        return True
+        #return getattr(self.product, 'should_index', True)
 
     def should_index_spanish(self):
-        return getattr(self.product, 'should_index_spanish', True)
+        return True
+        #return getattr(self.product, 'should_index_spanish', True)
 
 
 class AlgoliaBasicModelFieldsMixin(models.Model):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -108,7 +108,7 @@ class EnglishProductIndex(BaseProductIndex):
     language = 'en'
 
     search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys',
-                     'primary_description', 'secondary_description', 'tertiary_description')
+                     'primary_description', 'secondary_description', 'tertiary_description', 'tags')
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
@@ -138,11 +138,12 @@ class EnglishProductIndex(BaseProductIndex):
             'unordered(primary_description)',
             'unordered(secondary_description)',
             'unordered(tertiary_description)',
+            'tags'
         ],
         'attributesForFaceting': [
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)', 'skills.skill',
-            'skills.category', 'skills.subcategory',
+            'skills.category', 'skills.subcategory', 'tags',
         ],
         'customRanking': ['asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
@@ -154,7 +155,7 @@ class SpanishProductIndex(BaseProductIndex):
     language = 'es_419'
 
     search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys',
-                     'primary_description', 'secondary_description', 'tertiary_description')
+                     'primary_description', 'secondary_description', 'tertiary_description', 'tags')
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
@@ -185,11 +186,12 @@ class SpanishProductIndex(BaseProductIndex):
             'unordered(primary_description)',
             'unordered(secondary_description)',
             'unordered(tertiary_description)',
+            'tags'
         ],
         'attributesForFaceting': [
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)',
-            'skills.skill', 'skills.category', 'skills.subcategory'
+            'skills.skill', 'skills.category', 'skills.subcategory', 'tags'
         ],
         'customRanking': ['desc(promoted_in_spanish_index)', 'asc(availability_rank)', 'desc(recent_enrollment_count)']
     }

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -10,7 +10,7 @@ class BaseProductIndex(AlgoliaIndex):
     language = None
 
     def get_contentful_data(self): 
-        # Example with mock data returned to test locally on algolia staging:
+        # Example 1: using mock data returned to test locally:
         # mock_data = {
         #     '3f10df65-fd06-41df-9b42-ad2cbaeb7fee': {
         #         'taxi_form_title': 'some testing value'
@@ -23,15 +23,20 @@ class BaseProductIndex(AlgoliaIndex):
         # return mock_data
 
         ###################################
-        #Example with real data from contentful:
+        #Example 2: using real data fetched from contentful:
         client = Client(
-            '',
-            ''
+            '<space_id>',
+            '<content_delivery_api_key>'
         )
         degree_page_entries = client.entries({'content_type': 'degreeDetailPage', 'include': 10, 'limit': 1000})
         contentful_data_dict = {}
         for degree_entry in degree_page_entries:
             uuid = degree_entry.uuid
+            print("real degree uuid from contentful was: ", uuid)
+            uuid = 'd1ca3a84-e51c-4246-aff6-e1e26cf6d587' #my local program uuid
+            # currently the contentful degree UUID is different than my local program
+            # we can either change one of them to match, or just overwrite here for testing locally
+            print("overwrite with uuid: ", uuid)
             taxi_form_title = degree_entry.taxi_form.title
             for module in degree_entry.modules:
                 if module.content_type.id == 'aboutTheProgramModule':
@@ -103,7 +108,7 @@ class EnglishProductIndex(BaseProductIndex):
     language = 'en'
 
     search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys',
-                     'primary_description', 'secondary_description', 'tertiary_description', 'tags')
+                     'primary_description', 'secondary_description', 'tertiary_description')
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
@@ -133,12 +138,11 @@ class EnglishProductIndex(BaseProductIndex):
             'unordered(primary_description)',
             'unordered(secondary_description)',
             'unordered(tertiary_description)',
-            'tags'
         ],
         'attributesForFaceting': [
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)', 'skills.skill',
-            'skills.category', 'skills.subcategory', 'tags',
+            'skills.category', 'skills.subcategory',
         ],
         'customRanking': ['asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
@@ -150,7 +154,7 @@ class SpanishProductIndex(BaseProductIndex):
     language = 'es_419'
 
     search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys',
-                     'primary_description', 'secondary_description', 'tertiary_description', 'tags')
+                     'primary_description', 'secondary_description', 'tertiary_description')
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
@@ -181,12 +185,11 @@ class SpanishProductIndex(BaseProductIndex):
             'unordered(primary_description)',
             'unordered(secondary_description)',
             'unordered(tertiary_description)',
-            'tags'
         ],
         'attributesForFaceting': [
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)',
-            'skills.skill', 'skills.category', 'skills.subcategory', 'tags'
+            'skills.skill', 'skills.category', 'skills.subcategory'
         ],
         'customRanking': ['desc(promoted_in_spanish_index)', 'asc(availability_rank)', 'desc(recent_enrollment_count)']
     }

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 certifi==2022.9.24
     # via
@@ -47,7 +47,7 @@ pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2
     # via elasticsearch-dsl
-pytz==2022.5
+pytz==2022.6
     # via babel
 requests==2.28.1
     # via sphinx

--- a/requirements/local.in
+++ b/requirements/local.in
@@ -5,6 +5,7 @@
 -r test.in
 -r docs.in
 
+contentful
 django-debug-toolbar
 django-elasticsearch-debug-toolbar
 docker-compose

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -19,10 +19,6 @@ amqp==5.1.1
     # via kombu
 asgiref==3.5.2
     # via django
-asn1crypto==1.5.1
-    # via
-    #   oscrypto
-    #   snowflake-connector-python
 astroid==2.12.12
     # via
     #   pylint
@@ -47,7 +43,7 @@ authlib==1.0.0rc1
     # via
     #   -c requirements/constraints.txt
     #   simple-salesforce
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 backoff==2.2.1
     # via -r requirements/base.in
@@ -64,18 +60,14 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.25.4
+boto3==1.26.2
     # via django-ses
-botocore==1.28.4
+botocore==1.29.2
     # via
     #   boto3
     #   s3transfer
 bracex==2.3.post1
     # via wcmatch
-cached-property==1.5.2
-    # via zeep
-cachetools==5.2.0
-    # via google-auth
 cairocffi==1.4.0
     # via cairosvg
 cairosvg==2.5.2
@@ -128,6 +120,8 @@ code-annotations==1.3.0
     #   edx-toggles
 colorama==0.4.6
     # via semgrep
+contentful==1.13.1
+    # via -r requirements/local.in
 coreapi==2.3.3
     # via drf-yasg
 coreschema==0.0.4
@@ -138,7 +132,7 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==36.0.2
+cryptography==38.0.3
     # via
     #   authlib
     #   paramiko
@@ -276,7 +270,7 @@ django-object-actions==4.0.0
     # via -r requirements/base.in
 django-parler==2.3
     # via -r requirements/base.in
-django-ses==3.2.1
+django-ses==3.2.2
     # via taxonomy-connector
 django-simple-history==3.0.0
     # via
@@ -325,7 +319,7 @@ djangorestframework-csv==2.1.1
     # via -r requirements/base.in
 djangorestframework-xml==2.0.0
     # via -r requirements/base.in
-docker[ssh]==6.0.0
+docker[ssh]==6.0.1
     # via docker-compose
 docker-compose==1.29.2
     # via -r requirements/local.in
@@ -370,7 +364,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==1.4.3
+edx-event-bus-kafka==1.5.0
     # via -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via -r requirements/local.in
@@ -413,7 +407,7 @@ face==22.0.0
     # via glom
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==15.1.1
+faker==15.1.3
     # via factory-boy
 fastavro==1.7.0
     # via openedx-events
@@ -428,14 +422,6 @@ future==0.18.2
     # via pyjwkest
 glom==22.1.0
     # via semgrep
-google-auth==2.13.0
-    # via
-    #   google-auth-oauthlib
-    #   gspread
-google-auth-oauthlib==0.7.0
-    # via gspread
-gspread==5.6.2
-    # via -r requirements/base.in
 h11==0.14.0
     # via wsproto
 html2text==2020.1.16
@@ -544,18 +530,12 @@ pluggy==1.0.0
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-prompt-toolkit==3.0.31
+prompt-toolkit==3.0.32
     # via click-repl
 psutil==5.9.3
     # via edx-django-utils
 py==1.11.0
     # via tox
-pyasn1==0.4.8
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.2.8
-    # via google-auth
 pycodestyle==2.9.1
     # via -r requirements/test.in
 pycountry==22.3.5
@@ -592,7 +572,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==3.12.3
+pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via
@@ -604,7 +584,7 @@ pyopenssl==22.0.0
     #   snowflake-connector-python
 pyparsing==3.0.9
     # via packaging
-pyrsistent==0.19.1
+pyrsistent==0.19.2
     # via jsonschema
 pysocks==1.7.1
     # via urllib3
@@ -630,6 +610,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.in
     #   botocore
+    #   contentful
     #   edx-drf-extensions
     #   elasticsearch-dsl
     #   faker
@@ -650,7 +631,7 @@ python-stdnum==1.17
     # via django-localflavor
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2022.5
+pytz==2022.6
     # via
     #   -r requirements/base.in
     #   babel
@@ -678,6 +659,7 @@ requests==2.28.1
     # via
     #   -r requirements/base.in
     #   algoliasearch
+    #   contentful
     #   coreapi
     #   docker
     #   docker-compose
@@ -699,9 +681,7 @@ requests==2.28.1
 requests-file==1.5.1
     # via zeep
 requests-oauthlib==1.3.1
-    # via
-    #   google-auth-oauthlib
-    #   social-auth-core
+    # via social-auth-core
 requests-toolbelt==0.10.1
     # via zeep
 responses==0.22.0
@@ -803,9 +783,9 @@ stevedore==4.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.25.0
+taxonomy-connector==1.26.0
     # via -r requirements/base.in
-testfixtures==7.0.0
+testfixtures==7.0.3
     # via -r requirements/test.in
 text-unidecode==1.3
     # via python-slugify
@@ -843,7 +823,6 @@ typing-extensions==4.4.0
     #   django-countries
     #   pylint
     #   semgrep
-    #   snowflake-connector-python
 ujson==5.5.0
     # via python-lsp-jsonrpc
 unicodecsv==0.14.1
@@ -889,7 +868,7 @@ wsproto==1.2.0
     # via trio-websocket
 xss-utils==0.4.0
     # via -r requirements/base.in
-zeep==4.1.0
+zeep==4.2.0
     # via simple-salesforce
 zipp==3.10.0
     # via importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -39,16 +39,12 @@ beautifulsoup4==4.11.1
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.25.4
+boto3==1.26.2
     # via django-ses
-botocore==1.28.4
+botocore==1.29.2
     # via
     #   boto3
     #   s3transfer
-cached-property==1.5.2
-    # via zeep
-cachetools==5.2.0
-    # via google-auth
 cairocffi==1.4.0
     # via cairosvg
 cairosvg==2.5.2
@@ -95,7 +91,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==36.0.2
+cryptography==38.0.3
     # via
     #   authlib
     #   pyjwt
@@ -218,7 +214,7 @@ django-object-actions==4.0.0
     # via -r requirements/base.in
 django-parler==2.3
     # via -r requirements/base.in
-django-ses==3.2.1
+django-ses==3.2.2
     # via
     #   -r requirements/production.in
     #   taxonomy-connector
@@ -304,7 +300,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==1.4.3
+edx-event-bus-kafka==1.5.0
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -337,15 +333,9 @@ filelock==3.8.0
     # via snowflake-connector-python
 future==0.18.2
     # via pyjwkest
-gevent==22.10.1
+gevent==22.10.2
     # via -r requirements/production.in
-google-auth==2.13.0
-    # via
-    #   google-auth-oauthlib
-    #   gspread
-google-auth-oauthlib==0.7.0
-    # via gspread
-greenlet==1.1.3.post0
+greenlet==2.0.0
     # via gevent
 gspread==5.6.2
     # via -r requirements/base.in
@@ -354,9 +344,7 @@ gunicorn==20.1.0
 html2text==2020.1.16
     # via -r requirements/base.in
 idna==3.4
-    # via
-    #   requests
-    #   snowflake-connector-python
+    # via requests
 importlib-metadata==5.0.0
     # via
     #   -r requirements/base.in
@@ -416,7 +404,7 @@ pillow==9.3.0
     #   django-stdimage
 platformdirs==2.5.2
     # via zeep
-prompt-toolkit==3.0.31
+prompt-toolkit==3.0.32
     # via click-repl
 psutil==5.9.3
     # via edx-django-utils
@@ -444,7 +432,7 @@ pyjwt[crypto]==2.6.0
     #   edx-rest-api-client
     #   snowflake-connector-python
     #   social-auth-core
-pymongo==3.12.3
+pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -472,7 +460,7 @@ python-stdnum==1.17
     # via django-localflavor
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2022.5
+pytz==2022.6
     # via
     #   -r requirements/base.in
     #   celery
@@ -512,9 +500,7 @@ requests==2.28.1
 requests-file==1.5.1
     # via zeep
 requests-oauthlib==1.3.1
-    # via
-    #   google-auth-oauthlib
-    #   social-auth-core
+    # via social-auth-core
 requests-toolbelt==0.10.1
     # via zeep
 rjsmin==1.2.0
@@ -573,7 +559,7 @@ stevedore==4.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.25.0
+taxonomy-connector==1.26.0
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -582,9 +568,7 @@ tinycss2==1.2.1
     #   cairosvg
     #   cssselect2
 typing-extensions==4.4.0
-    # via
-    #   django-countries
-    #   snowflake-connector-python
+    # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1
@@ -612,13 +596,13 @@ wrapt==1.14.1
     # via deprecated
 xss-utils==0.4.0
     # via -r requirements/base.in
-zeep==4.1.0
+zeep==4.2.0
     # via simple-salesforce
 zipp==3.10.0
     # via importlib-metadata
 zope-event==4.5.0
     # via gevent
-zope-interface==5.5.0
+zope-interface==5.5.1
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This is a simple example of how we can fetch specific data (such as degrees) from Contentful and create a dictionary where each key is a degree UUID (and value contains the fields to be indexed for that degree), that can then be matched with degrees from our DB. 

This way we can add additional fields to `AlgoliaProxyProduct`, which results in these Contentful-based fields being indexed in Algolia together with disco-based fields.

This is a very simple/raw example. Please read the [spike description and summary available here](https://2u-internal.atlassian.net/wiki/spaces/WS/pages/216269142/SPIKE+Indexing+Contentful+data+in+Algolia) for more in-depth tips on actual implementation. 

Also, ignore all package-related changes that came from me upgrading all packages locally. We only need to install the `contentful` package for this implementation.

