### PR TITLE
fix: update keywords in case for empty tags list

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1426,7 +1426,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
             instance.product_meta = ProductMeta.objects.create(**product_meta_data)
             instance.save()
 
-        if keywords and instance.product_meta:
+        if instance.product_meta and keywords is not None:
             instance.product_meta.keywords.set(keywords, clear=True)
             instance.product_meta.save()
 


### PR DESCRIPTION
Description:
This PR updates `update_product_meta` method to update keywords in case of empty tags list

On testing Publisher with newly added additional metadata fields I've found a scenario where keywords can't update to empty list once it populated