### PR TITLE
fix: ignore empty fact objects in AdditionalMetadata

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1381,6 +1381,9 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
         else:
             instance.facts.clear()
             for fact in facts_data:
+                # skip objects that do not have a truthy heading
+                if 'heading' not in fact or not fact['heading']:
+                    continue
                 # we can query all orphan facts and use one of them but that is more computation
                 # therefore, just checking if a fact with same data exists
                 facts_queryset = Fact.objects.filter(**fact)


### PR DESCRIPTION
# [PROD-3215](https://2u-internal.atlassian.net/browse/PROD-3215)

## Description

This PR ignores empty fact objects in AdditionalMetadataSerializer i.e if an empty fact is passed in additionalMetadata from the frontend it will no longer be created in the database