### PR TITLE
feat: update additionalMetadata serializer to include external_course_marketing_type

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -700,7 +700,7 @@ class AdditionalMetadataSerializer(BaseModelSerializer):
             'external_identifier', 'external_url', 'lead_capture_form_url',
             'facts', 'certificate_info', 'organic_url', 'start_date', 'end_date',
             'registration_deadline', 'variant_id', 'course_term_override', 'product_status',
-            'product_meta',
+            'product_meta', 'external_course_marketing_type',
         )
 
     def _update_product_meta(self, instance, product_meta):

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2008,7 +2008,8 @@ class AdditionalMetadataSerializerTests(TestCase):
             'registration_deadline': serialize_datetime(additional_metadata.registration_deadline),
             'variant_id': str(additional_metadata.variant_id),
             'course_term_override': additional_metadata.course_term_override,
-            'product_status': additional_metadata.product_status
+            'product_status': additional_metadata.product_status,
+            'external_course_marketing_type': additional_metadata.external_course_marketing_type,
         }
         assert serializer.data == expected
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1106,7 +1106,8 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
             'variant_id': str(uuid4()),
             'course_term_override': 'Example Program',
             'product_status': 'published',
-            'product_meta': None
+            'product_meta': None,
+            'external_course_marketing_type': None,
         }
         url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})
         course_data = {
@@ -1194,7 +1195,8 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
             'variant_id': str(uuid4()),
             'course_term_override': 'Example Program',
             'product_status': 'published',
-            'product_meta': None
+            'product_meta': None,
+            'external_course_marketing_type': None
         }
         additional_metadata_1 = {
             **additional_metadata,
@@ -1295,7 +1297,8 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
             'variant_id': str(uuid4()),
             'course_term_override': 'Example Program',
             'product_status': 'published',
-            'product_meta': product_meta
+            'product_meta': product_meta,
+            'external_course_marketing_type': None
         }
 
         url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -550,7 +550,7 @@ class CertificateInfoAdmin(admin.ModelAdmin):
 class AdditionalMetadataAdmin(admin.ModelAdmin):
     list_display = (
         'id', 'external_identifier', 'external_url', 'lead_capture_form_url',
-        'courses', 'facts_list', 'certificate_info', 'organic_url'
+        'courses', 'facts_list', 'certificate_info', 'organic_url', 'external_course_marketing_type'
     )
     search_fields = ('external_identifier', 'external_url')
     list_filter = ('product_status', )

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -9,7 +9,7 @@ from taxonomy.models import CourseSkills, ProgramSkill, Skill
 
 from course_discovery.apps.core.tests.factories import PartnerFactory, UserFactory, add_m2m_data
 from course_discovery.apps.core.tests.utils import FuzzyURL
-from course_discovery.apps.course_metadata.choices import ExternalProductStatus
+from course_discovery.apps.course_metadata.choices import ExternalCourseMarketingType, ExternalProductStatus
 from course_discovery.apps.course_metadata.models import *  # pylint: disable=wildcard-import
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 
@@ -119,7 +119,7 @@ class AdditionalMetadataFactory(factory.django.DjangoModelFactory):
     course_term_override = FuzzyText()
     product_meta = factory.SubFactory(ProductMetaFactory, keywords=['test', 'test2'])
     product_status = ExternalProductStatus.Published
-    external_course_marketing_type = None
+    external_course_marketing_type = FuzzyChoice([name for name, __ in ExternalCourseMarketingType.choices])
 
     @factory.post_generation
     def facts(self, create, extracted, **kwargs):


### PR DESCRIPTION
# [PROD-3125](https://2u-internal.atlassian.net/browse/PROD-3125)

## Description

This PR updates the additionalMetadata serializer to include external_course_marketing_type
