### PR TITLE
feat: index meta title in algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -66,7 +66,9 @@ def delegate_attributes(cls):
     result_fields = ['product_marketing_url', 'product_card_image_url', 'product_uuid', 'product_weeks_to_complete',
                      'product_max_effort', 'product_min_effort', 'active_run_key', 'active_run_start',
                      'active_run_type', 'owners', 'program_types', 'course_titles', 'tags',
-                     'product_organization_short_code_override', 'product_organization_logo_override', 'skills']
+                     'product_organization_short_code_override', 'product_organization_logo_override', 'skills',
+                     'product_meta_title',
+                     ]
     object_id_field = ['custom_object_id', ]
     fields = product_type_fields + search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -199,6 +201,15 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
         if self.type.slug == CourseType.BOOTCAMP_2U:
             return 'Boot Camp'
         return 'Course'
+
+    @property
+    def product_meta_title(self):
+        """
+        Meta title will only be present for ExecEd courses.
+        """
+        if self.type.slug == CourseType.EXECUTIVE_EDUCATION_2U and self.additional_metadata.product_meta:
+            return self.additional_metadata.product_meta.title
+        return None
 
     @property
     def custom_object_id(self):
@@ -537,6 +548,14 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
     @property
     def is_2u_degree_program(self):
         return hasattr(self, 'degree') and hasattr(self.degree, 'additional_metadata')
+
+    @property
+    def product_meta_title(self):
+        """
+        Programs currently do not have any meta title. Returning an explicit None here to avoid
+        any Algolia indexing issues.
+        """
+        return None
 
 
 class SearchDefaultResultsConfiguration(models.Model):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -79,8 +79,9 @@ class EnglishProductIndex(BaseProductIndex):
                      ('product_max_effort', 'max_effort'), ('product_min_effort', 'min_effort'),
                      ('product_organization_short_code_override', 'organization_short_code_override'),
                      ('product_organization_logo_override', 'organization_logo_override'),
+                     ('product_meta_title', 'meta_title'),
                      'active_run_key', 'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags',
-                     'skills')
+                     'skills', )
 
     # Algolia needs this
     object_id_field = (('custom_object_id', 'objectID'), )
@@ -127,6 +128,7 @@ class SpanishProductIndex(BaseProductIndex):
                      ('product_max_effort', 'max_effort'), ('product_min_effort', 'min_effort'), 'active_run_key',
                      ('product_organization_short_code_override', 'organization_short_code_override'),
                      ('product_organization_logo_override', 'organization_logo_override'),
+                     ('product_meta_title', 'meta_title'),
                      'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags', 'skills')
 
     # Algolia uses objectID as unique identifier. Can't use straight uuids because a program and a course could

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -341,7 +341,7 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         )
         if expected_title:
             course.additional_metadata.product_meta = ProductMetaFactory(
-                    title="Meta Product Title"
+                title="Meta Product Title"
             )
 
         assert course.product_meta_title == expected_title

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -13,10 +13,11 @@ from course_discovery.apps.core.models import Partner
 from course_discovery.apps.core.tests.factories import PartnerFactory, SiteFactory
 from course_discovery.apps.course_metadata.algolia_models import AlgoliaProxyCourse, AlgoliaProxyProgram
 from course_discovery.apps.course_metadata.choices import ProgramStatus
-from course_discovery.apps.course_metadata.models import CourseRunStatus
+from course_discovery.apps.course_metadata.models import CourseRunStatus, CourseType
 from course_discovery.apps.course_metadata.tests.factories import (
-    CourseFactory, CourseRunFactory, DegreeAdditionalMetadataFactory, DegreeFactory, LevelTypeFactory,
-    OrganizationFactory, ProgramFactory, ProgramTypeFactory, SeatFactory, SeatTypeFactory, SubjectFactory
+    AdditionalMetadataFactory, CourseFactory, CourseRunFactory, CourseTypeFactory, DegreeAdditionalMetadataFactory,
+    DegreeFactory, LevelTypeFactory, OrganizationFactory, ProductMetaFactory, ProgramFactory, ProgramTypeFactory,
+    SeatFactory, SeatTypeFactory, SubjectFactory
 )
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 
@@ -184,6 +185,7 @@ class TestAlgoliaProxyWithEdxPartner(TestCase, TestAlgoliaDataMixin):
         cls.edxPartner.name = 'edX'
 
 
+@ddt.ddt
 @pytest.mark.django_db
 class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
 
@@ -319,6 +321,30 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         english_course = self.create_course_with_basic_active_course_run(language=american_english)
         assert spanish_course.promoted_in_spanish_index
         assert not english_course.promoted_in_spanish_index
+
+    @ddt.data(
+        (CourseType.EXECUTIVE_EDUCATION_2U, 'Meta Product Title'),
+        (CourseType.EXECUTIVE_EDUCATION_2U, None),
+        (CourseType.BOOTCAMP_2U, None),
+    )
+    @ddt.unpack
+    def test_product_meta_title(self, type_slug, expected_title):
+        """
+        Verify the meta title is returned only for ExecEd course type if product meta info is present.
+        """
+        course = AlgoliaProxyCourseFactory(
+            partner=self.__class__.edxPartner,
+            type=CourseTypeFactory(
+                slug=type_slug
+            ),
+            additional_metadata=AdditionalMetadataFactory(product_meta=None)
+        )
+        if expected_title:
+            course.additional_metadata.product_meta = ProductMetaFactory(
+                    title="Meta Product Title"
+            )
+
+        assert course.product_meta_title == expected_title
 
 
 @ddt.ddt
@@ -539,3 +565,10 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
             'course2_topic1', 'course2_topic2', 'program_label1'
         ]
         assert sorted(program.tags) == sorted(expected_tags)
+
+    def test_product_meta_title(self):
+        """
+        Verify the meta title for programs is None.
+        """
+        program = AlgoliaProxyProgramFactory()
+        assert program.product_meta_title is None


### PR DESCRIPTION
### [PROD-3009](https://2u-internal.atlassian.net/browse/PROD-3009)

### Description

- Index product meta title in Algolia. This field will only be populated for active ExecEd courses.