### PR TITLE
WS-4069: add learning_type facet to algolia index

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -63,7 +63,7 @@ def delegate_attributes(cls):
     search_fields = ['partner_names', 'partner_keys', 'product_title', 'product_source', 'primary_description',
                      'secondary_description', 'tertiary_description']
     facet_fields = ['availability_level', 'subject_names', 'levels', 'active_languages', 'staff_slugs',
-                    'product_allowed_in', 'product_blocked_in']
+                    'product_allowed_in', 'product_blocked_in', 'learning_type']
     ranking_fields = ['availability_rank', 'product_recent_enrollment_count', 'promoted_in_spanish_index',
                       'product_value_per_click_usa', 'product_value_per_click_international',
                       'product_value_per_lead_usa', 'product_value_per_lead_international']
@@ -289,6 +289,10 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
     @property
     def program_types(self):
         return [program.type.name_t for program in self.programs.all()]
+
+    @property
+    def learning_type(self):
+        return [self.product_type, *self.program_types]
 
     @property
     def product_card_image_url(self):
@@ -528,6 +532,12 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
         if self.type:
             return [self.type.name_t]
         return None
+
+    @property
+    def learning_type(self):
+        if self.type:
+            return [self.type.name_t]
+        return []
 
     @property
     def tags(self):

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -80,7 +80,7 @@ class EnglishProductIndex(BaseProductIndex):
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
                     ('product_blocked_in', 'blocked_in'), 'subscription_eligible',
-                    'subscription_prices')
+                    'subscription_prices', 'learning_type',)
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'),
                       ('product_value_per_click_usa', 'value_per_click_usa'),
                       ('product_value_per_click_international', 'value_per_click_international'),
@@ -116,6 +116,7 @@ class EnglishProductIndex(BaseProductIndex):
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)', 'skills.skill',
             'skills.category', 'skills.subcategory', 'tags', 'subscription_eligible', 'subscription_prices',
+            'learning_type',
         ],
         'customRanking': ['asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
@@ -132,7 +133,7 @@ class SpanishProductIndex(BaseProductIndex):
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
                     ('product_blocked_in', 'blocked_in'), 'subscription_eligible',
-                    'subscription_prices',)
+                    'subscription_prices', 'learning_type',)
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'),
                       ('product_value_per_click_usa', 'value_per_click_usa'),
                       ('product_value_per_click_international', 'value_per_click_international'),
@@ -170,7 +171,7 @@ class SpanishProductIndex(BaseProductIndex):
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)',
             'skills.skill', 'skills.category', 'skills.subcategory', 'tags', 'subscription_eligible',
-            'subscription_prices',
+            'subscription_prices', 'learning_type',
         ],
         'customRanking': ['desc(promoted_in_spanish_index)', 'asc(availability_rank)', 'desc(recent_enrollment_count)']
     }

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -499,6 +499,28 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         assert course.product_value_per_lead_usa == ProductValue.DEFAULT_VALUE_PER_LEAD
         assert course.product_value_per_lead_international == ProductValue.DEFAULT_VALUE_PER_LEAD
 
+    @ddt.data(False, True)
+    def test_learning_type_open_course(self, has_program):
+        course_type = CourseTypeFactory()
+        course = AlgoliaProxyCourseFactory(partner=self.__class__.edxPartner, type=course_type)
+        if has_program:
+            program_type = ProgramTypeFactory()
+            program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
+            course.programs.set([program])
+            assert course.learning_type == ['Course', program_type.name_t]
+        else:
+            assert course.learning_type == ['Course']
+
+    @ddt.data(
+        (CourseType.EXECUTIVE_EDUCATION_2U, 'Executive Education'),
+        (CourseType.BOOTCAMP_2U, 'Boot Camp'),
+    )
+    @ddt.unpack
+    def test_learning_type_non_open_course(self, course_type_slug, expected_result):
+        course = AlgoliaProxyCourseFactory(partner=self.__class__.edxPartner)
+        course.type = CourseTypeFactory(slug=course_type_slug)
+        assert course.learning_type == [expected_result]
+
 
 @ddt.ddt
 @pytest.mark.django_db
@@ -810,3 +832,8 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         assert program.product_value_per_click_international == ProductValue.DEFAULT_VALUE_PER_CLICK
         assert program.product_value_per_lead_usa == ProductValue.DEFAULT_VALUE_PER_LEAD
         assert program.product_value_per_lead_international == ProductValue.DEFAULT_VALUE_PER_LEAD
+
+    def test_learning_type(self):
+        program_type = ProgramTypeFactory()
+        program = AlgoliaProxyProgramFactory(partner=self.__class__.edxPartner, type=program_type)
+        assert program.learning_type == [program_type.name_t]


### PR DESCRIPTION
Context: we currently have a "program type" filter in the product index, which is limited to just OC program types. We would like to introduce a new filter that includes all types of products, including courses, degree programs, etc.

This adds `learning_type` as a facet field, which, in most cases, returns a list with a single item representing the product type (`['Masters']`, `['Professional Certificate']`, `['Boot Camp']`, etc).

The exceptions to this are OC courses, which can also return the types of programs they belong to. For example, if a course belongs to both a Masters and Professional Certificate program, the return value would be `['Course', 'Masters', 'Professional Certificate']`.

Internal ticket: https://2u-internal.atlassian.net/browse/WS-4069