### PR TITLE
refactor: ignore non-english transcripts in xblock provider

### DIFF
--- a/course_discovery/apps/core/tests/mixins.py
+++ b/course_discovery/apps/core/tests/mixins.py
@@ -187,7 +187,8 @@ class LMSAPIClientMixin:
                 'index_dictionary': {
                     'content': {
                         'display_name': 'Welcome!',
-                        'transcript_en': ' ERIC: Hi, and welcome to the edX demonstration course.'
+                        'transcript_en': ' ERIC: Hi, and welcome to the edX demonstration course.',
+                        'transcript_hi': 'Should not be included in tagging content.'
                     },
                     'content_type': 'Video'
                 }


### PR DESCRIPTION
The current implementation of skill tagging in taxonomy_connector only supports english text via lightcast api. This commit ignores all other transcripts while collecting the text representation of any video xblock.

## Testing instructions

- Checkout https://github.com/openedx/edx-platform/pull/32099, this is required due a bug in multiple transcripts uploader.
- Start `lms` and `discovery` service in devstack using `make lms-up discovery-up`
- Follow instructions in https://github.com/openedx/edx-platform/pull/32099 to add multiple transcripts to any video xblock.
- Check whether the api returns multiple transcripts for the video using below url:
```
# change the block key to the video xblock usage key that you are testing.
http://localhost:18000/api/courses/v2/block_metadata/block-v1:edX+DemoX+Demo_Course+type@video+block@7e3e72fda7054aeeb7fd343f93ebb520?include=index_dictionary
```
- Follow [instructions given here](https://github.com/openedx/taxonomy-connector#getting-started) to setup taxonomy-connector in course-discovery, make sure to clone `https://github.com/open-craft/taxonomy-connector` in `<devstack-base-dir>/src/`
- Open discovery shell using `make discovery-shell`
- Run `./manage.py migrate`
- Open django shell using `./manage.py shell`
- Run below commands to make
```python
from course_discovery.apps.taxonomy_support.providers import DiscoveryXBlockMetadataProvider
provider = DiscoveryXBlockMetadataProvider()
blocks = provider.get_xblocks(["<use_the_same_video_xblock_usage_key"])
print(blocks) # should only contain the english transcript in content.
```

**Dependencies:** https://github.com/openedx/edx-platform/pull/32099