### PR TITLE
chore: version bump of taxonomy-connector

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -75,7 +75,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   elasticsearch
     #   requests

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -64,9 +64,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.14
+boto3==1.26.16
     # via django-ses
-botocore==1.29.14
+botocore==1.29.16
     # via
     #   boto3
     #   s3transfer
@@ -411,7 +411,7 @@ face==22.0.0
     # via glom
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==15.3.2
+faker==15.3.3
     # via factory-boy
 fastavro==1.7.0
     # via openedx-events
@@ -503,7 +503,7 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==3.0.1
+openedx-events==3.1.0
     # via edx-event-bus-kafka
 oscrypto==1.3.0
     # via snowflake-connector-python
@@ -554,7 +554,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pycodestyle==2.9.1
+pycodestyle==2.10.0
     # via -r requirements/test.in
 pycountry==22.3.5
     # via -r requirements/base.in
@@ -802,13 +802,13 @@ stevedore==4.1.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.28.1
+taxonomy-connector==1.28.2
     # via -r requirements/base.in
 testfixtures==7.0.3
     # via -r requirements/test.in
 text-unidecode==1.3
     # via python-slugify
-texttable==1.6.5
+texttable==1.6.7
     # via docker-compose
 tinycss2==1.2.1
     # via
@@ -851,7 +851,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3[socks]==1.26.12
+urllib3[socks]==1.26.13
     # via
     #   botocore
     #   docker

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -39,9 +39,9 @@ beautifulsoup4==4.11.1
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.26.14
+boto3==1.26.16
     # via django-ses
-botocore==1.29.14
+botocore==1.29.16
     # via
     #   boto3
     #   s3transfer
@@ -397,7 +397,7 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==3.0.1
+openedx-events==3.1.0
     # via edx-event-bus-kafka
 oscrypto==1.3.0
     # via snowflake-connector-python
@@ -572,7 +572,7 @@ stevedore==4.1.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.28.1
+taxonomy-connector==1.28.2
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -590,7 +590,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   botocore
     #   elasticsearch


### PR DESCRIPTION
Version bump for new release of taxonomy connector library. Added a new field in Algilia Jobs Serializers. 

JIRA: [ENT-6411](https://2u-internal.atlassian.net/browse/ENT-6411)