### PR TITLE
chore: unpin django-autocomplete-light to add dark mode support on admin

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/bulk_upload_tags.py
+++ b/course_discovery/apps/course_metadata/management/commands/bulk_upload_tags.py
@@ -99,7 +99,6 @@ class Command(BaseCommand):
             return
 
         for obj in query_set:
-            # pylint: disable=logging-not-lazy
             logger.info(f'Setting tags for {product_type} with uuid -{product_uuid}: {tags}')
             getattr(obj, field).set(tags)
             obj.save()

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,7 @@ cairosvg
 contentful
 django
 django-admin-sortable2
-django-autocomplete-light==3.9.0rc1
+django-autocomplete-light
 django-choices
 django-compressor
 django-config-models

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -44,3 +44,6 @@ cairocffi < 1.5.0
 
 # 1.0.0 has breaking changes
 requests-toolbelt==0.10.1
+
+# 4.0.0 introduces some breaking changes  which will be resolved in a followup PR
+edx-event-bus-kafka==3.9.6

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -71,9 +71,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.26.129
+boto3==1.26.132
     # via django-ses
-botocore==1.29.129
+botocore==1.29.132
     # via
     #   boto3
     #   s3transfer
@@ -179,6 +179,7 @@ distro==1.8.0
     #   algoliasearch-django
     #   django-admin-sortable2
     #   django-appconf
+    #   django-autocomplete-light
     #   django-choices
     #   django-config-models
     #   django-contrib-comments
@@ -222,7 +223,7 @@ django-admin-sortable2==1.0.4
     #   -r requirements/base.in
 django-appconf==1.0.5
     # via django-compressor
-django-autocomplete-light==3.9.0rc1
+django-autocomplete-light==3.9.5
     # via -r requirements/base.in
 django-choices==1.7.2
     # via
@@ -383,7 +384,9 @@ edx-drf-extensions==8.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
 edx-event-bus-kafka==3.9.6
-    # via -r requirements/base.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via -r requirements/local.in
 edx-lint==5.3.4
@@ -425,7 +428,7 @@ face==22.0.0
     # via glom
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.6.2
+faker==18.7.0
     # via factory-boy
 fastavro==1.7.4
     # via openedx-events
@@ -442,7 +445,7 @@ frozenlist==1.3.3
     #   aiosignal
 future==0.18.3
     # via pyjwkest
-getsmarter-api-clients==0.5.1
+getsmarter-api-clients==0.5.4
     # via -r requirements/base.in
 glom==22.1.0
     # via semgrep
@@ -450,7 +453,7 @@ google-api-core==2.11.0
     # via google-api-python-client
 google-api-python-client==2.86.0
     # via -r requirements/base.in
-google-auth==2.17.3
+google-auth==2.18.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -465,7 +468,7 @@ google-auth-oauthlib==1.0.0
     # via gspread
 googleapis-common-protos==1.59.0
     # via google-api-core
-gspread==5.8.0
+gspread==5.9.0
     # via -r requirements/base.in
 h11==0.14.0
     # via wsproto
@@ -550,7 +553,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openai==0.27.6
     # via taxonomy-connector
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector
@@ -597,7 +600,7 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.38
     # via click-repl
-protobuf==4.22.4
+protobuf==4.23.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -630,7 +633,7 @@ pygments==2.15.1
     #   sphinx
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
     #   edx-auth-backends
@@ -738,7 +741,7 @@ pyyaml==5.4.1
     #   responses
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.4
+redis==4.5.5
     # via -r requirements/base.in
 requests==2.30.0
     # via
@@ -784,7 +787,7 @@ rjsmin==1.2.1
     # via django-compressor
 rsa==4.9
     # via google-auth
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via
     #   drf-yasg
     #   semgrep
@@ -792,7 +795,7 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 s3transfer==0.6.1
     # via boto3
-selenium==4.9.0
+selenium==4.9.1
     # via -r requirements/test.in
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -878,7 +881,7 @@ stevedore==5.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.38.0
+taxonomy-connector==1.38.1
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in
@@ -938,6 +941,7 @@ urllib3[socks]==1.26.15
     #   botocore
     #   docker
     #   elasticsearch
