### PR TITLE
feat: Automate Exec Ed Ingestion flow

### DIFF
--- a/course_discovery/apps/course_metadata/emails.py
+++ b/course_discovery/apps/course_metadata/emails.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 from urllib.parse import urljoin
 
@@ -314,6 +315,7 @@ def send_ingestion_email(partner, subject, to_users, product_type, ingestion_det
             product_type (str): the product whose ingestion has been run
             ingestion_details (dict): Stats of ingestion, along with reported errors
     """
+    products_json = ingestion_details.pop('products_json', None)
     context = {
         **ingestion_details,
         'product_type': product_type,
@@ -331,6 +333,9 @@ def send_ingestion_email(partner, subject, to_users, product_type, ingestion_det
         subject, plain_content, settings.PUBLISHER_FROM_EMAIL, to_users
     )
     email_msg.attach_alternative(html_content, 'text/html')
+    if products_json:
+        products_json = json.dumps(products_json, indent=2)
+        email_msg.attach(filename='products.json', content=products_json, mimetype='application/json')
 
     try:
         email_msg.send()

--- a/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
@@ -2,6 +2,7 @@
 Management command to import, create, and/or update course and course run information for
 executive education courses.
 """
+import csv
 import logging
 from datetime import datetime
 
@@ -92,7 +93,7 @@ class Command(BaseCommand):
         for model in apps.get_app_config('course_metadata').get_models():
             for signal in (post_save, post_delete):
                 signal.disconnect(receiver=api_change_receiver, sender=model)
-
+        products_json = []
         try:
             loader = CSVDataLoader(
                 partner,
@@ -102,6 +103,10 @@ class Command(BaseCommand):
                 product_type=self.PRODUCT_TYPE_SLUG_MAP[product_type],
                 product_source=source.slug
             )
+            if csv_path:
+                with open(csv_path, mode='r', encoding='utf-8') as csv_file:
+                    products_json = list(csv.DictReader(csv_file))
+
             logger.info("Starting CSV loader import flow for partner {}".format(partner_short_code))  # lint-amnesty, pylint: disable=logging-format-interpolation
             ingestion_time = datetime.now()
             loader.ingest()
@@ -123,7 +128,8 @@ class Command(BaseCommand):
             to_users = product_mapping['EMAIL_NOTIFICATION_LIST']
             ingestion_details = {
                 'ingestion_run_time': ingestion_time,
-                **loader.get_ingestion_stats()
+                **loader.get_ingestion_stats(),
+                'products_json': products_json
             }
             send_ingestion_email(
                 partner, email_subject, to_users, product_type, ingestion_details,

--- a/course_discovery/apps/course_metadata/management/commands/ingest_getsmarter_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/ingest_getsmarter_data.py
@@ -1,0 +1,46 @@
+"""
+Management command to ingest executive education course data from a CSV file.
+This command collectively calls the following commands:
+    - populate_executive_education_data_csv
+    - import_course_metadata
+"""
+
+import logging
+import tempfile
+
+from django.core.management import BaseCommand, CommandError, call_command
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Ingest executive education course data using GetSmarter API.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--product_source',
+            help='Slug of product source with whom the ingested courses are to be linked.',
+            type=str,
+            required=True
+        )
+
+    def handle(self, *args, **options):
+        """
+        Fetch products data from the GetSmarter API to populate a CSV file and ingest the data from the CSV file.
+        """
+        product_source = options.get('product_source')
+        try:
+            with tempfile.NamedTemporaryFile(suffix='.csv') as csv_file:
+                csv_path = csv_file.name
+                logger.info(
+                    'Populating executive education data CSV file at path: %s', csv_path)
+                call_command('populate_executive_education_data_csv',
+                             use_getsmarter_api_client=True, output_csv=csv_path)
+                logger.info(
+                    'Ingesting executive education data from CSV file at path: %s', csv_path)
+                call_command('import_course_metadata', csv_path=csv_path,
+                             product_type='EXECUTIVE_EDUCATION', product_source=product_source)
+        except Exception as exc:
+            raise CommandError(
+                f'Error while ingesting executive education data from CSV file at: {csv_path} with exception: {exc}'
+            ) from exc

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_ingest_getsmarter_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_ingest_getsmarter_data.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for the ingest_getsmarter_data management command.
+"""
+from unittest.mock import patch
+
+import mock
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.tests.constants import MOCK_PRODUCTS_DATA
+from course_discovery.apps.course_metadata.tests.factories import SourceFactory
+
+LOGGER_PATH = 'course_discovery.apps.course_metadata.management.commands.ingest_getsmarter_data'
+
+
+class IngestGetSmarterDataCommandTests(TestCase):
+    """
+    Tests for the ingest_getsmarter_data management command.
+    """
+    def setUp(self):
+        super().setUp()
+        self.source = SourceFactory(name='test source')
+        self.products_data = {
+            'products': MOCK_PRODUCTS_DATA
+        }
+
+    @mock.patch('course_discovery.apps.course_metadata.utils.GetSmarterEnterpriseApiClient')
+    def test_executive_education_ingestion_command(self, mock_get_smarter_client):
+        """
+        Verify the command is called with correct arguments.
+        """
+        mock_get_smarter_client.return_value.request.return_value.json.return_value = self.products_data
+        with patch('django.core.management.call_command') as mock_call_command, patch(LOGGER_PATH + '.logger.info') as mock_logger_info:  # pylint: disable=line-too-long
+            call_command(
+                'ingest_getsmarter_data',
+                '--product_source', self.source.slug,
+            )
+            mock_logger_info.assert_has_calls([
+                mock.call(
+                    'Populating executive education data CSV file at path: %s', mock.ANY),
+                mock.call(
+                    'Ingesting executive education data from CSV file at path: %s', mock.ANY)
+            ])
+            mock_call_command.assert_any_call(
+                'populate_executive_education_data_csv',
+                use_getsmarter_api_client=True,
+                output_csv=mock.ANY
+            )
+            mock_call_command.assert_any_call(
+                'import_course_metadata',
+                csv_path=mock.ANY,
+                product_type='EXECUTIVE_EDUCATION',
+                product_source=self.source.slug
+            )
+
+    def test_executive_education_ingestion_command__with_missing_product_source(self):
+        """
+        Verify the command raises CommandError if product_source is not passed.
+        """
+        with patch(LOGGER_PATH + '.logger.info') as mock_logger_info:
+            with self.assertRaises(CommandError) as ex:
+                call_command(
+                    'ingest_getsmarter_data',
+                )
+            mock_logger_info.assert_not_called()
+            self.assertEqual(
+                "Error: the following arguments are required: --product_source",
+                str(ex.exception)
+            )

--- a/course_discovery/apps/course_metadata/tests/constants.py
+++ b/course_discovery/apps/course_metadata/tests/constants.py
@@ -1,0 +1,83 @@
+"""
+Constants defined for use in unit tests.
+"""
+
+MOCK_PRODUCTS_DATA = [
+    {
+        "id": "12345678",
+        "name": "CSV Course",
+        "altName": "Alternative CSV Course",
+        "abbreviation": "TC",
+        "altAbbreviation": "UCT",
+        "blurb": "A short description for CSV course",
+        "language": "Español",
+        "subjectMatter": "Marketing",
+        "altSubjectMatter": "Design and Marketing",
+        "altSubjectMatter1": "Marketing, Sales, and Techniques",
+        "universityAbbreviation": "edX",
+        "altUniversityAbbreviation": "altEdx",
+        "cardUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS9pbWFnZS5qcGc=",
+        "edxRedirectUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS8=",
+        "edxPlpUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS8=",
+        "durationWeeks": 10,
+        "effort": "7–10 hours per week",
+        'introduction': 'Very short description\n',
+        'isThisCourseForYou': 'This is supposed to be a long description',
+        'whatWillSetYouApart': "New ways to learn",
+        "videoURL": "",
+        "lcfURL": "d3d3LmV4YW1wbGUuY29tL2xlYWQtY2FwdHVyZT9pZD0xMjM=",
+        "logoUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS9pbWFnZS5qcGc=g",
+        "metaTitle": "SEO Title",
+        "metaDescription": "SEO Description",
+        "metaKeywords": "Keyword 1, Keyword 2",
+        "slug": "csv-course-slug",
+        "productType": "short_course",
+        "variant": {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "endDate": "2022-05-06",
+                "finalPrice": "1998",
+                "startDate": "2022-03-06",
+                "regCloseDate": "2022-02-06",
+        },
+        "curriculum": {
+            "heading": "Course curriculum",
+            "blurb": "Test Curriculum",
+            "modules": [
+                {
+                    "module_number": 0,
+                    "heading": "Module 0",
+                    "description": "Welcome to your course"
+                },
+                {
+                    "module_number": 1,
+                    "heading": "Module 1",
+                    "description": "Welcome to Module 1"
+                },
+            ]
+        },
+        "testimonials": [
+            {
+                "name": "Lorem Ipsum",
+                "title": "Gibberish",
+                "text": " This is a good course"
+            },
+        ],
+        "faqs": [
+            {
+                "id": "faq-1",
+                "headline": "FAQ 1",
+                "blurb": "This should answer it"
+            }
+        ],
+        "certificate": {
+            "headline": "About the certificate",
+            "blurb": "how this makes you special"
+        },
+        "stats": {
+            "stat1": "90%",
+            "stat1Blurb": "<p>A vast number of special beings take this course</p>",
+            "stat2": "100 million",
+            "stat2Blurb": "<p>VC fund</p>"
+        }
+    },
+]

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -21,6 +21,7 @@ from course_discovery.apps.course_metadata.exceptions import (
     EcommerceSiteAPIClientException, MarketingSiteAPIClientException
 )
 from course_discovery.apps.course_metadata.models import Course, CourseEditor, CourseRun, Seat, SeatType, Track
+from course_discovery.apps.course_metadata.tests.constants import MOCK_PRODUCTS_DATA
 from course_discovery.apps.course_metadata.tests.factories import (
     CourseEditorFactory, CourseEntitlementFactory, CourseFactory, CourseRunFactory, ModeFactory, OrganizationFactory,
     ProgramFactory, SeatFactory, SeatTypeFactory
@@ -909,84 +910,7 @@ class TestGEAGApiProductDetails(TestCase):
     Test for GEAG API Product Details using getsmarter_api_client
     """
     SUCCESS_API_RESPONSE = {
-        'products': [
-            {
-                "id": "12345678",
-                "name": "CSV Course",
-                "altName": "Alternative CSV Course",
-                "abbreviation": "TC",
-                "altAbbreviation": "UCT",
-                "blurb": "A short description for CSV course",
-                "language": "Español",
-                "subjectMatter": "Marketing",
-                "altSubjectMatter": "Design and Marketing",
-                "altSubjectMatter1": "Marketing, Sales, and Techniques",
-                "universityAbbreviation": "edX",
-                "altUniversityAbbreviation": "altEdx",
-                "cardUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS9pbWFnZS5qcGc=",
-                "edxRedirectUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS8=",
-                "edxPlpUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS8=",
-                "durationWeeks": 10,
-                "effort": "7–10 hours per week",
-                'introduction': 'Very short description\n',
-                'isThisCourseForYou': 'This is supposed to be a long description',
-                'whatWillSetYouApart': "New ways to learn",
-                "videoURL": "",
-                "lcfURL": "d3d3LmV4YW1wbGUuY29tL2xlYWQtY2FwdHVyZT9pZD0xMjM=",
-                "logoUrl": "aHR0cHM6Ly9leGFtcGxlLmNvbS9pbWFnZS5qcGc=g",
-                "metaTitle": "SEO Title",
-                "metaDescription": "SEO Description",
-                "metaKeywords": "Keyword 1, Keyword 2",
-                "slug": "csv-course-slug",
-                "variant": {
-                    "id": "00000000-0000-0000-0000-000000000000",
-                    "endDate": "2022-05-06",
-                    "finalPrice": "1998",
-                    "startDate": "2022-03-06",
-                    "regCloseDate": "2022-02-06",
-                },
-                "curriculum": {
-                    "heading": "Course curriculum",
-                    "blurb": "Test Curriculum",
-                    "modules": [
-                        {
-                            "module_number": 0,
-                            "heading": "Module 0",
-                            "description": "Welcome to your course"
-                        },
-                        {
-                            "module_number": 1,
-                            "heading": "Module 1",
-                            "description": "Welcome to Module 1"
-                        },
-                    ]
-                },
-                "testimonials": [
-                    {
-                        "name": "Lorem Ipsum",
-                        "title": "Gibberish",
-                        "text": " This is a good course"
-                    },
-                ],
-                "faqs": [
-                    {
-                        "id": "faq-1",
-                        "headline": "FAQ 1",
-                        "blurb": "This should answer it"
-                    }
-                ],
-                "certificate": {
-                    "headline": "About the certificate",
-                    "blurb": "how this makes you special"
-                },
-                "stats": {
-                    "stat1": "90%",
-                    "stat1Blurb": "<p>A vast number of special beings take this course</p>",
-                    "stat2": "100 million",
-                    "stat2Blurb": "<p>VC fund</p>"
-                }
-            },
-        ]
+        'products': MOCK_PRODUCTS_DATA
     }
 
     def tearDown(self):

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -898,7 +898,7 @@ def fetch_getsmarter_products():
     )
     try:
         response = getsmarter_api_client.request(method='GET',
-                                                 url=settings.GETSMARTER_CLIENT_CREDENTIALS['PRODUCTS_DETAILS_URL'])
+                                                 url=f"{settings.GETSMARTER_CLIENT_CREDENTIALS['PRODUCTS_DETAILS_URL']}?detail=2")  # pylint: disable=line-too-long
         response.raise_for_status()
         response = response.json()
 


### PR DESCRIPTION
### [PROD-3117](https://2u-internal.atlassian.net/browse/PROD-3117)

## Overview 
This PR updates the management command 'populate_executive_education_data_csv' to take in getsmarter_flag as a parameter. This flag will be used to determine whether the data is to be populated using the GetSmarter APIClient or from auth_token generated from the Postman.
For Organization Mapping, `OrganizationMapping` is used containing three fields
```
organization: Foreign key of Organization table in our DB
source: Foreign key of the Source table in our DB
external_organization_code: organization code coming from external parties 
```

## Testing
- Activate the discovery shell using `make discovery-shell`
- Create the `OrganizationMapping` instances using Django Admin
- Make sure to add `GETSMARTER_CLIENT_CREDENTIALS` in `private.py`
```bash
GETSMARTER_CLIENT_CREDENTIALS = {
    'CLIENT_ID' : '',
    'CLIENT_SECRET' : '',
    'API_URL' : '',
    'PROVIDER_URL' : '',
    'PRODUCTS_DETAILS_URL' : '',
} 
```
 - Run the following command to run the management command
```
./manage.py ingest_executive_education_data --product_source={product-source-slug}
```

Todo:
- [ ] - Create the  `OrganizationMapping` model instances using admin prod and stage 