### PR TITLE
fix: add verified only course type

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -2162,7 +2162,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         CourseEntitlementFactory(course=self.course, mode=SeatTypeFactory.verified())
 
         url = reverse('api:v1:course-detail', kwargs={'key': self.course.uuid})
-        with self.assertNumQueries(40, threshold=0):
+        with self.assertNumQueries(41, threshold=0):
             response = self.client.options(url)
         assert response.status_code == 200
 

--- a/course_discovery/apps/course_metadata/migrations/0321_add_verified_only_course_type.py
+++ b/course_discovery/apps/course_metadata/migrations/0321_add_verified_only_course_type.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+TYPE_NAME = 'Verified Only'
+SLUG = 'verified'
+
+
+def add_verified_only_types(apps, schema_editor):
+    CourseType = apps.get_model('course_metadata', 'CourseType')
+    CourseRunType = apps.get_model('course_metadata', 'CourseRunType')
+    Track = apps.get_model('course_metadata', 'Track')
+    Mode = apps.get_model('course_metadata', 'Mode')
+    SeatType = apps.get_model('course_metadata', 'SeatType')
+
+    mode = Mode.objects.get(slug=SLUG)
+    seat_type = SeatType.objects.get(slug=SLUG)
+    run_type, _ = CourseRunType.objects.update_or_create(name=TYPE_NAME, slug=SLUG)
+    run_type.tracks.set([Track.objects.get(mode=mode, seat_type=seat_type)])
+
+    course_type, _ = CourseType.objects.update_or_create(name=TYPE_NAME, slug=SLUG)
+    course_type.entitlement_types.set([seat_type])
+    course_type.course_run_types.set([run_type])
+
+
+def remove_verified_only_types(apps, schema_editor):
+    CourseType = apps.get_model('course_metadata', 'CourseType')
+    CourseRunType = apps.get_model('course_metadata', 'CourseRunType')
+
+    CourseType.objects.filter(slug=SLUG).delete()
+    CourseRunType.objects.filter(slug=SLUG).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('course_metadata', '0320_allow_blank_exclude_from_search_and_seo'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=add_verified_only_types,
+            reverse_code=remove_verified_only_types,
+        ),
+    ]


### PR DESCRIPTION
This is a backport of the #3744

Discovery fires the error when the `refresh_course_metadata` management command works if ecommerce has the `verified only` course set up. This PR introduces the migration to add missing course/courserun type.