### PR TITLE
chore: remove unnecessary collaborators manual handling in Course API

### DIFF
--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -377,12 +377,7 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
             img_name, img_data = decode_image_data(org_logo_override_image)
             course.organization_logo_override.save(img_name, img_data)
 
-        if data.get('collaborators'):
-            collaborators_uuids = data.get('collaborators')
-            collaborators = Collaborator.objects.filter(uuid__in=collaborators_uuids)
-            course.collaborators.add(*collaborators)
-
-        # If price didnt change, check the other fields on the course
+        # If price didn't change, check the other fields on the course
         # (besides image and video, they are popped off above)
         changed_fields = reviewable_data_has_changed(
             course,


### PR DESCRIPTION
### Description

This bug/unnecessary code portion was discovered during the investigations of https://2u-internal.atlassian.net/browse/PROD-3297. Collaborator is defined as [SlugRelatedFieldWithReadSerializer](https://github.com/openedx/course-discovery/blob/c1017e5981c9ab5ca1162ca3359a60cf9236a9b2/course_discovery/apps/api/fields.py#L76) in Course serializer with many=True. The serializer uses collaborator uuids to auto-get Collab objects and add to Course's M2M relation when DRF's create/update is called. There is no need to handle the collab uuids in course api manually. It is just adding extra DB calls.

The changes were added in PR https://github.com/openedx/course-discovery/pull/2662