### PR TITLE
feat: serialize subscription fields

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -41,8 +41,8 @@ from course_discovery.apps.course_metadata.models import (
     CourseType, Curriculum, CurriculumCourseMembership, CurriculumProgramMembership, Degree, DegreeAdditionalMetadata,
     DegreeCost, DegreeDeadline, Endorsement, Fact, GeoLocation, IconTextPairing, Image, LevelType, Mode, Organization,
     Pathway, Person, PersonAreaOfExpertise, PersonSocialNetwork, Position, Prerequisite, ProductMeta, ProductValue,
-    Program, ProgramLocationRestriction, ProgramType, Ranking, Seat, SeatType, Source, Specialization, Subject,
-    TaxiForm, Topic, Track, Video
+    Program, ProgramLocationRestriction, ProgramSubscription, ProgramSubscriptionPrice, ProgramType, Ranking, Seat,
+    SeatType, Source, Specialization, Subject, TaxiForm, Topic, Track, Video
 )
 from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours, parse_course_key_fragment
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
@@ -1869,6 +1869,38 @@ class DegreeSerializer(BaseModelSerializer):
         return list(degree.specializations.values_list('value', flat=True))
 
 
+class ProgramSubscriptionPriceSerializer(BaseModelSerializer):
+    """
+    Serializer for the ``ProgramSubscriptionPrice`` model.
+    """
+    currency = serializers.SlugRelatedField(read_only=True, slug_field='code')
+
+    class Meta:
+        model = ProgramSubscriptionPrice
+        fields = ['price', 'currency']
+
+    @classmethod
+    def prefetch_queryset(cls, queryset):
+        return queryset.select_related('currency')
+
+
+class ProgramSubscriptionSerializer(BaseModelSerializer):
+    """
+    Serializer for the ``ProgramSubscription`` model.
+    """
+    prices = ProgramSubscriptionPriceSerializer(many=True)
+
+    class Meta:
+        model = ProgramSubscription
+        fields = ['subscription_eligible', 'prices']
+
+    @classmethod
+    def prefetch_queryset(cls, queryset):
+        return queryset.prefetch_related(
+            'prices',
+        )
+
+
 class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, BaseModelSerializer):
     """
     Basic program serializer
@@ -1894,6 +1926,7 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
     language_override = serializers.SlugRelatedField(slug_field='code', read_only=True)
     labels = TagListSerializerField()
     taxi_form = TaxiFormSerializer()
+    subscription = ProgramSubscriptionSerializer()
 
     def get_organization_logo_override_url(self, obj):
         logo_image_override = getattr(obj, 'organization_logo_override', None)
@@ -1916,6 +1949,7 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
             'authoring_organizations',
             'degree',
             'curricula',
+            'subscription__prices__currency',
             Prefetch('courses', queryset=MinimalProgramCourseSerializer.prefetch_queryset()),
         )
 
@@ -1928,7 +1962,8 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
             'total_hours_of_effort', 'recent_enrollment_count', 'organization_short_code_override',
             'organization_logo_override_url', 'primary_subject_override', 'level_type_override', 'language_override',
             'labels', 'taxi_form', 'program_duration_override', 'data_modified_timestamp',
-            'excluded_from_search', 'excluded_from_seo'
+            'excluded_from_search', 'excluded_from_seo', 'subscription',
+
         )
         read_only_fields = ('uuid', 'marketing_url', 'banner_image', 'data_modified_timestamp')
 
@@ -2019,6 +2054,19 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
         if obj.card_image:
             return obj.card_image.url
         return obj.card_image_url
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+
+        # Remove subscription object and get its nested properties
+        subscription = data.pop('subscription')
+        # For keeping the structure of data consistent even if some program hasn't been marked
+        # as either subscription eligible or not yet we explicitly send None.
+
+        data['subscription_eligible'] = None if not subscription else subscription.get('subscription_eligible', None)
+        data['subscription_prices'] = [] if not subscription else subscription.get('prices', [])
+
+        return data
 
 
 class MinimalExtendedProgramSerializer(MinimalProgramSerializer):

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -258,7 +258,7 @@ class TestProgramViewSet(SerializationMixin):
         program_type_name = 'foo'
         program = ProgramFactory(type__name_t=program_type_name, partner=self.partner)
         url = self.list_path + '?type=' + program_type_name
-        self.assert_list_results(url, [program], 18)
+        self.assert_list_results(url, [program], 21)
 
         url = self.list_path + '?type=bar'
         self.assert_list_results(url, [], 5)
@@ -336,10 +336,10 @@ class TestProgramViewSet(SerializationMixin):
         retired = ProgramFactory(status=ProgramStatus.Retired, partner=self.partner)
 
         url = self.list_path + '?status=active'
-        self.assert_list_results(url, [active], 18)
+        self.assert_list_results(url, [active], 21)
 
         url = self.list_path + '?status=retired'
-        self.assert_list_results(url, [retired], 18)
+        self.assert_list_results(url, [retired], 21)
 
         url = self.list_path + '?status=active&status=retired'
         self.assert_list_results(url, [active, retired], 27)
@@ -350,16 +350,16 @@ class TestProgramViewSet(SerializationMixin):
         not_hidden = ProgramFactory(hidden=False, partner=self.partner)
 
         url = self.list_path + '?hidden=True'
-        self.assert_list_results(url, [hidden], 18)
+        self.assert_list_results(url, [hidden], 21)
 
         url = self.list_path + '?hidden=False'
-        self.assert_list_results(url, [not_hidden], 18)
+        self.assert_list_results(url, [not_hidden], 21)
 
         url = self.list_path + '?hidden=1'
-        self.assert_list_results(url, [hidden], 18)
+        self.assert_list_results(url, [hidden], 21)
 
         url = self.list_path + '?hidden=0'
-        self.assert_list_results(url, [not_hidden], 18)
+        self.assert_list_results(url, [not_hidden], 21)
 
     def test_filter_by_marketing_slug(self):
         """ The endpoint should support filtering programs by marketing slug. """
@@ -375,13 +375,13 @@ class TestProgramViewSet(SerializationMixin):
         program.marketing_slug = SLUG
         program.save()
 
-        self.assert_list_results(url, [program], 25)
+        self.assert_list_results(url, [program], 28)
 
     def test_list_exclude_utm(self):
         """ Verify the endpoint returns marketing URLs without UTM parameters. """
         url = self.list_path + '?exclude_utm=1'
         program = self.create_program()
-        self.assert_list_results(url, [program], 24, extra_context={'exclude_utm': 1})
+        self.assert_list_results(url, [program], 27, extra_context={'exclude_utm': 1})
 
     def test_minimal_serializer_use(self):
         """ Verify that the list view uses the minimal serializer. """

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -67,7 +67,8 @@ def delegate_attributes(cls):
                      'product_max_effort', 'product_min_effort', 'active_run_key', 'active_run_start',
                      'active_run_type', 'owners', 'program_types', 'course_titles', 'tags',
                      'product_organization_short_code_override', 'product_organization_logo_override', 'skills',
-                     'product_meta_title', 'product_display_on_org_page', 'contentful_fields',]
+                     'product_meta_title', 'product_display_on_org_page', 'contentful_fields',
+                     'subscription_eligible', 'subscription_prices',]
     object_id_field = ['custom_object_id', ]
     fields = product_type_fields + search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -404,6 +405,16 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
             return self.advertised_course_run.start.timestamp()
         return None  # Algolia will deprioritize entries where a ranked field is empty
 
+    @property
+    def subscription_eligible(self):
+        """ Courses do not have subscription_eligible attribute. Returning None explicitly"""
+        return None
+
+    @property
+    def subscription_prices(self):
+        """ Courses do not have subscription_prices attribute. Returning empty list explicitly"""
+        return []
+
 
 class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
 
@@ -601,6 +612,20 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
         any Algolia indexing issues.
         """
         return None
