### PR TITLE
feat: add product meta info to Additional Metadata serializer

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -28,10 +28,10 @@ from course_discovery.apps.api.serializers import (
     LevelTypeSerializer, MinimalCourseRunSerializer, MinimalCourseSerializer, MinimalOrganizationSerializer,
     MinimalPersonSerializer, MinimalProgramCourseSerializer, MinimalProgramSerializer, NestedProgramSerializer,
     OrganizationSerializer, PathwaySerializer, PersonSerializer, PositionSerializer, PrerequisiteSerializer,
-    ProductValueSerializer, ProgramLocationRestrictionSerializer, ProgramsAffiliateWindowSerializer, ProgramSerializer,
-    ProgramTypeAttrsSerializer, ProgramTypeSerializer, RankingSerializer, SeatSerializer, SubjectSerializer,
-    TopicSerializer, TypeaheadCourseRunSearchSerializer, TypeaheadProgramSearchSerializer, VideoSerializer,
-    get_lms_course_url_for_archived, get_utm_source_for_user
+    ProductMetaSerializer, ProductValueSerializer, ProgramLocationRestrictionSerializer,
+    ProgramsAffiliateWindowSerializer, ProgramSerializer, ProgramTypeAttrsSerializer, ProgramTypeSerializer,
+    RankingSerializer, SeatSerializer, SubjectSerializer, TopicSerializer, TypeaheadCourseRunSearchSerializer,
+    TypeaheadProgramSearchSerializer, VideoSerializer, get_lms_course_url_for_archived, get_utm_source_for_user
 )
 from course_discovery.apps.api.tests.mixins import SiteMixin
 from course_discovery.apps.api.tests.test_utils import make_post_request, make_request
@@ -1996,6 +1996,7 @@ class AdditionalMetadataSerializerTests(TestCase):
             'lead_capture_form_url': additional_metadata.lead_capture_form_url,
             'certificate_info': CertificateInfoSerializer(additional_metadata.certificate_info).data,
             'facts': FactSerializer(additional_metadata.facts, many=True).data,
+            'product_meta': ProductMetaSerializer(additional_metadata.product_meta).data,
             'organic_url': additional_metadata.organic_url,
             'start_date': serialize_datetime(additional_metadata.start_date),
             'registration_deadline': serialize_datetime(additional_metadata.registration_deadline),

--- a/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_catalogs.py
@@ -317,7 +317,7 @@ class CatalogViewSetTests(ElasticsearchTestMixin, SerializationMixin, OAuth2Mixi
             # to be included.
             filtered_course_run = CourseRunFactory(course=course)
 
-            with self.assertNumQueries(40, threshold=3):
+            with self.assertNumQueries(44, threshold=3):
                 response = self.client.get(url)
 
             assert response.status_code == 200

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -107,6 +107,7 @@ class AdditionalMetadataFactory(factory.django.DjangoModelFactory):
     registration_deadline = FuzzyDateTime(datetime.datetime(2014, 1, 1, tzinfo=UTC), force_microsecond=0)
     variant_id = factory.LazyFunction(uuid4)
     course_term_override = FuzzyText()
+    product_meta = factory.SubFactory(ProductMetaFactory, keywords=['test', 'test2'])
 
     @factory.post_generation
     def facts(self, create, extracted, **kwargs):


### PR DESCRIPTION
[PROD-3005](https://2u-internal.atlassian.net/browse/PROD-3005)
Adding Product meta info to additional metadata serializer with following description:
- Add ProductMetaSerializer for storing SEO/Meta fields for external product lines, ExecEd specifically.
- Link the serializer with AdditionalMetadataSerializer

Testing method based out of:
- [PROD-3004](https://2u-internal.atlassian.net/browse/PROD-3004)
- #3660 


