### PR TITLE
feat: Get active courses from lms for lms data loading

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -79,7 +79,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
         response = self._make_request(page)
         self._process_response(response)
 
-    # The courses endpoint has a 40 requests/minute rate limit.
+    # The courses endpoint has 40 requests/minute rate limit.
     # This will back off at a rate of 60/120/240 seconds (from the factor 60 and default value of base 2).
     # This backoff code can still fail because of the concurrent requests all requesting at the same time.
     # So even in the case of entering into the next minute, if we still exceed our limit for that min,
@@ -93,7 +93,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
     )
     def _make_request(self, page):
         logger.info('Requesting course run page %d...', page)
-        params = {'page': page, 'page_size': self.PAGE_SIZE, 'username': self.username}
+        params = {'page': page, 'page_size': self.PAGE_SIZE, 'username': self.username, 'active_only': True}
         response = self.api_client.get(self.api_url + '/courses/', params=params)
         response.raise_for_status()
         return response.json()


### PR DESCRIPTION
### [PROD-3099](https://2u-internal.atlassian.net/browse/PROD-3099)

### Description
Followup of https://github.com/openedx/edx-platform/pull/31502, use the active_only flag to get active courses during RCM LMS data loading. This reduces the significant pain in terms of data fetching, getting only the courses that should be updated. 

This will be merged once platform PR is merged and deployed.