### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@
 import datetime
 import os
 
-import edx_theme
+
 
 # on_rtd is whether we are on readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -29,7 +29,6 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'edx_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -46,7 +45,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'edX Discovery Service'
-copyright = f'2015-{datetime.date.today().year}, edX Inc.'
+copyright = f'2015-{datetime.date.today().year}, Axim Collaborative, Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,15 +95,45 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'edx_theme'
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    "repository_url": "https://github.com/openedx/course-discovery",
+    "repository_branch": "master",
+    "path_to_docs": "docs/",
+    "home_page_in_toc": True,
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+    # Please don't change unless you know what you're doing.
+    "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >Axim Collaborative, Inc</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [edx_theme.get_html_theme_path()]
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -115,12 +144,12 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-# html_logo = None
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-# html_favicon = None
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -4,5 +4,5 @@
 -r github.in              # Forks and other dependencies not yet on PyPI
 
 django-elasticsearch-dsl
-edx-sphinx-theme
+sphinx-book-theme
 Sphinx

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,10 +4,16 @@
 #
 #    pip-compile --output-file=requirements/docs.txt requirements/docs.in
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 certifi==2022.12.7
     # via
     #   elasticsearch
@@ -17,9 +23,9 @@ charset-normalizer==3.1.0
 django-elasticsearch-dsl==7.3
     # via -r requirements/docs.in
 docutils==0.19
-    # via sphinx
-edx-sphinx-theme==3.1.0
-    # via -r requirements/docs.in
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 elasticsearch==7.13.4
     # via
     #   -c requirements/common_constraints.txt
@@ -40,9 +46,16 @@ jinja2==3.1.2
 markupsafe==2.1.2
     # via jinja2
 packaging==23.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.0
-    # via sphinx
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 python-dateutil==2.8.2
     # via elasticsearch-dsl
 pytz==2023.3
@@ -52,17 +65,21 @@ requests==2.28.2
 six==1.16.0
     # via
     #   django-elasticsearch-dsl
-    #   edx-sphinx-theme
     #   elasticsearch-dsl
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/docs.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -75,6 +92,8 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+typing-extensions==4.5.0
+    # via pydata-sphinx-theme
 urllib3==1.26.15
     # via
     #   elasticsearch

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements/local.txt requirements/local.in
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 algoliasearch==1.20.0
@@ -43,7 +45,9 @@ attrs==21.4.0
     #   trio
     #   zeep
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 backoff==2.2.1
     # via -r requirements/base.in
 bcrypt==4.0.1
@@ -51,6 +55,7 @@ bcrypt==4.0.1
 beautifulsoup4==4.12.2
     # via
     #   -r requirements/base.in
+    #   pydata-sphinx-theme
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
@@ -330,7 +335,9 @@ dockerpty==0.4.1
 docopt==0.6.2
     # via docker-compose
 docutils==0.19
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 drf-extensions==0.7.1
     # via -r requirements/base.in
 drf-flex-fields==1.0.2
@@ -384,8 +391,6 @@ edx-rest-api-client==5.5.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
-edx-sphinx-theme==3.1.0
-    # via -r requirements/docs.in
 edx-toggles==5.0.0
     # via edx-event-bus-kafka
 elasticsearch==7.13.4
@@ -539,6 +544,7 @@ packaging==21.3
     #   django-nine
     #   docker
     #   drf-yasg
+    #   pydata-sphinx-theme
     #   pytest
     #   semgrep
     #   snowflake-connector-python
@@ -596,8 +602,13 @@ pycryptodomex==3.17
     # via
     #   pyjwkest
     #   snowflake-connector-python
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.0
-    # via sphinx
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 pyjwkest==1.4.2
     # via edx-drf-extensions
 pyjwt[crypto]==2.6.0
@@ -783,7 +794,6 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-lint
-    #   edx-sphinx-theme
     #   elasticsearch-dsl
     #   google-auth
     #   google-auth-httplib2
@@ -821,7 +831,10 @@ sphinx==5.3.0
     #   -c requirements/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/docs.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/docs.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -881,6 +894,7 @@ typing-extensions==4.5.0
     # via
     #   astroid
     #   django-countries
+    #   pydata-sphinx-theme
     #   pylint
     #   semgrep
     #   snowflake-connector-python


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:** 
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme
