### PR TITLE
WS-3994: add subscription eligibility to availability

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -583,6 +583,9 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
             for status in course_status:
                 availability.add(status)
 
+        if self.subscription_eligible:
+            availability.add(_('Available by subscription'))
+
         return list(availability)
 
     @property

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -747,6 +747,10 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         program.subscription = None if subscription_eligible is None else \
             ProgramSubscriptionFactory(subscription_eligible=subscription_eligible)
         self.assertEqual(program.subscription_eligible, subscription_eligible)
+        if subscription_eligible:
+            assert 'Available by subscription' in program.availability_level
+        else:
+            assert program.availability_level == []
 
     @ddt.data(
         None,


### PR DESCRIPTION
Use the `subscription_eligible` field to add an "Available by subscription" option to `availability_level` for programs only.

Tested with stage index to confirm that this option does NOT automatically appear in the frontend filters, so we can merge this before implementing the frontend changes.

Internal ticket: https://2u-internal.atlassian.net/browse/WS-3994