### PR TITLE
fix: fix the reviewable_data_has_changed to properly handle dictionaries

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -325,7 +325,7 @@ class VideoSerializer(MediaSerializer):
 
 class GeoLocationSerializer(BaseModelSerializer):
     """Serializer for the ``GeoLocation`` model."""
-    location_name = serializers.CharField(allow_null=True, max_length=128)
+    location_name = serializers.CharField(allow_blank=True, allow_null=True, max_length=128)
     lat = serializers.DecimalField(
         max_digits=GeoLocation.LAT_MAX_DIGITS,
         decimal_places=GeoLocation.DECIMAL_PLACES,
@@ -686,7 +686,7 @@ class AdditionalMetadataSerializer(BaseModelSerializer):
     """Serializer for the ``AdditionalMetadata`` model."""
 
     facts = FactSerializer(many=True)
-    certificate_info = CertificateInfoSerializer()
+    certificate_info = CertificateInfoSerializer(allow_null=True)
     product_meta = ProductMetaSerializer(required=False, allow_null=True)
     start_date = serializers.DateTimeField()
     end_date = serializers.DateTimeField()

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -362,7 +362,8 @@ class CourseRunViewSet(ValidElasticSearchQueryRequiredMixin, viewsets.ModelViewS
         changed_fields = reviewable_data_has_changed(
             course_run,
             serializer.validated_data.items(),
-            CourseRun.STATUS_CHANGE_EXEMPT_FIELDS
+            CourseRun.STATUS_CHANGE_EXEMPT_FIELDS,
+            serializer
         )
         response = self._update_course_run(course_run, draft, bool(changed_fields),
                                            serializer, request, prices, upgrade_deadline_override,)

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -57,7 +57,7 @@ def writable_request_wrapper(method):
             content = str(e)
             if hasattr(e, 'content'):
                 content = e.content.decode('utf8') if isinstance(e.content, bytes) else e.content
-            msg = _('Failed to set data: {}').format(content)
+            msg = _('Faileding to set data: {} {}').format(content, type(e))
             logger.exception(msg)
             return Response(msg, status=status.HTTP_400_BAD_REQUEST)
     return inner
@@ -379,7 +379,7 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
 
         # If price didnt change, check the other fields on the course
         # (besides image and video, they are popped off above)
-        changed_fields = reviewable_data_has_changed(course, serializer.validated_data.items())
+        changed_fields = reviewable_data_has_changed(course, serializer.validated_data.items(), serializer=serializer)
         changed = changed or bool(changed_fields)
 
         if url_slug:


### PR DESCRIPTION
[PROD-3202](https://2u-internal.atlassian.net/browse/PROD-3202)

## Description

In this PR, we fix the reviewable_data_has_changed function to properly handle dictionaries.

## Context
As things stand now, every request to update a course is considered as having changed the course data regardless of whether any data has actually changed or not. This is because the geolocation and location_restriction fields (which are dicts) are not properly handled by reviewable_data_has_changed. This causes the issue mentioned in the ticket above. That is, it is not possible to have multiple course runs in scheduled state. As soon as you finish the review of a course run(to move it into scheduled state) the reviewable_data_has_changed decides that course data has changed and removes all runs from scheduled state to unsubmitted. This PR attempts to fix this issue.

## Testing

1. Create a course on publisher
2. Complete its review process
3. Make multiple(>1) runs of this course with publish dates in future
4. Complete their review process.
5. Ensure that moving one run into scheduled state does not change status of another run
6. Ensure that at the end all runs are in scheduled state.