### PR TITLE
chore: upgraded version of taxonomy-connector 1.37.0

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -60,9 +60,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.101
+boto3==1.26.103
     # via django-ses
-botocore==1.29.101
+botocore==1.29.103
     # via
     #   boto3
     #   s3transfer
@@ -201,6 +201,7 @@ distro==1.8.0
     #   edx-toggles
     #   jsonfield
     #   openedx-events
+    #   social-auth-app-django
     #   taxonomy-connector
     #   xss-utils
 django-admin-sortable2==1.0.4
@@ -433,7 +434,7 @@ google-api-core==2.11.0
     # via google-api-python-client
 google-api-python-client==2.83.0
     # via -r requirements/base.in
-google-auth==2.17.0
+google-auth==2.17.1
     # via
     #   google-api-core
     #   google-api-python-client
@@ -517,7 +518,7 @@ mock==5.0.1
     # via -r requirements/test.in
 mysqlclient==2.1.1
     # via -r requirements/test.in
-newrelic==8.7.1
+newrelic==8.8.0
     # via edx-django-utils
 numpy==1.24.2
     # via pandas
@@ -708,7 +709,7 @@ pyyaml==5.4.1
     #   responses
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.3
+redis==4.5.4
     # via -r requirements/base.in
 requests==2.28.2
     # via
@@ -804,11 +805,11 @@ snowballstemmer==2.2.0
     # via sphinx
 snowflake-connector-python==3.0.2
     # via -r requirements/base.in
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   edx-auth-backends
     #   social-auth-app-django
@@ -843,7 +844,7 @@ stevedore==5.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.36.3
+taxonomy-connector==1.37.0
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -37,9 +37,9 @@ beautifulsoup4==4.12.0
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.26.101
+boto3==1.26.103
     # via django-ses
-botocore==1.29.101
+botocore==1.29.103
     # via
     #   boto3
     #   s3transfer
@@ -149,6 +149,7 @@ django==3.2.18
     #   edx-toggles
     #   jsonfield
     #   openedx-events
+    #   social-auth-app-django
     #   taxonomy-connector
     #   xss-utils
 django-admin-sortable2==1.0.4
@@ -344,7 +345,7 @@ google-api-core==2.11.0
     # via google-api-python-client
 google-api-python-client==2.83.0
     # via -r requirements/base.in
-google-auth==2.17.0
+google-auth==2.17.1
     # via
     #   google-api-core
     #   google-api-python-client
@@ -409,7 +410,7 @@ markupsafe==2.1.2
     # via jinja2
 mysqlclient==2.1.1
     # via -r requirements/production.in
-newrelic==8.7.1
+newrelic==8.8.0
     # via
     #   -r requirements/production.in
     #   edx-django-utils
@@ -523,7 +524,7 @@ pyyaml==6.0
     #   edx-django-release-util
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.3
+redis==4.5.4
     # via -r requirements/base.in
 requests==2.28.2
     # via
@@ -592,11 +593,11 @@ slumber==0.7.1
     # via edx-rest-api-client
 snowflake-connector-python==3.0.2
     # via -r requirements/base.in
-social-auth-app-django==5.1.0
+social-auth-app-django==5.2.0
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.4.0
+social-auth-core==4.4.1
     # via
     #   edx-auth-backends
     #   social-auth-app-django
@@ -609,7 +610,7 @@ stevedore==5.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.36.3
+taxonomy-connector==1.37.0
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6975](https://2u-internal.atlassian.net/browse/ENT-6975)

__Description:__

This PR contains version bump for taxonomy connector, new version of the taxonomy connector has [these changes](https://github.com/openedx/taxonomy-connector/compare/1.36.3...1.37.0).