### PR TITLE
fix: No matching product source found for empty product_source

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1289,7 +1289,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
         Conversion of the source slug to the source serializer data
         """
         representation = super().to_representation(instance)
-        if 'product_source' in representation:
+        if representation.get('product_source'):
             representation['product_source'] = SourceSerializer(Source.objects.get(slug=representation['product_source'])).data  # pylint: disable=line-too-long
         return representation
 


### PR DESCRIPTION
This PR fixes `to_representation` courseSerializer method in case for a `None` product_source

Ref PR:
https://github.com/openedx/course-discovery/pull/3766
The Courses API is causing a 500 internal error because it cannot find a matching source for empty product_source.