### PR TITLE
fix: gsmarter command Mapping issue

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/ingest_getsmarter_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/ingest_getsmarter_data.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
                 logger.info(
                     'Populating executive education data CSV file at path: %s', csv_path)
                 call_command('populate_executive_education_data_csv',
-                             use_getsmarter_api_client=True, output_csv=csv_path)
+                             use_getsmarter_api_client=True, output_csv=csv_path, product_source=product_source)
                 logger.info(
                     'Ingesting executive education data from CSV file at path: %s', csv_path)
                 call_command('import_course_metadata', csv_path=csv_path,

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_ingest_getsmarter_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_ingest_getsmarter_data.py
@@ -44,7 +44,8 @@ class IngestGetSmarterDataCommandTests(TestCase):
             mock_call_command.assert_any_call(
                 'populate_executive_education_data_csv',
                 use_getsmarter_api_client=True,
-                output_csv=mock.ANY
+                output_csv=mock.ANY,
+                product_source=self.source.slug,
             )
             mock_call_command.assert_any_call(
                 'import_course_metadata',


### PR DESCRIPTION
This PR fixes organization mapping issue in `ingest_getsmarter_data` command. By default, `edx` passed as a default param to the command.