### PR TITLE
fix: add only allowed attributes to anchor tag

### DIFF
--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -15,6 +15,8 @@ IMAGE_TYPES = {
     'image/svg+xml': 'svg'  # SVG image will be converted into PNG, not stored as SVG
 }
 
+ALLOWED_ANCHOR_TAG_ATTRIBUTES = ['href', 'title', 'target', 'rel']
+
 DRIVE_LINK_PATTERNS = [r"https://docs\.google\.com/uc\?id=\w+",
                        r"https://drive\.google\.com/file/d/\w+/view?usp=sharing"]
 

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -626,6 +626,10 @@ class UtilsTests(TestCase):
         # pylint: disable=line-too-long
         ('<a href="https://yahoo.com" target="_blank" rel="noopener">link</a>', '<p><a href="https://yahoo.com" rel="noopener" target="_blank">link</a></p>'),
 
+        # Make sure not to add data-ol-has-click-handler attribute to anchor tags if they are in attributes list
+        # pylint: disable=line-too-long
+        ('<p>please visit this <a title="less go" href="https://google.com" data-ol-has-click-handler="true">link</a></p>', '<p>please visit this <a href="https://google.com" title="less go">link</a></p>'),
+
         # And make sure we strip what we should
         ('<p class="float">Class</p>', '<p>Class</p>'),
         ('<p style="float">Inline Style</p>', '<p>Inline Style</p>'),

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -21,7 +21,7 @@ from stdimage.models import StdImageFieldFile
 
 from course_discovery.apps.core.models import SalesforceConfiguration
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.course_metadata.constants import IMAGE_TYPES
+from course_discovery.apps.course_metadata.constants import ALLOWED_ANCHOR_TAG_ATTRIBUTES, IMAGE_TYPES
 from course_discovery.apps.course_metadata.exceptions import (
     EcommerceSiteAPIClientException, MarketingSiteAPIClientException
 )
@@ -662,11 +662,12 @@ class HTML2TextWithLangSpans(html2text.HTML2Text):
                 self.in_lang_span = False
 
         if tag == 'a':
-            # override the default behavior of html2text to include all attributes from attr_dict for <a> tags
+            # override the default behavior of html2text to include only allowed tags from attr_dict for <a> tags
             # because by default it only includes the href and title attributes
             if attrs and start and 'href' in dict(attrs):
                 self.outtextf('<a')
-                for attr, value in dict(attrs).items():
+                filtered_attrs_list = [(attr, value) for attr, value in dict(attrs).items() if attr in ALLOWED_ANCHOR_TAG_ATTRIBUTES]  # pylint: disable=line-too-long
+                for attr, value in filtered_attrs_list:
                     self.outtextf(f' {attr}="{value}"')
                 self.outtextf('>')
             if not start:


### PR DESCRIPTION
## Overview
Exec Ed ingestion throwing an error because of `data-ol-has-click-handler` attribute in anchor tag `invalid html`. This PR resolves this issue by specifying only allowed attributes for anchor tag