+    #   google-auth
     #   requests
     #   responses
     #   selenium

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -44,9 +44,9 @@ beautifulsoup4==4.12.2
     #   taxonomy-connector
 billiard==3.6.4.0
     # via celery
-boto3==1.26.129
+boto3==1.26.132
     # via django-ses
-botocore==1.29.129
+botocore==1.29.132
     # via
     #   boto3
     #   s3transfer
@@ -125,6 +125,7 @@ django==3.2.19
     #   algoliasearch-django
     #   django-admin-sortable2
     #   django-appconf
+    #   django-autocomplete-light
     #   django-choices
     #   django-config-models
     #   django-contrib-comments
@@ -166,7 +167,7 @@ django-admin-sortable2==1.0.4
     #   -r requirements/base.in
 django-appconf==1.0.5
     # via django-compressor
-django-autocomplete-light==3.9.0rc1
+django-autocomplete-light==3.9.5
     # via -r requirements/base.in
 django-choices==1.7.2
     # via
@@ -312,7 +313,9 @@ edx-drf-extensions==8.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
 edx-event-bus-kafka==3.9.6
-    # via -r requirements/base.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.in
@@ -349,7 +352,7 @@ frozenlist==1.3.3
     #   aiosignal
 future==0.18.3
     # via pyjwkest
-getsmarter-api-clients==0.5.1
+getsmarter-api-clients==0.5.4
     # via -r requirements/base.in
 gevent==22.10.2
     # via -r requirements/production.in
@@ -357,7 +360,7 @@ google-api-core==2.11.0
     # via google-api-python-client
 google-api-python-client==2.86.0
     # via -r requirements/base.in
-google-auth==2.17.3
+google-auth==2.18.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -374,7 +377,7 @@ googleapis-common-protos==1.59.0
     # via google-api-core
 greenlet==2.0.2
     # via gevent
-gspread==5.8.0
+gspread==5.9.0
     # via -r requirements/base.in
 gunicorn==20.1.0
     # via -r requirements/production.in
@@ -440,7 +443,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openai==0.27.6
     # via taxonomy-connector
-openedx-events==7.1.0
+openedx-events==7.2.0
     # via
     #   edx-event-bus-kafka
     #   taxonomy-connector
@@ -464,7 +467,7 @@ platformdirs==3.5.0
     # via zeep
 prompt-toolkit==3.0.38
     # via click-repl
-protobuf==4.22.4
+protobuf==4.23.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -486,7 +489,7 @@ pycryptodomex==3.17
     #   snowflake-connector-python
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
     #   edx-auth-backends
@@ -543,7 +546,7 @@ pyyaml==6.0
     #   edx-django-release-util
 rcssmin==1.1.1
     # via django-compressor
-redis==4.5.4
+redis==4.5.5
     # via -r requirements/base.in
 requests==2.30.0
     # via
@@ -580,7 +583,7 @@ rjsmin==1.2.1
     # via django-compressor
 rsa==4.9
     # via google-auth
-ruamel-yaml==0.17.24
+ruamel-yaml==0.17.26
     # via drf-yasg
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -632,7 +635,7 @@ stevedore==5.0.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.38.0
+taxonomy-connector==1.38.1
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -659,6 +662,7 @@ urllib3==1.26.15
     # via
     #   botocore
     #   elasticsearch
+    #   google-auth
     #   requests
     #   snowflake-connector-python
 vine==5.0.0


### PR DESCRIPTION
### [PROD-3222](https://2u-internal.atlassian.net/browse/PROD-3222)

### Description
This PR unpins django-autocomplete-light to get admin dark support. This package was pinned in https://github.com/openedx/course-discovery/pull/3163. The dark mode support has been added in the package https://github.com/yourlabs/django-autocomplete-light/pull/1308.
<img width="1304" alt="Screenshot 2023-05-11 at 10 55 45 AM" src="https://github.com/openedx/course-discovery/assets/40599381/926fca62-88c1-44ac-bad6-249d7236569e">


