### PR TITLE
feat: add googleapiclent to communicate with drive images

### DIFF
--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -18,7 +18,7 @@ IMAGE_TYPES = {
 DRIVE_LINK_PATTERNS = [r"https://docs\.google\.com/uc\?id=\w+",
                        r"https://drive\.google\.com/file/d/\w+/view?usp=sharing"]
 
-GOOGLE_CLIENT_API_SCOPE = ['https://www.googleapis.com/auth/drive']
+GOOGLE_CLIENT_API_SCOPE = ['https://www.googleapis.com/auth/drive.readonly']
 
 
 class PathwayType(Enum):

--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -15,6 +15,11 @@ IMAGE_TYPES = {
     'image/svg+xml': 'svg'  # SVG image will be converted into PNG, not stored as SVG
 }
 
+DRIVE_LINK_PATTERNS = [r"https://docs\.google\.com/uc\?id=\w+",
+                       r"https://drive\.google\.com/file/d/\w+/view?usp=sharing"]
+
+GOOGLE_CLIENT_API_SCOPE = ['https://www.googleapis.com/auth/drive']
+
 
 class PathwayType(Enum):
     """ Allowed values for Pathway.pathway_type """

--- a/course_discovery/apps/course_metadata/googleapi_client.py
+++ b/course_discovery/apps/course_metadata/googleapi_client.py
@@ -1,0 +1,51 @@
+import logging
+import re
+
+from django.conf import settings
+from googleapiclient.discovery import build
+from oauth2client.service_account import ServiceAccountCredentials
+
+from course_discovery.apps.course_metadata.constants import GOOGLE_CLIENT_API_SCOPE
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleAPIClient:
+    """
+    API Client for Google API to communicate with drive files
+    """
+
+    def __init__(self):
+        try:
+            credentials = ServiceAccountCredentials.from_json_keyfile_dict(
+                settings.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS, GOOGLE_CLIENT_API_SCOPE)
+            self.service = build('drive', 'v3', credentials=credentials)
+            logger.info('[Connection Successful]: Successful connection with google service account')
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.exception(f'[Connection Failed]: Failed to connect with google service account error_message: {ex}')
+
+    def get_file_metadata(self, url):
+        try:
+            file_id = self.get_file_id_from_url(url)
+            file = self.service.files().get(fileId=file_id).execute()  # pylint: disable=no-member
+            logger.info(f'[File Found]: Found google file {file_id} on requesting {url}')
+            return file
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.exception(f'[File Not Found]: No file found for id: {file_id} error_message: {ex}')
+        return None
+
+    @staticmethod
+    def get_file_id_from_url(url):
+        match = re.search(r'id=(\w+)', url) or re.search(r'/(?:file/d/|uc\?id=)([-\w]{25,})(?:[&/]|$)', url)
+        return match.group(1) if match else None
+
+    def download_file_by_url(self, url):
+        content = None
+        try:
+            file_id = self.get_file_id_from_url(url)
+            request = self.service.files().get_media(fileId=file_id)  # pylint: disable=no-member
+            content = request.execute()
+            logger.info(f'[File Downloaded]: Downloading google file {file_id}')
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.exception(f'[File Not Downloaded]: No file found for id: {file_id} error_message: {ex}')
+        return content

--- a/course_discovery/apps/course_metadata/googleapi_client.py
+++ b/course_discovery/apps/course_metadata/googleapi_client.py
@@ -2,8 +2,8 @@ import logging
 import re
 
 from django.conf import settings
+from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
-from oauth2client.service_account import ServiceAccountCredentials
 
 from course_discovery.apps.course_metadata.constants import GOOGLE_CLIENT_API_SCOPE
 
@@ -17,8 +17,10 @@ class GoogleAPIClient:
 
     def __init__(self):
         try:
-            credentials = ServiceAccountCredentials.from_json_keyfile_dict(
-                settings.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS, GOOGLE_CLIENT_API_SCOPE)
+            credentials = Credentials.from_service_account_info(
+                settings.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS, scopes=GOOGLE_CLIENT_API_SCOPE
+            )
+            credentials = credentials.with_subject(settings.LOADER_INGESTION_CONTACT_EMAIL)
             self.service = build('drive', 'v3', credentials=credentials)
             logger.info('[Connection Successful]: Successful connection with google service account')
         except Exception as ex:  # pylint: disable=broad-except

--- a/course_discovery/apps/course_metadata/tests/test_googleapi.py
+++ b/course_discovery/apps/course_metadata/tests/test_googleapi.py
@@ -15,35 +15,38 @@ class GoogleAPIClientTests(TestCase):
     ]
 
     @mock.patch('course_discovery.apps.course_metadata.googleapi_client.logger')
