### PR TITLE
feat: add handling of slug in CSV for ExecEd

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/constants.py
+++ b/course_discovery/apps/course_metadata/data_loaders/constants.py
@@ -34,10 +34,10 @@ class CSVIngestionErrorMessages:
     MISSING_REQUIRED_DATA = '[MISSING_REQUIRED_DATA] Course {course_title} is missing the required data for ' \
                             'ingestion. The missing data elements are "{missing_data}"'
 
-    COURSE_CREATE_ERROR = '[COURSE_CREATE_ERROR] Unable to create course {course_title} in the system. The ingestion' \
+    COURSE_CREATE_ERROR = '[COURSE_CREATE_ERROR] Unable to create course {course_title} in the system. The ingestion ' \
                           'failed with the exception: {exception_message}'
 
-    COURSE_UPDATE_ERROR = '[COURSE_UPDATE_ERROR] Unable to update course {course_title} in the system. The update' \
+    COURSE_UPDATE_ERROR = '[COURSE_UPDATE_ERROR] Unable to update course {course_title} in the system. The update ' \
                           'failed with the exception: {exception_message}'
 
     COURSE_RUN_UPDATE_ERROR = '[COURSE_RUN_UPDATE_ERROR] Unable to update course run of the course {course_title} ' \

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -157,9 +157,12 @@ class CSVDataLoader(AbstractDataLoader):
                 try:
                     _ = self._create_course(row, course_type, course_run_type.uuid)
                 except Exception as exc:  # pylint: disable=broad-except
+                    exception_message = exc
+                    if hasattr(exc, 'response'):
+                        exception_message = exc.response.content.decode('utf-8')
                     error_message = CSVIngestionErrorMessages.COURSE_CREATE_ERROR.format(
                         course_title=course_title,
-                        exception_message=exc
+                        exception_message=exception_message
                     )
                     logger.exception(error_message)
                     self._register_ingestion_error(CSVIngestionErrors.COURSE_CREATE_ERROR, error_message)
@@ -189,9 +192,12 @@ class CSVDataLoader(AbstractDataLoader):
             try:
                 self._update_course(row, course, is_draft)
             except Exception as exc:  # pylint: disable=broad-except
+                exception_message = exc
+                if hasattr(exc, 'response'):
+                    exception_message = exc.response.content.decode('utf-8')
                 error_message = CSVIngestionErrorMessages.COURSE_UPDATE_ERROR.format(
                     course_title=course_title,
-                    exception_message=exc
+                    exception_message=exception_message
                 )
                 logger.exception(error_message)
                 self._register_ingestion_error(CSVIngestionErrors.COURSE_UPDATE_ERROR, error_message)
@@ -221,9 +227,12 @@ class CSVDataLoader(AbstractDataLoader):
                 try:
                     self._update_course_run(row, course_run, course_type, is_draft)
                 except Exception as exc:  # pylint: disable=broad-except
+                    exception_message = exc
+                    if hasattr(exc, 'response'):
+                        exception_message = exc.response.content.decode('utf-8')
                     error_message = CSVIngestionErrorMessages.COURSE_RUN_UPDATE_ERROR.format(
                         course_title=course_title,
-                        exception_message=exc
+                        exception_message=exception_message
                     )
                     logger.exception(error_message)
                     self._register_ingestion_error(CSVIngestionErrors.COURSE_RUN_UPDATE_ERROR, error_message)

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -345,7 +345,7 @@ class CSVDataLoader(AbstractDataLoader):
             'draft': is_draft,
             'key': course.key,
             'uuid': str(course.uuid),
-            'url_slug': course.active_url_slug,
+            'url_slug': data.get('slug') or course.active_url_slug,
             'type': str(course.type.uuid),
             'subjects': subjects,
             'collaborators': collaborator_uuids,

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -237,7 +237,7 @@ class CSVLoaderMixin:
         'upgrade_deadline_override_date', 'upgrade_deadline_override_time', 'redirect_url', 'external_identifier',
         'lead_capture_form_url', 'organic_url', 'certificate_header', 'certificate_text', 'stat1', 'stat1_text',
         'stat2', 'stat2_text', 'organization_logo_override', 'organization_short_code_override', 'variant_id',
-        'meta_title', 'meta_description', 'meta_keywords',
+        'meta_title', 'meta_description', 'meta_keywords', 'slug'
     ]
     # The list of minimal data headers
     MINIMAL_CSV_DATA_KEYS_ORDER = [

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3162,6 +3162,7 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     "meta_title": "SEO Title",
     "meta_description": "SEO Description",
     "meta_keywords": "Keyword 1, Keyword 2",
+    "slug": ""
 }
 
 VALID_MINIMAL_COURSE_AND_COURSE_RUN_CSV_DICT = {

--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         'upgrade_deadline_override_date', 'upgrade_deadline_override_time', 'redirect_url', 'external_identifier',
         'lead_capture_form_url', 'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2',
         'stat2_text', 'organic_url', 'organization_short_code_override', 'organization_logo_override', 'variant_id',
-        'meta_title', 'meta_description', 'meta_keywords',
+        'meta_title', 'meta_description', 'meta_keywords', 'slug'
     ]
 
     # Mapping English and Spanish languages to IETF equivalent variants
@@ -306,6 +306,7 @@ class Command(BaseCommand):
             'meta_title': product_dict.get('metaTitle', ''),
             'meta_description': product_dict.get('metaDescription', ''),
             'meta_keywords': product_dict.get('metaKeywords', ''),
+            'slug': product_dict.get('slug', ''),
 
             'title': partially_filled_csv_dict.get('title') or product_dict['altName'] or product_dict['name'],
             '2u_title': product_dict['name'],

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -52,6 +52,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 "metaTitle": "SEO Title",
                 "metaDescription": "SEO Description",
                 "metaKeywords": "Keyword 1, Keyword 2",
+                "slug": "csv-course-slug",
                 "variant": {
                     "id": "00000000-0000-0000-0000-000000000000",
                     "endDate": "2022-05-06",
@@ -342,3 +343,4 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
         assert data_row['Meta Title'] == 'SEO Title'
         assert data_row['Meta Description'] == 'SEO Description'
         assert data_row['Meta Keywords'] == 'Keyword 1, Keyword 2'
+        assert data_row['Slug'] == 'csv-course-slug'


### PR DESCRIPTION
### [PROD-3027](https://2u-internal.atlassian.net/browse/PROD-3027)

### Description

- Add the handling of the newly added slug field in detail=2 endpoint of product API in data transformation command
- Use the slug in CSV in CSV loader, falling back to default course slug if CSV slug is not present
- **Unrelated to Ticket AC** Fix some logging behavior involving exceptions. Instead of logging the exception message, log the response message from exception as that contain the actual useful information

### Testing

- Check out this branch on your local
- Get auth token from post collection
- Go to discovery shell
- Run `./manage.py populate_executive_education_data_csv --auth_token=<token> --output_csv=test.csv`
- Make sure the output csv has slug column
- You can choose to keep small number of rows. Change 1-2 slugs to values that are present in the DB `/admin/course_metadata/courseurlslug/`
- Run the CSV loader `./manage.py import_course_metadata --csv_path=test.csv`
- Verify the slug is updated for valid columns and that the error is raised for the slug already present in the DB.