### PR TITLE
test: add threshold in query count for test_search

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -537,15 +537,9 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
 
         # Filter results excluding expired course runs but inclusing published course runs.
         if request_method == "GET":
-
-            from django.db import connection
-            from django.test.utils import CaptureQueriesContext
             query = {'content_type': 'course', 'status': 'published', 'exclude_expired_course_run': 'true'}
-
-            with CaptureQueriesContext(connection) as ctx:
-                with self.assertNumQueries(12, threshold=3):  # CI is often 13 on MySQL 8
-                    response = self.get_response(query, endpoint=self.list_path)
-                print(ctx.captured_queries)
+            with self.assertNumQueries(12, threshold=3):  # CI is often 13 on MySQL 8
+                response = self.get_response(query, endpoint=self.list_path)
         else:
             data = {'content_type': 'course', 'status': 'published'}
             query = {'exclude_expired_course_run': 'true'}


### PR DESCRIPTION
### Description

- Adding threshold for `test_results_filtered_by_exclude_expired_course_run` test in test_search.py which has been failing more often on CI.
- On Local, the total queries executed are 12 for GET requests, printed following the info from https://stackoverflow.com/questions/13162771/django-how-to-see-sql-query-when-running-tests
- The previous tests were passing because there is a default threshold of 2 in APITestCase. I am attaching the executed SQL queries below to compare info if needed:

