### PR TITLE
feat: update geoloc handling in course API

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -2071,8 +2071,8 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         course_data = {'geolocation': {'lat': lat, 'lng': lng, 'location_name': 'New location'}, 'draft': False}
         response = self.client.patch(url, course_data, format='json')
 
-        expected_error_message = f"Geolocation object with " \
-                                 f"lat: -47.97350000000, lng: 23.95000000000 exists with name Alps"
+        expected_error_message = "Geolocation object with lat: -47.97350000000, " \
+                                 "lng: 23.95000000000 exists with name Alps"
         assert response.status_code == 400
         assert expected_error_message in response.data
         assert GeoLocation.objects.count() == 1


### PR DESCRIPTION
### [PROD-3198](https://2u-internal.atlassian.net/browse/PROD-3198)

### Description
Updating geolocation handling in the course API.

* Filter geolocation object against provided longitude & latitude.
* If the object is found
  * Verify the name of the object is the same. Otherwise, raise the validation error.
  * If the name is the same, assign geolocation to the course.
* If geolocation is not found, create a new geolocation object.


**This PR fixes a bug where if a geolocation object is linked to multiple courses, changing geoloc info on one course incorrectly updated geoloc for all the linked courses.**