### PR TITLE
feat: add error handling with geag api mapping

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -291,7 +291,7 @@ class CSVDataLoader(AbstractDataLoader):
 
         for field in required_fields:
             if not (field in data and data[field]):
-                missing_fields.append(field)
+                missing_fields.append(settings.GEAG_API_INGESTION_FIELDS_MAPPING.get(field) or field)
 
         if missing_fields:
             return ', '.join(missing_fields)

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -775,7 +775,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
          ('Executive Education(2U)', 'executive-education-2u'),
          'ext_source',
          '[MISSING_REQUIRED_DATA] Course CSV Course is missing the required data for ingestion. '
-         'The missing data elements are "image, long_description, primary_subject"'
+         'The missing data elements are "cardUrl, long_description, primary_subject"'
          ),
         (['publish_date', 'organic_url', 'stat1_text'],
          ('Executive Education(2U)', 'executive-education-2u'),
@@ -793,7 +793,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
          ('Bootcamp(2U)', 'bootcamp-2u'),
          'ext_source',
          '[MISSING_REQUIRED_DATA] Course CSV Course is missing the required data for ingestion. '
-         'The missing data elements are "image, long_description, primary_subject"'
+         'The missing data elements are "cardUrl, long_description, primary_subject"'
          ),
         (['redirect_url', 'organic_url'],
          ('Bootcamp(2U)', 'bootcamp-2u'),

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -106,6 +106,12 @@ CSV_LOADER_TYPE_SOURCE_REQUIRED_FIELDS.update(
     }
 )
 
+GEAG_API_INGESTION_FIELDS_MAPPING = {
+    'title': 'altName, name',
+    'number': 'abbreviation',
+    'image': 'cardUrl'
+}
+
 GETSMARTER_CLIENT_CREDENTIALS = {
     'CLIENT_ID' : 'test_id',
     'CLIENT_SECRET' : 'test_secret',


### PR DESCRIPTION
[PROD-3314](https://2u-internal.atlassian.net/browse/PROD-3314)
Consuming GEAG api mapping for exec-ed ingestion fields. This mapping is to be used in error handling to show which field in GEAG api was missing.