-    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.ServiceAccountCredentials')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.Credentials.with_subject')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.Credentials')
     @mock.patch('course_discovery.apps.course_metadata.googleapi_client.build')
-    def test_connection_with_google(self, mock_googleapi_connection, mock_account_credentials, mock_logger):
+    def test_connection_with_google(self, mock_googleapi_connection, mock_account_credentials, _mock_with_subject, mock_logger):  # pylint: disable=line-too-long
         GoogleAPIClient()
-        assert mock_account_credentials.from_json_keyfile_dict.called is True
+        assert mock_account_credentials.from_service_account_info.called is True
         assert mock_googleapi_connection.called is True
         mock_logger.info.assert_called_with(
             '[Connection Successful]: Successful connection with google service account'
         )
 
     @ddt.data(*Google_DRIVE_API_TEST_DATA)
-    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.ServiceAccountCredentials')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.Credentials.with_subject')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.Credentials')
     @mock.patch('course_discovery.apps.course_metadata.googleapi_client.build')
     @ddt.unpack
-    def test_get_file_id_from_url(self, file_url, expected_file_id, mock_googleapi_connection, mock_account_credentials):  # pylint: disable=line-too-long
+    def test_get_file_id_from_url(self, file_url, expected_file_id, mock_googleapi_connection, mock_account_credentials, _mock_with_subject):  # pylint: disable=line-too-long
         client = GoogleAPIClient()
-        assert mock_account_credentials.from_json_keyfile_dict.called is True
+        assert mock_account_credentials.from_service_account_info.called is True
         assert mock_googleapi_connection.called is True
         file_id = client.get_file_id_from_url(file_url)
         assert file_id == expected_file_id
 
     @ddt.data(*Google_DRIVE_API_TEST_DATA)
     @mock.patch('course_discovery.apps.course_metadata.googleapi_client.logger')
-    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.ServiceAccountCredentials')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.Credentials.with_subject')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.Credentials')
     @mock.patch('course_discovery.apps.course_metadata.googleapi_client.build')
     @ddt.unpack
-    def test_get_file_metadata(self, file_url, expected_file_id, mock_googleapi_connection, mock_account_credentials, mock_logger):  # pylint: disable=line-too-long
+    def test_get_file_metadata(self, file_url, expected_file_id, mock_googleapi_connection, mock_account_credentials, _mock_with_subject, mock_logger):  # pylint: disable=line-too-long
         client = GoogleAPIClient()
-        assert mock_account_credentials.from_json_keyfile_dict.called is True
+        assert mock_account_credentials.from_service_account_info.called is True
         assert mock_googleapi_connection.called is True
         client.get_file_metadata(file_url)
         mock_logger.info.assert_called_with(
@@ -52,10 +55,11 @@ class GoogleAPIClientTests(TestCase):
 
     @ddt.data(*Google_DRIVE_API_TEST_DATA)
     @mock.patch('course_discovery.apps.course_metadata.googleapi_client.logger')
-    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.ServiceAccountCredentials')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.Credentials.with_subject')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.Credentials')
     @mock.patch('course_discovery.apps.course_metadata.googleapi_client.build')
     @ddt.unpack
