### PR TITLE
feat: transform csvLoader for edX bootcamps

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
@@ -26,7 +26,8 @@ class Command(BaseCommand):
 
     PRODUCT_TYPE_SLUG_MAP = {
         'EXECUTIVE_EDUCATION': CourseType.EXECUTIVE_EDUCATION_2U,
-        'BOOTCAMPS': CourseType.BOOTCAMP_2U
+        'BOOTCAMPS': CourseType.BOOTCAMP_2U,
+        'BOOTCAMPS_EDX': CourseType.BOOTCAMP_EDX
     }
 
     def add_arguments(self, parser):
@@ -46,7 +47,7 @@ class Command(BaseCommand):
             help='Product Type to ingest',
             type=str,
             required=True,
-            choices=['EXECUTIVE_EDUCATION', 'BOOTCAMPS']
+            choices=['EXECUTIVE_EDUCATION', 'BOOTCAMPS', 'BOOTCAMPS_EDX']
         )
         parser.add_argument(
             '--product_source',

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -585,6 +585,7 @@ class CourseType(TimeStampedModel):
     EMPTY = 'empty'
     EXECUTIVE_EDUCATION_2U = 'executive-education-2u'
     BOOTCAMP_2U = 'bootcamp-2u'
+    BOOTCAMP_EDX = 'bootcamp-edx'
 
     uuid = models.UUIDField(default=uuid4, editable=False, verbose_name=_('UUID'), unique=True)
     name = models.CharField(max_length=64)

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -682,6 +682,14 @@ PRODUCT_METADATA_MAPPING = {
             'EMAIL_NOTIFICATION_LIST': []
         }
     },
+    'bootcamp-edx': {
+        'ext_source': {
+            'SHEET_ID': '',
+            'INPUT_TAB_ID': '',
+            'ERROR_TAB_ID': '',
+            'EMAIL_NOTIFICATION_LIST': []
+        }
+    },
     'DEGREES': {
         'SHEET_ID': '',
         'INPUT_TAB_ID': '',


### PR DESCRIPTION
### [PROD-3185](https://2u-internal.atlassian.net/browse/PROD-3185)

This PR updates the `import_course_metadata` mgmt command to bulk upload edx-boot camps

Sample CSV to test the command: https://docs.google.com/spreadsheets/d/1JGuxa_d_9HAKPr-hdNKBFl5wsLCS1jdZ57Es1AkJGr0/edit#

Testing Instructions:
---------------------
- First Create new `CourseType` named `Bootcamp(edX)` with slug `bootcamp-edx`
- Whitelist organizations against that `CourseType`
- Make sure you have `CourseLevel`, `CourseRunType`, `Organization`, and `Primary Subject` on your local discovery admin which is mentioned in the sample csv above, otherwise, you need to create them or can replace their values with existing attributes values on your local env
- Replace ['ext_source'](https://github.com/openedx/course-discovery/pull/3837/files#diff-eb03c6f7b7eb75088077d97eef345f19d0c5ed87008db901439e587c3afffd99R686) with `edx` in `base.py` file.
- Activate Discovery shell: `make dev.shell.discovery`
- Run the following command
```bash
./manage.py import_course_metadata --csv_path=data2.csv --partner_code=edx --product_type=BOOTCAMPS_EDX --product_source=edxrt_course_metadata --csv_path=data2.csv --partner_code=edx --product_type=BOOTCAMPS_EDX --product
```

Todos:
- [ ] Make a PR for edx-internal (as soon as the csv is provided by the PCs so that I will add the csv links to it)
- [ ] Create a new `courseType` on both stage and prod named `Bootcamp(edX)` with slug `bootcamp-edx`  
