### PR TITLE
feat: transform degree data from contentful to algolia for indexing

### DIFF
--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -3,7 +3,9 @@ from algoliasearch_django import AlgoliaIndex, register
 from course_discovery.apps.course_metadata.algolia_models import (
     AlgoliaProxyCourse, AlgoliaProxyProduct, AlgoliaProxyProgram, SearchDefaultResultsConfiguration
 )
-from course_discovery.apps.course_metadata.contentful_utils import fetch_and_transform_bootcamp_contentful_data
+from course_discovery.apps.course_metadata.contentful_utils import (
+    fetch_and_transform_bootcamp_contentful_data, fetch_and_transform_degree_contentful_data
+)
 
 
 class BaseProductIndex(AlgoliaIndex):
@@ -17,10 +19,15 @@ class BaseProductIndex(AlgoliaIndex):
         if not self.language:
             raise Exception('Cannot update Algolia index \'{index_name}\'. No language set'.format(
                 index_name=self.index_name))
-        contentful_data = fetch_and_transform_bootcamp_contentful_data()
-        qs1 = [AlgoliaProxyProduct(course, self.language, contentful_data)
+
+        bootcamp_contentful_data = fetch_and_transform_bootcamp_contentful_data()
+        qs1 = [AlgoliaProxyProduct(course, self.language, contentful_data=bootcamp_contentful_data)
                for course in AlgoliaProxyCourse.objects.all()]
-        qs2 = [AlgoliaProxyProduct(program, self.language) for program in AlgoliaProxyProgram.objects.all()]
+
+        degree_contentful_data = fetch_and_transform_degree_contentful_data()
+        qs2 = [AlgoliaProxyProduct(program, self.language, contentful_data=degree_contentful_data)
+               for program in AlgoliaProxyProgram.objects.all()]
+
         return qs1 + qs2
 
     def generate_empty_query_rule(self, rule_object_id, product_type, results):

--- a/course_discovery/apps/course_metadata/tests/contentful_utils/contentful_mock_data.py
+++ b/course_discovery/apps/course_metadata/tests/contentful_utils/contentful_mock_data.py
@@ -1,0 +1,136 @@
+# pylint: disable=line-too-long
+"""
+Mock data for testing purposes of Contentful Bootcamp Data transformation utils.
+"""
+import random
+import string
+
+from contentful import Entry
+
+
+def create_contentful_entry(entry_name, fields):
+    return Entry({
+        'metadata': {'tags': []},
+        'sys': {
+            'space': {'sys': {'type': 'Link', 'linkType': 'Space', 'id': 'test_space_id'}},
+            'id': ''.join(random.choices(string.ascii_letters + string.digits, k=22)),
+            'type': 'Entry',
+            'createdAt': '2022-12-05T21:20:18.606Z',
+            'updatedAt': '2022-12-05T21:20:18.606Z',
+            'environment': {'sys': {'id': 'master', 'type': 'Link', 'linkType': 'Environment'}},
+            'revision': 1,
+            'contentType': {
+                'sys': {'type': 'Link', 'linkType': 'ContentType', 'id': entry_name}},
+            'locale': 'en-US'
+        },
+        'fields': fields
+    })
+
+
+class MockContenfulDegreeResponse:
+    """
+    Mock Contentful Degree Response
+    """
+
+    degree_transformed_data = None
+    mock_contentful_degree_entry = None
+
+    def __init__(self):
+        seo_entry = create_contentful_entry('seo', {
+            'pageTitle': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'pageDescription': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'languageCode': 'en'
+        })
+        hero_entry = create_contentful_entry('hero', {
+            'internalName': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'subheading': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'textList': {'nodeType': 'document', 'data': {}, 'content': [{'nodeType': 'unordered-list', 'data': {}, 'content': [{'nodeType': 'list-item', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum:', 'nodeType': 'text', 'marks': [{'type': 'bold'}], 'data': {}}, {'value': ' dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}, {'nodeType': 'list-item', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum:', 'nodeType': 'text', 'marks': [{'type': 'bold'}], 'data': {}}, {'value': ' dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}, {'nodeType': 'list-item', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum:', 'nodeType': 'text', 'marks': [{'type': 'bold'}], 'data': {}}, {'value': ' dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}, {'nodeType': 'list-item', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum:', 'nodeType': 'text', 'marks': [{'type': 'bold'}], 'data': {}}, {'value': ' dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}]}]},
+        })
+        about_the_program_entry = create_contentful_entry('aboutTheProgramModule', {
+            'internalName': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'heading': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'content': {'nodeType': 'document', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]},
+            'checkmarkedItems': create_contentful_entry('textListModule', {
+                'title': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'theme': 'background-white',
+                'textListItems': [create_contentful_entry('textListItem', {
+                    'header': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                    'description': {'nodeType': 'document', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum:', 'nodeType': 'text', 'marks': [{'type': 'bold'}], 'data': {}}, {'value': ' dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}
+                })]
+            }),
+        })
+        placement_about_section_entry = create_contentful_entry('placementAboutSection', {
+            'internalName': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'heading': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'bodyText': {'nodeType': 'document', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum:', 'nodeType': 'text', 'marks': [{'type': 'bold'}], 'data': {}}, {'value': ' dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}
+        })
+        featured_products_entry = create_contentful_entry('featuredProductsModule', {
+            'internalName': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'heading': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'introduction': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'productList': create_contentful_entry('textListModule', {
+                'title': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'theme': 'background-white',
+                'textListItems': [create_contentful_entry('textListItem', {
+                    'header': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                    'description': {'nodeType': 'document', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum:', 'nodeType': 'text', 'marks': [{'type': 'bold'}], 'data': {}}, {'value': ' dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}
+                })]
+            }),
+        })
+        faq_entry = create_contentful_entry('faqModule', {
+            'name': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'faqs': [
+                create_contentful_entry('faq', {
+                    'name': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                    'question': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                    'answerRichText': {'nodeType': 'document', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}, {'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [{'type': 'bold'}], 'data': {}}]}, {'nodeType': 'unordered-list', 'data': {}, 'content': [{'nodeType': 'list-item', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}, {'nodeType': 'list-item', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}, {'nodeType': 'list-item', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}, {'nodeType': 'list-item', 'data': {}, 'content': [{'nodeType': 'paragraph', 'data': {}, 'content': [{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit', 'nodeType': 'text', 'marks': [], 'data': {}}]}]}]}]}
+                })
+            ]
+        })
+        self.mock_contentful_degree_entry = create_contentful_entry('degreeDetailPage', {
+            'internalName': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+            'uuid': 'test-uuid',
+            'seo': seo_entry,
+            'hero': hero_entry,
+            'modules': [
+                about_the_program_entry,
+                faq_entry,
+                placement_about_section_entry,
+                featured_products_entry
+            ]
+        })
+
+        self.degree_transformed_data = {
+            'test-uuid': {
+                'page_title': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'subheading': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'about_program_heading': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'about_program_content': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'about_program_checkmarked_items': [
+                    'Lorem ipsum: dolor sit amet, consectetur adipiscing elit'
+                ],
+                'faq_items': [
+                    {
+                        'question': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                        'answer': 'Lorem ipsum dolor sit amet, consectetur adipiscing elitLorem ipsum dolor sit amet,'
+                        ' consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elitLorem'
+                        ' ipsum dolor sit amet, consectetur adipiscing elitLorem ipsum dolor sit amet, '
+                        'consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elit'
+                    },
+                ],
+                "featured_products": {
+                    "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                    "introduction": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                    "product_list": [
+                        {
+                            "header": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                            "description": "Lorem ipsum: dolor sit amet, consectetur adipiscing elit"
+                        },
+                    ],
+                },
+                "placement_about_section": {
+                    "heading": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+                    "body_text": "Lorem ipsum: dolor sit amet, consectetur adipiscing elit",
+                }
+            }
+        }

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -84,3 +84,5 @@ CELERY_BROKER_URL = 'memory://localhost/'
 PRODUCT_API_URL = 'http://www.example.com'
 
 BOOTCAMP_CONTENTFUL_CONTENT_TYPE = 'bootCampPage'
+
+DEGREE_CONTENTFUL_CONTENT_TYPE = 'degreeDetailPage'


### PR DESCRIPTION
[PROD-3047](https://2u-internal.atlassian.net/browse/PROD-3047)

This PR adds util functions that transforms degrees data from Contentful. The transformed fields will be sent to algolia for indexing and lightcast for skill extraction.

### Testing Instructions for Contentful data transformation
Follow instructions mentioned in #3714 but change wherever necessary.

1. Set the following variables in `private.py` file:
```
BOOTCAMP_CONTENTFUL_CONTENT_TYPE = 'degreeDetailPage'
```

2. Run python shell in discovery shell: `make discovery-shell` `./manage.py shell`
3. Run the following code in shell to read the data from contentful:
```
from course_discovery.apps.course_metadata.contentful_utils import fetch_and_transform_degree_contentful_data
fetch_and_transform_degree_contentful_data()
```

### Testing Instructions for Algolia Reindexing on local
Follow the instructions mentioned in #3714 

### Post-merge:
- [ ] Run Algolia-reindexing on staging and verify degree data properly updated on EdX-Staging