-    def test_download_file_by_url(self, file_url, expected_file_id, _mock_googleapi_connection, _mock_account_credentials, mock_logger):  # pylint: disable=line-too-long
+    def test_download_file_by_url(self, file_url, expected_file_id, _mock_googleapi_connection, _mock_account_credentials, _mock_with_subject, mock_logger):  # pylint: disable=line-too-long
         client = GoogleAPIClient()
         client.download_file_by_url(file_url)
         mock_logger.info.assert_called_with(f'[File Downloaded]: Downloading google file {expected_file_id}')

--- a/course_discovery/apps/course_metadata/tests/test_googleapi.py
+++ b/course_discovery/apps/course_metadata/tests/test_googleapi.py
@@ -1,0 +1,61 @@
+from unittest import mock
+
+import ddt
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.googleapi_client import GoogleAPIClient
+
+
+@ddt.ddt
+class GoogleAPIClientTests(TestCase):
+
+    Google_DRIVE_API_TEST_DATA = [
+        ('https://docs.google.com/uc?id=abc123Id', 'abc123Id'),
+        ('https://drive.google.com/file/d/1Xv36dVXFC-eU2Oks_EcRdbtgv47D-osP/view?usp=sharing', '1Xv36dVXFC-eU2Oks_EcRdbtgv47D-osP'),  # pylint: disable=line-too-long
+    ]
+
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.logger')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.ServiceAccountCredentials')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.build')
+    def test_connection_with_google(self, mock_googleapi_connection, mock_account_credentials, mock_logger):
+        GoogleAPIClient()
+        assert mock_account_credentials.from_json_keyfile_dict.called is True
+        assert mock_googleapi_connection.called is True
+        mock_logger.info.assert_called_with(
+            '[Connection Successful]: Successful connection with google service account'
+        )
+
+    @ddt.data(*Google_DRIVE_API_TEST_DATA)
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.ServiceAccountCredentials')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.build')
+    @ddt.unpack
+    def test_get_file_id_from_url(self, file_url, expected_file_id, mock_googleapi_connection, mock_account_credentials):  # pylint: disable=line-too-long
+        client = GoogleAPIClient()
+        assert mock_account_credentials.from_json_keyfile_dict.called is True
+        assert mock_googleapi_connection.called is True
+        file_id = client.get_file_id_from_url(file_url)
+        assert file_id == expected_file_id
+
+    @ddt.data(*Google_DRIVE_API_TEST_DATA)
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.logger')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.ServiceAccountCredentials')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.build')
+    @ddt.unpack
+    def test_get_file_metadata(self, file_url, expected_file_id, mock_googleapi_connection, mock_account_credentials, mock_logger):  # pylint: disable=line-too-long
+        client = GoogleAPIClient()
+        assert mock_account_credentials.from_json_keyfile_dict.called is True
+        assert mock_googleapi_connection.called is True
+        client.get_file_metadata(file_url)
+        mock_logger.info.assert_called_with(
+            f'[File Found]: Found google file {expected_file_id} on requesting {file_url}'
+        )
+
+    @ddt.data(*Google_DRIVE_API_TEST_DATA)
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.logger')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.ServiceAccountCredentials')
+    @mock.patch('course_discovery.apps.course_metadata.googleapi_client.build')
+    @ddt.unpack
+    def test_download_file_by_url(self, file_url, expected_file_id, _mock_googleapi_connection, _mock_account_credentials, mock_logger):  # pylint: disable=line-too-long
+        client = GoogleAPIClient()
+        client.download_file_by_url(file_url)
+        mock_logger.info.assert_called_with(f'[File Downloaded]: Downloading google file {expected_file_id}')

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -776,7 +776,7 @@ class TestDownloadAndSaveImage(TestCase):
         course = CourseFactory(card_image_url=image_url, image=None)
         download_and_save_course_image(course, course.card_image_url, data_field='image', headers=None)
         image_url, content = self.mock_image_response()
-        response = requests.get('https://example.com/image.jpg')
+        response = requests.get('https://example.com/image.jpg', timeout=5)
         assert response.content == content
         assert course.card_image_url == image_url
         assert course.image is not None
