### PR TITLE
feat: generate oauth geag api token through request lib

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -899,14 +899,10 @@ class TestDownloadAndSaveImage(TestCase):
         assert str(course.uuid) in course.organization_logo_override.name
 
 
-class TestGEAGAPIAccesToken(TestCase):
-    """ Tests for GEA GAPI access token. """
+class TestGEAGApiAccesToken(TestCase):
+    """ Tests for GEAG API access token. """
     def setUp(self):
-        self.url = 'https://test.getsmarter.com/oauth2/token'
-        self.client_id = 'test_client_id'
-        self.client_secret = 'test_client_secret'
-        self.access_token_url = 'test.getsmarter.com/oauth2/token'
-        self.auth_url = 'https://test.geag.auth.com/oauth2/token'
+        self.url = 'test.getsmarter.com/oauth2/token'
 
     def mock_geag_api_token_response(self, status=200, token_type='Bearer', expires_in=3600, access_token=''):
         """ Mocks the response from the getsmarter API. """
@@ -915,7 +911,7 @@ class TestGEAGAPIAccesToken(TestCase):
             'expires_in': expires_in,
             'access_token': access_token
         }
-        responses.add(responses.POST, self.url, json=body, status=status)
+        responses.add(responses.POST, 'https://' + self.url, json=body, status=status)
         return body
 
     def tearDown(self):
@@ -927,17 +923,17 @@ class TestGEAGAPIAccesToken(TestCase):
     def test_get_access_token__with_valid_credentials(self, mock_logger):
         """ Verify that get_access_token returns access token. """
         response = self.mock_geag_api_token_response(access_token='test_access_token')
-        token = get_geag_api_access_token(self.client_id, self.client_secret, self.access_token_url, self.auth_url)
+        token = get_geag_api_access_token(self.url)
         assert token == response['access_token']
         mock_logger.assert_called_once_with('Successfully retrieved access token for getsmarter API.')
         assert token is not None
 
     @responses.activate
     @mock.patch('course_discovery.apps.course_metadata.utils.logger.error')
-    def test_get_geag_api_access_token__with_invalid_client_id(self, mock_logger):
-        """ Verify that get_access_token returns None when client_id is invalid. """
+    def test_get_geag_api_access_token__with_invalid_credentials(self, mock_logger):
+        """ Verify that get_access_token returns None when invalid credentials are provided. """
         _ = self.mock_geag_api_token_response(access_token=None, token_type=None, expires_in=None, status=400)
-        token = get_geag_api_access_token('invalid_client_id', self.client_secret, self.access_token_url, self.auth_url)
+        token = get_geag_api_access_token(self.url)
         msg = 'Failed to retrieve access token for getsmarter API. Status code: %s'
         mock_logger.assert_called_once_with(msg, 400)
         assert token is None

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import re
 import urllib
 from unittest import mock
@@ -910,21 +911,25 @@ class TestGEAGAPIAccesToken(TestCase):
 
     def mock_geag_api_token_response(self, status=200, token_type='Bearer', expires_in=3600, access_token=''):
         """ Mocks the response from the getsmarter API. """
