### PR TITLE
feat: make product_source required in django admin and non-editable i…

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -148,9 +148,12 @@ class CourseAdmin(DjangoObjectActions, admin.ModelAdmin):
             flag_name = f'{obj._meta.app_label}.{obj.__class__.__name__}.make_uuid_editable'
             flag = get_waffle_flag_model().get(flag_name)
             if flag.is_active(request):
-                return self.readonly_fields
+                # add product_source to readonly_fields only if course is already created because
+                # we don't want to allow user to change product_source for existing course.
+                return self.readonly_fields + ('product_source')
 
-        return self.readonly_fields + ('uuid',)
+        return (self.readonly_fields + ('uuid', 'product_source')
+                if obj else self.readonly_fields + ('uuid',))
 
     def get_change_actions(self, request, object_id, form_url):
         """
@@ -375,6 +378,12 @@ class ProgramAdmin(DjangoObjectActions, admin.ModelAdmin):
     change_actions = ('refresh_program_skills', )
 
     save_error = False
+
+    def get_readonly_fields(self, request, obj=None):
+        """
+        Make product_source field readonly if program obj is already created.
+        """
+        return self.readonly_fields + ('product_source',) if obj else self.readonly_fields
 
     def get_urls(self):
         """

--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -49,6 +49,8 @@ class ProgramAdminForm(forms.ModelForm):
         self.fields['type'].required = True
         self.fields['marketing_slug'].required = True
         self.fields['courses'].required = False
+        if self.fields.get('product_source'):
+            self.fields['product_source'].required = True
 
     def clean(self):
 
@@ -91,6 +93,11 @@ class CourseAdminForm(forms.ModelForm):
         model = Course
         fields = '__all__'
         exclude = ('slug', 'url_slug', )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.fields.get('product_source'):
+            self.fields['product_source'].required = True
 
 
 class CourseRunAdminForm(forms.ModelForm):


### PR DESCRIPTION
### [PROD-3196](https://2u-internal.atlassian.net/browse/PROD-3196)
Overview:
This PR covers the following:
- Make Product Source as a required field for both Course and Program models in Django Admin
- Make Product Source not editable in Django Admin for both Course and Program models after the object is created
 
#### Non-editable field in edit form
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/78806673/225350998-3ecaeafa-a6db-455d-bc23-6838758d5f15.png">


#### Course and Program creation Form (Product Source --> Required Field
<img width="915" alt="image" src="https://user-images.githubusercontent.com/78806673/225351809-7324cb6c-01fb-4da9-84c2-fd851ba28607.png">