@@ -801,7 +801,7 @@ class TestDownloadAndSaveImage(TestCase):
         course = CourseFactory(card_image_url=image_url, image=None)
         download_and_save_course_image(course, course.card_image_url, data_field='image', headers=None)
         image_url, content = self.mock_image_response(status=200, body=b'invalid', content_type='text/plain', url=image_url)  # pylint: disable=line-too-long
-        response = requests.get('https://www.example.com/image.pdf')
+        response = requests.get('https://www.example.com/image.pdf', timeout=5)
         assert response.content == content
         assert not bool(course.image)
 
@@ -823,7 +823,7 @@ class TestDownloadAndSaveImage(TestCase):
         program = ProgramFactory(card_image_url=image_url, card_image=None)
         download_and_save_program_image(program, program.card_image_url, data_field='image', headers=None)
         image_url, content = self.mock_image_response()
-        response = requests.get('https://example.com/image.jpg')
+        response = requests.get('https://example.com/image.jpg', timeout=5)
         assert response.content == content
         assert program.card_image is not None
 
@@ -845,6 +845,6 @@ class TestDownloadAndSaveImage(TestCase):
         program = ProgramFactory(card_image_url=image_url, card_image=None)
         download_and_save_program_image(program, program.card_image_url, data_field='image', headers=None)
         image_url, content = self.mock_image_response(status=200, body=b'invalid', content_type='text/plain', url=image_url)  # pylint: disable=line-too-long
-        response = requests.get('https://www.example.com/image.pdf')
+        response = requests.get('https://www.example.com/image.pdf', timeout=5)
         assert response.content == content
         assert not bool(program.card_image)

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -743,8 +743,7 @@ class TestDownloadAndSaveImage(TestCase):
                   b'\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc```\x00\x00\x00\x04\x00\x01\xf6\x178U\x00\x00\x00\x00' \
                   b'IEND\xaeB`\x82'
 
-    def mock_image_response(self, status=200, body=None, content_type='image/jpeg', url='https://example.com/image.jpg'):  # pylint: disable=invalid-name
-        """ Mock image response """
+    def mock_image_response(self, status=200, body=None, content_type='image/jpeg', url='https://example.com/image.jpg'):  # pylint: disable=line-too-long
         body = body or b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00' \
                        b'\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc```\x00\x00\x00\x04\x00\x01\xf6\x178U\x00\x00\x00\x00' \
                        b'IEND\xaeB`\x82'

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import random
+import re
 import string
 import uuid
 from tempfile import NamedTemporaryFile
@@ -21,10 +22,11 @@ from stdimage.models import StdImageFieldFile
 
 from course_discovery.apps.core.models import SalesforceConfiguration
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.course_metadata.constants import IMAGE_TYPES
+from course_discovery.apps.course_metadata.constants import DRIVE_LINK_PATTERNS, IMAGE_TYPES
 from course_discovery.apps.course_metadata.exceptions import (
     EcommerceSiteAPIClientException, MarketingSiteAPIClientException
 )
+from course_discovery.apps.course_metadata.googleapi_client import GoogleAPIClient
 from course_discovery.apps.course_metadata.salesforce import SalesforceUtil
 from course_discovery.apps.publisher.utils import VALID_CHARS_IN_COURSE_NUM_AND_ORG_KEY
 
@@ -690,6 +692,22 @@ def clean_html(content):
     return cleaned
 
 
+def get_file_from_drive_link(image_url):
+    """
+    Helper method to get the file content_type and content from a drive link
+
+    Keyword Arguments:
+        image_url {str} -- drive link of the file
+
+    Returns:
+        tuple --  content_type and content of the file
+    """
+    google_api_client = GoogleAPIClient()
+    content_type = google_api_client.get_file_metadata(image_url).get('mimeType')
+    content = google_api_client.download_file_by_url(image_url)
+    return content_type, content
+
+
 def download_and_save_course_image(course, image_url, data_field='image', headers=None):
     """
     Helper method to download an image from a provided image url and save it
@@ -697,38 +715,45 @@ def download_and_save_course_image(course, image_url, data_field='image', header
     """
     try:
         image_url = get_downloadable_url_from_drive_link(image_url)
