### PR TITLE
feat: modify bulk_upload_tags command to add tags to all product types

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/bulk_upload_tags.py
+++ b/course_discovery/apps/course_metadata/management/commands/bulk_upload_tags.py
@@ -6,13 +6,21 @@ import uuid
 
 from django.core.management import BaseCommand, CommandError
 
-from course_discovery.apps.course_metadata.models import BulkUploadTagsConfig, Course
+from course_discovery.apps.course_metadata.models import BulkUploadTagsConfig, Course, Degree, Program
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Add tags to courses from a csv file'
+    help = 'Add SEO tags to products parsed from a CSV file'
+
+    # Mapping of SEO tags field names to the corresponding product type
+    PRODUCT_TYPE_TO_TAGS_FIELD_MAPPING = {
+        'course': {'model': Course, 'field': 'topics'},
+        'program': {'model': Program, 'field': 'labels'},
+        'degree': {'model': Degree, 'field': 'labels'},
+    }
+    PRODUCT_TYPES = ['course', 'program', 'degree']
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -36,37 +44,70 @@ class Command(BaseCommand):
                 "Error occured while opening the tags csv.\n{}".format(exc)
             )
 
-        for line in file_handle:
-            if line:
-                course_uuid, tags = self.parse_line(line)
-                self.set_course_tags(course_uuid, tags)
+        for row in file_handle:
+            if row:
+                product_uuid, product_type, tags = self.parse_row(row)
+                if product_type not in self.PRODUCT_TYPES:
+                    logger.info(f'Invalid product type: {product_type}')
+                    continue
+                self.set_product_tags(product_uuid, tags, product_type)
 
         file_handle.close()
 
-    def parse_line(self, line):
+    def parse_row(self, row):
         """
+        Parse a line from the csv file and return the product uuid and list of tags
         uuid,tag1,tag2,tag3 -> uuid, [tag1, tag2, tag3]
         """
-        course_id, *tags = line.split(',')
-        return course_id.strip(), [tag.strip() for tag in tags]
+        product_uuid, product_type, *tags = row.split(',')
+        return product_uuid.strip().lower(), product_type.strip(), [tag.strip() for tag in tags]
 
-    def set_course_tags(self, course_uuid, tags):
-        if self.is_valid_uuid(course_uuid):
-            tags = [tag for tag in tags if tag]  # remove empty strings from tags
-            logger.info(f'Adding tags for {course_uuid}')
-            qs = Course.everything.filter(uuid=course_uuid)
-            if not qs:
-                logger.info(f'No course found with uuid: {course_uuid}')
-            for course in qs:
-                course.topics.set(tags)
-                course.save()
+    def set_product_tags(self, product_uuid, tags, product_type):
+        """
+        Set the tags for a product of the given type and UUID.
+
+        Args:
+            product_uuid (str): The UUID of the product to set tags for.
+            tags (List[str]): A list of tags to set for the product. Empty strings are ignored.
+            product_type (str): The type of product to set tags for. Must be one of 'course', 'program', or 'degree'.
+
+        Example usage:
+
+        ```
+        set_product_tags('dummy-uuid', ['tag1', 'tag2'], 'course')
+        ```
+        """
+        if not self.is_valid_uuid(product_uuid):
+            logger.info(f'Invalid uuid: {product_uuid}')
+            return
+        tags = [tag for tag in tags if tag]
+
+        mapping = self.PRODUCT_TYPE_TO_TAGS_FIELD_MAPPING.get(product_type)
+        if not mapping:
+            logger.info(f'Invalid product type: {product_type}')
+            return
+
+        model = mapping['model']
+        field = mapping['field']
+
+        if model == Course:
+            query_set = Course.everything.filter(uuid=product_uuid)
         else:
-            logger.info(f'{course_uuid} is not a valid uuid')
+            query_set = model.objects.filter(uuid=product_uuid)
+        if not query_set:
+            logger.info(f'No {product_type} found with uuid: {product_uuid}')
+            return
 
-    def is_valid_uuid(self, course_uuid):
-        """Check if course_uuid is a valid uuid"""
+        for obj in query_set:
+            # pylint: disable=logging-not-lazy
+            logger.info(f'Setting tags for {product_type} with uuid -{product_uuid}: {tags}')
+            getattr(obj, field).set(tags)
+            obj.save()
+
+    def is_valid_uuid(self, product_uuid):
+        """ Check if the product uuid is valid """
         try:
