### PR TITLE
feat: Added values for skills verification related settings in discovery settings.

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -599,6 +599,11 @@ TAXONOMY_PROGRAM_METADATA_PROVIDER = 'course_discovery.apps.taxonomy_support.pro
 TAXONOMY_XBLOCK_METADATA_PROVIDER = 'course_discovery.apps.taxonomy_support.providers.DiscoveryXBlockMetadataProvider'
 TAXONOMY_XBLOCK_SUPPORTED_TYPES = ['video', 'vertical']
 
+SKILLS_VERIFICATION_THRESHOLD = 10  # minimum votes required for a skill to be marked verified
+SKILLS_VERIFICATION_RATIO_THRESHOLD = 0.7 # 70% validation threshold out of total votes
+SKILLS_IGNORED_THRESHOLD = 10 # minimum votes required for skill to be marked ignored
+SKILLS_IGNORED_RATIO_THRESHOLD = 0.7 # 70% ignored threshold out of total votes
+
 # Settings related to the EMSI client
 EMSI_API_ACCESS_TOKEN_URL = 'https://auth.emsicloud.com/connect/token'
 EMSI_API_BASE_URL = 'https://emsiservices.com'


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7061](https://2u-internal.atlassian.net/browse/ENT-7061)

__Description:__
Skill tagging for xblock relies on some django settings, this PR introduces those settings with appropriate values. Related management command that needs these values is https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/management/commands/finalize_xblockskill_tags.py