### PR TITLE
feat: change term to match filter in elasticsearch for courseruns

### DIFF
--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -96,7 +96,7 @@ class CourseRunViewSet(ValidElasticSearchQueryRequiredMixin, viewsets.ModelViewS
             queryset = self.queryset
 
         if q:
-            qs = SearchQuerySetWrapper(CourseRun.search(q).filter('term', partner=partner.short_code))
+            qs = SearchQuerySetWrapper(CourseRun.search(q).filter('match', partner=partner.short_code))
             # This is necessary to avoid issues with the filter backend.
             qs.model = self.queryset.model
             return qs


### PR DESCRIPTION
# Description
This term is changed with the purpose of matching partners in the course runs API  when they are configurated in upper or with it short_code in upper.

## purpose
When the short_code of a partner and the name are in uppercase the course run filter isn't working.
The problem is explained by the way elasticsearch works.
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html
Also, they recommend using match instead term To search `text` field values.


Here I show you some shell commands that validated my search in my discovery container.
![image](https://user-images.githubusercontent.com/51926076/209374900-66d0b54a-86cf-4eed-9cd0-f93c94702f6b.png)

![2022-12-23_12-08](https://user-images.githubusercontent.com/51926076/209374395-65a66b8d-af9a-4eeb-8b18-ccc973750128.png)

![2022-12-23_12-08_1](https://user-images.githubusercontent.com/51926076/209374393-4cc80b08-fb03-4067-88dd-b003a36dbd54.png)
![2022-12-23_12-09](https://user-images.githubusercontent.com/51926076/209374383-716ae751-2152-4aba-9bff-b2d6c3d998f9.png)


