### PR TITLE
feat: add csv file to email attachment

### DIFF
--- a/course_discovery/apps/course_metadata/emails.py
+++ b/course_discovery/apps/course_metadata/emails.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+from email.mime.text import MIMEText
 from urllib.parse import urljoin
 
 import dateutil.parser
@@ -351,7 +352,11 @@ def send_ingestion_email(partner, subject, to_users, product_type, ingestion_det
 
 def send_email_for_slug_updates(stats, to_users):
     subject = 'Slugs Update Summary'
+    body = 'Please find the attached csv file for the summary of course slugs update.'
     email_msg = EmailMultiAlternatives(
-        subject, str(stats), settings.PUBLISHER_FROM_EMAIL, to_users
+        subject, body, settings.PUBLISHER_FROM_EMAIL, to_users
     )
+    attachment = MIMEText(stats, 'csv')
+    attachment.add_header('Content-Disposition', 'attachment', filename='slugs_update_summary.csv')
+    email_msg.attach(attachment)
     email_msg.send()

--- a/course_discovery/apps/course_metadata/management/commands/migrate_course_slugs.py
+++ b/course_discovery/apps/course_metadata/management/commands/migrate_course_slugs.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
         for course in courses:
             self._update_course_slug(course, dry_run)
 
-        send_email_for_slug_updates(self.slug_update_report, settings.NOTIFY_SLUG_UPDATE_RECIPIENTS)
+        send_email_for_slug_updates(self._get_report_in_csv_format(), settings.NOTIFY_SLUG_UPDATE_RECIPIENTS)
         self._log_report_in_csv_format()
 
     def _add_to_slug_update_report(self, course, new_slug=None, error=None):
@@ -162,11 +162,15 @@ class Command(BaseCommand):
 
         return Course.everything.filter(product_source__slug='edx', uuid__in=valid_course_uuids, draft=True)
 
-    def _log_report_in_csv_format(self):
+    def _get_report_in_csv_format(self):
         report_in_csv_format = "course_uuid,old_slug,new_slug,error\n"
 
         for record in self.slug_update_report:
             report_in_csv_format = report_in_csv_format + f"{record['course_uuid']},{record['old_slug']}," \
                                                           f"{record['new_slug']},{record['error']}\n"
 
+        return report_in_csv_format
+
+    def _log_report_in_csv_format(self):
+        report_in_csv_format = self._get_report_in_csv_format()
         logger.info(report_in_csv_format)

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -636,17 +636,27 @@ class TestSlugUpdatesEmail(TestCase):
     USER_EMAILS = ['edx@example.com']
 
     def test_send_email_for_slug_updates(self):
-        stats = [{
+        slugs_summary_data = [{
             'course_uuid': 'uuid-text',
             'old_slug': 'course-title',
             'new_slug': 'learn/subject/organization-course-title',
             'error': 'some error'
         }]
+        stats = 'course_uuid,old_url_slug,new_url_slug,error_msg\n'
+        for slug in slugs_summary_data:
+            stats += f"{slug['course_uuid']},{slug['old_slug']},{slug['new_slug']},{slug['error']}\n"
+
         emails.send_email_for_slug_updates(stats, self.USER_EMAILS)
         email = mail.outbox[0]
 
         assert email.to == self.USER_EMAILS
         assert str(email.subject) == self.EMAIL_SUBJECT
         assert len(mail.outbox) == 1
-        expected_response = str(stats)
+        expected_response = 'Please find the attached csv file for the summary of course slugs update.'
         assert email.body == expected_response
+
+        assert email.attachments is not None
+        assert len(email.attachments) == 1
+        assert email.attachments[0].get_filename() == 'slugs_update_summary.csv'
+        assert email.attachments[0].get_content_type() == 'text/csv'
+        assert email.attachments[0].get_payload() == stats


### PR DESCRIPTION
[PROD-3443](https://2u-internal.atlassian.net/browse/PROD-3443)
-------------
This PR adds `csv file` to email attachment instead of `JSON` form text
### Email Screennshot
<img width="1197" alt="image" src="https://github.com/openedx/course-discovery/assets/78806673/f20a4c00-9142-4aca-82be-e54fa1b875b0">

### Csv file
<img width="561" alt="image" src="https://github.com/openedx/course-discovery/assets/78806673/cb3f6499-8938-4ccf-a584-d439e7f054ed">
