### PR TITLE
feat: added management command, set is_marketable to False

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/change_is_marketable_to_false.py
+++ b/course_discovery/apps/course_metadata/management/commands/change_is_marketable_to_false.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
     Set 'is_marketable' to False for existing CourseRunType instances.
     ./manage.py change_is_marketable_to_false
     """
-    help = 'Change status is_marketable in available types to False for existing CourseRunType instances'
+    help = 'Change status is_marketable in available types to False for existing CourseRunType instances.'
 
     def handle(self, *args, **options):
         self.change_is_marketable_in_course_run_type()

--- a/course_discovery/apps/course_metadata/management/commands/change_is_marketable_to_false.py
+++ b/course_discovery/apps/course_metadata/management/commands/change_is_marketable_to_false.py
@@ -1,0 +1,25 @@
+import logging
+
+from django.core.management import BaseCommand
+
+from course_discovery.apps.course_metadata.models import CourseRunType
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Set 'is_marketable' to False for existing CourseRunType instances.
+    ./manage.py change_is_marketable_to_false
+    """
+    help = 'Change status is_marketable in available types to False for existing CourseRunType instances'
+
+    def handle(self, *args, **options):
+        self.change_is_marketable_in_course_run_type()
+
+    def change_is_marketable_in_course_run_type(self):
+        course_run_types = CourseRunType.objects.filter(is_marketable=True)
+        for course_run_type in course_run_types:
+            logger.info('Changed is_marketable status for CourseRunType: [%s] to False...', course_run_type.name)
+            course_run_type.is_marketable = False
+        CourseRunType.objects.bulk_update(course_run_types, ['is_marketable'])

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_change_is_marketable_to_false.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_change_is_marketable_to_false.py
@@ -1,0 +1,22 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.models import CourseRunType
+from course_discovery.apps.course_metadata.tests.factories import CourseRunTypeFactory
+
+
+class ChangeIsMarketableToCourseRunTypesCommandTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.course_run_type_1 = CourseRunTypeFactory()
+        self.course_run_type_2 = CourseRunTypeFactory()
+        self.course_run_type_3 = CourseRunTypeFactory()
+
+    def testNormalRunCommand(self):
+        call_command('change_is_marketable_to_false')
+        assert CourseRunType.objects.filter(uuid=self.course_run_type_1.uuid).exists()
+        assert CourseRunType.objects.get(uuid=self.course_run_type_1.uuid).is_marketable is False
+        assert CourseRunType.objects.filter(uuid=self.course_run_type_2.uuid).exists()
+        assert CourseRunType.objects.get(uuid=self.course_run_type_2.uuid).is_marketable is False
+        assert CourseRunType.objects.filter(uuid=self.course_run_type_3.uuid).exists()
+        assert CourseRunType.objects.get(uuid=self.course_run_type_3.uuid).is_marketable is False


### PR DESCRIPTION
### Description:
Added management command to set is_marketable to False for CourseRunType instances that have this parameter set to True.
This parameter is [set to True by default](https://github.com/openedx/course-discovery/blob/ea6e542f270a78ce2b26cfc51bccaec27a1853ab/course_discovery/apps/course_metadata/models.py#L539). This parameter [affects the formation of marketing_url](https://github.com/openedx/course-discovery/blob/ea6e542f270a78ce2b26cfc51bccaec27a1853ab/course_discovery/apps/course_metadata/models.py#L1949) for the CourseRun instance. These links are not always needed as not everyone in the community uses marketing sites for courses. In this case, the presence of this link leads to the creation of invalid links. For example in the cart (example for nutmeg release, but the same behavior for later versions.): 
![Screen_34](https://user-images.githubusercontent.com/98233552/220613454-c3ec446d-fb34-4d97-9e1e-e81a2d57e789.png)

![Screen_35](https://user-images.githubusercontent.com/98233552/220613469-6e12f251-a27b-49c0-a4ac-444964907f3e.png)

![Screen_36](https://user-images.githubusercontent.com/98233552/220613482-68c5e582-a6aa-4f0f-903a-d1b79a58c35d.png)

If is_marketable=False, then this link is a [link to the about page](https://github.com/openedx/ecommerce/blob/a4feac1a2b6da575064898bbade4644fe79dd7aa/ecommerce/extensions/basket/views.py#L355) it is a course. The presence of this link is the solution to this problem.

**It is corrected manually through the discovery admin panel:**
![Screen_30](https://user-images.githubusercontent.com/98233552/220610382-48a65558-3827-4b7d-9251-779b3909b603.png)

**However, the automation of this process allows you not to forget about this moment with each deployment.**