### PR TITLE
feat: indexing external_url to algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -150,10 +150,6 @@ class AlgoliaBasicModelFieldsMixin(models.Model):
         abstract = True
 
     @property
-    def product_external_url(self):
-        return self.additional_metadata.external_url if self.additional_metadata else None
-
-    @property
     def product_title(self):
         return self.title
 
@@ -359,6 +355,10 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
     def product_display_on_org_page(self):
         # Only courses display on organization pages
         return self.product_type == 'Course'
+
+    @property
+    def product_external_url(self):
+        return self.additional_metadata.external_url if self.additional_metadata else None
 
     @property
     def should_index(self):
@@ -630,6 +630,13 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
             data = [{'price': price.price, 'currency': price.currency.code} for price in prices]
             return data
         return []
+
+    @property
+    def product_external_url(self):
+        if hasattr(self, 'degree') and hasattr(self.degree, 'additional_metadata'):
+            return self.degree.additional_metadata.external_url
+        else:
+            return None
 
 
 class SearchDefaultResultsConfiguration(models.Model):

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -212,10 +212,6 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
 
     class Meta:
         proxy = True
-    
-    @property
-    def product_external_url(self):
-        return self.additional_metadata.external_url if self.additional_metadata else None
 
     @property
     def product_type(self):

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -67,7 +67,7 @@ def delegate_attributes(cls):
                      'product_max_effort', 'product_min_effort', 'active_run_key', 'active_run_start',
                      'active_run_type', 'owners', 'program_types', 'course_titles', 'tags',
                      'product_organization_short_code_override', 'product_organization_logo_override', 'skills',
-                     'product_meta_title', 'product_display_on_org_page', 'product_external_url', 
+                     'product_meta_title', 'product_display_on_org_page', 'product_external_url',
                      'contentful_fields', 'subscription_eligible', 'subscription_prices',]
     object_id_field = ['custom_object_id', ]
     fields = product_type_fields + search_fields + facet_fields + ranking_fields + result_fields + object_id_field
@@ -148,7 +148,7 @@ class AlgoliaBasicModelFieldsMixin(models.Model):
 
     class Meta:
         abstract = True
-    
+
     @property
     def product_external_url(self):
         return self.additional_metadata.external_url if self.additional_metadata else None

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -67,8 +67,8 @@ def delegate_attributes(cls):
                      'product_max_effort', 'product_min_effort', 'active_run_key', 'active_run_start',
                      'active_run_type', 'owners', 'program_types', 'course_titles', 'tags',
                      'product_organization_short_code_override', 'product_organization_logo_override', 'skills',
-                     'product_meta_title', 'product_display_on_org_page', 'contentful_fields',
-                     'subscription_eligible', 'subscription_prices',]
+                     'product_meta_title', 'product_display_on_org_page', 'product_external_url', 
+                     'contentful_fields', 'subscription_eligible', 'subscription_prices',]
     object_id_field = ['custom_object_id', ]
     fields = product_type_fields + search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -148,6 +148,10 @@ class AlgoliaBasicModelFieldsMixin(models.Model):
 
     class Meta:
         abstract = True
+    
+    @property
+    def product_external_url(self):
+        return self.additional_metadata.external_url if self.additional_metadata else None
 
     @property
     def product_title(self):
@@ -208,6 +212,10 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
 
     class Meta:
         proxy = True
+    
+    @property
+    def product_external_url(self):
+        return self.additional_metadata.external_url if self.additional_metadata else None
 
     @property
     def product_type(self):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -92,7 +92,8 @@ class EnglishProductIndex(BaseProductIndex):
                      ('product_organization_short_code_override', 'organization_short_code_override'),
                      ('product_organization_logo_override', 'organization_logo_override'),
                      ('product_meta_title', 'meta_title'), ('product_display_on_org_page', 'display_on_org_page'),
-                     'active_run_key', 'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags',
+                     ('product_external_url', 'external_url'), 'active_run_key',
+                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags',
                      'skills', 'contentful_fields',)
 
     # Algolia needs this
@@ -144,7 +145,8 @@ class SpanishProductIndex(BaseProductIndex):
                      ('product_organization_short_code_override', 'organization_short_code_override'),
                      ('product_organization_logo_override', 'organization_logo_override'),
                      ('product_meta_title', 'meta_title'), ('product_display_on_org_page', 'display_on_org_page'),
