### PR TITLE
fix: Product Value Data Loader checks existing product value correctly

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/product_value_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/product_value_loader.py
@@ -140,8 +140,8 @@ class ProductValueCSVDataLoader(AbstractDataLoader):
         for field in self.PRODUCT_VALUE_DATA_FIELDS:
             if (field in data and data[field]):
                 values[field] = data[field]
-            elif (field in product_value and product_value[field]):
-                values[field] = product_value[field]
+            elif hasattr(product_value, field):
+                values[field] = getattr(product_value, field)
             else:
                 values[field] = 0
         return values


### PR DESCRIPTION
There was an issue in the existing product value data loader where we were iterating over the fields on existing product values incorrectly. This PR fixes this overlook.