-            uuid.UUID(str(course_uuid))
+            uuid.UUID(str(product_uuid))
             return True
         except ValueError:
             return False

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_bulk_upload_tags.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_bulk_upload_tags.py
@@ -2,8 +2,10 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 
-from course_discovery.apps.course_metadata.models import Course
-from course_discovery.apps.course_metadata.tests.factories import BulkUploadTagsConfigFactory, CourseFactory
+from course_discovery.apps.course_metadata.models import Course, Degree, Program
+from course_discovery.apps.course_metadata.tests.factories import (
+    BulkUploadTagsConfigFactory, CourseFactory, DegreeFactory, ProgramFactory
+)
 
 
 class BulkUploadTagsCommandTests(TestCase):
@@ -12,16 +14,44 @@ class BulkUploadTagsCommandTests(TestCase):
     """
     def setUp(self):
         super().setUp()
+        self.test_tags1 = ['tag0', 'tag1', 'tag2', 'tag3']
+        self.test_tags2 = ['tag5', 'tag6', 'tag7']
+
         self.course1 = CourseFactory()
         self.course2 = CourseFactory()
         self.course3 = CourseFactory()
-        self.csv_file_content = ','.join([str(self.course1.uuid), 'tag0', 'tag1']) + '\n'
-        self.csv_file_content += ','.join([str(self.course3.uuid), 'tag1', 'tag2', 'tag3']) + '\n'
+        self.degree1 = DegreeFactory()
+        self.degree2 = DegreeFactory()
+        self.program1 = ProgramFactory()
+        self.program2 = ProgramFactory()
+
+        self.csv_file_content = self.write_csv_file_content()
+
         self.csv_file = SimpleUploadedFile(
             name='test.csv',
             content=self.csv_file_content.encode('utf-8'),
             content_type='text/csv'
         )
+
+    def write_csv_file_content(self):
+        """
+        Write the csv file content to a file.
+        """
+        csv_file_content = ''
+        # list of tuples containing (product_uuid, product type and tags)
+        products_data = [
+            (self.course1.uuid, 'course', self.test_tags1),
+            (self.course3.uuid, 'course', self.test_tags2),
+            (self.degree1.uuid, 'degree', self.test_tags1),
+            (self.degree2.uuid, 'degree', self.test_tags2),
+            (self.program1.uuid, 'program', self.test_tags1),
+            (self.program2.uuid, 'program', self.test_tags2),
+        ]
+
+        for product_uuid, product_type, tags in products_data:
+            csv_file_content += ','.join([str(product_uuid), product_type] + tags) + '\n'
+
+        return csv_file_content
 
     def test_missing_csv(self):
         """
@@ -53,6 +83,17 @@ class BulkUploadTagsCommandTests(TestCase):
         tags_course_2 = [t.name for t in Course.objects.get(uuid=self.course2.uuid).topics.all()]
         tags_course_3 = [t.name for t in Course.objects.get(uuid=self.course3.uuid).topics.all()]
 
-        assert set(tags_course_1) == {'tag0', 'tag1'}
+        tags_degree_1 = [t.name for t in Degree.objects.get(uuid=self.degree1.uuid).labels.all()]
+        tags_degree_2 = [t.name for t in Degree.objects.get(uuid=self.degree2.uuid).labels.all()]
+
+        tags_program_1 = [t.name for t in Program.objects.get(uuid=self.program1.uuid).labels.all()]
+        tags_program_2 = [t.name for t in Program.objects.get(uuid=self.program2.uuid).labels.all()]
+
+        # Verify that the tags are updated correctly.
+        assert set(tags_course_1) == set(self.test_tags1)
         assert set(tags_course_2) == set()
-        assert set(tags_course_3) == {'tag1', 'tag2', 'tag3'}
+        assert set(tags_course_3) == set(self.test_tags2)
+        assert set(tags_degree_1) == set(self.test_tags1)
+        assert set(tags_degree_2) == set(self.test_tags2)
+        assert set(tags_program_1) == set(self.test_tags1)
+        assert set(tags_program_2) == set(self.test_tags2)


### PR DESCRIPTION
[PROD-3332](https://2u-internal.atlassian.net/browse/PROD-3332)
-----------

### Description
This PR modifies the `bulk_upload_tags` management command to allow for the bulk upload of tags for any product_type `['course', 'program', 'degree']`
instead of course only. This is done by adding a new column to the CSV file called `product_type` which will be used to determine the product type to which we want to upload the tags.

### Testing
- CSV file should be in the following format:
```
product_uuid,product_type,tag1,tag2,tag3,... so on
```
- [x] Create a CSV file with the above format
- [x] Make sure that the product with the given uuids already exists in the database
- [x] Run `./manage.py bulk_upload_tags --csv_path={file_path}`
- [x] Verify that the tags were uploaded to the correct product type with the given uuids present in the CSV file
- [x] Verify this command also by using `BulkUploadTagsConfig` model and upload your formatted csv to it 
