### PR TITLE
fix: backport docker-publish-workflow update

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,26 +4,25 @@ on:
   push:
     branches:
       - master
-    tags:
-      - open-release/*
+      - open-release/**
 jobs:
   push:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Use the release name as the image tag if we're building an open release tag.
-      # Examples: if we're building 'open-release/maple.1', tag the image as 'maple.1'.
+      # Examples: if we're building 'open-release/olive.master', tag the image as 'olive.master'.
       # Otherwise, we must be building from a push to master, so use 'latest'.
       - name: Get tag name
         id: get-tag-name
         uses: actions/github-script@v5
         with:
           script: |
-            const releasePrefix = 'refs/tags/open-release/';
-            const tagName = context.ref.split(releasePrefix)[1] || 'latest';
+            const branchName = context.ref.split('/').slice(-1)[0];
+            const tagName = branchName === 'master' ? 'latest' : branchName;
             console.log('Will use tag: ' + tagName);
             return tagName;
           result-encoding: string


### PR DESCRIPTION
Updated the docker-publish workflow to be triggered on branch name instead of tag