### PR TITLE
fix: add additional checks for M2M signal on CourseRun

### DIFF
--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -409,7 +409,7 @@ def course_run_m2m_changed(sender, instance, action, **kwargs):
     mutation even if  nothing was changed.
     @receiver(m2m_changed, sender=CourseRun.staff.through)
     """
-    if action in ['pre_add', 'pre_remove'] and instance.draft:
+    if hasattr(instance, 'course') and action in ['pre_add', 'pre_remove'] and not kwargs['reverse'] and instance.draft:
         logger.info(f"{sender} has been updated for course run {instance.key}.")
         Course.everything.filter(key=instance.course.key).update(
             data_modified_timestamp=datetime.now(pytz.UTC)


### PR DESCRIPTION
### [PROD-3330](https://2u-internal.atlassian.net/browse/PROD-3330)

### Description
- Ensure the timestamp is only updated when updating transcripts from CourseRun -- to support the regular data ingestion/authoring pipeline via publisher
- Add a check that ensures course obj is present & accessible on CourseRun. This is to support load_program_fixture management command that saves the json/serialized responses where CourseRun appears before Course and course is not accessible on courserun when it is saved https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/course_metadata/management/commands/load_program_fixture.py#L173. The command uses `/extensions/api/v1/program-fixture/` endpoint from Discovery.

**Tests are not added because signals tests were missed in PR https://github.com/openedx/course-discovery/pull/3867 and are yet to be added**