### PR TITLE
feat: allow registration_deadline to be null in AdditionalMetadata serializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -687,7 +687,7 @@ class AdditionalMetadataSerializer(BaseModelSerializer):
     product_meta = ProductMetaSerializer(required=False, allow_null=True)
     start_date = serializers.DateTimeField()
     end_date = serializers.DateTimeField()
-    registration_deadline = serializers.DateTimeField()
+    registration_deadline = serializers.DateTimeField(allow_null=True)
     variant_id = serializers.UUIDField(allow_null=True)
 
     @classmethod


### PR DESCRIPTION
# [PROD-3162](https://2u-internal.atlassian.net/browse/PROD-3162)

## Description

This PR allows null values for `registration_deadline` in AdditionalMetadata serializer. This is required so as to complete publisher flow for emeritus courses for which we do not have a registration deadline