### PR TITLE
feat: add product source API for publisher access

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/mixins.py
+++ b/course_discovery/apps/api/v1/tests/test_views/mixins.py
@@ -110,6 +110,9 @@ class SerializationMixin:
     def serialize_subject(self, subject, many=False, format=None, extra_context=None):
         return self._serialize_object(serializers.SubjectSerializer, subject, many, format, extra_context)
 
+    def serialize_source(self, source, many=False, format=None, extra_context=None):
+        return self._serialize_object(serializers.SourceSerializer, source, many, format, extra_context)
+
     def serialize_topic(self, topic, many=False, format=None, extra_context=None):
         return self._serialize_object(serializers.TopicSerializer, topic, many, format, extra_context)
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -21,7 +21,7 @@ from course_discovery.apps.course_metadata.choices import CourseRunStatus, Progr
 from course_discovery.apps.course_metadata.models import CourseRun, CourseRunType, Seat, SeatType
 from course_discovery.apps.course_metadata.tests.factories import (
     CourseEditorFactory, CourseFactory, CourseRunFactory, CourseRunTypeFactory, CourseTypeFactory, OrganizationFactory,
-    PersonFactory, ProgramFactory, SeatFactory, TrackFactory
+    PersonFactory, ProgramFactory, SeatFactory, SourceFactory, TrackFactory
 )
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.tests.factories import OrganizationExtensionFactory
@@ -32,6 +32,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
     def setUp(self):
         super().setUp()
         self.user = UserFactory(is_staff=True)
+        self.product_source = SourceFactory(name='test source')
         self.client.force_authenticate(self.user)
         self.course_run = CourseRunFactory(course__partner=self.partner)
         self.course_run_2 = CourseRunFactory(course__key='Test+Course', course__partner=self.partner)
@@ -880,6 +881,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
             'number': 'test101',
             'org': OrganizationFactory(key='test-key').key,
             'type': str(original_course_type.uuid),
