### PR TITLE
fix: fix django-admin pages breaking due to incomplete fact data

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -171,9 +171,7 @@ class AbstractHeadingBlurbModel(TimeStampedModel):
     blurb = NullHtmlField()
 
     def __str__(self):
-        if self.heading:
-            return self.heading
-        return self.blurb
+        return self.heading if self.heading else f"{self.blurb}"
 
     class Meta:
         abstract = True


### PR DESCRIPTION
## Description

In the case of an empty Fact object i.e if it has a falsy heading value and a non-string blurb value (this is usually None) some of the admin pages break with the error `__str__ returned non-string`. This PR is a fix for that