### PR TITLE
fix: update Geolocation create behavior in Geolocation CSV loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/geolocation_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/geolocation_loader.py
@@ -18,7 +18,7 @@ class GeolocationCSVDataLoader(AbstractDataLoader):
     # Below are the minimum required fields needed for successful data upload
     # Additional column names (for info purposes only) may be Product Name, Partner, Notes
     GEOLOCATION_REQUIRED_DATA_FIELDS = [
-        'uuid', 'product_type', 'location_name', 'latitude', 'longtitude',
+        'uuid', 'product_type', 'location_name', 'latitude', 'longitude',
     ]
 
     def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, csv_path=None, csv_file=None):
@@ -56,7 +56,7 @@ class GeolocationCSVDataLoader(AbstractDataLoader):
             geolocation = {
                 'location_name': row['location_name'],
                 'lat': row['latitude'],
-                'lng': row['longtitude'],
+                'lng': row['longitude'],
             }
 
             err_message = self.validate_geolocation_data(row)
@@ -89,7 +89,12 @@ class GeolocationCSVDataLoader(AbstractDataLoader):
             action_taken = 'Created'
             existing_geolocation_id = product_obj.geolocation.id if product_obj.geolocation else None  # lint-amnesty
 
-            product_obj.geolocation = GeoLocation.objects.create(**geolocation)
+            geolocation_obj, created = GeoLocation.objects.get_or_create(**geolocation)
+            if created:
+                logger.info(f"Created new geolocation object with id {geolocation_obj.pk} for product {row_uuid}")
+            else:
+                logger.info(f"Using existing geolocation object with id {geolocation_obj.pk} for product {row_uuid}")
+            product_obj.geolocation = geolocation_obj
             product_obj.save()
 
             if existing_geolocation_id:

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -178,13 +178,13 @@ class GeotargetingCSVLoaderMixin:
         """
         setup test-only course.
         """
-        CourseFactory(uuid=course_uuid, location_restriction=None)
+        CourseFactory(uuid=course_uuid, location_restriction=None, geolocation=None)
 
     def _setup_program(self, program_uuid):
         """
-        setup test-only course.
+        setup test-only program.
         """
-        ProgramFactory(uuid=program_uuid, location_restriction=None)
+        ProgramFactory(uuid=program_uuid, location_restriction=None, geolocation=None)
 
     CSV_DATA_KEYS_ORDER = [
         'UUID',
@@ -226,7 +226,7 @@ class GeolocationCSVLoaderMixin(GeotargetingCSVLoaderMixin):
         'PRODUCT TYPE',
         'LOCATION NAME',
         'LATITUDE',
-        'LONGTITUDE',
+        'LONGITUDE',
     ]
 
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -3283,7 +3283,7 @@ VALID_GEOTARGETING_CSV_DICT = {
 VALID_GEOLOCATION_CSV_DICT = {
     'UUID': '3f10df65fd0641df9b42ad2cbaeb7fee',
     'PRODUCT TYPE': 'course',
-    'LOCATION NAME': 'Harvard Univeristy',
+    'LOCATION NAME': 'Harvard University',
     'LATITUDE': '40.146339',
-    'LONGTITUDE': '-73.971038',
+    'LONGITUDE': '-73.971038',
 }

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -181,6 +181,7 @@ class CoursesApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     def test_ingest_verified_deadline(self, mock_push_to_ecomm):
         """ Verify the method ingests data from the Courses API. """
         TieredCache.dangerous_clear_all_tiers()
+        responses.calls.reset()  # pylint: disable=no-member
         api_data = self.mock_api()
 
         assert Course.objects.count() == 0
@@ -252,6 +253,7 @@ class CoursesApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         end date changes if bypass switch is active.
         """
         TieredCache.dangerous_clear_all_tiers()
+        responses.calls.reset()  # pylint: disable=no-member
         api_data = self.mock_api()
         assert Course.objects.count() == 0
         assert CourseRun.objects.count() == 0


### PR DESCRIPTION
### [PROD-3169](https://2u-internal.atlassian.net/browse/PROD-3169)

### Description
GeoLocation model in Discovery has a uniqueness constraint on lng, lat on model level. That implies that it is not possible to have multiple GeoLoc objects against the same lat and lng. Conceptually, it also makes sense to not have two places on same coordinates. 

However, in GeoLocationCSVLoader, there is a bug. The loader always attempts to make geoloc objects against provided data. Let's say location 1, lat=50,lng=50 is associated with Course 1 and we want to associate the same with Course 2, the ingestion will fail with a uniqueness error. 

This PR changes the behavior of CSV loader. If a geoloc object is already present against the provided data, use that object instead of creating a new object. That also results in the same geoloc object linking with multiple products. Changes in geoloc object will show up across all products.

**Besides updating Geolocation CSV loader, this change also fixes flaky tests in LMS Data loader. The tests were failing because of an additional OAuth call that happened during test suite setUp. This resulted in responses call count incrementing by 1 and failing the tests.**

### Testing
Here is a CSV file as a sample. [geoloc.csv](https://github.com/openedx/course-discovery/files/10755346/geoloc.csv). Change UUID columns to match UUID values from your system. 


- Command to run in discovery shell `./manage.py import_geolocation_data --csv_path=geoloc.csv`
- Verify same geoloc will be used with multiple products
- Verify new geoloc objects are created if lat,lng, location combination is not present.
