### PR TITLE
fix: downgrade build-push-action version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
           result-encoding: string
 
       - name: Build and push Dev Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v1
         with:
           push: true
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Upgrading the action version caused permission denied error when pushing the changes so trying to downgrade the version to fix it.