### PR TITLE
chore: upgrade taxonomy-connector 1.36.2

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,7 +12,7 @@ certifi==2022.12.7
     # via
     #   elasticsearch
     #   requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 django-elasticsearch-dsl==7.3
     # via -r requirements/docs.in

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -62,9 +62,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.84
+boto3==1.26.86
     # via django-ses
-botocore==1.29.84
+botocore==1.29.86
     # via
     #   boto3
     #   s3transfer
@@ -124,7 +124,7 @@ code-annotations==1.3.0
     #   edx-toggles
 colorama==0.4.6
     # via semgrep
-contentful==1.13.1
+contentful==2.1.1
     # via -r requirements/base.in
 coreapi==2.3.3
     # via drf-yasg
@@ -571,7 +571,7 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.38
     # via click-repl
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -608,7 +608,7 @@ pyjwt[crypto]==2.6.0
     #   simple-salesforce
     #   snowflake-connector-python
     #   social-auth-core
-pylint==2.16.3
+pylint==2.16.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -841,7 +841,7 @@ stevedore==5.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.36.1
+taxonomy-connector==1.36.2
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.38.4
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.5.0
+setuptools==67.5.1
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -37,9 +37,9 @@ beautifulsoup4==4.11.2
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.26.84
+boto3==1.26.86
     # via django-ses
-botocore==1.29.84
+botocore==1.29.86
     # via
     #   boto3
     #   s3transfer
@@ -85,7 +85,7 @@ click-repl==0.2.0
     # via celery
 code-annotations==1.3.0
     # via edx-toggles
-contentful==1.13.1
+contentful==2.1.1
     # via -r requirements/base.in
 coreapi==2.3.3
     # via drf-yasg
@@ -442,7 +442,7 @@ platformdirs==3.1.0
     # via zeep
 prompt-toolkit==3.0.38
     # via click-repl
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -607,7 +607,7 @@ stevedore==5.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.36.1
+taxonomy-connector==1.36.2
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
This PR bumps taxonomy-connector version from 1.36.1 to 1.36.2.