### PR TITLE
feat: add endpoint for fetching AdditionalMetadata field choices on publisher

### DIFF
--- a/course_discovery/apps/api/v1/urls.py
+++ b/course_discovery/apps/api/v1/urls.py
@@ -11,7 +11,9 @@ from course_discovery.apps.api.v1.views.collaborators import CollaboratorViewSet
 from course_discovery.apps.api.v1.views.comments import CommentViewSet
 from course_discovery.apps.api.v1.views.course_editors import CourseEditorViewSet
 from course_discovery.apps.api.v1.views.course_runs import CourseRunViewSet
-from course_discovery.apps.api.v1.views.courses import CourseRecommendationViewSet, CourseViewSet
+from course_discovery.apps.api.v1.views.courses import (
+    AdditionalMetadataFieldOptionsViewSet, CourseRecommendationViewSet, CourseViewSet
+)
 from course_discovery.apps.api.v1.views.currency import CurrencyView
 from course_discovery.apps.api.v1.views.level_types import LevelTypeViewSet
 from course_discovery.apps.api.v1.views.organizations import OrganizationViewSet
@@ -44,6 +46,8 @@ urlpatterns = [
 ]
 
 router = routers.SimpleRouter()
+router.register(r'additional_metadata_field_options', AdditionalMetadataFieldOptionsViewSet,
+                basename='additional_metadata_field_options')
 router.register(r'catalogs', CatalogViewSet)
 router.register(r'comments', CommentViewSet, basename='comment')
 router.register(r'courses', CourseViewSet, basename='course')


### PR DESCRIPTION
[PROD-3274](https://2u-internal.atlassian.net/browse/PROD-3274)

This PR adds end-point for fetching additional metadata fields options. The options are fetched from the discovery service.

Testing Instructions:
- Setup discovery service shell.
        `make dev.shell.discovery`
- Hit the end-point for fetching options.
       `http://localhost:18381/api/v1/additional_metadata_field_options/?attribute=product_status&attribute=external_course_marketing_type`
- Verify that the response is a dictionary with the attribute as key and list of options as value.
