### PR TITLE
chore: upgraded version of taxonomy-connector 1.37.1

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -33,7 +33,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.2.1
+importlib-metadata==6.3.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
@@ -41,7 +41,7 @@ markupsafe==2.1.2
     # via jinja2
 packaging==23.0
     # via sphinx
-pygments==2.14.0
+pygments==2.15.0
     # via sphinx
 python-dateutil==2.8.2
     # via elasticsearch-dsl

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -59,9 +59,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.109
+boto3==1.26.110
     # via django-ses
-botocore==1.29.109
+botocore==1.29.110
     # via
     #   boto3
     #   s3transfer
@@ -465,7 +465,7 @@ idna==3.4
     #   trio
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.2.1
+importlib-metadata==6.3.0
     # via
     #   -r requirements/base.in
     #   markdown
@@ -596,7 +596,7 @@ pycryptodomex==3.17
     # via
     #   pyjwkest
     #   snowflake-connector-python
-pygments==2.14.0
+pygments==2.15.0
     # via sphinx
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -843,7 +843,7 @@ stevedore==5.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.37.0
+taxonomy-connector==1.37.1
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -37,9 +37,9 @@ beautifulsoup4==4.12.2
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.26.109
+boto3==1.26.110
     # via django-ses
-botocore==1.29.109
+botocore==1.29.110
     # via
     #   boto3
     #   s3transfer
@@ -376,7 +376,7 @@ idna==3.4
     # via
     #   requests
     #   snowflake-connector-python
-importlib-metadata==6.2.1
+importlib-metadata==6.3.0
     # via
     #   -r requirements/base.in
     #   markdown
@@ -610,7 +610,7 @@ stevedore==5.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.37.0
+taxonomy-connector==1.37.1
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
[JIRA ENT-6976](https://2u-internal.atlassian.net/browse/ENT-6976)

**Description**

This PR contains version bump for taxonomy connector, new version of the taxonomy connector has [these changes](https://github.com/openedx/taxonomy-connector/pull/152/files)