-        response = requests.get(image_url, headers=headers)  # pylint: disable=missing-timeout
 
-        if response.status_code == requests.codes.ok:  # pylint: disable=no-member
-            content_type = response.headers['Content-Type'].lower()
+        if is_google_drive_url(image_url):
+            content_type, content = get_file_from_drive_link(image_url)
             extension = IMAGE_TYPES.get(content_type)
-
-            if extension:
-                filename = '{uuid}.{extension}'.format(uuid=str(course.uuid), extension=extension)
-                # TODO: Get field from _meta.get_field. Tried that approach initially but was getting
-                # field save errors for some reasons.
-                if data_field == 'image':
-                    course.image.save(filename, ContentFile(response.content))
-                elif data_field == 'organization_logo_override':
-                    image_file = ContentFile(response.content)
-                    if extension == 'svg':
-                        filename = '{uuid}.png'.format(uuid=str(course.uuid))
-                        image_file = convert_svg_to_png_from_url(image_url)
-                    if image_file:
-                        course.organization_logo_override.save(filename, image_file)
-                    else:
-                        logger.error('Update organization logo override failed for course [%s]', course.key)
-                        return False
-                logger.info('Image for course [%s] successfully updated.', course.key)
-                return True
-            else:
-                # pylint: disable=line-too-long
-                msg = 'Image retrieved for course [%s] from [%s] has an unknown content type [%s] and will not be saved.'
-                logger.error(msg, course.key, image_url, content_type)
-
         else:
-            msg = 'Failed to download image for course [%s] from [%s]! Response was [%d]:\n%s'
-            logger.error(msg, course.key, image_url, response.status_code, response.content)
+            response = requests.get(image_url, headers=headers)  # pylint: disable=missing-timeout
+
+            if response.status_code == requests.codes.ok:  # pylint: disable=no-member
+                content_type = response.headers['Content-Type'].lower()
+                extension = IMAGE_TYPES.get(content_type)
+                content = response.content
+
+            else:
+                msg = 'Failed to download image for course [%s] from [%s]! Response was [%d]:\n%s'
+                logger.error(msg, course.key, image_url, response.status_code, response.content)
+                return False
+
+        if extension:
+            filename = '{uuid}.{extension}'.format(uuid=str(course.uuid), extension=extension)
+            # TODO: Get field from _meta.get_field. Tried that approach initially but was getting
+            # field save errors for some reasons.
+            if data_field == 'image':
+                course.image.save(filename, ContentFile(content))
+            elif data_field == 'organization_logo_override':
+                image_file = ContentFile(response.content)
+                if extension == 'svg':
+                    filename = '{uuid}.png'.format(uuid=str(course.uuid))
+                    image_file = convert_svg_to_png_from_url(image_url)
+                if image_file:
+                    course.organization_logo_override.save(filename, image_file)
+                else:
+                    logger.error('Update organization logo override failed for course [%s]', course.key)
+                    return False
+            logger.info('Image for course [%s] successfully updated.', course.key)
+            return True
+        else:
+            msg = 'Image retrieved for course [%s] from [%s] has an unknown content type [%s] and will not be saved.'
+            logger.error(msg, course.key, image_url, content_type)
+
     except Exception:  # pylint: disable=broad-except
         logger.exception('An unknown exception occurred while downloading image for course [%s]', course.key)
     return False
@@ -761,6 +786,13 @@ def get_downloadable_url_from_drive_link(file_path):
     return file_path
 
 
