### PR TITLE
chore: taxonomy-connector version bump to 1.40.1

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -60,6 +60,7 @@ backoff==2.2.1
 backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
+    #   celery
     #   kombu
 bcrypt==4.0.1
     # via paramiko
@@ -68,16 +69,16 @@ beautifulsoup4==4.12.2
     #   -r requirements/base.in
     #   pydata-sphinx-theme
     #   taxonomy-connector
-billiard==3.6.4.0
+billiard==4.1.0
     # via celery
 boltons==21.0.0
     # via
     #   face
     #   glom
     #   semgrep
-boto3==1.26.146
+boto3==1.26.147
     # via django-ses
-botocore==1.29.146
+botocore==1.29.147
     # via
     #   boto3
     #   s3transfer
@@ -91,7 +92,7 @@ cairocffi==1.4.0
     #   cairosvg
 cairosvg==2.7.0
     # via -r requirements/base.in
-celery==5.2.7
+celery==5.3.0
     # via
     #   -c requirements/constraints.txt
     #   taxonomy-connector
@@ -266,7 +267,7 @@ django-elasticsearch-dsl==7.3
     #   django-elasticsearch-dsl-drf
 django-elasticsearch-dsl-drf==0.22.5
     # via -r requirements/base.in
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.in
 django-filter==23.2
     # via
@@ -704,6 +705,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.in
     #   botocore
+    #   celery
     #   contentful
     #   edx-drf-extensions
     #   elasticsearch-dsl
@@ -730,7 +732,6 @@ pytz==2023.3
     # via
     #   -r requirements/base.in
     #   babel
-    #   celery
     #   django
     #   django-ses
     #   djangorestframework
@@ -895,7 +896,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.40.0
+taxonomy-connector==1.40.1
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in
@@ -944,6 +945,7 @@ typing-extensions==4.6.3
 tzdata==2023.3
     # via
     #   backports-zoneinfo
+    #   celery
     #   pandas
 ujson==5.7.0
     # via python-lsp-jsonrpc

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -41,16 +41,17 @@ backoff==2.2.1
 backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
+    #   celery
     #   kombu
 beautifulsoup4==4.12.2
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
-billiard==3.6.4.0
+billiard==4.1.0
     # via celery
-boto3==1.26.146
+boto3==1.26.147
     # via django-ses
-botocore==1.29.146
+botocore==1.29.147
     # via
     #   boto3
     #   s3transfer
@@ -62,7 +63,7 @@ cairocffi==1.4.0
     #   cairosvg
 cairosvg==2.7.0
     # via -r requirements/base.in
-celery==5.2.7
+celery==5.3.0
     # via
     #   -c requirements/constraints.txt
     #   taxonomy-connector
@@ -205,7 +206,7 @@ django-elasticsearch-dsl==7.3
     #   django-elasticsearch-dsl-drf
 django-elasticsearch-dsl-drf==0.22.5
     # via -r requirements/base.in
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.in
 django-filter==23.2
     # via
@@ -520,6 +521,7 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.in
     #   botocore
+    #   celery
     #   contentful
     #   edx-drf-extensions
     #   elasticsearch-dsl
@@ -539,7 +541,6 @@ python3-openid==3.2.0
 pytz==2023.3
     # via
     #   -r requirements/base.in
-    #   celery
     #   django
     #   django-ses
     #   djangorestframework
@@ -649,7 +650,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.40.0
+taxonomy-connector==1.40.1
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -668,6 +669,7 @@ typing-extensions==4.6.3
 tzdata==2023.3
     # via
     #   backports-zoneinfo
+    #   celery
     #   pandas
 unicodecsv==0.14.1
     # via djangorestframework-csv


### PR DESCRIPTION
**Decription**
This PR is purely for taxonomy-connector verison bump. Ran `make upgrade`. 

JIRA: [ENT-7192](https://2u-internal.atlassian.net/browse/ENT-7192)