### PR TITLE
feat: add external_course_marketing_type in elasticsearch search/all endpoint

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2232,6 +2232,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
                 )
             ],
             'course_length': course.course_length,
+            'external_course_marketing_type': course.additional_metadata.external_course_marketing_type,
         }
 
         serializer = self.serialize_course(course, request)
@@ -2326,6 +2327,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             'level_type': course.level_type.name,
             'modified': course.modified,
             'course_length': course.course_length,
+            'external_course_marketing_type': course.additional_metadata.external_course_marketing_type,
         }
         if is_post_request:
             del expected['outcome']
@@ -2391,6 +2393,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
                 )
             ],
             'course_length': course.course_length,
+            'external_course_marketing_type': course.additional_metadata.external_course_marketing_type,
         }
 
 

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -161,6 +161,7 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         'content_type': {'field': 'content_type', 'enabled': True},
         'course_type': {'field': 'course_type', 'enabled': True},
         'enterprise_subscription_inclusion': {'field': 'enterprise_subscription_inclusion', 'enabled': True},
+        'external_course_marketing_type': {'field': 'external_course_marketing_type', 'enabled': True},
         'first_enrollable_paid_seat_price': {'field': 'first_enrollable_paid_seat_price', 'enabled': True},
         'language': {'field': 'language.raw', 'enabled': True},
         'level_type': {'field': 'level_type.raw', 'enabled': True},
@@ -196,6 +197,9 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         'enterprise_subscription_inclusion': {
             'field': 'enterprise_subscription_inclusion',
             'lookups': [LOOKUP_FILTER_TERM],
+        },
+        'external_course_marketing_type': {
+            'field': 'external_course_marketing_type', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]
         },
         'first_enrollable_paid_seat_price': {
             'field': 'first_enrollable_paid_seat_price',

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -54,6 +54,7 @@ class CourseDocument(BaseCourseDocument):
     course_type = fields.KeywordField(multi=True)
     enterprise_subscription_inclusion = fields.BooleanField()
     course_length = fields.KeywordField()
+    external_course_marketing_type = fields.KeywordField(multi=True)
 
     def prepare_aggregation_key(self, obj):
         return 'course:{}'.format(obj.key)
@@ -131,6 +132,9 @@ class CourseDocument(BaseCourseDocument):
 
     def prepare_enterprise_subscription_inclusion(self, obj):
         return obj.enterprise_subscription_inclusion
+
+    def prepare_external_course_marketing_type(self, obj):
+        return obj.additional_metadata.external_course_marketing_type if obj.additional_metadata else None
 
     class Django:
         """

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -155,6 +155,7 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
             'course_type',
             'course_length',
             'enterprise_subscription_inclusion',
+            'external_course_marketing_type',
         )
 
 


### PR DESCRIPTION
[PROD-3139](https://2u-internal.atlassian.net/browse/PROD-3139)
Adds `external_course_marketing_type` in search/all endpoint. Downstream consumers of Discovery - like Enterprise Catalog Service - require search/all responses to contain the new field for indexing/filtering.

## Testing Instructions:
1. From Discovery Admin, edit an additional_metadata field for a **non-draft** exec-ed course by selecting an option for `external_course_marketing_type` (complete the review process in case you have a draft exec-ed course entry)
2. Run the following commands in discovery-shell:
```
./manage.py search_index --disable-change-limit --create
./manage.py search_index --disable-change-limit --populate
```
3. You can see `external_course_marketing_type` when you visit https://discovery.edx.org/api/v1/search/all/