### PR TITLE
feat: Default coordinates in Algolia

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -19,6 +19,10 @@ from course_discovery.apps.course_metadata.utils import transform_skills_data
 # Algolia can't filter on an empty list, provide a value we can still filter on
 ALGOLIA_EMPTY_LIST = ['null']
 
+# Every record needs geolocation data to show up in results after we turn on georanking.
+# These are the coordinates of the HQ office in Maryland
+ALGOLIA_DEFAULT_GEO_COORDINATES = 38.951302, -76.873100
+
 
 # Utility methods used by both courses and programs
 def get_active_language_tag(course):
@@ -132,10 +136,7 @@ class AlgoliaProxyProduct(Program):
 
     @property
     def coordinates(self):
-        geolocation = getattr(self.product, 'geolocation', None)
-        if geolocation:
-            return getattr(geolocation, 'coordinates', None)
-        return None
+        return self.coordinates
 
     # should_index is called differently from algoliasearch_django, can't use the delegate_attributes trick
     def should_index(self):
@@ -197,6 +198,13 @@ class AlgoliaBasicModelFieldsMixin(models.Model):
     @property
     def product_source(self):
         return self.product_source.slug if self.product_source else None
+
+    @property
+    def coordinates(self):
+        geolocation = getattr(self, 'geolocation', None)
+        if geolocation:
+            return getattr(geolocation, 'coordinates', None)
+        return ALGOLIA_DEFAULT_GEO_COORDINATES
 
 
 class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -16,7 +16,7 @@ from course_discovery.apps.course_metadata.choices import ExternalProductStatus,
 from course_discovery.apps.course_metadata.models import CourseRunStatus, CourseType, ProductValue
 from course_discovery.apps.course_metadata.tests.factories import (
     AdditionalMetadataFactory, CourseFactory, CourseRunFactory, CourseTypeFactory, DegreeAdditionalMetadataFactory,
-    DegreeFactory, LevelTypeFactory, OrganizationFactory, ProductMetaFactory, ProgramFactory,
+    DegreeFactory, GeoLocationFactory, LevelTypeFactory, OrganizationFactory, ProductMetaFactory, ProgramFactory,
     ProgramSubscriptionFactory, ProgramSubscriptionPriceFactory, ProgramTypeFactory, SeatFactory, SeatTypeFactory,
     SourceFactory, SubjectFactory, VideoFactory
 )
@@ -452,6 +452,21 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         course = AlgoliaProxyCourseFactory()
         assert len(course.subscription_prices) == 0
 
+    def test_course_coordinates_match_geolocation(self):
+        """
+        Verify the course's coordinates match its associated geolocation
+        """
+        geolocation = GeoLocationFactory()
+        course = AlgoliaProxyCourseFactory(geolocation=geolocation)
+        assert course.coordinates == geolocation.coordinates
+
+    def test_default_course_coordinates_if_no_geolocation(self):
+        """
+        Verify default course coordinates if geolocation is None
+        """
+        course = AlgoliaProxyCourseFactory(geolocation=None)
+        assert course.coordinates == (38.951302, -76.8731)
+
     def test_course_key(self):
         """
         Verify the course key is returned for course.
@@ -751,6 +766,21 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         else:
             program = AlgoliaProxyProgramFactory(subscription=None)
             assert len(program.subscription_prices) == 0
+
+    def test_coordinates_match_geolocation(self):
+        """
+        Verify the program's coordinates match its associated geolocation
+        """
+        geolocation = GeoLocationFactory()
+        program = AlgoliaProxyProgramFactory(geolocation=geolocation)
+        assert program.coordinates == geolocation.coordinates
+
+    def test_default_coordinates_if_no_geolocation(self):
+        """
+        Verify default program coordinates if geolocation is None
+        """
+        program = AlgoliaProxyProgramFactory(geolocation=None)
+        assert program.coordinates == (38.951302, -76.8731)
 
     def test_external_url_when_present(self):
         program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner)


### PR DESCRIPTION
Adds a default set of coordinates to courses and programs into Algolia during indexing.
The default coordinates are the Langham, MD Headquarters