### PR TITLE
fix: update transifex pull translations command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ extract_translations: ## Extract strings to be translated, outputting .po and .m
 
 # This Make target should not be removed since it is relied on by a Jenkins job (`edx-internal/tools-edx-jenkins/translation-jobs.yml`), using `ecommerce-scripts/transifex`.
 pull_translations: ## Pull translations from Transifex
-	tx pull -a -f --mode reviewed --minimum-perc=1
+	tx pull -a -f -t --mode reviewed --minimum-perc=1
 
 # This Make target should not be removed since it is relied on by a Jenkins job (`edx-internal/tools-edx-jenkins/translation-jobs.yml`), using `ecommerce-scripts/transifex`.
 push_translations: ## Push source translation files (.po) to Transifex


### PR DESCRIPTION
### Description

- `transifex` latest version requires `-t` flag with the `tx pull` command. 
- Please see the issue https://github.com/edx/edx-arch-experiments/issues/77 for details on this parameter's usage.