### PR TITLE
feat: upgrade openedx-events

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -557,7 +557,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openai==0.27.6
     # via taxonomy-connector
-openedx-events==7.2.0
+openedx-events==7.3.0
     # via
     #   edx-event-bus-kafka
     #   edx-event-bus-redis

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -447,7 +447,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openai==0.27.6
     # via taxonomy-connector
-openedx-events==7.2.0
+openedx-events==7.3.0
     # via
     #   edx-event-bus-kafka
     #   edx-event-bus-redis


### PR DESCRIPTION
Generated by changing the Makefile to use `--upgrade-package openedx-events`. Necessary to remove the signal argument from the consumer.