### PR TITLE
feat: remove empty tags form html content which were converted to hr tags

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -672,6 +672,9 @@ class UtilsTests(TestCase):
 </li>
 </ol>
 <p><img src='file:////Users/myuser/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_image001.png' width='276' height='208' /></p>"""),
+        ("<div><p>online course.</p><p><b></b></p><p><strong>Module 1:</strong></p></div>",
+         """<p>online course.</p>
+<p><strong>Module 1:</strong></p>"""),
     )
     @ddt.unpack
     def test_clean_html(self, content, expected):

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -689,6 +689,8 @@ def clean_html(content):
     cleaned = str(BeautifulSoup(cleaned, 'lxml'))
     # Need to re-replace the · middot with the entity so that html2text can transform it to * for <ul> in markdown
     cleaned = cleaned.replace('·', '&middot;')
+    # Need to clean empty <b> and <p> tags which are converted to <hr/> by html2text
+    cleaned = cleaned.replace('<p><b></b></p>', '')
     html_converter = HTML2TextWithLangSpans(bodywidth=None)
     html_converter.wrap_links = False
     cleaned = html_converter.handle(cleaned).strip()


### PR DESCRIPTION
## Description
We are cleaning html before adding it to our database, during cleaning it was converting `<p><b></b></p>` to `<hr />`. And we don't allow this tag in our html so we need to remove these empty tags