### PR TITLE
feat: add external_course_marketing_type in csv_loader ingestion

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -11,7 +11,9 @@ from django.db.models import Q
 from django.urls import reverse
 
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.course_metadata.choices import CourseRunStatus, ExternalProductStatus
+from course_discovery.apps.course_metadata.choices import (
+    CourseRunStatus, ExternalCourseMarketingType, ExternalProductStatus
+)
 from course_discovery.apps.course_metadata.data_loaders import AbstractDataLoader
 from course_discovery.apps.course_metadata.data_loaders.constants import (
     CSV_LOADER_ERROR_LOG_SEQUENCE, CSVIngestionErrorMessages, CSVIngestionErrors
@@ -717,6 +719,7 @@ class CSVDataLoader(AbstractDataLoader):
         )
         registration_deadline = data.get('reg_close_date', '')
         variant_id = data.get('variant_id', '')
+        external_course_marketing_type = data.get('external_course_marketing_type', '')
         if lead_capture_url:
             additional_metadata.update({'lead_capture_form_url': lead_capture_url})
         if organic_url:
@@ -737,4 +740,6 @@ class CSVDataLoader(AbstractDataLoader):
                 data['meta_description'],
                 data['meta_keywords']
             )})
+        if external_course_marketing_type in dict(ExternalCourseMarketingType):
+            additional_metadata.update({'external_course_marketing_type': external_course_marketing_type})
         return additional_metadata

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3162,7 +3162,8 @@ VALID_COURSE_AND_COURSE_RUN_CSV_DICT = {
     "meta_title": "SEO Title",
     "meta_description": "SEO Description",
     "meta_keywords": "Keyword 1, Keyword 2",
-    "slug": ""
+    "slug": "",
+    'external_course_marketing_type': "course_stack"
 }
 
 VALID_MINIMAL_COURSE_AND_COURSE_RUN_CSV_DICT = {

--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         'upgrade_deadline_override_date', 'upgrade_deadline_override_time', 'redirect_url', 'external_identifier',
         'lead_capture_form_url', 'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2',
         'stat2_text', 'organic_url', 'organization_short_code_override', 'organization_logo_override', 'variant_id',
-        'meta_title', 'meta_description', 'meta_keywords', 'slug'
+        'meta_title', 'meta_description', 'meta_keywords', 'slug', 'external_course_marketing_type'
     ]
 
     # Mapping English and Spanish languages to IETF equivalent variants
@@ -326,4 +326,5 @@ class Command(BaseCommand):
             'minimum_effort': minimum_effort,
             'maximum_effort': maximum_effort,
             'organization_logo_override': utils.format_base64_strings(product_dict['logoUrl']),
+            'external_course_marketing_type': product_dict['productType'],
         }

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -53,6 +53,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 "metaDescription": "SEO Description",
                 "metaKeywords": "Keyword 1, Keyword 2",
                 "slug": "csv-course-slug",
+                "productType": "short_course",
                 "variant": {
                     "id": "00000000-0000-0000-0000-000000000000",
                     "endDate": "2022-05-06",
@@ -344,3 +345,4 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
         assert data_row['Meta Description'] == 'SEO Description'
         assert data_row['Meta Keywords'] == 'Keyword 1, Keyword 2'
         assert data_row['Slug'] == 'csv-course-slug'
+        assert data_row['External Course Marketing Type'] == "short_course"

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -806,7 +806,7 @@ class TestDownloadAndSaveImage(TestCase):
         """ Verify that download_and_save_course_image will not save image in course model """
         image_url = 'https://www.example.com/image.pdf'
         course = CourseFactory(card_image_url=image_url, image=None)
-        image_url, _ = self.mock_image_response(status=200, body=b'invalid', content_type='text/plain', url=image_url)  # pylint: disable=line-too-long
+        image_url, _ = self.mock_image_response(body=b'invalid', content_type='text/plain', url=image_url)
         assert download_and_save_course_image(course, course.card_image_url, data_field='image', headers=None) is False
         course.refresh_from_db()
         assert course.card_image_url == image_url


### PR DESCRIPTION
[PROD-3102](https://2u-internal.atlassian.net/browse/PROD-3102)
Includes the `external_course_marketing_type` field in csv_loader. This field is populated through the `productType` field from GEAG api.