+def is_google_drive_url(url):
+    """
+    Helper method to check if the file url is a drive url or not
+    """
+    return any(re.match(pattern, url) for pattern in DRIVE_LINK_PATTERNS)
+
+
 def download_and_save_program_image(program, image_url, data_field='image', headers=None):
     """
     Helper method to download an image from a provided image url and save it
@@ -769,30 +801,36 @@ def download_and_save_program_image(program, image_url, data_field='image', head
     # TODO: refactor and merge program image download to use the same code as course image download
     try:
         image_url = get_downloadable_url_from_drive_link(image_url)
-        response = requests.get(image_url, headers=headers)  # pylint: disable=missing-timeout
 
-        if response.status_code == requests.codes.ok:  # pylint: disable=no-member
-            content_type = response.headers['Content-Type'].lower()
+        if is_google_drive_url(image_url):
+            content_type, content = get_file_from_drive_link(image_url)
             extension = IMAGE_TYPES.get(content_type)
-
-            if extension:
-                filename = '{uuid}.{extension}'.format(uuid=str(program.uuid), extension=extension)
-                # TODO: Get field from _meta.get_field. Tried that approach initially but was getting
-                # field save errors for some reasons.
-                if data_field == 'image':
-                    program.card_image.save(filename, ContentFile(response.content))
-                elif data_field == 'organization_logo_override':
-                    program.organization_logo_override.save(filename, ContentFile(response.content))
-                logger.info('Image for program [%s] successfully updated.', program.title)
-                return True
-            else:
-                # pylint: disable=line-too-long
-                msg = 'Image retrieved for program [%s] from [%s] has an unknown content type [%s] and will not be saved.'
-                logger.error(msg, program.title, image_url, content_type)
-
         else:
-            msg = 'Failed to download image for program [%s] from [%s]! Response was [%d]:\n%s'
-            logger.error(msg, program.title, image_url, response.status_code, response.content)
+            response = requests.get(image_url, headers=headers)  # pylint: disable=missing-timeout
+
+            if response.status_code == requests.codes.ok:  # pylint: disable=no-member
+                content_type = response.headers['Content-Type'].lower()
+                extension = IMAGE_TYPES.get(content_type)
+                content = response.content
+            else:
+                msg = 'Failed to download image for program [%s] from [%s]! Response was [%d]:\n%s'
+                logger.error(msg, program.title, image_url, response.status_code, response.content)
+                return False
+
+        if extension:
+            filename = '{uuid}.{extension}'.format(uuid=str(program.uuid), extension=extension)
+            # TODO: Get field from _meta.get_field. Tried that approach initially but was getting
+            # field save errors for some reasons.
+            if data_field == 'image':
+                program.card_image.save(filename, ContentFile(content))
+            elif data_field == 'organization_logo_override':
+                program.organization_logo_override.save(filename, ContentFile(content))
+            logger.info('Image for program [%s] successfully updated.', program.title)
+            return True
+        else:
+            msg = 'Image retrieved for program [%s] from [%s] has an unknown content type [%s] and will not be saved.'
+            logger.error(msg, program.title, image_url, content_type)
+
     except Exception:  # pylint: disable=broad-except
         logger.exception('An unknown exception occurred while downloading image for program [%s]', program.title)
     return False

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -58,7 +58,6 @@ google-auth-httplib2
 gspread
 html2text
 lxml
-oauth2client
 jsonfield
 markdown
 pillow

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -53,9 +53,12 @@ edx-opaque-keys
 edx-rest-api-client
 elasticsearch
 elasticsearch-dsl
+google-api-python-client
+google-auth-httplib2
 gspread
 html2text
 lxml
+oauth2client
 jsonfield
 markdown
 pillow

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -75,7 +75,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   elasticsearch
     #   requests

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -64,9 +64,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.46
+boto3==1.26.48
     # via django-ses
-botocore==1.29.46
+botocore==1.29.48
     # via
     #   boto3
     #   s3transfer
@@ -134,7 +134,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.0.4
+coverage[toml]==7.0.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -412,7 +412,7 @@ face==22.0.0
     # via glom
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==16.1.0
+faker==16.3.0
     # via factory-boy
 fastavro==1.7.0
     # via openedx-events
@@ -427,21 +427,35 @@ future==0.18.2
     # via pyjwkest
 glom==22.1.0
     # via semgrep
+google-api-core==2.11.0
+    # via google-api-python-client
+google-api-python-client==2.72.0
+    # via -r requirements/base.in
 google-auth==2.16.0
     # via
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
     #   google-auth-oauthlib
     #   gspread
-google-auth-oauthlib==0.8.0
-google-api-python-client==2.70.0
-    # via -r requirements/base.in
 google-auth-httplib2==0.1.0
-    # via google-api-python-client
+    # via
+    #   -r requirements/base.in
+    #   google-api-python-client
+google-auth-oauthlib==0.8.0
+    # via gspread
+googleapis-common-protos==1.58.0
+    # via google-api-core
 gspread==5.7.2
     # via -r requirements/base.in
 h11==0.14.0
     # via wsproto
 html2text==2020.1.16
     # via -r requirements/base.in
+httplib2==0.21.0
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
 idna==3.4
     # via
     #   requests
@@ -513,9 +527,6 @@ openedx-events==4.1.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector
-
-oauth2client==4.1.3
-    # via -r requirements/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python
 outcome==1.2.0
@@ -535,7 +546,7 @@ paramiko==2.12.0
     # via docker
 path==16.6.0
     # via edx-i18n-tools
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
 peewee==3.15.4
     # via semgrep
@@ -557,6 +568,10 @@ polib==1.1.1
     # via edx-i18n-tools
 prompt-toolkit==3.0.36
     # via click-repl
+protobuf==4.21.12
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
 psutil==5.9.4
     # via edx-django-utils
 py==1.11.0
@@ -612,7 +627,9 @@ pynacl==1.5.0
 pyopenssl==22.1.0
     # via snowflake-connector-python
 pyparsing==3.0.9
-    # via packaging
+    # via
+    #   httplib2
+    #   packaging
 pyrsistent==0.19.3
     # via jsonschema
 pysocks==1.7.1
@@ -684,7 +701,7 @@ pyyaml==5.4.1
     #   edx-i18n-tools
 rcssmin==1.1.1
     # via django-compressor
-redis==4.4.1
+redis==4.4.2
     # via -r requirements/base.in
 requests==2.28.1
     # via
@@ -697,6 +714,7 @@ requests==2.28.1
     #   edx-analytics-data-api-client
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   google-api-core
     #   pyjwkest
     #   requests-file
     #   requests-oauthlib
@@ -760,6 +778,7 @@ six==1.16.0
     #   edx-sphinx-theme
     #   elasticsearch-dsl
     #   google-auth
+    #   google-auth-httplib2
     #   isodate
     #   jsonschema
     #   paramiko
@@ -868,7 +887,8 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3[socks]==1.26.13
+    #   google-api-python-client
+urllib3[socks]==1.26.14
     # via
     #   botocore
     #   docker

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -432,7 +432,10 @@ google-auth==2.16.0
     #   google-auth-oauthlib
     #   gspread
 google-auth-oauthlib==0.8.0
-    # via gspread
+google-api-python-client==2.70.0
+    # via -r requirements/base.in
+google-auth-httplib2==0.1.0
+    # via google-api-python-client
 gspread==5.7.2
     # via -r requirements/base.in
 h11==0.14.0
@@ -510,6 +513,9 @@ openedx-events==4.1.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector
+
+oauth2client==4.1.3
+    # via -r requirements/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python
 outcome==1.2.0

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,20 +4,18 @@
 #
 #    pip-compile --output-file=requirements/pip_tools.txt requirements/pip_tools.in
 #
-build==0.9.0
+build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
 packaging==23.0
     # via build
-pep517==0.13.0
-    # via build
 pip-tools==6.12.1
     # via -r requirements/pip_tools.in
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
-    # via
-    #   build
-    #   pep517
+    # via build
 wheel==0.38.4
     # via pip-tools
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -39,9 +39,9 @@ beautifulsoup4==4.11.1
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.26.46
+boto3==1.26.48
     # via django-ses
-botocore==1.29.46
+botocore==1.29.48
     # via
     #   boto3
     #   s3transfer
@@ -338,16 +338,25 @@ future==0.18.2
     # via pyjwkest
 gevent==22.10.2
     # via -r requirements/production.in
+google-api-core==2.11.0
+    # via google-api-python-client
+google-api-python-client==2.72.0
+    # via -r requirements/base.in
 google-auth==2.16.0
     # via
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
     #   google-auth-oauthlib
     #   gspread
+google-auth-httplib2==0.1.0
+    # via
+    #   -r requirements/base.in
+    #   google-api-python-client
 google-auth-oauthlib==0.8.0
     # via gspread
-google-api-python-client==2.70.0
-    # via -r requirements/base.in
-google-auth-httplib2==0.1.0
-    # via google-api-python-client
+googleapis-common-protos==1.58.0
+    # via google-api-core
 greenlet==2.0.1
     # via gevent
 gspread==5.7.2
@@ -356,6 +365,10 @@ gunicorn==20.1.0
     # via -r requirements/production.in
 html2text==2020.1.16
     # via -r requirements/base.in
+httplib2==0.21.0
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
 idna==3.4
     # via
     #   requests
@@ -408,8 +421,6 @@ openedx-events==4.1.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector
-oauth2client==4.1.3
-    # via -r requirements/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python
 packaging==23.0
@@ -418,7 +429,7 @@ packaging==23.0
     #   drf-yasg
 pandas==1.5.2
     # via taxonomy-connector
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
 pillow==9.4.0
     # via
@@ -429,6 +440,10 @@ platformdirs==2.6.2
     # via zeep
 prompt-toolkit==3.0.36
     # via click-repl
+protobuf==4.21.12
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
 psutil==5.9.4
     # via edx-django-utils
 pyasn1==0.4.8
@@ -461,6 +476,8 @@ pynacl==1.5.0
     # via edx-django-utils
 pyopenssl==22.1.0
     # via snowflake-connector-python
+pyparsing==3.0.9
+    # via httplib2
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.in
@@ -500,7 +517,7 @@ pyyaml==6.0
     #   edx-django-release-util
 rcssmin==1.1.1
     # via django-compressor
-redis==4.4.1
+redis==4.4.2
     # via -r requirements/base.in
 requests==2.28.1
     # via
@@ -511,6 +528,7 @@ requests==2.28.1
     #   edx-analytics-data-api-client
     #   edx-drf-extensions
     #   edx-rest-api-client
+    #   google-api-core
     #   pyjwkest
     #   requests-file
     #   requests-oauthlib
@@ -556,6 +574,7 @@ six==1.16.0
     #   edx-drf-extensions
     #   elasticsearch-dsl
     #   google-auth
+    #   google-auth-httplib2
     #   isodate
     #   pyjwkest
     #   python-dateutil
@@ -601,7 +620,8 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.13
+    #   google-api-python-client
+urllib3==1.26.14
     # via
     #   botocore
     #   elasticsearch

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -344,6 +344,10 @@ google-auth==2.16.0
     #   gspread
 google-auth-oauthlib==0.8.0
     # via gspread
+google-api-python-client==2.70.0
+    # via -r requirements/base.in
+google-auth-httplib2==0.1.0
+    # via google-api-python-client
 greenlet==2.0.1
     # via gevent
 gspread==5.7.2
@@ -404,6 +408,8 @@ openedx-events==4.1.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector
+oauth2client==4.1.3
+    # via -r requirements/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python
 packaging==23.0


### PR DESCRIPTION
[PROD-2903](https://2u-internal.atlassian.net/browse/PROD-2903?atlOrigin=eyJpIjoiM2EzZTFjNjk4ZDFlNDFhYWFkZDhhYTRmNzc2MDE5M2EiLCJwIjoiaiJ9)

### Description
This PR updates the download_and_save_image function (for both degree and programs) to use GoogleAPIClient class (using `googleapiclient`, `google-auth-httplib2` and `google-auth` libraries) instead of the simple `requests` library. This is to avoid too many automated requests errors that we are getting from the `requests` library.

#### Todo:
- [ ] Enable the Google Drive API on 2u's account
- [ ] Create a service account and download the credentials file
- [ ] Add service account to the image folder on Google Drive

Testcases Snapshot:
![image](https://user-images.githubusercontent.com/78806673/210043490-9e47a83f-f55b-4dc1-9f1d-af94101f269b.png)
