### PR TITLE
fix: increase throttling limit of course_review and course_recommenda…

### DIFF
--- a/course_discovery/apps/api/v1/views/course_review.py
+++ b/course_discovery/apps/api/v1/views/course_review.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.throttling import UserRateThrottle
 
 from course_discovery.apps.api.serializers import CourseReviewSerializer
 from course_discovery.apps.course_metadata.models import CourseReview
@@ -7,6 +8,9 @@ from course_discovery.apps.course_metadata.models import CourseReview
 
 class CourseReviewViewSet(viewsets.ReadOnlyModelViewSet):
     """ CourseReview. """
+
+    throttle_classes = [UserRateThrottle]
+    throttle_rate = '150/hour'
     queryset = CourseReview.objects.all()
     serializer_class = CourseReviewSerializer
     permission_classes = (IsAuthenticated,)

--- a/course_discovery/apps/taxonomy_support/api/v1/views.py
+++ b/course_discovery/apps/taxonomy_support/api/v1/views.py
@@ -1,6 +1,7 @@
 from rest_framework import permissions
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 
 from course_discovery.apps.course_metadata.models import Course
 from course_discovery.apps.taxonomy_support.api.v1.serializers import CourseRecommendationsSerializer
@@ -12,6 +13,8 @@ class CourseRecommendationsAPIView(ListAPIView):
     Example:
         GET discovery.edx.org/taxonomy/api/v1/course_recommendations/edX+DemoX/
     """
+    throttle_classes = [UserRateThrottle]
+    throttle_rate = '150/hour'
     permission_classes = (permissions.IsAuthenticated,)
     queryset = Course.objects.all()
     serializer_class = CourseRecommendationsSerializer


### PR DESCRIPTION
**Description**
we are getting 429 Errors from these endpoints:
- https://discovery.edx.org/taxonomy/api/v1/course_recommendations/DelftX+UnixTx/
- https://discovery.edx.org/api/v1/course_review/DelftX+UnixTx/

**Solution**
I have increased the throttle limit from 100/hour to 150/hour to avoid 429 errors for these endpoints.

[JIRA ENT-7138](https://2u-internal.atlassian.net/browse/ENT-7138)