### PR TITLE
feat: Upgrade edx-event-bus-kafka to 3.9.1 (adds audit logging)

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -366,7 +366,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==3.8.0
+edx-event-bus-kafka==3.9.1
     # via -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via -r requirements/local.in
@@ -521,7 +521,7 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -299,7 +299,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==3.8.0
+edx-event-bus-kafka==3.9.1
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -414,7 +414,7 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector


### PR DESCRIPTION
openedx-events major version bump is a change to how consumers send
metadata to signal receivers, and is coordinated with the event-bus-kafka
3.8.1 version.