### PR TITLE
chore: update logs in LMS data loader to log create operations

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -108,6 +108,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
     def process_single_course_run(self, body):
         course_run_id = body['id']
 
+        logger.info(f"Starting course processing for id {course_run_id}")
         try:
             body = self.clean_strings(body)
             official_run, draft_run = self.get_course_run(body)
@@ -123,6 +124,8 @@ class CoursesApiDataLoader(AbstractDataLoader):
                 course, created = self.get_or_create_course(body)
                 course_run = self.create_course_run(course, body)
                 if created:
+                    logger.info(f"Course created with uuid {str(course.uuid)} and key {course.key}")
+                    logger.info(f"Course run created with uuid {str(course_run.uuid)} and key {course_run.key}")
                     course.canonical_course_run = course_run
                     course.save()
         except Exception:  # pylint: disable=broad-except
@@ -166,7 +169,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
             if not has_upgrade_deadline_override and official_run:
                 push_to_ecommerce_for_course_run(official_run)
 
-        logger.info('Processed course run with UUID [%s].', run.uuid)
+        logger.info(f'Processed course run with UUID [{str(run.uuid)}] and key [{run.key}].')
 
     def create_course_run(self, course, body):
         defaults = self.format_course_run_data(body, course=course)

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -124,8 +124,8 @@ class CoursesApiDataLoader(AbstractDataLoader):
                 course, created = self.get_or_create_course(body)
                 course_run = self.create_course_run(course, body)
                 if created:
-                    logger.info(f"Course created with uuid {str(course.uuid)} and key {course.key}")
-                    logger.info(f"Course run created with uuid {str(course_run.uuid)} and key {course_run.key}")
+                    logger.info(f"Course created with uuid {course.uuid} and key {course.key}")
+                    logger.info(f"Course run created with uuid {course_run.uuid} and key {course_run.key}")
                     course.canonical_course_run = course_run
                     course.save()
         except Exception:  # pylint: disable=broad-except
@@ -169,7 +169,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
             if not has_upgrade_deadline_override and official_run:
                 push_to_ecommerce_for_course_run(official_run)
 
-        logger.info(f'Processed course run with UUID [{str(run.uuid)}] and key [{run.key}].')
+        logger.info(f'Processed course run with UUID [{run.uuid}] and key [{run.key}].')
 
     def create_course_run(self, course, body):
         defaults = self.format_course_run_data(body, course=course)

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -1,3 +1,4 @@
+
 import datetime
 from re import escape
 from unittest import mock
@@ -854,4 +855,4 @@ class TestCourseDataUpdateSignal(TestCase):
         )
         with self.assertLogs('course_discovery.apps.course_metadata.data_loaders.api') as captured_logs:
             update_course_data_from_event(catalog_info=catalog_data)
-            assert 'An error occurred while updating' in captured_logs.output[0]
+            assert 'An error occurred while updating' in captured_logs.output[1]


### PR DESCRIPTION
### [PROD-3068](https://2u-internal.atlassian.net/browse/PROD-3068)

### Description

Updating LMS data loader logs to log course and course run create information. This will help verify if the course in Discovery has been created via LMS loader (RCM or event bus) and help diagnose any data inconsistencies.