### PR TITLE
feat: return default product values in algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -12,7 +12,7 @@ from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.course_metadata.choices import CourseRunStatus, ExternalProductStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import (
-    AbstractLocationRestrictionModel, Course, CourseType, Program, ProgramType
+    AbstractLocationRestrictionModel, Course, CourseType, ProductValue, Program, ProgramType
 )
 from course_discovery.apps.course_metadata.utils import transform_skills_data
 
@@ -166,29 +166,23 @@ class AlgoliaBasicModelFieldsMixin(models.Model):
     def product_recent_enrollment_count(self):
         return self.recent_enrollment_count
 
+    # For product_value_per_*, return default values if in_year_value is None to ensure that products don't get lost
+    # in the ranking
     @property
     def product_value_per_click_usa(self):
-        if self.in_year_value:
-            return self.in_year_value.per_click_usa
-        return None
+        return getattr(self.in_year_value, 'per_click_usa', ProductValue.DEFAULT_VALUE_PER_CLICK)
 
     @property
     def product_value_per_click_international(self):
-        if self.in_year_value:
-            return self.in_year_value.per_click_international
-        return None
+        return getattr(self.in_year_value, 'per_click_international', ProductValue.DEFAULT_VALUE_PER_CLICK)
 
     @property
     def product_value_per_lead_usa(self):
-        if self.in_year_value:
-            return self.in_year_value.per_lead_usa
-        return None
+        return getattr(self.in_year_value, 'per_lead_usa', ProductValue.DEFAULT_VALUE_PER_LEAD)
 
     @property
     def product_value_per_lead_international(self):
-        if self.in_year_value:
-            return self.in_year_value.per_lead_international
-        return None
+        return getattr(self.in_year_value, 'per_lead_international', ProductValue.DEFAULT_VALUE_PER_LEAD)
 
     @property
     def product_organization_short_code_override(self):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1077,23 +1077,30 @@ class ProductValue(TimeStampedModel):
     """
     ProductValue model, with fields related to projected value for a product.
     """
+    DEFAULT_VALUE_PER_LEAD = 0
+    DEFAULT_VALUE_PER_CLICK = 5
+
     per_lead_usa = models.IntegerField(
-        null=True, blank=True, default=0, verbose_name=_('U.S. Value Per Lead'), help_text=_(
+        null=True, blank=True, default=DEFAULT_VALUE_PER_LEAD,
+        verbose_name=_('U.S. Value Per Lead'), help_text=_(
             'U.S. value per lead in U.S. dollars.'
         )
     )
     per_lead_international = models.IntegerField(
-        null=True, blank=True, default=0, verbose_name=_('International Value Per Lead'), help_text=_(
+        null=True, blank=True, default=DEFAULT_VALUE_PER_LEAD,
+        verbose_name=_('International Value Per Lead'), help_text=_(
             'International value per lead in U.S. dollars.'
         )
     )
     per_click_usa = models.IntegerField(
-        null=True, blank=True, default=5, verbose_name=_('U.S. Value Per Click'), help_text=_(
+        null=True, blank=True, default=DEFAULT_VALUE_PER_CLICK,
+        verbose_name=_('U.S. Value Per Click'), help_text=_(
             'U.S. value per click in U.S. dollars.'
         )
     )
     per_click_international = models.IntegerField(
-        null=True, blank=True, default=5, verbose_name=_('International Value Per Click'), help_text=_(
+        null=True, blank=True, default=DEFAULT_VALUE_PER_CLICK,
+        verbose_name=_('International Value Per Click'), help_text=_(
             'International value per click in U.S. dollars.'
         )
     )

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -13,7 +13,7 @@ from course_discovery.apps.core.models import Currency, Partner
 from course_discovery.apps.core.tests.factories import PartnerFactory, SiteFactory
 from course_discovery.apps.course_metadata.algolia_models import AlgoliaProxyCourse, AlgoliaProxyProgram
 from course_discovery.apps.course_metadata.choices import ExternalProductStatus, ProgramStatus
-from course_discovery.apps.course_metadata.models import CourseRunStatus, CourseType
+from course_discovery.apps.course_metadata.models import CourseRunStatus, CourseType, ProductValue
 from course_discovery.apps.course_metadata.tests.factories import (
     AdditionalMetadataFactory, CourseFactory, CourseRunFactory, CourseTypeFactory, DegreeAdditionalMetadataFactory,
     DegreeFactory, LevelTypeFactory, OrganizationFactory, ProductMetaFactory, ProgramFactory,
@@ -475,6 +475,15 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         )
         assert product.product_marketing_video_url is product_marketing_video_url
 
+    def test_null_in_year_value(self):
+        course = self.create_course_with_basic_active_course_run()
+        course.authoring_organizations.add(OrganizationFactory())
+        course.in_year_value = None
+        assert course.product_value_per_click_usa == ProductValue.DEFAULT_VALUE_PER_CLICK
+        assert course.product_value_per_click_international == ProductValue.DEFAULT_VALUE_PER_CLICK
+        assert course.product_value_per_lead_usa == ProductValue.DEFAULT_VALUE_PER_LEAD
+        assert course.product_value_per_lead_international == ProductValue.DEFAULT_VALUE_PER_LEAD
+
 
 @ddt.ddt
 @pytest.mark.django_db
@@ -759,3 +768,11 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
     def test_external_url_when_no_degree_is_present(self):
         program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
         assert program.product_external_url is None
+
+    def test_null_in_year_value(self):
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)
+        program.in_year_value = None
+        assert program.product_value_per_click_usa == ProductValue.DEFAULT_VALUE_PER_CLICK
+        assert program.product_value_per_click_international == ProductValue.DEFAULT_VALUE_PER_CLICK
+        assert program.product_value_per_lead_usa == ProductValue.DEFAULT_VALUE_PER_LEAD
+        assert program.product_value_per_lead_international == ProductValue.DEFAULT_VALUE_PER_LEAD


### PR DESCRIPTION
Follow up to https://github.com/openedx/course-discovery/pull/3902. Although default values were added in that PR, `in_year_value` is still a foreign key field, so entries won't be created automatically on course/program creation.

This is mainly important for search. Instead of creating unnecessary `ProductValue` entries when courses/programs are created (which can get messy), this simply returns the default values in Algolia when `in_year_value` is null, in order to ensure that new products don't get lost in the ranking before we get the chance to add product values for them.

Internal ticket: https://2u-internal.atlassian.net/browse/WS-3859