### PR TITLE
fix: fix subscription keyerror

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -2059,7 +2059,7 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
         data = super().to_representation(instance)
 
         # Remove subscription object and get its nested properties
-        subscription = data.pop('subscription')
+        subscription = data.pop('subscription', None)
         # For keeping the structure of data consistent even if some program hasn't been marked
         # as either subscription eligible or not yet we explicitly send None.
 


### PR DESCRIPTION
Default fallback against `subscription` key is added in this PR whose absence caused failure in prospectus's multiple flow(s).