### PR TITLE
feat: update elastic search DSL query pagination size

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -459,11 +459,11 @@ SYNONYMS_MODULE = 'course_discovery.settings.synonyms'
 # (by default it uses the database driver's default setting)
 # https://docs.djangoproject.com/en/3.1/ref/models/querysets/#iterator
 # Thus set the 'chunk_size'
-ELASTICSEARCH_DSL_QUERYSET_PAGINATION = 5000
+ELASTICSEARCH_DSL_QUERYSET_PAGINATION = 10000
 
 # Defining default pagination for all requests to ElasticSearch,
 # whose parameters 'size' and 'from' are not explicitly set.
-ELASTICSEARCH_DSL_LOAD_PER_QUERY = 5000
+ELASTICSEARCH_DSL_LOAD_PER_QUERY = 10000
 
 ELASTICSEARCH_DSL = {
     'default': {'hosts': '127.0.0.1:9200'}


### PR DESCRIPTION
[Fix Discovery's CatalogQueryContainsViewSet Elasticsearch org query bug](https://2u-internal.atlassian.net/browse/PROD-3062)

## Context:
This API endpoint is behaving weird `https://discovery.edx.org/api/v1/catalog/query_contains/?course_uuids=1a66672095074ea7992e8a956c83d775&query=org:(-GTx)` because we have now a big data set and when we get all courses other than a specific organization, we get more than 5000 records and our logic check a specific course_uuid in all records, when we get 5000 records it misses other and returns wrong value. So we need to increase this limit so we can get all records and our query can search on all records rather in just 5000