### PR TITLE
feat: index course_key and video_url in algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -68,7 +68,8 @@ def delegate_attributes(cls):
                      'active_run_type', 'owners', 'program_types', 'course_titles', 'tags',
                      'product_organization_short_code_override', 'product_organization_logo_override', 'skills',
                      'product_meta_title', 'product_display_on_org_page', 'product_external_url',
-                     'contentful_fields', 'subscription_eligible', 'subscription_prices',]
+                     'contentful_fields', 'subscription_eligible', 'subscription_prices', 'product_key',
+                     'product_marketing_video_url', ]
     object_id_field = ['custom_object_id', ]
     fields = product_type_fields + search_fields + facet_fields + ranking_fields + result_fields + object_id_field
     for field in fields:
@@ -418,6 +419,14 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
     def subscription_prices(self):
         """ Courses do not have subscription_prices attribute. Returning empty list explicitly"""
         return []
+
+    @property
+    def product_key(self):
+        return self.key
+
+    @property
+    def product_marketing_video_url(self):
+        return self.video.src if self.video else None
 
 
 class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -94,7 +94,7 @@ class EnglishProductIndex(BaseProductIndex):
                      ('product_meta_title', 'meta_title'), ('product_display_on_org_page', 'display_on_org_page'),
                      ('product_external_url', 'external_url'), 'active_run_key',
                      'active_run_start', 'active_run_type', 'owners', 'course_titles', 'tags',
-                     'skills', 'contentful_fields',)
+                     'skills', 'contentful_fields', 'product_key', 'product_marketing_video_url', )
 
     # Algolia needs this
     object_id_field = (('custom_object_id', 'objectID'), )
@@ -147,7 +147,7 @@ class SpanishProductIndex(BaseProductIndex):
                      ('product_meta_title', 'meta_title'), ('product_display_on_org_page', 'display_on_org_page'),
                      ('product_external_url', 'external_url'), 'active_run_start',
                      'active_run_type', 'owners', 'course_titles', 'tags', 'skills',
-                     'contentful_fields',)
+                     'contentful_fields', 'product_key', 'product_marketing_video_url', )
 
     # Algolia uses objectID as unique identifier. Can't use straight uuids because a program and a course could
     # have the same one, so we add 'course' or 'program' as a prefix

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -18,7 +18,7 @@ from course_discovery.apps.course_metadata.tests.factories import (
     AdditionalMetadataFactory, CourseFactory, CourseRunFactory, CourseTypeFactory, DegreeAdditionalMetadataFactory,
     DegreeFactory, LevelTypeFactory, OrganizationFactory, ProductMetaFactory, ProgramFactory,
     ProgramSubscriptionFactory, ProgramSubscriptionPriceFactory, ProgramTypeFactory, SeatFactory, SeatTypeFactory,
-    SourceFactory, SubjectFactory
+    SourceFactory, SubjectFactory, VideoFactory
 )
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 
@@ -451,6 +451,29 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         """
         course = AlgoliaProxyCourseFactory()
         assert len(course.subscription_prices) == 0
+
+    def test_course_key(self):
+        """
+        Verify the course key is returned for course.
+        """
+        product_key = 'test+TestCourse'
+        product = AlgoliaProxyCourseFactory(
+            partner=self.__class__.edxPartner,
+            key=product_key
+        )
+        assert product.product_key is product_key
+
+    def test_product_marketing_video_url(self):
+        """
+        Verify the product marketing video url is returned for course.
+        """
+        product_marketing_video_url = 'example.com/video_url'
+        video = VideoFactory(src=product_marketing_video_url)
+        product = AlgoliaProxyCourseFactory(
+            partner=self.__class__.edxPartner,
+            video=video
+        )
+        assert product.product_marketing_video_url is product_marketing_video_url
 
 
 @ddt.ddt


### PR DESCRIPTION
[PROD-3321](https://2u-internal.atlassian.net/browse/PROD-3321)
Adds course_key and video_url in algolia to be indexed for courses only.

