### PR TITLE
feat: send contentful data to lightcast to get EMSI skills

### DIFF
--- a/course_discovery/apps/course_metadata/contentful_utils.py
+++ b/course_discovery/apps/course_metadata/contentful_utils.py
@@ -298,3 +298,13 @@ def fetch_and_transform_bootcamp_contentful_data():
             transformed_bootcamp_data[product_uuid].update({'faq_items': faq_items})
 
     return transformed_bootcamp_data
+
+
+def get_aggregated_data_from_contentful_data(data, product_uuid):
+    if (data is None) or (product_uuid not in data):
+        return None
+    faqs = [f"{faq['question']} {faq['answer']}" for faq in data[product_uuid]['faq_items']]
+    aggregated_text = ' '.join(faqs)
+    if 'hero_text_list' in data[product_uuid]:
+        aggregated_text = aggregated_text + ' ' + data[product_uuid]['hero_text_list']
+    return aggregated_text

--- a/course_discovery/apps/course_metadata/tests/test_contentful_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_contentful_utils.py
@@ -10,8 +10,8 @@ from django.test import TestCase
 from testfixtures import LogCapture
 
 from course_discovery.apps.course_metadata.contentful_utils import (
-    contentful_cache_key, fetch_and_transform_bootcamp_contentful_data, get_data_from_contentful,
-    rich_text_to_plain_text
+    contentful_cache_key, fetch_and_transform_bootcamp_contentful_data, get_aggregated_data_from_contentful_data,
+    get_data_from_contentful, rich_text_to_plain_text
 )
 from course_discovery.apps.course_metadata.tests.contentful_bootcamp_mock_data import (
     MockContentBootcampResponse, about_the_program_entry, bootcamp_transformed_data, mock_contentful_bootcamp_entry
@@ -79,3 +79,21 @@ class TestContentfulUtils(TestCase):
         """
         transformed_data = fetch_and_transform_bootcamp_contentful_data()
         self.assertDictEqual(transformed_data, bootcamp_transformed_data)
+
+    def test_get_aggregated_data_from_contentful_data(self):
+        expected_data = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit Lorem ipsum dolor sit amet, ' \
+                        'consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elitLorem ' \
+                        'ipsum dolor sit amet, consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur ' \
+                        'adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elitLorem ipsum dolor sit ' \
+                        'amet, consectetur adipiscing elit Lorem ipsum dolor sit amet, consectetur adipiscing elit ' \
+                        'Lorem ipsum dolor sit amet, consectetur adipiscing elitLorem ipsum dolor sit amet, ' \
+                        'consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elitLorem ' \
+                        'ipsum dolor sit amet, consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur ' \
+                        'adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elit Lorem ipsum: dolor ' \
+                        'sit amet, consectetur adipiscing elitLorem ipsum: dolor sit amet, consectetur adipiscing ' \
+                        'elitLorem ipsum: dolor sit amet, consectetur adipiscing elitLorem ipsum: dolor sit amet, ' \
+                        'consectetur adipiscing elit'
+
+        assert get_aggregated_data_from_contentful_data({}, 'uuid_123') is None
+        assert get_aggregated_data_from_contentful_data(bootcamp_transformed_data, 'no_uuid') is None
+        assert get_aggregated_data_from_contentful_data(bootcamp_transformed_data, 'test-uuid') == expected_data

--- a/course_discovery/apps/taxonomy_support/tests/test_providers.py
+++ b/course_discovery/apps/taxonomy_support/tests/test_providers.py
@@ -23,6 +23,7 @@ same repository, so whenever a new dependency (e.g. a new method or a new field 
 provider its validator is also updated in the same pull request. This ensures that the provider implementation in
 discovery and its interface in taxonomy are always in sync.
 """
+from unittest import mock
 
 from django.test import TestCase
 from taxonomy.validators import CourseMetadataProviderValidator, ProgramMetadataProviderValidator
@@ -34,8 +35,9 @@ class TaxonomyIntegrationTests(TestCase):
     """
     Validate integration of taxonomy_support and metadata providers.
     """
-
-    def test_validate_course_metadata(self):
+    @mock.patch('course_discovery.apps.course_metadata.contentful_utils.fetch_and_transform_bootcamp_contentful_data',
+                return_value={})
+    def test_validate_course_metadata(self, _contentful_data):
         """
         Validate that there are no integration issues.
         """


### PR DESCRIPTION
[Add ability to read data from Contentful and send to Lightcast for skills for Degrees](https://2u-internal.atlassian.net/browse/PROD-3025)
[Add ability to read data from Contentful and send to Lightcast for skills for Bootcamps](https://2u-internal.atlassian.net/browse/PROD-3061)

## Description
We need to send Contentful data to Lightcast API to get skills tagging, So in this PR we are sending the data we are getting from contenful to Taxonomy Connector which will send that data to EMSI API and save skills for that product

## Test instruction
To test this we need to go on Course page from discovery admin, and click on refresh_skills button for the desired course. 
It will get data from contentful and extract skills from that data