### PR TITLE
feat: expose product source to algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -56,8 +56,8 @@ def delegate_attributes(cls):
     '''
 
     product_type_fields = ['product_type']
-    search_fields = ['partner_names', 'partner_keys', 'product_title', 'primary_description', 'secondary_description',
-                     'tertiary_description']
+    search_fields = ['partner_names', 'partner_keys', 'product_title', 'product_source', 'primary_description',
+                     'secondary_description', 'tertiary_description']
     facet_fields = ['availability_level', 'subject_names', 'levels', 'active_languages', 'staff_slugs',
                     'product_allowed_in', 'product_blocked_in']
     ranking_fields = ['availability_rank', 'product_recent_enrollment_count', 'promoted_in_spanish_index',
@@ -67,8 +67,7 @@ def delegate_attributes(cls):
                      'product_max_effort', 'product_min_effort', 'active_run_key', 'active_run_start',
                      'active_run_type', 'owners', 'program_types', 'course_titles', 'tags',
                      'product_organization_short_code_override', 'product_organization_logo_override', 'skills',
-                     'product_meta_title', 'product_display_on_org_page', 'contentful_fields'
-                     ]
+                     'product_meta_title', 'product_display_on_org_page', 'contentful_fields',]
     object_id_field = ['custom_object_id', ]
     fields = product_type_fields + search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -192,6 +191,10 @@ class AlgoliaBasicModelFieldsMixin(models.Model):
         if self.organization_logo_override:
             return getattr(self.organization_logo_override, 'url', None)
         return None
+
+    @property
+    def product_source(self):
+        return self.product_source.slug if self.product_source else None
 
 
 class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -74,7 +74,7 @@ class BaseProductIndex(AlgoliaIndex):
 class EnglishProductIndex(BaseProductIndex):
     language = 'en'
 
-    search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys',
+    search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys', 'product_source',
                      'primary_description', 'secondary_description', 'tertiary_description', 'tags')
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
@@ -124,7 +124,7 @@ class EnglishProductIndex(BaseProductIndex):
 class SpanishProductIndex(BaseProductIndex):
     language = 'es_419'
 
-    search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys',
+    search_fields = (('product_title', 'title'), ('partner_names', 'partner'), 'partner_keys', 'product_source',
                      'primary_description', 'secondary_description', 'tertiary_description', 'tags')
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -17,7 +17,7 @@ from course_discovery.apps.course_metadata.models import CourseRunStatus, Course
 from course_discovery.apps.course_metadata.tests.factories import (
     AdditionalMetadataFactory, CourseFactory, CourseRunFactory, CourseTypeFactory, DegreeAdditionalMetadataFactory,
     DegreeFactory, LevelTypeFactory, OrganizationFactory, ProductMetaFactory, ProgramFactory, ProgramTypeFactory,
-    SeatFactory, SeatTypeFactory, SubjectFactory
+    SeatFactory, SeatTypeFactory, SourceFactory, SubjectFactory
 )
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 
@@ -373,6 +373,30 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         if type_slug:
             course.type = CourseTypeFactory(slug=type_slug)
         assert course.product_display_on_org_page == display_on_org_page
+
+    @ddt.data((AlgoliaProxyCourse, 'source_1'), (AlgoliaProxyProgram, 'source_2'))
+    @ddt.unpack
+    def test_product_source_with_non_empty_source(self, model_factory, product_source):
+        """
+        Verify the product source is returned as expected.
+        """
+        product = model_factory(
+            partner=self.__class__.edxPartner,
+            product_source=SourceFactory(name=product_source)
+        )
+        assert product.product_source.name == product_source
+
+    @ddt.data((AlgoliaProxyCourse, None), (AlgoliaProxyProgram, None))
+    @ddt.unpack
+    def test_product_source_with_empty_source(self, model_factory, product_source):
+        """
+        Verify the product source is returned as None if not present.
+        """
+        product = model_factory(
+            partner=self.__class__.edxPartner,
+            product_source=product_source
+        )
+        assert product.product_source is None
 
 
 @ddt.ddt


### PR DESCRIPTION
[PROD-3167](https://2u-internal.atlassian.net/browse/PROD-3167)

This PR add the `product_source` field to the algolia model, so that they are returned in search results plus it also index `product_source` in algolia 

## Testing 
- For testing you can follow following doc
[Testing Algolia Indexing Locally](https://2u-internal.atlassian.net/wiki/spaces/WS/pages/8749500/Algolia+Indexing#How-to-test-the-indexing-locally)