### PR TITLE
chore: taxonomy-connector version bump

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -79,5 +79,5 @@ urllib3==1.26.14
     # via
     #   elasticsearch
     #   requests
-zipp==3.12.1
+zipp==3.13.0
     # via importlib-metadata

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -62,9 +62,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.67
+boto3==1.26.68
     # via django-ses
-botocore==1.29.67
+botocore==1.29.68
     # via
     #   boto3
     #   s3transfer
@@ -337,7 +337,7 @@ drf-flex-fields==1.0.0
     # via -r requirements/base.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via
     #   -r requirements/base.in
     #   edx-api-doc-tools
@@ -410,7 +410,7 @@ face==22.0.0
     # via glom
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==16.7.0
+faker==16.8.1
     # via factory-boy
 fastavro==1.7.1
     # via openedx-events
@@ -513,7 +513,7 @@ mock==5.0.1
     # via -r requirements/test.in
 mysqlclient==2.1.1
     # via -r requirements/test.in
-newrelic==8.5.0
+newrelic==8.6.0
     # via edx-django-utils
 numpy==1.24.2
     # via pandas
@@ -834,7 +834,7 @@ stevedore==4.1.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.35.0
+taxonomy-connector==1.35.1
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in
@@ -923,7 +923,7 @@ xss-utils==0.4.0
     # via -r requirements/base.in
 zeep==4.2.1
     # via simple-salesforce
-zipp==3.12.1
+zipp==3.13.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -37,9 +37,9 @@ beautifulsoup4==4.11.2
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.26.67
+boto3==1.26.68
     # via django-ses
-botocore==1.29.67
+botocore==1.29.68
     # via
     #   boto3
     #   s3transfer
@@ -270,7 +270,7 @@ drf-flex-fields==1.0.0
     # via -r requirements/base.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
-drf-yasg==1.21.4
+drf-yasg==1.21.5
     # via
     #   -r requirements/base.in
     #   edx-api-doc-tools
@@ -404,7 +404,7 @@ markupsafe==2.1.2
     # via jinja2
 mysqlclient==2.1.1
     # via -r requirements/production.in
-newrelic==8.5.0
+newrelic==8.6.0
     # via
     #   -r requirements/production.in
     #   edx-django-utils
@@ -600,7 +600,7 @@ stevedore==4.1.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.35.0
+taxonomy-connector==1.35.1
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -640,7 +640,7 @@ xss-utils==0.4.0
     # via -r requirements/base.in
 zeep==4.2.1
     # via simple-salesforce
-zipp==3.12.1
+zipp==3.13.0
     # via importlib-metadata
 zope-event==4.6
     # via gevent


### PR DESCRIPTION
# Description
`taxonomy-connector` version bump to the latest version. It includes changes from this [PR](https://github.com/openedx/taxonomy-connector/pull/142) for [ENT-6405](https://2u-internal.atlassian.net/browse/ENT-6405). 