### PR TITLE
feat: expose product_source in elasticsearch search/all

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2233,6 +2233,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             ],
             'course_length': course.course_length,
             'external_course_marketing_type': course.additional_metadata.external_course_marketing_type,
+            'product_source': course.product_source.slug,
         }
 
         serializer = self.serialize_course(course, request)
@@ -2328,6 +2329,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             'modified': course.modified,
             'course_length': course.course_length,
             'external_course_marketing_type': course.additional_metadata.external_course_marketing_type,
+            'product_source': course.product_source.slug,
         }
         if is_post_request:
             del expected['outcome']
@@ -2394,6 +2396,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             ],
             'course_length': course.course_length,
             'external_course_marketing_type': course.additional_metadata.external_course_marketing_type,
+            'product_source': course.product_source.slug,
         }
 
 

--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -162,6 +162,7 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         'course_type': {'field': 'course_type', 'enabled': True},
         'enterprise_subscription_inclusion': {'field': 'enterprise_subscription_inclusion', 'enabled': True},
         'external_course_marketing_type': {'field': 'external_course_marketing_type', 'enabled': True},
+        'product_source': {'field': 'product_source', 'enabled': True},
         'first_enrollable_paid_seat_price': {'field': 'first_enrollable_paid_seat_price', 'enabled': True},
         'language': {'field': 'language.raw', 'enabled': True},
         'level_type': {'field': 'level_type.raw', 'enabled': True},
@@ -200,6 +201,9 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         },
         'external_course_marketing_type': {
             'field': 'external_course_marketing_type', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]
+        },
+        'product_source': {
+            'field': 'product_source', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]
         },
         'first_enrollable_paid_seat_price': {
             'field': 'first_enrollable_paid_seat_price',

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -55,6 +55,7 @@ class CourseDocument(BaseCourseDocument):
     enterprise_subscription_inclusion = fields.BooleanField()
     course_length = fields.KeywordField()
     external_course_marketing_type = fields.KeywordField(multi=True)
+    product_source = fields.KeywordField(multi=True)
 
     def prepare_aggregation_key(self, obj):
         return 'course:{}'.format(obj.key)
@@ -135,6 +136,9 @@ class CourseDocument(BaseCourseDocument):
 
     def prepare_external_course_marketing_type(self, obj):
         return obj.additional_metadata.external_course_marketing_type if obj.additional_metadata else None
+
+    def prepare_product_source(self, obj):
+        return obj.product_source.slug if obj.product_source else None
 
     class Django:
         """

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -156,6 +156,7 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
             'course_length',
             'enterprise_subscription_inclusion',
             'external_course_marketing_type',
+            'product_source',
         )
 
 


### PR DESCRIPTION
[PROD-3166](https://2u-internal.atlassian.net/browse/PROD-3166)
Adds `product_source` in search/all endpoint. Downstream consumers of Discovery - like Enterprise Catalog Service - require search/all responses to contain the new field for indexing/filtering.

## Testing Instructions:
1. From Discovery Admin, edit an additional_metadata field for a **non-draft** exec-ed course by selecting an option for `product_source` (complete the review process in case you have a draft exec-ed course entry)
2. Run the following commands in discovery-shell:
```
./manage.py search_index --disable-change-limit --create
./manage.py search_index --disable-change-limit --populate
```
3. You can see `product_source` when you visit https://discovery.edx.org/api/v1/search/all/