```
SELECT "django_site"."id", "django_site"."domain", "django_site"."name" FROM "django_site" WHERE "django_site"."domain" LIKE 'testserver.fake' ESCAPE '\' LIMIT 21

SELECT "django_session"."session_key", "django_session"."session_data", "django_session"."expire_date" FROM "django_session" WHERE ("django_session"."expire_date" > '2022-11-08 07:10:36.983839' AND "django_session"."session_key" = 'fyi4jpdcz2jntjyiw3lgxa2jksaov557') LIMIT 21

SELECT "core_user"."id", "core_user"."password", "core_user"."last_login", "core_user"."is_superuser", "core_user"."username", "core_user"."first_name", "core_user"."last_name", "core_user"."email", "core_user"."is_staff", "core_user"."is_active", "core_user"."date_joined", "core_user"."full_name", "core_user"."referral_tracking_id" FROM "core_user" WHERE "core_user"."id" = 1 LIMIT 21

SELECT "core_partner"."id", "core_partner"."created", "core_partner"."modified", "core_partner"."name", "core_partner"."short_code", "core_partner"."courses_api_url", "core_partner"."lms_coursemode_api_url", "core_partner"."ecommerce_api_url", "core_partner"."organizations_api_url", "core_partner"."programs_api_url", "core_partner"."marketing_site_api_url", "core_partner"."marketing_site_url_root", "core_partner"."marketing_site_api_username", "core_partner"."marketing_site_api_password", "core_partner"."studio_url", "core_partner"."publisher_url", "core_partner"."site_id", "core_partner"."lms_url", "core_partner"."lms_admin_url", "core_partner"."analytics_url", "core_partner"."analytics_token" FROM "core_partner" WHERE "core_partner"."site_id" = 1 LIMIT 21

SELECT "course_metadata_course"."id", "course_metadata_course"."created", "course_metadata_course"."modified", "course_metadata_course"."draft", "course_metadata_course"."draft_version_id", "course_metadata_course"."partner_id", "course_metadata_course"."uuid", "course_metadata_course"."canonical_course_run_id", "course_metadata_course"."key", "course_metadata_course"."key_for_reruns", "course_metadata_course"."title", "course_metadata_course"."url_slug", "course_metadata_course"."short_description", "course_metadata_course"."full_description", "course_metadata_course"."extra_description_id", "course_metadata_course"."additional_metadata_id", "course_metadata_course"."course_length", "course_metadata_course"."level_type_id", "course_metadata_course"."outcome", "course_metadata_course"."prerequisites_raw", "course_metadata_course"."syllabus_raw", "course_metadata_course"."card_image_url", "course_metadata_course"."image", "course_metadata_course"."video_id", "course_metadata_course"."faq", "course_metadata_course"."learner_testimonials", "course_metadata_course"."enrollment_count", "course_metadata_course"."recent_enrollment_count", "course_metadata_course"."salesforce_id", "course_metadata_course"."salesforce_case_id", "course_metadata_course"."type_id", "course_metadata_course"."number", "course_metadata_course"."additional_information", "course_metadata_course"."organization_short_code_override", "course_metadata_course"."organization_logo_override", "course_metadata_course"."geolocation_id", "course_metadata_course"."location_restriction_id", "course_metadata_course"."in_year_value_id", "course_metadata_course"."enterprise_subscription_inclusion" FROM "course_metadata_course" WHERE ("course_metadata_course"."draft" = 0 AND "course_metadata_course"."id" = 1) LIMIT 21

SELECT "course_metadata_courserun"."id", "course_metadata_courserun"."created", "course_metadata_courserun"."modified", "course_metadata_courserun"."draft", "course_metadata_courserun"."draft_version_id", "course_metadata_courserun"."uuid", "course_metadata_courserun"."course_id", "course_metadata_courserun"."key", "course_metadata_courserun"."external_key", "course_metadata_courserun"."status", "course_metadata_courserun"."title_override", "course_metadata_courserun"."start", "course_metadata_courserun"."end", "course_metadata_courserun"."go_live_date", "course_metadata_courserun"."enrollment_start", "course_metadata_courserun"."enrollment_end", "course_metadata_courserun"."announcement", "course_metadata_courserun"."short_description_override", "course_metadata_courserun"."full_description_override", "course_metadata_courserun"."min_effort", "course_metadata_courserun"."max_effort", "course_metadata_courserun"."weeks_to_complete", "course_metadata_courserun"."language_id", "course_metadata_courserun"."pacing_type", "course_metadata_courserun"."syllabus_id", "course_metadata_courserun"."enrollment_count", "course_metadata_courserun"."recent_enrollment_count", "course_metadata_courserun"."card_image_url", "course_metadata_courserun"."video_id", "course_metadata_courserun"."slug", "course_metadata_courserun"."hidden", "course_metadata_courserun"."mobile_available", "course_metadata_courserun"."course_overridden", "course_metadata_courserun"."reporting_type", "course_metadata_courserun"."eligible_for_financial_aid", "course_metadata_courserun"."license", "course_metadata_courserun"."outcome_override", "course_metadata_courserun"."type_id", "course_metadata_courserun"."has_ofac_restrictions", "course_metadata_courserun"."ofac_comment", "course_metadata_courserun"."expected_program_type_id", "course_metadata_courserun"."expected_program_name", "course_metadata_courserun"."salesforce_id", "course_metadata_courserun"."enterprise_subscription_inclusion" FROM "course_metadata_courserun" WHERE "course_metadata_courserun"."course_id" IN (1)

SELECT "course_metadata_seat"."id", "course_metadata_seat"."created", "course_metadata_seat"."modified", "course_metadata_seat"."draft", "course_metadata_seat"."draft_version_id", "course_metadata_seat"."course_run_id", "course_metadata_seat"."type", "course_metadata_seat"."price", "course_metadata_seat"."currency_id", "course_metadata_seat"."upgrade_deadline", "course_metadata_seat"."upgrade_deadline_override", "course_metadata_seat"."credit_provider", "course_metadata_seat"."credit_hours", "course_metadata_seat"."sku", "course_metadata_seat"."bulk_sku" FROM "course_metadata_seat" WHERE "course_metadata_seat"."course_run_id" IN (1, 2, 3, 4) ORDER BY "course_metadata_seat"."created" ASC

SELECT "course_metadata_seattype"."id", "course_metadata_seattype"."created", "course_metadata_seattype"."modified", "course_metadata_seattype"."name", "course_metadata_seattype"."slug" FROM "course_metadata_seattype" WHERE "course_metadata_seattype"."slug" IN ('dukryfkawfbk', 'sfeemehervtj', 'giwtrirahfck', 'uinylyqrbdso')

SELECT "course_metadata_courseruntype"."id", "course_metadata_courseruntype"."created", "course_metadata_courseruntype"."modified", "course_metadata_courseruntype"."uuid", "course_metadata_courseruntype"."name", "course_metadata_courseruntype"."slug", "course_metadata_courseruntype"."is_marketable" FROM "course_metadata_courseruntype" WHERE "course_metadata_courseruntype"."id" = 9 LIMIT 21

SELECT "course_metadata_courseruntype"."id", "course_metadata_courseruntype"."created", "course_metadata_courseruntype"."modified", "course_metadata_courseruntype"."uuid", "course_metadata_courseruntype"."name", "course_metadata_courseruntype"."slug", "course_metadata_courseruntype"."is_marketable" FROM "course_metadata_courseruntype" WHERE "course_metadata_courseruntype"."id" = 10 LIMIT 21

SELECT "course_metadata_courseruntype"."id", "course_metadata_courseruntype"."created", "course_metadata_courseruntype"."modified", "course_metadata_courseruntype"."uuid", "course_metadata_courseruntype"."name", "course_metadata_courseruntype"."slug", "course_metadata_courseruntype"."is_marketable" FROM "course_metadata_courseruntype" WHERE "course_metadata_courseruntype"."id" = 11 LIMIT 21

SELECT "taxonomy_courseskills"."id", "taxonomy_courseskills"."created", "taxonomy_courseskills"."modified", "taxonomy_courseskills"."course_key", "taxonomy_courseskills"."skill_id", "taxonomy_courseskills"."confidence", "taxonomy_courseskills"."is_blacklisted", "taxonomy_skill"."id", "taxonomy_skill"."created", "taxonomy_skill"."modified", "taxonomy_skill"."external_id", "taxonomy_skill"."name", "taxonomy_skill"."description", "taxonomy_skill"."info_url", "taxonomy_skill"."type_id", "taxonomy_skill"."type_name", "taxonomy_skill"."category_id", "taxonomy_skill"."subcategory_id" FROM "taxonomy_courseskills" INNER JOIN "taxonomy_skill" ON ("taxonomy_courseskills"."skill_id" = "taxonomy_skill"."id") WHERE ("taxonomy_courseskills"."course_key" = 'edX+DemoX' AND NOT "taxonomy_courseskills"."is_blacklisted") ORDER BY "taxonomy_courseskills"."created" ASC

```