### PR TITLE
feat: xblock metadata provider in taxonomy support

### DIFF
--- a/course_discovery/apps/core/api_client/lms.py
+++ b/course_discovery/apps/core/api_client/lms.py
@@ -2,8 +2,10 @@
 API Client for LMS.
 """
 import logging
-from urllib.parse import urljoin
+from typing import Optional, Union
+from urllib.parse import urlencode, urljoin
 
+from django.conf import settings
 from django.core.cache import cache
 from edx_django_utils.cache import get_cache_key
 from requests.exceptions import RequestException
@@ -51,7 +53,7 @@ class LMSAPIClient:
                 "contacted": True
             }
         """
-        resource = 'api-admin/api/v1/api_access_request/'
+        resource = settings.LMS_API_URLS['api_access_request']
         query_parameters = {
             'user__username': user.username
         }
@@ -89,3 +91,121 @@ class LMSAPIClient:
                              exception.__class__.__name__, user.username)
 
         return api_access_request
+
+    def _get_blocks_data(
+        self,
+        item_id: str,
+        cache_key: str,
+        query_parameters: Union[str, dict],
+        resource: str,
+        response_root_key: Optional[str] = None,
+    ):
+        """
+        Helper function to fetch blocks based on given resourse and item_id.
+
+        Args:
+            item_id (str): course_id or block_id
+            cache_key (str): cache key
+            query_parameters (Union[str, dict]): query parameters for the request
+            resource (str): resource url
+
+        Returns:
+            (dict): dict with xblock data
+        """
+        cached_blocks = cache.get(cache_key)
+
+        if cached_blocks is SENTINEL_NO_RESULT:
+            return None
+
+        if cached_blocks:
+            return cached_blocks
+
+        blocks = None
+        try:
+            resource_url = urljoin(self.lms_url, resource)
+            response = self.client.get(resource_url, params=query_parameters)
+            response.raise_for_status()
+            blocks = response.json()
+            if response_root_key:
+                blocks = blocks[response_root_key]
+            if blocks:
+                cache.set(cache_key, blocks, ONE_HOUR)
+            else:
+                cache.set(cache_key, SENTINEL_NO_RESULT, ONE_HOUR)
+                logger.info('No blocks found for [%s].', item_id)
+
+        except (RequestException, KeyError) as exception:
+            cache.set(cache_key, SENTINEL_NO_RESULT, ONE_MINUTE)
+            logger.exception('%s: Failed to fetch blocks from LMS for [%s].',
+                             exception.__class__.__name__, item_id)
+
+        return blocks
+
+    def get_course_blocks_data(self, course_id: str, **kwargs):
+        """
+        Get all xblocks under a given course.
+
+        Args:
+            course_id (str): course key
+            **kwargs: Can be used to pass additional query params to api
+
+        Returns:
+            (dict): dict with xblock data
+        """
+        resource = settings.LMS_API_URLS['blocks']
+        query_parameters = {
+            'course_id': course_id,
+            'all_blocks': True,
+            'depth': 'all',
+            'requested_fields': 'children',
+            **kwargs,
+        }
+        encoded_query_parameters = urlencode(query_parameters, safe=':')
+        cache_key = get_cache_key(course_id=course_id, resource=resource)
+        return self._get_blocks_data(
+            course_id,
+            cache_key,
+            encoded_query_parameters,
+            resource,
+            response_root_key='blocks',
+        )
+
+    def get_blocks_data(self, block_id: str, **kwargs):
+        """
+        Get xblock data for given block_id or all blocks for given course_id.
+
+        Args:
+            block_id (str): usage key
+            **kwargs: Can be used to pass additional query params to api
+
+        Returns:
+            (dict): dict with xblock data
+        """
+        resource = settings.LMS_API_URLS['blocks'] + block_id
+        query_parameters = {
+            'all_blocks': True,
+            'depth': 'all',
+            'requested_fields': 'children',
+            **kwargs,
+        }
+        cache_key = get_cache_key(block_id=block_id, resource=resource)
+        return self._get_blocks_data(block_id, cache_key, query_parameters, resource, response_root_key='blocks')
+
+    def get_blocks_metadata(self, block_id: str, **kwargs):
+        """
+        Get xblock metadata for given block_id.
+
+        Args:
+            block_id (str): usage key
+            **kwargs: Can be used to pass additional query params to api
+
+        Returns:
+            (dict): dict with xblock data
+        """
+        resource = settings.LMS_API_URLS['block_metadata'] + block_id
+        query_parameters = {
+            'include': 'index_dictionary',
+            **kwargs,
+        }
+        cache_key = get_cache_key(block_id=block_id, resource=resource)
+        return self._get_blocks_data(block_id, cache_key, query_parameters, resource)

