### PR TITLE
chore: make in_year_value status change exempt

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1348,9 +1348,10 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
     # Changing these fields at the course level will not trigger re-reviews
     # on related course runs that are already in the scheduled state
     STATUS_CHANGE_EXEMPT_FIELDS = [
+        'additional_metadata',
         'geolocation',
+        'in_year_value',
         'location_restriction',
-        'additional_metadata'
     ]
 
     everything = CourseQuerySet.as_manager()


### PR DESCRIPTION
[PROD-3202](https://2u-internal.atlassian.net/browse/PROD-3202)

## Description
In [this PR](https://github.com/openedx/course-discovery/pull/3912), we forgot to add in_year_value to status exempt fields. Hence when we had non-null value of in_year_value coming from the frontend, it was considered as a change to the course and related course runs in scheduled state were being unpublished. This PR fixes that behavior