### PR TITLE
feat: organization searching based on product_source in create form

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -367,13 +367,14 @@ class ProgramAdmin(DjangoObjectActions, admin.ModelAdmin):
         'uuid', 'title', 'subtitle', 'marketing_hook', 'status', 'type', 'partner', 'banner_image', 'banner_image_url',
         'card_image', 'marketing_slug', 'overview', 'credit_redemption_overview', 'video', 'total_hours_of_effort',
         'weeks_to_complete', 'min_hours_effort_per_week', 'max_hours_effort_per_week', 'courses',
-        'order_courses_by_start_date', 'custom_course_runs_display', 'excluded_course_runs', 'authoring_organizations',
-        'credit_backing_organizations', 'one_click_purchase_enabled', 'hidden', 'corporate_endorsements', 'faq',
-        'individual_endorsements', 'job_outlook_items', 'expected_learning_items', 'instructor_ordering',
-        'enrollment_count', 'recent_enrollment_count', 'credit_value', 'organization_short_code_override',
-        'organization_logo_override', 'primary_subject_override', 'level_type_override', 'language_override',
-        'enterprise_subscription_inclusion', 'in_year_value', 'labels', 'geolocation', 'program_duration_override',
-        'product_source', 'ofac_comment', 'data_modified_timestamp', 'excluded_from_search', 'excluded_from_seo'
+        'order_courses_by_start_date', 'custom_course_runs_display', 'excluded_course_runs', 'product_source',
+        'authoring_organizations', 'credit_backing_organizations', 'one_click_purchase_enabled', 'hidden',
+        'corporate_endorsements', 'faq', 'individual_endorsements', 'job_outlook_items', 'expected_learning_items',
+        'instructor_ordering', 'enrollment_count', 'recent_enrollment_count', 'credit_value',
+        'organization_short_code_override', 'organization_logo_override', 'primary_subject_override',
+        'level_type_override', 'language_override', 'enterprise_subscription_inclusion', 'in_year_value', 'labels',
+        'geolocation', 'program_duration_override', 'ofac_comment', 'data_modified_timestamp', 'excluded_from_search',
+        'excluded_from_seo'
     )
     change_actions = ('refresh_program_skills', )
 

--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -26,14 +26,16 @@ class ProgramAdminForm(forms.ModelForm):
                 attrs={
                     'data-minimum-input-length': 3,
                     'class': 'sortable-select',
-                }
+                },
+                forward=['product_source'],
             ),
             'credit_backing_organizations': SortedModelSelect2Multiple(
                 url='admin_metadata:organisation-autocomplete',
                 attrs={
                     'data-minimum-input-length': 3,
                     'class': 'sortable-select',
-                }
+                },
+                forward=['product_source'],
             ),
             'instructor_ordering': SortedModelSelect2Multiple(
                 url='admin_metadata:person-autocomplete',

--- a/course_discovery/apps/course_metadata/lookups.py
+++ b/course_discovery/apps/course_metadata/lookups.py
@@ -39,7 +39,11 @@ class CourseRunAutocomplete(autocomplete.Select2QuerySetView):
 class OrganizationAutocomplete(autocomplete.Select2QuerySetView):
     def get_queryset(self):
         if self.request.user.is_authenticated and self.request.user.is_staff:
-            qs = Organization.objects.all()
+            product_source = self.forwarded.get('product_source', None)
+            if product_source:
+                qs = Organization.objects.filter(organizationmapping__source=product_source)
+            else:
+                qs = Organization.objects.all()
 
             if self.q:
                 qs = qs.filter(Q(key__icontains=self.q) | Q(name__icontains=self.q))

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -328,15 +328,15 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
             'field-credit_redemption_overview', 'field-video', 'field-total_hours_of_effort', 'field-weeks_to_complete',
             'field-min_hours_effort_per_week', 'field-max_hours_effort_per_week', 'field-courses',
             'field-order_courses_by_start_date', 'field-custom_course_runs_display', 'field-excluded_course_runs',
-            'field-authoring_organizations', 'field-credit_backing_organizations', 'field-one_click_purchase_enabled',
-            'field-hidden', 'field-corporate_endorsements', 'field-faq', 'field-individual_endorsements',
-            'field-job_outlook_items', 'field-expected_learning_items', 'field-instructor_ordering',
-            'field-enrollment_count', 'field-recent_enrollment_count', 'field-credit_value',
-            'field-organization_short_code_override', 'field-organization_logo_override',
+            'field-product_source', 'field-authoring_organizations', 'field-credit_backing_organizations',
+            'field-one_click_purchase_enabled', 'field-hidden', 'field-corporate_endorsements', 'field-faq',
+            'field-individual_endorsements', 'field-job_outlook_items', 'field-expected_learning_items',
+            'field-instructor_ordering', 'field-enrollment_count', 'field-recent_enrollment_count',
+            'field-credit_value', 'field-organization_short_code_override', 'field-organization_logo_override',
             'field-primary_subject_override', 'field-level_type_override', 'field-language_override',
             'field-enterprise_subscription_inclusion', 'field-in_year_value', 'field-labels', 'field-geolocation',
-            'field-program_duration_override', 'field-product_source', 'field-ofac_comment',
-            'field-data_modified_timestamp', 'field-excluded_from_search', 'field-excluded_from_seo'
+            'field-program_duration_override', 'field-ofac_comment', 'field-data_modified_timestamp',
+            'field-excluded_from_search', 'field-excluded_from_seo'
         ]
         assert actual == expected
 


### PR DESCRIPTION
[PROD-3194](https://2u-internal.atlassian.net/browse/PROD-3194)
Adds autocomplete functionality for organization based on product_source while creating program through django admin form. You need to first select the product_source for the organizations to show up in the form. 