--- a/course_discovery/apps/core/tests/mixins.py
+++ b/course_discovery/apps/core/tests/mixins.py
@@ -124,3 +124,91 @@ class LMSAPIClientMixin:
             content_type='application/json',
             status=status,
         )
+
+    def mock_blocks_data_request(self, lms_url, override_blocks=None, status=200):
+        """
+        Mock the blocks data requests endpoint response of the LMS.
+        """
+        data = {
+            'root': 'block-v1:edX+DemoX+Demo_Course+type@course+block@course',
+            'blocks': {
+                'block-v1:edX+DemoX+Demo_Course+type@html+block@030e35c4756a4ddc8d40b95fbbfff4d4': {
+                    'id': 'block-v1:edX+DemoX+Demo_Course+type@html+block@030e35c4756a4ddc8d40b95fbbfff4d4',
+                    'block_id': '030e35c4756a4ddc8d40b95fbbfff4d4',
+                    'type': 'html',
+                    'display_name': 'Blank HTML Page',
+                },
+                'block-v1:edX+DemoX+Demo_Course+type@video+block@0b9e39477cf34507a7a48f74be381fdd': {
+                    'id': 'block-v1:edX+DemoX+Demo_Course+type@video+block@0b9e39477cf34507a7a48f74be381fdd',
+                    'block_id': '0b9e39477cf34507a7a48f74be381fdd',
+                    'type': 'video',
+                    'display_name': 'Welcome!',
+                },
+                'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc': {
+                    'id': 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc',
+                    'block_id': 'vertical_0270f6de40fc',
+                    'type': 'vertical',
+                    'display_name': 'Introduction: Video and Sequences',
+                    'children': [
+                        'block-v1:edX+DemoX+Demo_Course+type@html+block@030e35c4756a4ddc8d40b95fbbfff4d4',
+                        'block-v1:edX+DemoX+Demo_Course+type@video+block@0b9e39477cf34507a7a48f74be381fdd'
+                    ]
+                },
+            }
+        }
+        if override_blocks is not None:
+            data['blocks'] = override_blocks
+
+        responses.add(
+            responses.GET,
+            lms_url,
+            body=json.dumps(data),
+            content_type='application/json',
+            status=status,
+        )
+        return data
+
+    def mock_block_metadata_request(self, base_url, status=200):
+        data = {
+            'block-v1:edX+DemoX+Demo_Course+type@html+block@030e35c4756a4ddc8d40b95fbbfff4d4': {
+                'id': 'block-v1:edX+DemoX+Demo_Course+type@html+block@030e35c4756a4ddc8d40b95fbbfff4d4',
+                'type': 'html',
+                'index_dictionary': {
+                    'content': {
+                        'display_name': 'Blank HTML Page',
+                        'html_content': 'Welcome to the Open edX Demo Course Introduction.'
+                    },
+                    'content_type': 'Text'
+                }
+            },
+            'block-v1:edX+DemoX+Demo_Course+type@video+block@0b9e39477cf34507a7a48f74be381fdd': {
+                'id': 'block-v1:edX+DemoX+Demo_Course+type@video+block@0b9e39477cf34507a7a48f74be381fdd',
+                'type': 'video',
+                'index_dictionary': {
+                    'content': {
+                        'display_name': 'Welcome!',
+                        'transcript_en': ' ERIC: Hi, and welcome to the edX demonstration course.'
+                    },
+                    'content_type': 'Video'
+                }
+            },
+            'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc': {
+                'id': 'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc',
+                'type': 'vertical',
+                'index_dictionary': {
+                    'content': {
+                        'display_name': 'Introduction: Video and Sequences'
+                    },
+                    'content_type': 'Sequence'
+                },
+            }
+        }
+        for block_id, block_body in data.items():
+            responses.add(
+                responses.GET,
+                base_url + block_id,
+                body=json.dumps(block_body),
+                content_type='application/json',
+                status=status,
+            )
+        return data

