### PR TITLE
chore: updated security contact email

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ Reporting Security Issues
 **************************
 
 
-Please do not report security issues in public. Please email security@tcril.org.
+Please do not report security issues in public. Please email security@openedx.org.
 
 More Help
 *********


### PR DESCRIPTION
This PR relies on this [issue](https://github.com/openedx/wg-security/issues/15) to update the security email contact.