### PR TITLE
feat: handle timestamp updates for additional metadata in course api

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -1120,6 +1120,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         course = CourseFactory(additional_metadata=None, type=type_2U)
         current = datetime.datetime.now(pytz.UTC)
         future = current + datetime.timedelta(days=10)
+        previous_data_modified_timestamp = course.data_modified_timestamp
 
         additional_metadata = {
             'external_url': 'https://example.com/',
@@ -1154,6 +1155,9 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         course = Course.everything.get(uuid=course.uuid, draft=True)
         self.assertDictEqual(self.serialize_course(course)['additional_metadata'], additional_metadata)
 
+        assert previous_data_modified_timestamp < course.data_modified_timestamp
+        previous_data_modified_timestamp = course.data_modified_timestamp
+
         # test if object update on same course is successful
         new_facts = [
             {
@@ -1164,17 +1168,11 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
                 'heading': 'New Fact heading 333',
                 'blurb': '<p>New Fact blurb 2</p>',
             }
-
         ]
-        new_cert = {
-            'heading': 'New Certificate heading',
-            'blurb': '<p>New Certificate blurb</p>',
-        }
         course_data = {
             'additional_metadata': {
                 'external_identifier': '67890',  # change external_identifier
                 'facts': new_facts,
-                'certificate_info': new_cert,
             }
         }
         response = self.client.patch(url, course_data, format='json')
@@ -1183,8 +1181,26 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
 
         additional_metadata['external_identifier'] = '67890'  # to make sure that the value is updated
         additional_metadata['facts'] = new_facts
+        self.assertDictEqual(self.serialize_course(course)['additional_metadata'], additional_metadata)
+        assert previous_data_modified_timestamp < course.data_modified_timestamp
+        previous_data_modified_timestamp = course.data_modified_timestamp
+
+        new_cert = {
+            'heading': 'New Certificate heading',
+            'blurb': '<p>New Certificate blurb</p>',
+        }
+        course_data = {
+            'additional_metadata': {
+                'certificate_info': new_cert,
+            }
+        }
+        response = self.client.patch(url, course_data, format='json')
+        assert response.status_code == 200
+        course = Course.everything.get(uuid=course.uuid, draft=True)
+
         additional_metadata['certificate_info'] = new_cert
         self.assertDictEqual(self.serialize_course(course)['additional_metadata'], additional_metadata)
+        assert previous_data_modified_timestamp < course.data_modified_timestamp
 
     @ddt.data(CourseType.VERIFIED_AUDIT, CourseType.PROFESSIONAL)
     @responses.activate
@@ -1206,13 +1222,16 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         assert self.serialize_course(course)['additional_metadata'] is None
 
     @responses.activate
-    def test_update_facts_with_additional_metadata(self):
+    def test_update_facts_with_additional_metadata(self):  # pylint: disable=too-many-statements
         current = datetime.datetime.now(pytz.UTC)
 
         EE_type_2U = CourseTypeFactory(slug=CourseType.EXECUTIVE_EDUCATION_2U)
         course_1 = CourseFactory(additional_metadata=None, type=EE_type_2U)
         course_2 = CourseFactory(additional_metadata=None, type=EE_type_2U)
         course_3 = CourseFactory(additional_metadata=None, type=EE_type_2U)
+        course_1_previous_data_modified_timestamp = course_1.data_modified_timestamp
+        course_2_previous_data_modified_timestamp = course_2.data_modified_timestamp
+        course_3_previous_data_modified_timestamp = course_3.data_modified_timestamp
         fact_1 = {'heading': 'Fact1 heading', 'blurb': '<p>Fact1 blurb</p>'}
         fact_2 = {'heading': 'Fact2 heading', 'blurb': '<p>Fact2 blurb</p>'}
         fact_3 = {'heading': 'Fact3 heading', 'blurb': '<p>Fact3 blurb</p>'}
@@ -1276,6 +1295,14 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         self.assertDictEqual(self.serialize_course(course_2)['additional_metadata'], additional_metadata_2)
         self.assertDictEqual(self.serialize_course(course_3)['additional_metadata'], additional_metadata_3)
 
+        assert course_1_previous_data_modified_timestamp < course_1.data_modified_timestamp
+        assert course_2_previous_data_modified_timestamp < course_2.data_modified_timestamp
+        assert course_3_previous_data_modified_timestamp < course_3.data_modified_timestamp
+
+        course_1_previous_data_modified_timestamp = course_1.data_modified_timestamp
+        course_2_previous_data_modified_timestamp = course_2.data_modified_timestamp
+        course_3_previous_data_modified_timestamp = course_3.data_modified_timestamp
+
         response_1 = self.client.patch(url_1, {'additional_metadata': {'facts': [fact_3]}}, format='json')
         assert response_1.status_code == 200
         assert Fact.objects.count() == 6    # orphaned fact 1, and just removed 2 from relation, created 3
@@ -1285,7 +1312,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         assert Fact.objects.count() == 6    # fact 1 was already orphaned, it just used it
 
         response_3 = self.client.patch(url_3, {'additional_metadata': {'facts': [fact_1, fact_3]}}, format='json')
-        assert response_2.status_code == 200
+        assert response_3.status_code == 200
         assert Fact.objects.count() == 6    # no new fact created, just updated/overwrite self facts as count is same
 
         course_1 = Course.everything.get(uuid=course_1.uuid, draft=True)
@@ -1299,6 +1326,9 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         self.assertDictEqual(self.serialize_course(course_1)['additional_metadata'], additional_metadata_1)
         self.assertDictEqual(self.serialize_course(course_2)['additional_metadata'], additional_metadata_2)
         self.assertDictEqual(self.serialize_course(course_3)['additional_metadata'], additional_metadata_3)
+        assert course_1_previous_data_modified_timestamp < course_1.data_modified_timestamp
+        assert course_2_previous_data_modified_timestamp < course_2.data_modified_timestamp
+        assert course_3_previous_data_modified_timestamp < course_3.data_modified_timestamp
 
     @ddt.data(
         (
@@ -1356,6 +1386,7 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
 
         EE_type_2U = CourseTypeFactory(slug=CourseType.EXECUTIVE_EDUCATION_2U)
         course = CourseFactory(additional_metadata=None, type=EE_type_2U)
+        previous_data_modified_timestamp = course.data_modified_timestamp
         product_meta = {
             "title": "Test",
             "description": "Test Description",
@@ -1386,7 +1417,6 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         }
 
         url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})
-
         response = self.client.patch(url, {'additional_metadata': additional_metadata}, format='json')
 
         assert response.status_code == 200
@@ -1394,13 +1424,41 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         # The ProductMeta objects are being created 2 times.
         # Once when the CourseViewSetTests create a Factory Course
         # and once while running this testcase.
-        assert ProductMeta.objects.count() == 2    # created two new objects
+        assert ProductMeta.objects.count() == 2
 
         course = Course.everything.get(uuid=course.uuid, draft=True)
 
         self.assertDictEqual(self.serialize_course(course)['additional_metadata'], additional_metadata)
-
         self.assertDictEqual(self.serialize_course(course)['additional_metadata']['product_meta'], product_meta)
+        assert previous_data_modified_timestamp < course.data_modified_timestamp
+
+        previous_data_modified_timestamp = course.data_modified_timestamp
+        # Some flaky behavior was observed on local due to element being in different order in serialized response.
+        # the following order of element is same as serialized response.
+        # Added this note in case this test causes odd behavior in the future.
+        product_meta['keywords'] = ['test2', 'test3']
+        response = self.client.patch(
+            url, {'additional_metadata': {'product_meta': product_meta}}, format='json'
+        )
+        additional_metadata['product_meta'] = product_meta
+        assert response.status_code == 200
+        course = Course.everything.get(uuid=course.uuid, draft=True)
+
+        self.assertDictEqual(self.serialize_course(course)['additional_metadata'], additional_metadata)
+        self.assertDictEqual(self.serialize_course(course)['additional_metadata']['product_meta'], product_meta)
+        assert previous_data_modified_timestamp < course.data_modified_timestamp
+
+        # If there is no product meta or keywords change, the timestamp won't be updated.
+        previous_data_modified_timestamp = course.data_modified_timestamp
+        response = self.client.patch(
+            url, {'additional_metadata': {'product_meta': product_meta}}, format='json'
+        )
+        additional_metadata['product_meta'] = product_meta
+        assert response.status_code == 200
+        course = Course.everything.get(uuid=course.uuid, draft=True)
+        self.assertDictEqual(self.serialize_course(course)['additional_metadata'], additional_metadata)
+        self.assertDictEqual(self.serialize_course(course)['additional_metadata']['product_meta'], product_meta)
+        assert previous_data_modified_timestamp == course.data_modified_timestamp
 
     @responses.activate
     def test_update_success_with_course_type_verified(self):

--- a/course_discovery/apps/core/tests/test_utils.py
+++ b/course_discovery/apps/core/tests/test_utils.py
@@ -1,10 +1,13 @@
+from ddt import data, ddt, unpack
 from django.db import models
 from django.test import TestCase
 
-from course_discovery.apps.core.utils import SearchQuerySetWrapper, delete_orphans, get_all_related_field_names
+from course_discovery.apps.core.utils import (
+    SearchQuerySetWrapper, delete_orphans, get_all_related_field_names, update_instance
+)
 from course_discovery.apps.course_metadata.models import Video
 from course_discovery.apps.course_metadata.search_indexes.documents import CourseRunDocument
-from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, VideoFactory
+from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, ImageFactory, VideoFactory
 
 
 class UnrelatedModel(models.Model):
@@ -35,6 +38,7 @@ class M2MRelatedModel(models.Model):
         managed = False
 
 
+@ddt
 class ModelUtilTests(TestCase):
     def test_get_all_related_field_names(self):
         """ Verify the method returns the names of all relational fields for a model. """
@@ -58,6 +62,44 @@ class ModelUtilTests(TestCase):
         delete_orphans(Video, {orphan.pk})
 
         assert orphan.__class__.objects.filter(pk=orphan.pk).exists()
+
+    @data(
+        (ImageFactory, {'description': 'new image description'}),
+        (VideoFactory, {'description': 'new video description'})
+    )
+    @unpack
+    def test_update_instance(self, instance_factory, updated_data):
+        """
+        Verify update_instance commit changes to DB if commit flag is True.
+        """
+        instance = instance_factory()
+        _, changed = update_instance(instance, updated_data, True)
+        instance.refresh_from_db()
+        assert changed is True
+        assert instance.description == updated_data['description']
+
+    @data(
+        (ImageFactory, {'description': 'new image description'}),
+        (VideoFactory, {'description': 'new video description'})
+    )
+    @unpack
+    def test_update_instance__no_commit(self, instance_factory, updated_data):
+        """
+        Verify update_instance does not commit changes to DB if commit flag is False.
+        """
+        instance = instance_factory()
+        _, changed = update_instance(instance, updated_data)
+        instance.refresh_from_db()
+        assert changed is True
+        assert instance.description != updated_data['description']
+
+    def test_update_instance__no_instance(self):
+        """
+        Verify the default values if no instance is provided to update_instance.
+        """
+        instance, changed = update_instance(None, {})
+        assert instance is None
+        assert changed is False
 
 
 class SearchQuerySetWrapperTests(TestCase):

--- a/course_discovery/apps/core/tests/test_utils.py
+++ b/course_discovery/apps/core/tests/test_utils.py
@@ -75,7 +75,7 @@ class ModelUtilTests(TestCase):
         instance = instance_factory()
         _, changed = update_instance(instance, updated_data, True)
         instance.refresh_from_db()
-        assert changed is True
+        assert changed
         assert instance.description == updated_data['description']
 
     @data(
@@ -90,7 +90,7 @@ class ModelUtilTests(TestCase):
         instance = instance_factory()
         _, changed = update_instance(instance, updated_data)
         instance.refresh_from_db()
-        assert changed is True
+        assert changed
         assert instance.description != updated_data['description']
 
     def test_update_instance__no_instance(self):
@@ -99,7 +99,7 @@ class ModelUtilTests(TestCase):
         """
         instance, changed = update_instance(None, {})
         assert instance is None
-        assert changed is False
+        assert not changed
 
 
 class SearchQuerySetWrapperTests(TestCase):

--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -180,3 +180,33 @@ def use_read_replica_if_available(queryset):
     If there is a database called 'read_replica', use that database for the queryset.
     """
     return queryset.using("read_replica") if "read_replica" in settings.DATABASES else queryset
+
+
+def update_instance(instance, data, should_commit=False, **kwargs):
+    """
+    Utility method to set any number of fields dynamically on a model instance and commit the changes
+    if applicable.
+
+    Arguments:
+        * instance (Model Object)
+        * data (dict): The dictionary containing mapping of model_fields -> values. The fields are not related fields.
+        * should_commit (Boolean): If provided, the changes in instance should be committed to DB
+        * kwargs (dict): additional params to pass to save() if provided
+
+    Return:
+        Tuple containing instance and boolean specify if the instance was updated.
+    """
+    if not instance:
+        return None, False
+
+    updated = False
+
+    for attr, value in data.items():
+        if hasattr(instance, attr) and getattr(instance, attr) != value:
+            setattr(instance, attr, value)
+            updated = True
+
+    if updated and should_commit:
+        instance.save(**kwargs)
+
+    return instance, updated

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -404,6 +404,9 @@ def course_m2m_changed(sender, instance, action, **kwargs):
 
 @receiver(m2m_changed, sender=ProductMeta.keywords.through)
 def course_taggable_manager_changed(sender, instance, action, **kwargs):
+    """
+    Signal handler to handle Taggable manager changes for the course tag field or course related models' tag fields.
+    """
     if action in ['pre_add', 'pre_remove'] and not kwargs['reverse'] \
             and kwargs['pk_set'] and instance._meta.label == 'course_metadata.ProductMeta':
         logger.info(f"{sender} has been updated for ProductMeta {instance.pk}.")


### PR DESCRIPTION
### [PROD-3296](https://2u-internal.atlassian.net/browse/PROD-3296)

### Description
This PR is a followup to https://github.com/openedx/course-discovery/pull/3867. One of the todos in the PR mentioned that AdditionalMetadata and its related models in course api are using .update() to update the underlying objects. When using queryset update(), save() is not called by Django internally, and thus no signals are sent. 

This PR changes AdditionalMetadata & related objects handling in course api to ensure the data modified timestamp is updated for Course when in course api:
- Any of field on AdditionalMetadata is updated in course
- CertificateInfo, one of FK on AdditionalMetadata, has one of its fields change
- Facts, a M2M field, has either m2m _relationship change or any of underlying Fact objects in the relationship is updated
- ProductMeta, one of FK on AdditionalMetadata, has its fields or **keywords** Taggable manager(M2M) change

### Testing
- Make sure you have one ExecEd course in your local discovery
- Checkout this branch.
- Run latest publisher on your local. 
- Go to ExecEd course. Change any of the main fields for AdditionalMetadata. Verify data modified timestamp for the course is updated
- Change any of CertificateInfo field and verify data modified timestamp for the course is updated
- Update product meta's title or description.  Verify data modified timestamp for the course is updated
- Add keywords on product meta.  Verify data modified timestamp for the course is updated
- Update product meta's title but do not change keyword. Verify from logs that m2m_changed is not called for ProductMeta
- Edit any fact object and verify data modified timestamp for the course is updated