### PR TITLE
build: backport ansible-removal dockerfile update

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .dev/
 htmlcov/
+Dockerfile
+


### PR DESCRIPTION
The Dockerfile has been updated to migrate from using Ansible to Dockerfile for building docker image. This change was merged in master in the PR https://github.com/openedx/course-discovery/pull/3575.
The workflow to trigger the build with new Dockerfile has already been backported.