### PR TITLE
feat!: Update CSV loader to cater to product source

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -8,7 +8,7 @@ from course_discovery.apps.course_metadata.models import (
 )
 from course_discovery.apps.course_metadata.tests.factories import (
     CourseFactory, CourseRunTypeFactory, CourseTypeFactory, LevelTypeFactory, ModeFactory, OrganizationFactory,
-    PartnerFactory, ProgramFactory, SeatTypeFactory, SubjectFactory, TrackFactory
+    PartnerFactory, ProgramFactory, SeatTypeFactory, SourceFactory, SubjectFactory, TrackFactory
 )
 
 
@@ -331,6 +331,7 @@ class CSVLoaderMixin:
             course_run_types=[self.course_run_type],
             entitlement_types=[seat_type]
         )
+        self.source = SourceFactory(slug='ext_source')
 
     def _write_csv(self, csv, lines_dict_list, headers=None):
         """
@@ -429,6 +430,7 @@ class CSVLoaderMixin:
         assert course.level_type.name_t == expected_data['level_type']
         assert course.video.src == expected_data['about_video_link']
         assert course.type == self.course_type
+        assert course.product_source == self.source
         assert course.organization_short_code_override == 'Org Override'
         assert course_entitlement.price == expected_data['verified_price']
         assert course.additional_metadata.external_url == expected_data['external_url']

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_import_degree_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_import_degree_data.py
@@ -58,7 +58,7 @@ class TestImportDegreeData(DegreeCSVLoaderMixin, OAuth2Mixin, APITestCase):
                 CommandError, 'CSV loader import could not be completed due to unexpected errors.'
         ):
             call_command(
-                'import_course_metadata', '--partner_code', self.partner.short_code, '--csv_path', 'no-path',
+                'import_degree_data', '--partner_code', self.partner.short_code, '--csv_path', 'no-path',
             )
 
     def test_no_csv_file(self, jwt_decode_patch):  # pylint: disable=unused-argument

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -694,3 +694,11 @@ LMS_API_URLS = {
     'blocks': 'api/courses/v1/blocks/',
     'block_metadata': 'api/courses/v1/block_metadata/',
 }
+
+# Map defining the required data fields against courses types and course's product source.
+# Mapping pattern: course_type_slug -> product_source_slug -> fields list (excluding base fields present in CSV loader).
+CSV_LOADER_TYPE_SOURCE_REQUIRED_FIELDS = {
+    'audit': {
+        'openedx': ['staff']
+    },
+}

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -87,6 +87,24 @@ BOOTCAMP_CONTENTFUL_CONTENT_TYPE = 'bootCampPage'
 
 DEGREE_CONTENTFUL_CONTENT_TYPE = 'degreeDetailPage'
 
+CSV_LOADER_TYPE_SOURCE_REQUIRED_FIELDS.update(
+    {
+        'executive-education-2u': {
+            'ext_source': [
+                'syllabus', 'redirect_url', 'organic_url', 'external_identifier', 'lead_capture_form_url',
+                'certificate_header', 'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text',
+                'frequently_asked_questions', 'reg_close_date', 'reg_close_time', 'variant_id',
+            ],
+            'dbz_source': [
+                'redirect_url', 'organic_url', 'external_identifier',
+            ]
+        },
+        'bootcamp-2u': {
+            'ext_source': ['redirect_url', 'organic_url', 'external_identifier']
+        }
+    }
+)
+
 GETSMARTER_CLIENT_CREDENTIALS = {
     'CLIENT_ID' : 'test_id',
     'CLIENT_SECRET' : 'test_secret',


### PR DESCRIPTION
### [PROD-3147](https://2u-internal.atlassian.net/browse/PROD-3147)

### Description
This PRs updates import_course_metadata management command and CSV loader to consider product_source as a required attribute. Based on the product source and course type combination, CSV loader will verify different levels of field presence checks during ingestion. The aim of this change is to allow ingesting the same course type products that have different sources and different field level requirement validations.

**This PR introduces some breaking changes in CSV loader flow. First of all, a valid product source slug must be provided so that courses can be associated with that source. The field-level validations are now being decided on product source + course type. Before it was course type only. That also means that some variables that were present in CSV loader before have now been turned into setting variables to have flexibility in defining required fields.**



### Testing


#### private.py updates
Add dict in similar format in private.py in settings directory to allow different field validations for execEd and bootcamps against different sources.
```
from .devstack import  CSV_LOADER_TYPE_SOURCE_REQUIRED_FIELDS


CSV_LOADER_TYPE_SOURCE_REQUIRED_FIELDS.update(
    {
        'executive-education-2u': {
            'source_1': [
                'syllabus', 'redirect_url', 'organic_url', 'external_identifier', 'lead_capture_form_url', 'certificate_header',
                'certificate_text', 'stat1', 'stat1_text', 'stat2', 'stat2_text', 'frequently_asked_questions',
                'reg_close_date', 'reg_close_time', 'variant_id',
            ],
            'source_2': ['redirect_url', 'organic_url', 'external_identifier']
        },
        'bootcamp-2u': {
            'source_1': ['redirect_url', 'organic_url', 'external_identifier']
        }
    }
)
```

1. Ensure you have atleast two product sources created in Discovery. They can be added from admin `/admin/course_metadata/source/`. 
2. Also, make sure you have two different CSV files of same/different product types that are to be assigned to product source
3. Run import_course_metadata command with one source `./manage.py import_course_metadata --csv_path=data.csv --product_source=source_1 --product_type=EXECUTIVE_EDUCATION`. Verify the source is assigned correctly. If the course is draft, complete publication flow via publisher and ensure source is visible on non-draft version. If the course is already published, ensure source is present on both draft and non-draft versions
4. Repeat 3 but with different csv and source


### Actions before the merge
- [ ] Add settings variables in edx-internal for stage and prod to define extra required field mappings for Bootcamp and ExecEd. Related PR: https://github.com/edx/edx-internal/pull/7779

### Todos/Missing Items

- Update Archive flow to cater to product source as a check. This is needed because archive products of the same type but from different source should not be considered for archived flow. 