### PR TITLE
chore: revert lms api page size to 50

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -43,7 +43,7 @@ def _fatal_code(ex):
 class CoursesApiDataLoader(AbstractDataLoader):
     """ Loads course runs from the Courses API. """
 
-    PAGE_SIZE = 10
+    PAGE_SIZE = 50
 
     def ingest(self):
         logger.info('Refreshing Courses and CourseRuns from %s...', self.partner.courses_api_url)


### PR DESCRIPTION
### Description

This PR reverts the page size back to 50 for LMS courses API call. The page size was reduced to 10 because the parallel worker call was causing 500 on LMS, thus failing LMS data loading. The parallel call behavior was disabled but the page size was never increased. This resulted in the RCM job taking way too long to run. This PR aims to verify if the timeout issue still happens at page size 50 with no parallel calls.