### PR TITLE
fix: remove unique constraint from GeoLocation in serializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -346,6 +346,9 @@ class GeoLocationSerializer(BaseModelSerializer):
     class Meta:
         model = GeoLocation
         fields = ('lat', 'lng', 'location_name')
+        # set validators to empty to override the Unique Constraint Validator
+        # to handle this in update_geolocation in api/serializer`
+        validators = []
 
 
 class PositionSerializer(BaseModelSerializer):
@@ -1447,7 +1450,10 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
         # save() will be called by main update()
 
     def update_geolocation(self, instance, geolocation):
-        if instance.geolocation:
+        geo_location_entry = GeoLocation.objects.filter(**geolocation).first()
+        if geo_location_entry:
+            instance.geolocation = geo_location_entry
+        elif instance.geolocation:
             GeoLocation.objects.filter(id=instance.geolocation.id).update(**geolocation)
             instance.refresh_from_db()
         else:

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -997,6 +997,9 @@ class ProductValue(TimeStampedModel):
 
 
 class GeoLocation(TimeStampedModel):
+    """
+    Model to keep Geographic location for Products.
+    """
     DECIMAL_PLACES = 11
     LAT_MAX_DIGITS = 14
     LNG_MAX_DIGITS = 14
@@ -1030,7 +1033,7 @@ class GeoLocation(TimeStampedModel):
 
     @property
     def coordinates(self):
-        return (self.lat, self.lng)
+        return self.lat, self.lng
 
 
 class AbstractLocationRestrictionModel(TimeStampedModel):


### PR DESCRIPTION
[PROD-3188](https://2u-internal.atlassian.net/browse/PROD-3188)
Removes unique constraints on Lat/Long in GeoLocation which fixes the publisher workflow and allows same lat/long pair to be assigned to another product.