### PR TITLE
chore: disable data modified signals in load_program_fixture command

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/load_program_fixture.py
+++ b/course_discovery/apps/course_metadata/management/commands/load_program_fixture.py
@@ -17,8 +17,9 @@ from course_discovery.apps.course_metadata.models import (
 )
 from course_discovery.apps.course_metadata.signals import (
     check_curriculum_for_cycles, check_curriculum_program_membership_for_cycles,
-    ensure_external_key_uniqueness__course_run, ensure_external_key_uniqueness__curriculum,
-    ensure_external_key_uniqueness__curriculum_course_membership
+    connect_course_data_modified_timestamp_related_models, course_run_m2m_changed,
+    disconnect_course_data_modified_timestamp_related_models, ensure_external_key_uniqueness__course_run,
+    ensure_external_key_uniqueness__curriculum, ensure_external_key_uniqueness__curriculum_course_membership
 )
 
 logger = logging.getLogger(__name__)
@@ -63,16 +64,23 @@ def disconnect_program_signals():
             'signal': ensure_external_key_uniqueness__curriculum_course_membership,
             'sender': CurriculumCourseMembership,
         },
+        {
+            'action': db.models.signals.m2m_changed,
+            'signal': course_run_m2m_changed,
+            'sender': CourseRun.transcript_languages.through,
+        }
     ]
 
     for signal in signals_list:
         signal['action'].disconnect(signal['signal'], sender=signal['sender'])
+    disconnect_course_data_modified_timestamp_related_models()
 
     try:
         yield
     finally:
         for signal in signals_list:
             signal['action'].connect(signal['signal'], sender=signal['sender'])
+        connect_course_data_modified_timestamp_related_models()
 
 
 class Command(BaseCommand):

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -409,7 +409,7 @@ def course_run_m2m_changed(sender, instance, action, **kwargs):
     mutation even if  nothing was changed.
     @receiver(m2m_changed, sender=CourseRun.staff.through)
     """
-    if hasattr(instance, 'course') and action in ['pre_add', 'pre_remove'] and not kwargs['reverse'] and instance.draft:
+    if action in ['pre_add', 'pre_remove'] and not kwargs['reverse'] and instance.draft:
         logger.info(f"{sender} has been updated for course run {instance.key}.")
         Course.everything.filter(key=instance.course.key).update(
             data_modified_timestamp=datetime.now(pytz.UTC)


### PR DESCRIPTION
### [PROD-3330](https://2u-internal.atlassian.net/browse/PROD-3330)

### Description
This is a followup to https://github.com/openedx/course-discovery/pull/3918. This PR disables data modified timestamp signals in load_program_fixture. The prev PR did not fix the management command entirely. The command already disables some of the other signals. That command already disables a few Program related signals. I enabled one of the signals (ensure_external_key_uniqueness__curriculum_course_membership) and the unit tests received a similar error as m2m_changed case:

```
course_discovery/apps/course_metadata/management/commands/tests/test_load_program_fixture.py:114: in _call_load_program_fixture
    call_command(
../venvs/discovery/lib/python3.8/site-packages/django/core/management/__init__.py:181: in call_command
    return command.execute(*args, **defaults)
../venvs/discovery/lib/python3.8/site-packages/django/core/management/base.py:398: in execute
    output = self.handle(*args, **options)
course_discovery/apps/course_metadata/management/commands/load_program_fixture.py:159: in handle
    self.load_fixture(fixture, partner)
/usr/lib/python3.8/contextlib.py:75: in inner
    return func(*args, **kwds)
course_discovery/apps/course_metadata/management/commands/load_program_fixture.py:185: in load_fixture
    self.save_fixture_object(obj)
course_discovery/apps/course_metadata/management/commands/load_program_fixture.py:130: in save_fixture_object
    obj.save()
../venvs/discovery/lib/python3.8/site-packages/django/core/serializers/base.py:223: in save
    models.Model.save_base(self.object, using=using, raw=True, **kwargs)
../venvs/discovery/lib/python3.8/site-packages/django/db/models/base.py:763: in save_base
    pre_save.send(
../venvs/discovery/lib/python3.8/site-packages/django/dispatch/dispatcher.py:180: in send
    return [
../venvs/discovery/lib/python3.8/site-packages/django/dispatch/dispatcher.py:181: in <listcomp>
    (receiver, receiver(signal=self, sender=sender, **named))
course_discovery/apps/course_metadata/signals.py:159: in ensure_external_key_uniqueness__curriculum_course_membership
    course_runs = instance.course.course_runs.filter(external_key__isnull=False)
../venvs/discovery/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py:187: in __get__
    rel_obj = self.get_object(instance)
../venvs/discovery/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py:154: in get_object
    return qs.get(self.field.get_reverse_related_filter(instance))
```