### PR TITLE
feat: handle logic to ofac restrict programs

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -364,10 +364,10 @@ class ProgramAdmin(DjangoObjectActions, admin.ModelAdmin):
 
     # ordering the field display on admin page.
     fields = (
-        'uuid', 'title', 'subtitle', 'marketing_hook', 'status', 'type', 'partner', 'banner_image', 'banner_image_url',
-        'card_image', 'marketing_slug', 'overview', 'credit_redemption_overview', 'video', 'total_hours_of_effort',
-        'weeks_to_complete', 'min_hours_effort_per_week', 'max_hours_effort_per_week', 'courses',
-        'order_courses_by_start_date', 'custom_course_runs_display', 'excluded_course_runs', 'product_source',
+        'uuid', 'title', 'subtitle', 'marketing_hook', 'product_source', 'type', 'status', 'partner', 'banner_image',
+        'banner_image_url', 'card_image', 'marketing_slug', 'overview', 'credit_redemption_overview', 'video',
+        'total_hours_of_effort', 'weeks_to_complete', 'min_hours_effort_per_week', 'max_hours_effort_per_week',
+        'courses', 'order_courses_by_start_date', 'custom_course_runs_display', 'excluded_course_runs',
         'authoring_organizations', 'credit_backing_organizations', 'one_click_purchase_enabled', 'hidden',
         'corporate_endorsements', 'faq', 'individual_endorsements', 'job_outlook_items', 'expected_learning_items',
         'instructor_ordering', 'enrollment_count', 'recent_enrollment_count', 'credit_value',
@@ -447,6 +447,8 @@ class ProgramAdmin(DjangoObjectActions, admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         try:
+            if obj.product_source.ofac_restricted_program_types.filter(id=obj.type.id).exists():
+                obj.mark_ofac_restricted()
             super().save_model(request, obj, form, change)
         except (MarketingSitePublisherException, MarketingSiteAPIClientException):
             self.save_error = True
@@ -845,11 +847,11 @@ class DegreeAdmin(admin.ModelAdmin):
     )
     # ordering the field display on admin page.
     fields = (
-        'type', 'uuid', 'status', 'hidden', 'partner', 'authoring_organizations', 'marketing_slug', 'card_image_url',
-        'search_card_ranking', 'search_card_cost', 'search_card_courses', 'overall_ranking', 'campus_image', 'title',
-        'subtitle', 'title_background_image', 'banner_border_color', 'apply_url', 'overview', 'rankings',
-        'application_requirements', 'prerequisite_coursework', 'lead_capture_image', 'lead_capture_list_name',
-        'hubspot_lead_capture_form_id', 'taxi_form', 'micromasters_long_title',
+        'product_source', 'type', 'uuid', 'status', 'hidden', 'partner', 'authoring_organizations', 'marketing_slug',
+        'card_image_url', 'search_card_ranking', 'search_card_cost', 'search_card_courses', 'overall_ranking',
+        'campus_image', 'title', 'subtitle', 'title_background_image', 'banner_border_color', 'apply_url', 'overview',
+        'rankings', 'application_requirements', 'prerequisite_coursework', 'lead_capture_image',
+        'lead_capture_list_name', 'hubspot_lead_capture_form_id', 'taxi_form', 'micromasters_long_title',
         'micromasters_long_description', 'micromasters_url', 'micromasters_background_image',
         'micromasters_org_name_override', 'faq', 'costs_fine_print', 'deadlines_fine_print', 'specializations',
         'program_duration_override', 'display_on_org_page',

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -283,6 +283,10 @@ class DegreeCSVDataLoader(AbstractDataLoader):
             defaults=data_dict
         )
 
+        if degree.product_source and \
+                degree.product_source.ofac_restricted_program_types.filter(id=program_type.id).exists():
+            degree.mark_ofac_restricted()
+
         logger.info("Degree with slug {} is {}".format(    # lint-amnesty, pylint: disable=logging-format-interpolation
             degree.marketing_slug,
             "created" if created else "updated",

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -3428,6 +3428,11 @@ class Program(PkSearchableMixin, TimeStampedModel):
             logger.info('Signal fired to update program skills. Program: [%s]', self.uuid)
             UPDATE_PROGRAM_SKILLS.send(self.__class__, program_uuid=self.uuid)
 
+    def mark_ofac_restricted(self):
+        self.has_ofac_restrictions = True
+        self.ofac_comment = f"Program type {self.type.slug} is OFAC restricted for {self.product_source.name}"
+        self.save()
+
 
 class ProgramSubscription(PkSearchableMixin, TimeStampedModel):
     """Model for storing program subscription eligibility"""

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -323,12 +323,12 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
 
         expected = [
             'field-uuid', 'field-title', 'field-subtitle',
-            'field-marketing_hook', 'field-status', 'field-type', 'field-partner', 'field-banner_image',
-            'field-banner_image_url', 'field-card_image', 'field-marketing_slug', 'field-overview',
-            'field-credit_redemption_overview', 'field-video', 'field-total_hours_of_effort', 'field-weeks_to_complete',
-            'field-min_hours_effort_per_week', 'field-max_hours_effort_per_week', 'field-courses',
-            'field-order_courses_by_start_date', 'field-custom_course_runs_display', 'field-excluded_course_runs',
-            'field-product_source', 'field-authoring_organizations', 'field-credit_backing_organizations',
+            'field-marketing_hook', 'field-product_source', 'field-type', 'field-status', 'field-partner',
+            'field-banner_image', 'field-banner_image_url', 'field-card_image', 'field-marketing_slug',
+            'field-overview', 'field-credit_redemption_overview', 'field-video', 'field-total_hours_of_effort',
+            'field-weeks_to_complete', 'field-min_hours_effort_per_week', 'field-max_hours_effort_per_week',
+            'field-courses', 'field-order_courses_by_start_date', 'field-custom_course_runs_display',
+            'field-excluded_course_runs', 'field-authoring_organizations', 'field-credit_backing_organizations',
             'field-one_click_purchase_enabled', 'field-hidden', 'field-corporate_endorsements', 'field-faq',
             'field-individual_endorsements', 'field-job_outlook_items', 'field-expected_learning_items',
             'field-instructor_ordering', 'field-enrollment_count', 'field-recent_enrollment_count',


### PR DESCRIPTION
[Create a model that handles select program types based on select product Source to be automatically moved in Legal Review upon creation via CSV Ingestion or Django](https://2u-internal.atlassian.net/browse/PROD-3022)

## Description
We need to OFAC restrict specific program types of specific product source. So this PR will add logic to check if current program/degree object's program type exist in restricted program types, then it will be marked as OFAC restricted