### PR TITLE
fix: update archive_stale_products method to use ProductStatus.Archived status

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -401,12 +401,12 @@ class CSVDataLoader(AbstractDataLoader):
         all_product_additional_metadatas = AdditionalMetadata.objects.filter(
             related_courses__type__slug=self.product_type,
             related_courses__product_source=self.product_source,
-            product_status='Published'
+            product_status=ExternalProductStatus.Published,
         ).values_list('external_identifier', flat=True)
 
         archived_products = set(all_product_additional_metadatas).difference(course_external_identifiers)
         archived_products_queryset = AdditionalMetadata.objects.filter(external_identifier__in=archived_products)
-        archived_products_queryset.update(product_status="Archived")
+        archived_products_queryset.update(product_status=ExternalProductStatus.Archived)
         self.ingestion_summary['archived_products'] = list(archived_products)
 
         logger.info(

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -10,7 +10,7 @@ from testfixtures import LogCapture
 
 from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
-from course_discovery.apps.course_metadata.choices import ExternalCourseMarketingType
+from course_discovery.apps.course_metadata.choices import ExternalCourseMarketingType, ExternalProductStatus
 from course_discovery.apps.course_metadata.data_loaders.csv_loader import CSVDataLoader
 from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
 from course_discovery.apps.course_metadata.data_loaders.tests.mixins import CSVLoaderMixin
@@ -273,21 +273,21 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         self.mock_ecommerce_publication(self.partner)
         self.mock_image_response()
 
-        additional_metadata_one = AdditionalMetadataFactory(product_status="Published")
+        additional_metadata_one = AdditionalMetadataFactory(product_status=ExternalProductStatus.Published)
         CourseFactory(
             key='test+123', partner=self.partner, type=self.course_type,
             draft=False, additional_metadata=additional_metadata_one,
             product_source=self.source
         )
 
-        additional_metadata_two = AdditionalMetadataFactory(product_status="Published")
+        additional_metadata_two = AdditionalMetadataFactory(product_status=ExternalProductStatus.Published)
         CourseFactory(
             key='test+124', partner=self.partner, type=self.course_type,
             draft=False, additional_metadata=additional_metadata_two,
             product_source=self.source
         )
 
-        additional_metadata__source_2 = AdditionalMetadataFactory(product_status="Published")
+        additional_metadata__source_2 = AdditionalMetadataFactory(product_status=ExternalProductStatus.Published)
         CourseFactory(
             key='test+125', partner=self.partner, type=self.course_type,
             draft=False, additional_metadata=additional_metadata_two,
@@ -349,7 +349,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
 
                     # Assert that a product status with different product source is not affected in Archive flow.
                     additional_metadata__source_2.refresh_from_db()
-                    assert additional_metadata__source_2.product_status == "Published"
+                    assert additional_metadata__source_2.product_status == ExternalProductStatus.Published
 
     @responses.activate
     def test_ingest_flow_for_preexisting_published_course(self, jwt_decode_patch):  # pylint: disable=unused-argument


### PR DESCRIPTION
[PROD-3362](https://2u-internal.atlassian.net/browse/PROD-3362)
-------------

## Description
This PR replaces the hardcoded value of `product_status` with the `ExternalProductStatus` Choice object. 

The reason for this change is that currently, there are some courses where the product_status value is set to `Archived`, but it is not appearing as a selectable option in the dropdown menu on the publisher's Course Edit Form. This mismatch occurs because the available options for productStatusOptions, obtained from the API, have the product_status in lowercase (i.e., `archived`). As a result, the corresponding selection is not being made correctly selected from dropdown on publisher