### PR TITLE
feat: manually upgrade event-bus-kafka

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -363,7 +363,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==3.7.1
+edx-event-bus-kafka==3.8.0
     # via -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via -r requirements/local.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -297,7 +297,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==3.7.1
+edx-event-bus-kafka==3.8.0
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via


### PR DESCRIPTION
Brings in an update to edx-event-bus-kafka that will emit the original metadata from the course_catalog_info_changed signal event.

Done manually while `make upgrade` is busted, pending https://github.com/openedx/course-discovery/pull/3784