### PR TITLE
docs: add missing ADRs

### DIFF
--- a/docs/decisions/0019-geotagging-products.rst
+++ b/docs/decisions/0019-geotagging-products.rst
@@ -1,0 +1,40 @@
+19. Geotargetting Courses and Programs in Discovery
+------------------------------------------------------------------
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+The various products offered on edX that are modeled in Discovery are associated with a specific organization or partner. The partner organizations on the platform can be from
+any region of the world. But the question is, why is product location important?
+
+The geographical location is important for search experiences in the following scenarios:
+
+* Provided a user's location in form of longitude and latitude, the products close to that location should be higher up in search results.
+* Blacklisting or whitelisting a product in certain locations should not display that product in those regions.
+
+Discovery does not have capabilities to add geolocation information  and configure geolocation restriction to a product. These features can be useful for larger community in enhancing the search experience of  their catalogs configured on Discovery.
+
+Decision
+--------
+
+Two new models are to be added in Discovery course_metadata Django app:
+
+1. GeoLocation
+2. AbstractLocationRestrictionModel
+
+   * CourseLocationRestriction
+   * ProgramLocationRestriction
+
+GeoLocation model will be associated with Course and Program models. The association will allow tagging a product to a particular geographical location.
+
+AbstractLocationRestrictionModel contains the information of countries and states where the product will be either whitelisted or blacklisted. The abstract model is used to create Course and Program specific location restriction models which are then associated with respective product model.
+
+Future Enhancements
+--------------------
+
+* Provide Geolocation and LocationRestriction information on an Organization level and use Course/Program level geolocation fields as an override.

--- a/docs/decisions/0020-external-courses-marketing-type.rst
+++ b/docs/decisions/0020-external-courses-marketing-type.rst
@@ -1,4 +1,4 @@
-18. Defining Marketing category for External Courses
+20. Defining Marketing category for External Courses
 ------------------------------------------------------------------
 
 Status

--- a/docs/decisions/0020-external-courses-marketing-type.rst
+++ b/docs/decisions/0020-external-courses-marketing-type.rst
@@ -1,0 +1,29 @@
+18. Defining Marketing category for External Courses
+------------------------------------------------------------------
+
+Status
+------
+
+Accepted (January 2023)
+
+Context
+-------
+
+Discovery has been traditionally used to author the marketing information of the courses offered on the platform. The course authors or editors would setup course and course runs
+using Publisher MFE and use discovery APIs to get required information. Apart from providing on-site courses' marketing, there are capabilities in Discovery
+that allow it to act like a Marketplace where courses external to platform can be marketed. The external courses utilize the course
+and course run types present in Discovery.
+
+With external courses, there is one exception. How can they be marketed differently from existing course types? It is certainly possible to create new course
+and course run types to fulfill the marketing needs. The process of curating new course and course run types is complex. Creating a new course or course run type requires changes across Discovery, E-commerce, and Platform.
+
+Decision
+--------
+
+In AdditionalMetadata model, present in course_metadata app, a new field called **external_course_marketing_type** will be added. The field will contain the possible choices an external courses can have. The course will remain linked with the desired course type and use the newly added field to drive behavior on frontend experience.
+
+Consequences
+------------
+
+* The addition of the field assumes that the information is only intended for marketing or reporting purposes and there are no expectations of having an enrollment data against this. The enrollments, if done, will be linked against Course and Course run types.
+* The field is not linked with course and course run types. At this moment, there are no checks to validate if a marketing type is allowed under a certain course type. These checks might be added in form of Django setting variable if required.


### PR DESCRIPTION
### [PROD-3197](https://2u-internal.atlassian.net/browse/PROD-3197)

- Add ADR for external course marketing type field in AdditionalMetadata and Geolocating related models