### PR TITLE
feat: whitelist dir attribute for p tag

### DIFF
--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -16,6 +16,11 @@ IMAGE_TYPES = {
 }
 
 ALLOWED_ANCHOR_TAG_ATTRIBUTES = ['href', 'title', 'target', 'rel']
+ALLOWED_PARAGRAPH_TAG_ATTRIBUTES = ['dir', 'lang']
+HTML_TAGS_ATTRIBUTE_WHITELIST = {
+    'a': ALLOWED_ANCHOR_TAG_ATTRIBUTES,
+    'p': ALLOWED_PARAGRAPH_TAG_ATTRIBUTES,
+}
 
 DRIVE_LINK_PATTERNS = [r"https://docs\.google\.com/uc\?id=\w+",
                        r"https://drive\.google\.com/file/d/\w+/view?usp=sharing"]

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -641,6 +641,9 @@ class UtilsTests(TestCase):
         ('<script>Script</script>', ''),
         ('NB&nbsp;SP', '<p>NBSP</p>'),
 
+        # Make sure to add dir attribute to p tags if they are in attribute list
+        ('<p dir="rtl" class="float">Directed paragraph</p>', '<p dir="rtl">Directed paragraph</p>'),
+
         # Make sure that only spans with lang tags are preserved in the saved string
         ('<p><span lang="en">with lang</span></p>', '<p><span lang="en">with lang</span></p>'),
         ('<p><span class="body" lang="en">lang and class</span></p>', '<p><span lang="en">lang and class</span></p>'),

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -22,7 +22,7 @@ from stdimage.models import StdImageFieldFile
 
 from course_discovery.apps.core.models import SalesforceConfiguration
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.course_metadata.constants import ALLOWED_ANCHOR_TAG_ATTRIBUTES, IMAGE_TYPES
+from course_discovery.apps.course_metadata.constants import HTML_TAGS_ATTRIBUTE_WHITELIST, IMAGE_TYPES
 from course_discovery.apps.course_metadata.exceptions import (
     EcommerceSiteAPIClientException, MarketingSiteAPIClientException
 )
@@ -653,6 +653,37 @@ class HTML2TextWithLangSpans(html2text.HTML2Text):
         self.ignore_links = True
         self.in_lang_span = False
         self.images_with_size = True
+        self.is_p_tag_with_dir = False
+
+    def add_and_filter_attrs(self, tag, dict_attrs):
+        """
+        This method adds only allowed attributes to the whitelisted tags
+        """
+        self.outtextf(f'<{tag}')
+        filtered_attrs_list = [
+            (attr, value) for attr, value in dict_attrs.items()
+            if attr in HTML_TAGS_ATTRIBUTE_WHITELIST[tag]
+        ]
+        for attr, value in filtered_attrs_list:
+            self.outtextf(f' {attr}="{value}"')
+        self.outtextf('>')
+
+    def whitelist_html_tags_attribute(self, tag, dict_attrs, start):
+        """
+        This method overrides the default behavior of html2text to include only allowed tags from attr_dict
+        because by default it only includes the href and title attributes for <a> tags and
+        discards the dir attribrute for <p> tags
+        """
+        if tag in HTML_TAGS_ATTRIBUTE_WHITELIST:
+            if start:
+                if HTML_TAGS_ATTRIBUTE_WHITELIST[tag][0] in dict_attrs:
+                    if tag == 'p':
+                        self.is_p_tag_with_dir = True
+                    self.add_and_filter_attrs(tag, dict_attrs)
+            elif (tag == 'p' and self.is_p_tag_with_dir) or (tag == 'a'):
+                if tag == 'p':
+                    self.is_p_tag_with_dir = False
+                self.outtextf(f'</{tag}>')
 
     def handle_tag(self, tag, attrs, start):
         super().handle_tag(tag, attrs, start)
@@ -663,20 +694,7 @@ class HTML2TextWithLangSpans(html2text.HTML2Text):
             if not start and self.in_lang_span:
                 self.outtextf('</span>')
                 self.in_lang_span = False
-
-        if tag == 'a':
-            # override the default behavior of html2text to include only allowed tags from attr_dict for <a> tags
-            # because by default it only includes the href and title attributes
-            if attrs and start and 'href' in dict(attrs):
-                self.outtextf('<a')
-                filtered_attrs_list = [
-                    (attr, value) for attr, value in dict(attrs).items() if attr in ALLOWED_ANCHOR_TAG_ATTRIBUTES
-                ]
-                for attr, value in filtered_attrs_list:
-                    self.outtextf(f' {attr}="{value}"')
-                self.outtextf('>')
-            if not start:
-                self.outtextf('</a>')
+        self.whitelist_html_tags_attribute(tag, dict(attrs), start)
 
 
 def clean_html(content):


### PR DESCRIPTION
[PROD-3220](https://2u-internal.atlassian.net/browse/PROD-3220)

Description:
On testing, I figured out `clean_html` didn't add `dir` attribute to p tag. This PR covers the whitelisting of that attr for `p` tag