### PR TITLE
ENT-6682: version upgrade for taxonomy-connector to version 1.35.1

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -79,5 +79,5 @@ urllib3==1.26.14
     # via
     #   elasticsearch
     #   requests
-zipp==3.12.0
+zipp==3.12.1
     # via importlib-metadata

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -62,9 +62,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.63
+boto3==1.26.67
     # via django-ses
-botocore==1.29.63
+botocore==1.29.67
     # via
     #   boto3
     #   s3transfer
@@ -136,7 +136,7 @@ coverage[toml]==7.1.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   paramiko
     #   pyjwt
@@ -303,7 +303,7 @@ django-waffle==3.0.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-django-webpack-loader==1.8.0
+django-webpack-loader==1.8.1
     # via -r requirements/base.in
 djangorestframework==3.14.0
     # via
@@ -366,7 +366,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==3.8.0
+edx-event-bus-kafka==3.9.2
     # via -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via -r requirements/local.in
@@ -410,7 +410,7 @@ face==22.0.0
     # via glom
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==16.6.1
+faker==16.7.0
     # via factory-boy
 fastavro==1.7.1
     # via openedx-events
@@ -427,7 +427,7 @@ glom==22.1.0
     # via semgrep
 google-api-core==2.11.0
     # via google-api-python-client
-google-api-python-client==2.76.0
+google-api-python-client==2.77.0
     # via -r requirements/base.in
 google-auth==2.16.0
     # via
@@ -440,7 +440,7 @@ google-auth-httplib2==0.1.0
     # via
     #   -r requirements/base.in
     #   google-api-python-client
-google-auth-oauthlib==0.8.0
+google-auth-oauthlib==1.0.0
     # via gspread
 googleapis-common-protos==1.58.0
     # via google-api-core
@@ -515,13 +515,13 @@ mysqlclient==2.1.1
     # via -r requirements/test.in
 newrelic==8.5.0
     # via edx-django-utils
-numpy==1.24.1
+numpy==1.24.2
     # via pandas
 oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector
@@ -553,7 +553,7 @@ pillow==9.4.0
     #   -r requirements/base.in
     #   cairosvg
     #   django-stdimage
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   pylint
     #   virtualenv
@@ -649,7 +649,7 @@ pytest-responses==0.5.1
     # via -r requirements/test.in
 pytest-split==0.8.0
     # via -r requirements/local.in
-pytest-xdist==3.1.0
+pytest-xdist==3.2.0
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via
@@ -700,7 +700,7 @@ pyyaml==5.4.1
     #   edx-i18n-tools
 rcssmin==1.1.1
     # via django-compressor
-redis==4.4.2
+redis==4.5.1
     # via -r requirements/base.in
 requests==2.28.2
     # via
@@ -834,9 +834,9 @@ stevedore==4.1.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.34.0
+taxonomy-connector==1.35.0
     # via -r requirements/base.in
-testfixtures==7.0.4
+testfixtures==7.1.0
     # via -r requirements/test.in
 text-unidecode==1.3
     # via python-slugify
@@ -868,7 +868,7 @@ trio==0.22.0
     #   trio-websocket
 trio-websocket==0.9.2
     # via selenium
-types-toml==0.10.8.2
+types-toml==0.10.8.3
     # via responses
 typing-extensions==4.4.0
     # via
@@ -901,7 +901,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox
 wcmatch==8.4.1
     # via semgrep
@@ -923,7 +923,7 @@ xss-utils==0.4.0
     # via -r requirements/base.in
 zeep==4.2.1
     # via simple-salesforce
-zipp==3.12.0
+zipp==3.12.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.38.4
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0
     # via -r requirements/pip.in
-setuptools==67.1.0
+setuptools==67.2.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -37,9 +37,9 @@ beautifulsoup4==4.11.2
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.26.63
+boto3==1.26.67
     # via django-ses
-botocore==1.29.63
+botocore==1.29.67
     # via
     #   boto3
     #   s3transfer
@@ -93,7 +93,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==39.0.0
+cryptography==39.0.1
     # via
     #   pyjwt
     #   pyopenssl
@@ -246,7 +246,7 @@ django-waffle==3.0.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-django-webpack-loader==1.8.0
+django-webpack-loader==1.8.1
     # via -r requirements/base.in
 djangorestframework==3.14.0
     # via
@@ -299,7 +299,7 @@ edx-drf-extensions==8.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-edx-event-bus-kafka==3.8.0
+edx-event-bus-kafka==3.9.2
     # via -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -337,7 +337,7 @@ gevent==22.10.2
     # via -r requirements/production.in
 google-api-core==2.11.0
     # via google-api-python-client
-google-api-python-client==2.76.0
+google-api-python-client==2.77.0
     # via -r requirements/base.in
 google-auth==2.16.0
     # via
@@ -350,7 +350,7 @@ google-auth-httplib2==0.1.0
     # via
     #   -r requirements/base.in
     #   google-api-python-client
-google-auth-oauthlib==0.8.0
+google-auth-oauthlib==1.0.0
     # via gspread
 googleapis-common-protos==1.58.0
     # via google-api-core
@@ -408,13 +408,13 @@ newrelic==8.5.0
     # via
     #   -r requirements/production.in
     #   edx-django-utils
-numpy==1.24.1
+numpy==1.24.2
     # via pandas
 oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   social-auth-core
-openedx-events==4.2.0
+openedx-events==5.0.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector
@@ -433,7 +433,7 @@ pillow==9.4.0
     #   -r requirements/base.in
     #   cairosvg
     #   django-stdimage
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via zeep
 prompt-toolkit==3.0.36
     # via click-repl
@@ -515,7 +515,7 @@ pyyaml==6.0
     #   edx-django-release-util
 rcssmin==1.1.1
     # via django-compressor
-redis==4.4.2
+redis==4.5.1
     # via -r requirements/base.in
 requests==2.28.2
     # via
@@ -600,7 +600,7 @@ stevedore==4.1.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.34.0
+taxonomy-connector==1.35.0
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -640,7 +640,7 @@ xss-utils==0.4.0
     # via -r requirements/base.in
 zeep==4.2.1
     # via simple-salesforce
-zipp==3.12.0
+zipp==3.12.1
     # via importlib-metadata
 zope-event==4.6
     # via gevent


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6682](https://2u-internal.atlassian.net/browse/ENT-6682)

__Description:__
This is a version bump PR for the taxonomy-connector repo, new version contains [these changes](https://github.com/openedx/taxonomy-connector/compare/1.34.0...1.35.0).

**Note:**
There are 3 major upgrades in this PR, (These are not related to my changes so let me know if you would want me to pin these in `constraints.txt`)

1. google-auth-oauthlib
```diff
- google-auth-oauthlib==0.8.0
+ google-auth-oauthlib==1.0.0
```
2. openedx-events
```diff
- openedx-events==4.2.0
+ openedx-events==5.0.0
```
3. platformdirs
```diff
- platformdirs==2.6.2
+ platformdirs==3.0.0
```