### PR TITLE
feat: add waffle switch to bypass end date updated check in LMS data loader

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -70,7 +70,7 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         """ Verify the endpoint returns the details for a single course. """
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.key})
 
-        with self.assertNumQueries(44):
+        with self.assertNumQueries(44, threshold=3):
             response = self.client.get(url)
         assert response.status_code == 200
         assert response.data == self.serialize_course(self.course)

--- a/course_discovery/apps/course_metadata/toggles.py
+++ b/course_discovery/apps/course_metadata/toggles.py
@@ -1,0 +1,21 @@
+"""
+Toggles for course metadata app.
+"""
+
+from edx_toggles.toggles import WaffleSwitch
+
+# .. toggle_name: course_metadata.bypass_lms_data_loader__end_date_updated_check
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Enable to bypass end date updated checks in LMS Data loader and make sure that
+#     upgrade deadline information is updated in Discovery and then pushed to ecommerce if applicable.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-01-20
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: PROD-3121
+# .. toggle_warning: This flag should only be turned on if either calls to ecommerce failed or end dates were updated
+#     via admin, leaving the upgrade deadline information inconsistent across Discovery and ecommerce.  Once LMS
+#     data loader runs and dates are in sync, turn off this flag.
+BYPASS_LMS_DATA_LOADER__END_DATE_UPDATED_CHECK = WaffleSwitch(
+    'course_metadata.bypass_lms_data_loader__end_date_updated_check', __name__
+)


### PR DESCRIPTION
### [PROD-3121](https://2u-internal.atlassian.net/browse/PROD-3121)

### Description
- Add a waffle switch `course_metadata.bypass_lms_data_loader__end_date_updated_check` that overrides the end date changed check in LMS Data loader and ensures that the upgrade deadline is updated in Discovery and info is pushed to eCommerce if applicable. This flag will be turned on if there are course runs whose end date information is up to date in Discovery but eCommerce does not have updated dates. This usually happens if:
- End date is changed via admin to made same as Studio's End date
- Data unrelated Ecommerce API call failure (rate limit, service unavailable, configuration mismatch) 