--- a/course_discovery/apps/taxonomy_support/tests/test_providers.py
+++ b/course_discovery/apps/taxonomy_support/tests/test_providers.py
@@ -2,8 +2,8 @@
 Validate taxonomy integration.
 
 This file validates the following
-    1. Make sure the provider specified by `TAXONOMY_COURSE_METADATA_PROVIDER` and `TAXONOMY_PROGRAM_METADATA_PROVIDER`
-     implements all the abstract methods
+    1. Make sure the provider specified by `TAXONOMY_COURSE_METADATA_PROVIDER`, `TAXONOMY_PROGRAM_METADATA_PROVIDER`
+       and `TAXONOMY_XBLOCK_METADATA_PROVIDER` implements all the abstract methods
     2. Make sure the signature of all the methods match with the interfaces of the abstract class
     3. Make sure the data returned and the structure of the data matches with the definitions inside the interface.
 
@@ -17,6 +17,7 @@ method.
 Note: Course Metadata validator will use the provider pointed by the `TAXONOMY_COURSE_METADATA_PROVIDER` django setting.
 Note: Program Metadata validator will use the provider pointed by the `TAXONOMY_PROGRAM_METADATA_PROVIDER` django
 setting.
+Note: XBlock Metadata validator will use the provider pointed by the `TAXONOMY_XBLOCK_METADATA_PROVIDER` django setting.
 
 Reason behind keeping the validator a part of taxonomy-connector is to keep the provider and its validation logic in the
 same repository, so whenever a new dependency (e.g. a new method or a new field in the returned data) is added in the
