### PR TITLE
test: changing tearDown order to potentially fix list query test issue

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -48,8 +48,8 @@ class CourseViewSetTests(OAuth2Mixin, SerializationMixin, APITestCase):
         self.mock_access_token()
 
     def tearDown(self):
-        super().tearDown()
         self.client.logout()
+        super().tearDown()
 
     def mock_ecommerce_publication(self):
         url = f'{self.course.partner.ecommerce_api_url}publication/'


### PR DESCRIPTION
### Description
In test_courses.py, the unit test `test_list_query` was failing on various PRs on CI. It was not failing on local when run alone or in the complete suite.  Only the login sequence SQL queries were executed in the test, nothing else. The comment in the test mentioned it to be flaky prior to the addition of tearDown. I noticed the logout was being called after super.tearDown(). In tearDown(), what I have observed is that any suite-related cleanup is done, followed by super tearDown. I have updated the sequence to call logout before super.tearDown()