### PR TITLE
feat: send degrees contentful data to taxonomy for skills extraction

### DIFF
--- a/course_discovery/apps/course_metadata/contentful_utils.py
+++ b/course_discovery/apps/course_metadata/contentful_utils.py
@@ -354,10 +354,28 @@ def fetch_and_transform_bootcamp_contentful_data():
 def get_aggregated_data_from_contentful_data(data, product_uuid):
     if (data is None) or (product_uuid not in data):
         return None
-    faqs = [f"{faq['question']} {faq['answer']}" for faq in data[product_uuid]['faq_items']]
-    aggregated_text = ' '.join(faqs)
+
+    aggregated_text = ''
+    if 'faq_items' in data[product_uuid]:
+        faqs = [f"{faq['question']} {faq['answer']}" for faq in data[product_uuid]['faq_items']]
+        aggregated_text = ' '.join(faqs)
+
     if 'hero_text_list' in data[product_uuid]:
-        aggregated_text = aggregated_text + ' ' + data[product_uuid]['hero_text_list']
+        aggregated_text = f"{aggregated_text} {data[product_uuid]['hero_text_list']}"
+
+    if 'placement_about_section' in data[product_uuid]:
+        placement_about = data[product_uuid]['placement_about_section']
+        aggregated_text = f"{aggregated_text} {placement_about['heading']} {placement_about['body_text']}"
+
+    if 'featured_products' in data[product_uuid]:
+        featured_products = data[product_uuid]['featured_products']
+        featured_products_list = [
+            f"{product['header']} {product['description']}" for product in featured_products['product_list']
+        ]
+        featured_products_list = ' '.join(featured_products_list)
+        aggregated_text = f"{aggregated_text} {featured_products['heading']}" \
+                          f" {featured_products['introduction']} {featured_products_list}"
+
     return aggregated_text
 
 

--- a/course_discovery/apps/course_metadata/tests/test_contentful_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_contentful_utils.py
@@ -124,7 +124,7 @@ class TestContentfulUtils(TestCase):
         self.assertDictEqual(
             transformed_data, mock_bootcamp_response.bootcamp_transformed_data)
 
-    def test_get_aggregated_data_from_contentful_data(self):
+    def test_get_aggregated_data_from_contentful_data__bootcamp(self):
         mock_bootcamp_response = MockContentfulBootcampResponse()
         expected_data = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit Lorem ipsum dolor sit amet, ' \
                         'consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elitLorem ' \
@@ -144,6 +144,24 @@ class TestContentfulUtils(TestCase):
             mock_bootcamp_response.bootcamp_transformed_data, 'no_uuid') is None
         assert get_aggregated_data_from_contentful_data(
             mock_bootcamp_response.bootcamp_transformed_data, 'test-uuid') == expected_data
+
+    def test_get_aggregated_data_from_contentful_data__degree(self):
+        mock_degree_response = MockContenfulDegreeResponse()
+        expected_data = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit Lorem ipsum dolor sit amet, ' \
+                        'consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elitLorem ' \
+                        'ipsum dolor sit amet, consectetur adipiscing elitLorem ipsum dolor sit amet, consectetur ' \
+                        'adipiscing elitLorem ipsum dolor sit amet, consectetur adipiscing elitLorem ipsum dolor sit ' \
+                        'amet, consectetur adipiscing elit Lorem ipsum dolor sit amet, consectetur adipiscing elit ' \
+                        'Lorem ipsum: dolor sit amet, consectetur adipiscing elit Lorem ipsum dolor sit amet, ' \
+                        'consectetur adipiscing elit Lorem ipsum dolor sit amet, consectetur adipiscing elit Lorem ' \
+                        'ipsum dolor sit amet, consectetur adipiscing elit Lorem ipsum: dolor sit amet, consectetur ' \
+                        'adipiscing elit'
+
+        assert get_aggregated_data_from_contentful_data({}, 'uuid_123') is None
+        assert get_aggregated_data_from_contentful_data(
+            mock_degree_response.degree_transformed_data, 'no_uuid') is None
+        assert get_aggregated_data_from_contentful_data(
+            mock_degree_response.degree_transformed_data, 'test-uuid') == expected_data
 
     @mock.patch('course_discovery.apps.course_metadata.contentful_utils.get_data_from_contentful',
                 return_value=[MockContenfulDegreeResponse().mock_contentful_degree_entry])

--- a/course_discovery/apps/taxonomy_support/providers.py
+++ b/course_discovery/apps/taxonomy_support/providers.py
@@ -17,7 +17,8 @@ from edx_django_utils.db import chunked_queryset
 from taxonomy.providers import CourseMetadataProvider, ProgramMetadataProvider
 
 from course_discovery.apps.course_metadata.contentful_utils import (
-    fetch_and_transform_bootcamp_contentful_data, get_aggregated_data_from_contentful_data
+    fetch_and_transform_bootcamp_contentful_data, fetch_and_transform_degree_contentful_data,
+    get_aggregated_data_from_contentful_data
 )
 from course_discovery.apps.course_metadata.models import Course, Program
 
@@ -76,8 +77,7 @@ class DiscoveryProgramMetadataProvider(ProgramMetadataProvider):
         Get list of programs matching the given program UUIDs and return then in the form of a dict.
         """
         programs = Program.objects.filter(uuid__in=program_ids).distinct()
-        # Todo: use transform_degree_contentful_data method to get data from contentful
-        contentful_data = {}
+        contentful_data = fetch_and_transform_degree_contentful_data()
         return [{
             'uuid': program.uuid,
             'title': program.title,
@@ -91,8 +91,7 @@ class DiscoveryProgramMetadataProvider(ProgramMetadataProvider):
         Get iterator for all the programs.
         """
         all_programs = Program.objects.all()
-        # Todo: use transform_degree_contentful_data method to get data from contentful
-        contentful_data = {}
+        contentful_data = fetch_and_transform_degree_contentful_data()
         for chunked_programs in chunked_queryset(all_programs):
             for program in chunked_programs:
                 yield {

--- a/course_discovery/apps/taxonomy_support/tests/test_providers.py
+++ b/course_discovery/apps/taxonomy_support/tests/test_providers.py
@@ -35,7 +35,7 @@ class TaxonomyIntegrationTests(TestCase):
     """
     Validate integration of taxonomy_support and metadata providers.
     """
-    @mock.patch('course_discovery.apps.course_metadata.contentful_utils.fetch_and_transform_bootcamp_contentful_data',
+    @mock.patch('course_discovery.apps.taxonomy_support.providers.fetch_and_transform_bootcamp_contentful_data',
                 return_value={})
     def test_validate_course_metadata(self, _contentful_data):
         """
@@ -49,7 +49,9 @@ class TaxonomyIntegrationTests(TestCase):
         # Run all the validations, note that an assertion error will be raised if any of the validation fail.
         course_metadata_validator.validate()
 
-    def test_validate_program_metadata(self):
+    @mock.patch('course_discovery.apps.taxonomy_support.providers.fetch_and_transform_degree_contentful_data',
+                return_value={})
+    def test_validate_program_metadata(self, _contentful_data):
         """
         Validate that there are no integration issues.
         """


### PR DESCRIPTION
## Description:

In the follow up this PR https://github.com/openedx/course-discovery/pull/3721. We need to send degrees contentful data to Lightcast to extract skills as well. In this PR we will get aggregated data from contentful and send to lightcast for skills extraction