-                     'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags', 'skills',
+                     ('product_external_url', 'external_url'), 'active_run_start',
+                     'active_run_type', 'owners', 'course_titles', 'tags', 'skills',
                      'contentful_fields',)
 
     # Algolia uses objectID as unique identifier. Can't use straight uuids because a program and a course could

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -428,21 +428,15 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         course.authoring_organizations.add(OrganizationFactory())
         assert not course.should_index
 
-    @ddt.data(AlgoliaProxyCourse, AlgoliaProxyProgram)
-    def test_external_url_when_present(self, model_factory):
-        product = model_factory(
-            partner=self.__class__.edxPartner,
-            additional_metadata=AdditionalMetadataFactory(external_url='https://external-url.com'),
-        )
-        assert product.product_external_url == 'https://external-url.com'
+    def test_external_url_when_present(self):
+        course = self.create_course_with_basic_active_course_run()
+        course.additional_metadata = AdditionalMetadataFactory(external_url='https://external-url.com')
+        assert course.product_external_url == 'https://external-url.com'
 
-    @ddt.data(AlgoliaProxyCourse, AlgoliaProxyProgram)
-    def test_external_url_when_no_additional_metadata_is_present(self, model_factory):
-        product = model_factory(
-            partner=self.__class__.edxPartner,
-            additional_metadata=None,
-        )
-        assert product.product_external_url is None
+    def test_external_url_when_no_additional_metadata_is_present(self):
+        course = self.create_course_with_basic_active_course_run()
+        course.additional_metadata = None
+        assert course.product_external_url is None
 
     def test_course_subscription_eligibility(self):
         """
@@ -725,3 +719,20 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         else:
             program = AlgoliaProxyProgramFactory(subscription=None)
             assert len(program.subscription_prices) == 0
+
+    def test_external_url_when_present(self):
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
+        degree = DegreeFactory()
+        degree.additional_metadata = DegreeAdditionalMetadataFactory(external_url='https://external-url.com')
+        program.degree = degree
+        assert program.product_external_url == 'https://external-url.com'
+
+    def test_external_url_when_no_additional_metadata_is_present(self):
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
+        degree = DegreeFactory()
+        program.degree = degree
+        assert program.product_external_url is None
+
+    def test_external_url_when_no_degree_is_present(self):
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
+        assert program.product_external_url is None

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -434,7 +434,7 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
             partner=self.__class__.edxPartner,
             additional_metadata=AdditionalMetadataFactory(external_url='https://external-url.com'),
         )
-        assert product.product_external_url is 'https://external-url.com'
+        assert product.product_external_url == 'https://external-url.com'
 
     @ddt.data(AlgoliaProxyCourse, AlgoliaProxyProgram)
     def test_external_url_when_no_additional_metadata_is_present(self, model_factory):

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -423,10 +423,26 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         assert course.should_index
 
     @override_settings(ALGOLIA_INDEX_EXCLUDED_SOURCES=['blocked'])
-    def test_product_source_shoud_excluded(self):
+    def test_product_source_should_excluded(self):
         course = self.create_blocked_course_run()
         course.authoring_organizations.add(OrganizationFactory())
         assert not course.should_index
+
+    @ddt.data(AlgoliaProxyCourse, AlgoliaProxyProgram)
+    def test_external_url_when_present(self, model_factory):
+        product = model_factory(
+            partner=self.__class__.edxPartner,
+            additional_metadata=AdditionalMetadataFactory(external_url='https://external-url.com'),
+        )
+        assert product.product_external_url is 'https://external-url.com'
+
+    @ddt.data(AlgoliaProxyCourse, AlgoliaProxyProgram)
+    def test_external_url_when_no_additional_metadata_is_present(self, model_factory):
+        product = model_factory(
+            partner=self.__class__.edxPartner,
+            additional_metadata=None,
+        )
+        assert product.product_external_url is None
 
     def test_course_subscription_eligibility(self):
         """


### PR DESCRIPTION
Ensuring that prospectus search results can reference the external_url. For Emeritus products, because we will not be building pages for them, we will always use the external url and direct the user off site.

[WS-3714](https://2u-internal.atlassian.net/browse/WS-3714)