### PR TITLE
fix: bring back original logic for search indexing

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -137,24 +137,9 @@ class AlgoliaProxyProduct(Program):
 
     # should_index is called differently from algoliasearch_django, can't use the delegate_attributes trick
     def should_index(self):
-        # Do not index if entry for this object exists in contentful and was set to exclude from search
-        if (
-            hasattr(self.product, 'contentful_fields') and
-            hasattr(self.product.contentful_fields, 'excluded_from_search') and
-            self.product.contentful_fields.excluded_from_search
-        ):
-            return False
-        # Otherwise, look at regular conditions for indexing
         return getattr(self.product, 'should_index', True)
 
     def should_index_spanish(self):
-        if (
-            hasattr(self.product, 'contentful_fields') and
-            hasattr(self.product.contentful_fields, 'excluded_from_search') and
-            self.product.contentful_fields.excluded_from_search
-        ):
-            return False
-
         return getattr(self.product, 'should_index_spanish', True)
 
 
@@ -388,8 +373,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
                 self.partner.name == 'edX' and
                 self.availability_level and
                 bool(self.advertised_course_run) and
-                not self.advertised_course_run.hidden and
-                not self.excluded_from_search)
+                not self.advertised_course_run.hidden)
 
     @property
     def should_index_spanish(self):
@@ -593,8 +577,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
                 self.status == ProgramStatus.Active and
                 self.availability_level and
                 self.partner.name == 'edX' and
-                not self.hidden and
-                not self.excluded_from_search)
+                not self.hidden)
 
     @property
     def skills(self):


### PR DESCRIPTION
Brings back original logic to determine whether an item should or should not be indexed in search.