### PR TITLE
feat: use pre_save signal to determine data modified timestamp from related models

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -409,6 +409,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         timestamp_now = datetime.datetime.now().isoformat()
         for courseobj in [self.course, course1, course2, course3]:
             courseobj.short_description = 'test update'
+            courseobj.draft = True
             courseobj.save()
 
         url = f"{reverse('api:v1:course-list')}?editable=1&timestamp={timestamp_now}"

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -351,6 +351,11 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             course.entitlements.exclude(mode__in=entitlement_types).delete()
             course.entitlements.set(entitlements)
 
+            # If entitlement has changed, get updated course object from DB that has new value for
+            # data modified timestamp.
+            if changed:
+                course.refresh_from_db()
+
         # Save video if a new video source is provided, also allow removing the video from course
         if video_data:
             video_url = video_data.get('src')

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -1153,6 +1153,7 @@ class ProgramsApiDataLoaderTests(DataLoaderTestMixin, TestCase):
     @responses.activate
     def test_ingest_with_existing_banner_image(self):
         TieredCache.dangerous_clear_all_tiers()
+        responses.calls.reset()  # pylint: disable=no-member
         programs = self.mock_api()
 
         for program_data in programs:

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -912,3 +912,17 @@ def fetch_getsmarter_products():
     except Exception as ex:  # pylint: disable=broad-except
         logger.error(f"Failed to retrieve products from getsmarter API: {ex}")
     return products
+
+
+def data_modified_timestamp_update(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """
+    Receiver function to trigger update data modified timestamp on Course or Program
+    from one of their related models in reverse(ForeignKey or M2M).
+
+    This wrapper expects the following two things on a model instance:
+     * Field tracker
+     * A method called update_product_data_modified_stamp which will be implemented by each model
+     depending upon its relation with Course/Program.
+    """
+    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):
+        instance.update_product_data_modified_timestamp()


### PR DESCRIPTION
### [PROD-3261](https://2u-internal.atlassian.net/browse/PROD-3261)

### Description

1. Fix an issue with FieldTracker based updates where even saving a Course with no changes would result in timestamp update for Non-draft version. This happened because of how draft is converted to non-draft in Discovery using [set_official_state](https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/course_metadata/utils.py#L61) . The pk of non-draft is assigned to draft object to make it non-draft, with the original draft obj assigned to non-draft. This resulted in the field tracker picking non-draft course/course run as updated, resulting in timestamp update for non-draft version. This is also the reason that whenever RCM LMS data loader was run, all the courses had updated timestamps even if course run was not updated.
2. Add pre-save signal for following models to update data modified timestamp for Course if the related/reverse object. is changed but the course object is not changed. This also fixes the cases where CourseRun only updates on publisher or RCM were not updating timestamps
  - AdditionalMetadata
  - CertificateInfo
  - CourseRun
  - CourseLocationRestriction
  - CourseEntitlement
   - GeoLocation
   - ProductMeta
   - ProductValue
3. add m2m_changed signal for CourseRun's transcript_languages to update timestamp if transcript languages are updated for a Course Run (https://docs.djangoproject.com/en/4.2/ref/signals/#m2m-changed)
4. For pre_save signal specifically on CourseRun, the method in CourseRun uses `Course.everything` to update both timestamp for draft and non-draft versions of the Course. Ideally, based on draft status of CourseRun, the related Course version (draft/non-draft) should have been updated. I Implemented it that way but the timestamp was not updating for non-draft courses in RCM flow.  This is because RCM does not use [set_official_state](https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/course_metadata/utils.py#L61) to update non-draft version of CourseRun. Instead,  the data dict is manually updated for both draft and non-draft versions separately. 
### New Identified Issues / Todos

During the implementation of this work, a few more issues were identified:
- For M2M, there are 2 issues.
     - m2m_changed signal was being fired even if the object was not changing. This could be due to the behavior of the SortedManyToMany field. This results in data-modified timestamp updating even if there is no change in M2M.
    - Taggable manager’s m2m_changed signal is being sent by models other than Course. This is new and would require more digging.
- The handling of AdditionalMetadata and its related objects needs an update in course API. The current approach to updating AdditionalMeetadata uses .filter().update() which does not trigger pre_save signal.
- Create internal tickets test_signals update and to update draft & non-draft handling logic in RCM LMS data loader


### Testing

#### RCM

- Go to Studio and update the dates from Schedule & Details page (http://localhost:18010/settings/details/course-v1:testOrg+APSPM+1T2023)
- Go to Discovery shell and run refresh_course_metadata management command (`./manage.py refresh_course_metadata`)
- Make sure to notice CourseRun has updated in the logs
- verify the timestamp has been updated for Course in Discovery. Redo this by changing dates again from Studio and run RCM. Also, verify the course is listed when filtering via timestamp on Course API (http://localhost:18381/api/v1/courses/?timestamp=2023-04-06)
- Now, run RCM again without changing anything. Ensure no timestamp update happens


#### Publisher
- Open any course on publisher. Edit the data on course or course run form. Apart from the following fields, changing any data will result in updating timestamp:
   - Topics/Tags (Taggable manager)
   - Collaborators (Sorted M2M)
   - Subjects (Sorted M2M)
   - AdditionalMetadata (only for external courses, due to how it is handled in course API)
   - Staff (CourseRun, Sorted M2M)