@@ -24,14 +25,20 @@ provider its validator is also updated in the same pull request. This ensures th
 discovery and its interface in taxonomy are always in sync.
 """
 from unittest import mock
+from urllib.parse import urljoin
 
+from django.conf import settings
 from django.test import TestCase
-from taxonomy.validators import CourseMetadataProviderValidator, ProgramMetadataProviderValidator
+from taxonomy.validators import (
+    CourseMetadataProviderValidator, ProgramMetadataProviderValidator, XBlockMetadataProviderValidator
+)
 
+from course_discovery.apps.core.tests.factories import PartnerFactory
+from course_discovery.apps.core.tests.mixins import LMSAPIClientMixin
 from course_discovery.apps.course_metadata.tests.factories import CourseFactory, ProgramFactory
 
 
-class TaxonomyIntegrationTests(TestCase):
+class TaxonomyIntegrationTests(TestCase, LMSAPIClientMixin):
     """
     Validate integration of taxonomy_support and metadata providers.
     """
@@ -62,3 +69,24 @@ class TaxonomyIntegrationTests(TestCase):
 
         # Run all the validations, note that an assertion error will be raised if any of the validation fail.
         program_metadata_validator.validate()
+
+    def test_validate_xblock_metadata(self):
+        """
+        Validate that there are no integration issues in xblock provider.
+        """
+        self.mock_access_token()
+        partner = PartnerFactory.create(id=settings.DEFAULT_PARTNER_ID, lms_url='http://127.0.0.1:8000')
+        block_ids = [
+            'block-v1:edX+DemoX+Demo_Course+type@video+block@0b9e39477cf34507a7a48f74be381fdd',
+            'block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc',
+        ]
+        resource = settings.LMS_API_URLS['blocks']
+        for block_id in block_ids:
+            block_resource_url = urljoin(partner.lms_url, resource + block_id)
+            block_metadata_url = urljoin(partner.lms_url, 'api/courses/v1/block_metadata/')
+            self.mock_blocks_data_request(block_resource_url)
+            self.mock_block_metadata_request(block_metadata_url)
+        xblock_metadata_validator = XBlockMetadataProviderValidator(block_ids)
+
+        # Run all the validations, note that an assertion error will be raised if any of the validation fail.
+        xblock_metadata_validator.validate()

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -593,6 +593,8 @@ MEDIA_STORAGE_BACKEND = {
 # Settings related to the taxonomy_support
 TAXONOMY_COURSE_METADATA_PROVIDER = 'course_discovery.apps.taxonomy_support.providers.DiscoveryCourseMetadataProvider'
 TAXONOMY_PROGRAM_METADATA_PROVIDER = 'course_discovery.apps.taxonomy_support.providers.DiscoveryProgramMetadataProvider'
+TAXONOMY_XBLOCK_METADATA_PROVIDER = 'course_discovery.apps.taxonomy_support.providers.DiscoveryXBlockMetadataProvider'
+TAXONOMY_XBLOCK_SUPPORTED_TYPES = ['video', 'vertical']
 
 # Settings related to the EMSI client
 EMSI_API_ACCESS_TOKEN_URL = 'https://auth.emsicloud.com/connect/token'
@@ -679,3 +681,8 @@ PRODUCT_METADATA_MAPPING = {
 CONTENTFUL_SPACE_ID = None
 CONTENTFUL_CONTENT_DELIVERY_API_KEY = None
 CONTENTFUL_ENVIRONMENT = None
+LMS_API_URLS = {
+    'api_access_request': 'api-admin/api/v1/api_access_request/',
+    'blocks': 'api/courses/v1/blocks/',
+    'block_metadata': 'api/courses/v1/block_metadata/',
+}


### PR DESCRIPTION
## Description

Implements `XBlockMetadataProvider` based on `abstract XBlockMetadataProvider` from https://github.com/openedx/taxonomy-connector/pull/119 in [taxonomy/providers/xblock_metadata.py](https://github.com/openedx/taxonomy-connector/pull/119/files#diff-8141029820d082f307303dc4a5e1ece9f42d4b78715ecbda3437e53271e1af78). Utilizes `index_dictionary` from course blocks api added in https://github.com/openedx/edx-platform/pull/31273 to fetch text representation of xblock.

Currently the provider supports `video` and `vertical` block types, configured via `TAXONOMY_XBLOCK_SUPPORTED_TYPES` setting. It combines `index_dictionary` text from all children blocks.

## Supporting information

- `Private-ref`: [BB-6887](https://tasks.opencraft.com/browse/BB-6887)
- https://github.com/openedx/taxonomy-connector/pull/119
- https://github.com/openedx/edx-platform/pull/31273

## Testing instructions

- Checkout master branch in edx-platform.
- Start `lms` and `discovery` service in devstack using `make lms-up discovery-up`
- Follow [instructions given here](https://github.com/openedx/taxonomy-connector#getting-started) to setup taxonomy-connector in course-discovery, make sure to clone `https://github.com/open-craft/taxonomy-connector` in `<devstack-base-dir>/src/`
- Open discovery shell using `make discovery-shell`
- Run `./manage.py migrate`
- Open django shell using `./manage.py shell`
- Run below commands to make
```python
from course_discovery.apps.taxonomy_support.providers import DiscoveryXBlockMetadataProvider
provider = DiscoveryXBlockMetadataProvider()
course_blocks = provider.get_all_xblocks_in_course("course-v1:edX+DemoX+Demo_Course")
print(next(course_blocks)) # run few times to check fetched data
blocks = provider.get_xblocks(["block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc"])
print(blocks) # should print video and vertical block
```

### Pre-merge checklist

- [x] merge https://github.com/openedx/taxonomy-connector/pull/119
- [x] merge  https://github.com/openedx/edx-platform/pull/31273
- [x] Update `taxonomy-connector` in requirements (already updated as part of c0d4f28d2bf5cd2bb9197ee80f1b88906de81c4b)