+
+    @property
+    def subscription_eligible(self):
+        if hasattr(self, 'subscription'):
+            return self.subscription.subscription_eligible
+        return None
+
+    @property
+    def subscription_prices(self):
+        if hasattr(self, 'subscription') and hasattr(self.subscription, 'prices'):
+            prices = self.subscription.prices.all()
+            data = [{'price': price.price, 'currency': price.currency.code} for price in prices]
+            return data
+        return []
 
 
 class SearchDefaultResultsConfiguration(models.Model):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -79,7 +79,8 @@ class EnglishProductIndex(BaseProductIndex):
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
-                    ('product_blocked_in', 'blocked_in'))
+                    ('product_blocked_in', 'blocked_in'), 'subscription_eligible',
+                    'subscription_prices')
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'),
                       ('product_value_per_click_usa', 'value_per_click_usa'),
                       ('product_value_per_click_international', 'value_per_click_international'),
@@ -113,7 +114,7 @@ class EnglishProductIndex(BaseProductIndex):
         'attributesForFaceting': [
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)', 'skills.skill',
-            'skills.category', 'skills.subcategory', 'tags',
+            'skills.category', 'skills.subcategory', 'tags', 'subscription_eligible', 'subscription_prices',
         ],
         'customRanking': ['asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
@@ -129,7 +130,8 @@ class SpanishProductIndex(BaseProductIndex):
     facet_fields = (('availability_level', 'availability'), ('subject_names', 'subject'), ('levels', 'level'),
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
-                    ('product_blocked_in', 'blocked_in'))
+                    ('product_blocked_in', 'blocked_in'), 'subscription_eligible',
+                    'subscription_prices',)
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'),
                       ('product_value_per_click_usa', 'value_per_click_usa'),
                       ('product_value_per_click_international', 'value_per_click_international'),
@@ -165,7 +167,8 @@ class SpanishProductIndex(BaseProductIndex):
         'attributesForFaceting': [
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)',
-            'skills.skill', 'skills.category', 'skills.subcategory', 'tags'
+            'skills.skill', 'skills.category', 'skills.subcategory', 'tags', 'subscription_eligible',
+            'subscription_prices',
         ],
         'customRanking': ['desc(promoted_in_spanish_index)', 'asc(availability_rank)', 'desc(recent_enrollment_count)']
     }

--- a/course_discovery/settings/devstack.py
+++ b/course_discovery/settings/devstack.py
@@ -92,4 +92,3 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error
 
 DISCOVERY_BASE_URL = "http://edx.devstack.discovery:18381"
-


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/PON-3)(2u-Internal)

## Description

The new program subscription model “program_subscription“ which were added in this [PR](https://github.com/openedx/course-discovery/pull/3833) should be serialized into the Program serializer(s) and its fields should be synced in the Algolia connector for Algolia search indexing and Contentful data.