-        body = {
+        body={
             'token_type': token_type,
             'expires_in': expires_in,
             'access_token': access_token
         }
         responses.add(responses.POST, self.url, json=body, status=status)
-        return self.url, body
+        return body
+
+    def tearDown(self):
+        responses.reset()
+        return super().tearDown()
 
     @responses.activate
     @mock.patch('course_discovery.apps.course_metadata.utils.logger.info')
     def test_get_access_token__with_valid_credentials(self, mock_logger):
         """ Verify that get_access_token returns access token. """
-        _, body = self.mock_geag_api_token_response(access_token='test_access_token')
+        response = self.mock_geag_api_token_response(access_token='test_access_token')
         token = get_geag_api_access_token(self.client_id, self.client_secret, self.access_token_url, self.auth_url)
-        assert token == body['access_token']
+        assert token == response['access_token']
         mock_logger.assert_called_once_with('Successfully retrieved access token for getsmarter API.')
         assert token is not None
 

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 import re
 import urllib
 from unittest import mock

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -911,7 +911,7 @@ class TestGEAGAPIAccesToken(TestCase):
 
     def mock_geag_api_token_response(self, status=200, token_type='Bearer', expires_in=3600, access_token=''):
         """ Mocks the response from the getsmarter API. """
-        body={
+        body = {
             'token_type': token_type,
             'expires_in': expires_in,
             'access_token': access_token

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -880,3 +880,27 @@ def transform_skills_data(skills_data):
         }
         skills.append(skill_dict)
     return skills
+
+
+def get_geag_api_access_token(client_id, client_secret, acess_token_url, auth_url):
+    """
+    Returns a valid access token for the getsmarter API
+    """
+    url = f'https://{acess_token_url}'
+    access_token = None
+    try:
+        settings.GETSMARTER_API_CREDENTIALS['client_id'] = client_id
+        settings.GETSMARTER_API_CREDENTIALS['client_secret'] = client_secret
+        settings.GETSMARTER_API_CREDENTIALS['accessTokenUrl'] = acess_token_url
+        settings.GETSMARTER_API_CREDENTIALS['authUrl'] = auth_url
+        response = requests.post(url, data=settings.GETSMARTER_API_CREDENTIALS, timeout=settings.GETSMARTER_API_TIMEOUT)
+        if response.status_code == 200:
+            response_dict = dict(response.json())
+            access_token = response_dict.get('access_token')
+            if access_token:
+                logger.info('Successfully retrieved access token for getsmarter API.')
+        else:
+            logger.error('Failed to retrieve access token for getsmarter API. Status code: %s', response.status_code)
+    except requests.exceptions.ConnectionError as ex:
+        logger.error('Failed to retrieve access token for getsmarter API. Connection refused: %s', ex)
+    return access_token

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -882,17 +882,13 @@ def transform_skills_data(skills_data):
     return skills
 
 
-def get_geag_api_access_token(client_id, client_secret, acess_token_url, auth_url):
+def get_geag_api_access_token(access_token_url):
     """
     Returns a valid access token for the getsmarter API
     """
-    url = f'https://{acess_token_url}'
+    url = f'https://{access_token_url}'
     access_token = None
     try:
-        settings.GETSMARTER_API_CREDENTIALS['client_id'] = client_id
-        settings.GETSMARTER_API_CREDENTIALS['client_secret'] = client_secret
-        settings.GETSMARTER_API_CREDENTIALS['accessTokenUrl'] = acess_token_url
-        settings.GETSMARTER_API_CREDENTIALS['authUrl'] = auth_url
         response = requests.post(url, data=settings.GETSMARTER_API_CREDENTIALS, timeout=settings.GETSMARTER_API_TIMEOUT)
         if response.status_code == 200:
             response_dict = dict(response.json())

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -670,6 +670,17 @@ GETSMARTER_API_CREDENTIALS = {
 }
 GETSMARTER_API_TIMEOUT = 10
 
+GETSMARTER_KEYS_MAPPING = {
+    'CLIENT_ID' : 'client_id',
+    'CLIENT_SECRET' : 'client_secret',
+    'SCOPE' : 'scope',
+    'ACCESS_TOKEN_URL' : 'accessTokenUrl',
+    'TOKEN_NAME' : 'tokenName',
+    'CLIENT_AUTHENTICATION' : 'client_authentication',
+    'GRANT_TYPE' : 'grant_type',
+    'AUTH_URL' : 'authUrl',
+}
+
 PRODUCT_METADATA_MAPPING = {
     'EXECUTIVE_EDUCATION': {
         'SHEET_ID': '',

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -602,7 +602,6 @@ EMSI_API_BASE_URL = 'https://emsiservices.com'
 EMSI_CLIENT_ID = ''
 EMSI_CLIENT_SECRET = ''
 
-
 ################################### BEGIN CELERY ###################################
 
 # Message configuration
@@ -656,6 +655,20 @@ GOOGLE_SERVICE_ACCOUNT_CREDENTIALS = {
   'AUTH_PROVIDER_X509_CERT_URL': '',
   'CLIENT_X509_CERT_URL': ''
 }
+
+# Settings related to the GEAG API client for communicating with GetSmarter API
+GETSMARTER_API_CREDENTIALS = {
+  'client_id': '',
+  'client_secret' : '',
+  'scope' : 'geag/products.read',
+  'accessTokenUrl' : '',
+  'tokenName' : 'GEAG Access Token',
+  'client_authentication' : 'header',
+  'grant_type' : 'client_credentials',
+  'authUrl' : '',
+  'addTokenTo' : 'header',
+}
+GETSMARTER_API_TIMEOUT = 10
 
 PRODUCT_METADATA_MAPPING = {
     'EXECUTIVE_EDUCATION': {

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -91,3 +91,6 @@ AWS_DEFAULT_ACL = 'public-read'
 
 # Convert dict keys to lowercase
 GOOGLE_SERVICE_ACCOUNT_CREDENTIALS = {k.lower(): v for k, v in GOOGLE_SERVICE_ACCOUNT_CREDENTIALS.items()}
+
+# Mapping of getsmarter api secret keys to required format as some of them are in snake case and some are in camel case
+GETSMARTER_API_CREDENTIALS = {GETSMARTER_KEYS_MAPPING[k]: v for k, v in GETSMARTER_API_CREDENTIALS.items()}


### PR DESCRIPTION
[PROD-3116](https://2u-internal.atlassian.net/browse/PROD-3116)

This PR covers the getsmarter API access token through request library instead of generating it through postman. The access token is used to access the getsmarter API. The access token is generated by the getsmarter API and is valid for 24 hours.

#### Todos
- [ ] Add environment variables to the `edx-internal` repo for getsmarter API (both stage and prod)

#### Testing Instructions
- To test it locally set the `GETSMARTER_API_CREDENTIALS` environment variable in your `private.py` file