### PR TITLE
fix: add verified only course type

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -2165,7 +2165,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         CourseEntitlementFactory(course=self.course, mode=SeatTypeFactory.verified())
 
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.uuid})
-        with self.assertNumQueries(40, threshold=0):
+        with self.assertNumQueries(41, threshold=0):
             response = self.client.options(url)
         assert response.status_code == 200
 

--- a/course_discovery/apps/course_metadata/migrations/0324_add_verified_only_course_type.py
+++ b/course_discovery/apps/course_metadata/migrations/0324_add_verified_only_course_type.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+TYPE_NAME = 'Verified Only'
+SLUG = 'verified'
+
+
+def add_verified_only_types(apps, schema_editor):
+    CourseType = apps.get_model('course_metadata', 'CourseType')
+    CourseRunType = apps.get_model('course_metadata', 'CourseRunType')
+    Track = apps.get_model('course_metadata', 'Track')
+    Mode = apps.get_model('course_metadata', 'Mode')
+    SeatType = apps.get_model('course_metadata', 'SeatType')
+
+    mode = Mode.objects.get(slug=SLUG)
+    seat_type = SeatType.objects.get(slug=SLUG)
+    run_type, _ = CourseRunType.objects.update_or_create(name=TYPE_NAME, slug=SLUG)
+    run_type.tracks.set([Track.objects.get(mode=mode, seat_type=seat_type)])
+
+    course_type, _ = CourseType.objects.update_or_create(name=TYPE_NAME, slug=SLUG)
+    course_type.entitlement_types.set([seat_type])
+    course_type.course_run_types.set([run_type])
+
+
+def remove_verified_only_types(apps, schema_editor):
+    CourseType = apps.get_model('course_metadata', 'CourseType')
+    CourseRunType = apps.get_model('course_metadata', 'CourseRunType')
+
+    CourseType.objects.filter(slug=SLUG).delete()
+    CourseRunType.objects.filter(slug=SLUG).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('course_metadata', '0323_deduplicate_history_config_model'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=add_verified_only_types,
+            reverse_code=remove_verified_only_types,
+        ),
+    ]


### PR DESCRIPTION
Discovery fires the error when the `refresh_course_metadata` management command works if ecommerce has the `verified only` course set up. This PR introduces the migration to add missing course/courserun type.

example error logs:
```
2022-12-28 08:17:07,146 WARNING 356413 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:421 - Calculating course type failure occurred for [course-1+course-1: course-1].
2022-12-28 08:17:07,147 WARNING 356413 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:334 - Processing failure occurred caused by an exception on at least on of the threads, blocking deletes.
2022-12-28 08:17:07,148 ERROR 356413 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/backoff/_common.py:120 - Giving up run_loader(...) after 2 tries (django.core.management.base.CommandError: Ecommerce Data Loader failed to successfully load)
2022-12-28 08:17:07,148 ERROR 356413 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:40 - EcommerceApiDataLoader failed!
Traceback (most recent call last):
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py", line 37, in execute_loader
    run_loader()
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/backoff/_sync.py", line 105, in retry
    ret = target(*args, **kwargs)
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py", line 34, in run_loader
    return loader_class(*loader_args).ingest()
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py", line 338, in ingest
    raise CommandError('Ecommerce Data Loader failed to successfully load')
django.core.management.base.CommandError: Ecommerce Data Loader failed to successfully load
CommandError: One or more of the data loaders above failed.
```
Note: reproduced on Nutmeg and Olive