### PR TITLE
perf: Fix various N+1 issues on Course API

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -272,7 +272,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
 
         # Known to be flaky prior to the addition of tearDown()
         # and logout() code which is the same number of additional queries
-        with self.assertNumQueries(69, threshold=3):
+        with self.assertNumQueries(52, threshold=3):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -282,7 +282,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         keys = ','.join([course.key for course in courses])
         url = '{root}?{params}'.format(root=reverse('api:v1:course-list'), params=urlencode({'keys': keys}))
 
-        with self.assertNumQueries(69, threshold=3):
+        with self.assertNumQueries(51, threshold=3):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -294,7 +294,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         # Increasing threshold because Course skill fetch SQL queries are executed twice
         # on CI. Listing returns skill details and skill names as two separate fields.
         # TODO: Figure out why the cache behavior is not working as expected on CI.
-        with self.assertNumQueries(67, threshold=5):
+        with self.assertNumQueries(51, threshold=5):
             response = self.client.get(url)
         self.assertListEqual(response.data['results'], self.serialize_course(courses, many=True))
 
@@ -2165,7 +2165,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         CourseEntitlementFactory(course=self.course, mode=SeatTypeFactory.verified())
 
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.uuid})
-        with self.assertNumQueries(41, threshold=0):
+        with self.assertNumQueries(44, threshold=0):
             response = self.client.options(url)
         assert response.status_code == 200
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -188,7 +188,7 @@ class TestProgramViewSet(SerializationMixin):
         """ Verify the endpoint returns data for a program even if the program's courses have no course runs. """
         course = CourseFactory(partner=self.partner)
         program = ProgramFactory(courses=[course], partner=self.partner)
-        with django_assert_num_queries(FuzzyInt(40, 2)):
+        with django_assert_num_queries(FuzzyInt(43, 2)):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 


### PR DESCRIPTION
### [PROD-3313](https://2u-internal.atlassian.net/browse/PROD-3313)

### Description

This PR fixes various N+1 issues with Course API and its associated serializers. N+1 issues have been identified with Django Debug toolbar and https://github.com/jmcarp/nplusone. 

- select & prefetch related is missing for some fields when CourseWithProgramSerializer inherits from CourseSerializer. CourseSerializer had those calls in place in [prefetch_queryset](https://github.com/openedx/course-discovery/blob/28ec39978a59223a44ad9ac3046ea730cfb5b7db/course_discovery/apps/api/serializers.py#L1303) method but CourseWithProgramSerializer did not use them and had its own [repeated prefetch](https://github.com/openedx/course-discovery/blob/28ec39978a59223a44ad9ac3046ea730cfb5b7db/course_discovery/apps/api/serializers.py#L1517). 
- Fix N+1 on Related Fields in Serializers (See the note on top on https://www.django-rest-framework.org/api-guide/relations/, also https://www.django-rest-framework.org/api-guide/fields/#source)

For the tests whose query count bumped a bit after fixups:
- CourseViewSetTests::test_options, because of N+1, some extra items are fetched when executing OPTIONS on course endpoint instead of doing it later on demand i.e. lazy. fetch
- TestProgramViewSet::test_retrieve_without_course_runs --This is impacted due to N+1 changes in CourseSerializer on subjects. 


### Testing
- Checkout master discovery on your local
- Hit courses API (api/v1/courses) for listing and fetching a specific course. Do both the actions with ?editable=1 flag, to fetch draft versions.  Keep note of query count from Debug toolbar
- Checkout this branch and repeat above steps. Notice the decrease in query count

Following are count results from my devstack


Action | SQL count on master | SQL count after N+1 fixes
-- | -- | --
Course List (/api/v1/courses) | 344 | 174
Course List - Draft(/api/v1/courses?editable=1) | 370 | 204
Specific course (/api/v1/course/uuid) | 173 | 99
Specific course - Draft (/api/v1/course/uuid?editable=1) | 178 | 109
non-existent UUID | 77 | 16

