### PR TITLE
chore: superuser ability to add product source from admin for products with no source

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -280,7 +280,8 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
 
         self.excluded_course_run = factories.CourseRunFactory(course=self.courses[0])
         self.program = factories.ProgramFactory(
-            courses=self.courses, excluded_course_runs=[self.excluded_course_run], status=ProgramStatus.Unpublished
+            courses=self.courses, excluded_course_runs=[self.excluded_course_run], status=ProgramStatus.Unpublished,
+            product_source=None
         )
 
         self.user = UserFactory(is_staff=True, is_superuser=True)
@@ -376,9 +377,10 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
     def test_program_update(self):
         self._navigate_to_edit_page()
         self.assert_form_fields_present()
-
         title = 'Test Program'
         subtitle = 'This is a test.'
+
+        assert self.program.product_source is None
 
         # Update the program
         data = (
@@ -390,13 +392,14 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
             element = self.browser.find_element(By.ID, 'id_' + field)
             element.clear()
             element.send_keys(value)
-
+        self._select_option('id_product_source', str(self.product_source.id))
         self._submit_program_form()
 
         # Verify the program was updated
         self.program = Program.objects.get(pk=self.program.pk)
         assert self.program.title == title
         assert self.program.subtitle == subtitle
+        assert self.program.product_source == self.product_source
 
 
 class ProgramEligibilityFilterTests(SiteMixin, TestCase):


### PR DESCRIPTION
### [PROD-3400](https://2u-internal.atlassian.net/browse/PROD-3400)

### Description
- Add ability for superusers to assign product_source to course & program from admin if either model object does not have product_source. 
- Add list filter on product_source for Course & Program admins

### Testing
- Make sure you have at least one course and one program with no source value
- Go to admin as a superuser. Visit the course & program. The source will be editable
- Go to admin as a staff user (add perms to view & edit course & program). Visit the course & program. The source will not be editable
- As superuser, add product source to course and program. The source will no longer be editable after save.