+            'product_source': self.product_source.slug,
             'prices': {} if original_seat_type == 'audit' else {original_seat_type: 49},
             'course_run': {
                 'start': '2001-01-01T00:00:00Z',
@@ -939,6 +941,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
             'org': OrganizationFactory(key='test-key').key,
             'type': str(course_type.uuid),
             'prices': {Seat.VERIFIED: 49},
+            'product_source': self.product_source.slug,
             'course_run': {
                 'start': '2001-01-01T00:00:00Z',
                 'end': datetime.datetime.now() + datetime.timedelta(days=-1),

--- a/course_discovery/apps/api/v1/tests/test_views/test_sources.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_sources.py
@@ -1,0 +1,59 @@
+from django.urls import reverse
+
+from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, SerializationMixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from course_discovery.apps.course_metadata.models import Source
+from course_discovery.apps.course_metadata.tests.factories import SourceFactory
+
+
+class SourceViewSetTests(SerializationMixin, APITestCase):
+    list_path = reverse('api:v1:source-list')
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory(is_staff=True, is_superuser=True)
+        self.non_staff_user = UserFactory()
+        self.request.user = self.user
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+
+    def test_authentication(self):
+        """ Verify the endpoint requires the user to be authenticated. """
+        response = self.client.get(self.list_path)
+        assert response.status_code == 200
+
+        self.client.logout()
+        response = self.client.get(self.list_path)
+        assert response.status_code == 401
+
+    def assert_response_data_valid(self, response, source, many=True):
+        """ Asserts the response data (only) contains the expected sources. """
+        actual = response.data
+        serializer_data = self.serialize_source(source, many=many)
+        if many:
+            actual = actual['results']
+
+        self.assertCountEqual(actual, serializer_data)
+
+    def test_list(self):
+        """ Verify the endpoint returns a list of all sources. """
+        SourceFactory.create_batch(3)
+
+        with self.assertNumQueries(4):
+            response = self.client.get(self.list_path)
+
+        assert response.status_code == 200
+        self.assert_response_data_valid(response, Source.objects.all())
+
+    def test_retrieve(self):
+        """ Verify the endpoint returns details for a single source. """
+        source = SourceFactory()
+        url = reverse('api:v1:source-detail', kwargs={'slug': source.slug})
+        response = self.client.get(url)
+        assert response.status_code == 200
+        self.assert_response_data_valid(response, source, many=False)
+
+    def test_retrieve_not_found(self):
+        """ Verify the endpoint returns HTTP 404 if the specified slug does not match an source."""
+        url = reverse('api:v1:source-detail', kwargs={'slug': 'test-string'})
+        response = self.client.get(url)
+        assert response.status_code == 404

--- a/course_discovery/apps/api/v1/urls.py
+++ b/course_discovery/apps/api/v1/urls.py
@@ -19,6 +19,7 @@ from course_discovery.apps.api.v1.views.pathways import PathwayViewSet
 from course_discovery.apps.api.v1.views.people import PersonViewSet
 from course_discovery.apps.api.v1.views.program_types import ProgramTypeViewSet
 from course_discovery.apps.api.v1.views.programs import ProgramViewSet
+from course_discovery.apps.api.v1.views.sources import SourceViewSet
 from course_discovery.apps.api.v1.views.subjects import SubjectViewSet
 from course_discovery.apps.api.v1.views.topics import TopicViewSet
 from course_discovery.apps.api.v1.views.user_management import UsernameReplacementView
@@ -51,6 +52,7 @@ router.register(r'course_editors', CourseEditorViewSet, basename='course_editor'
 router.register(r'course_runs', CourseRunViewSet, basename='course_run')
 router.register(r'collaborators', CollaboratorViewSet, basename='collaborator')
 router.register(r'organizations', OrganizationViewSet, basename='organization')
+router.register(r'sources', SourceViewSet, basename='source')
 router.register(r'people', PersonViewSet, basename='person')
 router.register(r'subjects', SubjectViewSet, basename='subject')
 router.register(r'topics', TopicViewSet, basename='topic')

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -31,7 +31,7 @@ from course_discovery.apps.course_metadata.choices import CourseRunStatus, Progr
 from course_discovery.apps.course_metadata.constants import COURSE_ID_REGEX, COURSE_UUID_REGEX
 from course_discovery.apps.course_metadata.models import (
     Collaborator, Course, CourseEditor, CourseEntitlement, CourseRun, CourseType, CourseUrlSlug, Organization, Program,
-    Seat, Video
+    Seat, Source, Video
 )
 from course_discovery.apps.course_metadata.utils import (
     create_missing_entitlement, ensure_draft_world, validate_course_number
@@ -183,6 +183,7 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             'number': request.data.get('number'),
             'org': request.data.get('org'),
             'type': request.data.get('type'),
+            'product_source': request.data.get('product_source'),
         }
         url_slug = request.data.get('url_slug', '')
 
@@ -195,6 +196,10 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         if not CourseType.objects.filter(uuid=course_creation_fields['type']).exists():
             error_message += _('Course Type [{course_type}] does not exist. ').format(
                 course_type=course_creation_fields['type'])
+        if not Source.objects.get(slug=course_creation_fields['product_source']):
+            error_message += _('Product Source [{product_source}] does not exist. ').format(
+                product_source=course_creation_fields['product_source'])
+
         if error_message:
             return Response((_('Incorrect data sent. ') + error_message).strip(), status=status.HTTP_400_BAD_REQUEST)
 

--- a/course_discovery/apps/api/v1/views/sources.py
+++ b/course_discovery/apps/api/v1/views/sources.py
@@ -1,0 +1,16 @@
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+
+from course_discovery.apps.api import serializers
+from course_discovery.apps.api.cache import CompressedCacheResponseMixin
+from course_discovery.apps.api.permissions import IsCourseRunEditorOrDjangoOrReadOnly
+from course_discovery.apps.course_metadata.models import Source
+
+
+class SourceViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
+    """ Source resource. """
+
+    permission_classes = (IsAuthenticated, IsCourseRunEditorOrDjangoOrReadOnly)
+    serializer_class = serializers.SourceSerializer
+    lookup_field = 'slug'
+    queryset = Source.objects.all()

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -940,6 +940,7 @@ class SourceAdmin(admin.ModelAdmin):
     Admin for Source model.
     """
     list_display = ('id', 'name', 'slug', 'description')
+    readonly_fields = ('slug',)
 
 
 @admin.register(BulkUploadTagsConfig)

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -201,8 +201,8 @@ class CSVDataLoader(AbstractDataLoader):
                 logger.error(error_message)
                 self._register_ingestion_error(CSVIngestionErrors.IMAGE_DOWNLOAD_FAILURE, error_message)
                 continue
-
-            self.add_product_source(course)
+            if not is_course_created:
+                self.add_product_source(course)
 
             is_draft = self.get_draft_flag(course_run)
             logger.info(f"Draft flag is set to {is_draft} for the course {course_title}")
@@ -354,6 +354,7 @@ class CSVDataLoader(AbstractDataLoader):
         which will be used as input for course creation via course api.
         """
         pricing = self.get_pricing_representation(data['verified_price'], course_type)
+        product_source = self.product_source.slug if self.product_source else None
 
         course_run_creation_fields = {
             'pacing_type': self.get_pacing_type(data['course_pacing']),
@@ -366,6 +367,7 @@ class CSVDataLoader(AbstractDataLoader):
             'org': data['organization'],
             'title': data['title'],
             'number': data['number'],
+            'product_source': product_source,
             'type': str(course_type.uuid),
             'prices': pricing,
             'course_run': course_run_creation_fields

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -553,7 +553,6 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                     {**mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT, 'organization': test_org.key}
                 ]
             )
-
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -34,11 +34,11 @@ class AbstractHeadingBlurbModelFactory(factory.django.DjangoModelFactory):
 
 
 class SourceFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = Source
-
     name = FuzzyText()
     description = FuzzyText()
+
+    class Meta:
+        model = Source
 
 
 class ImageFactory(AbstractMediaModelFactory):


### PR DESCRIPTION
[PROD-3106](https://2u-internal.atlassian.net/browse/PROD-3106)

This PR covers updates courseViewSet create method to make product_source required for creating a course. We are passing the `product_souce.slug` in the request data to create a course.
- This PR also updates the CSVLoader to pass the `product_source.slug` in the request data to create a course if the course is not already created else it will update the course product_source using `add_product_source` method.

- This PR also updates the course and course_run factories to create a product_source for the course and course_run and update the tests accordingly.
- This PR also update CSV loader tests to also add product source to courses

