### PR TITLE
feat: modify course api update method for subdirectory slug format

### DIFF
--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -34,7 +34,7 @@ from course_discovery.apps.course_metadata.models import (
     Seat, Source, Video
 )
 from course_discovery.apps.course_metadata.utils import (
-    create_missing_entitlement, ensure_draft_world, validate_course_number
+    create_missing_entitlement, ensure_draft_world, validate_course_number, validate_slug_format
 )
 from course_discovery.apps.publisher.utils import is_publisher_user
 
@@ -314,7 +314,6 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         """ Updates an existing course from incoming data. """
         # logging to help debug error around course url slugs incrementing
         logger.info('The raw course data coming from publisher is {}.'.format(data))  # lint-amnesty, pylint: disable=logging-format-interpolation
-
         changed = False
         # Sending draft=False means the course data is live and updates should be pushed out immediately
         draft = data.pop('draft', True)
@@ -387,7 +386,8 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         changed = changed or bool(changed_fields)
 
         if url_slug:
-            validators.validate_slug(url_slug)
+            validate_slug_format(url_slug, course)
+
             all_course_historical_slugs_excluding_present = CourseUrlSlug.objects.filter(
                 url_slug=url_slug, partner=course.partner).exclude(course__uuid=course.uuid)
             if all_course_historical_slugs_excluding_present.exists():

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1904,6 +1904,9 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
         (False, _('Unrestricted')),
     )
 
+    IN_REVIEW_STATUS = [CourseRunStatus.InternalReview, CourseRunStatus.LegalReview]
+    POST_REVIEW_STATUS = [CourseRunStatus.Reviewed, CourseRunStatus.Published]
+
     uuid = models.UUIDField(default=uuid4, verbose_name=_('UUID'))
     course = models.ForeignKey(Course, models.CASCADE, related_name='course_runs')
     key = models.CharField(max_length=255)


### PR DESCRIPTION
Description:
----------------

This PR modifies course API `course_update` method to accept the subdirectory slug format for OCM courses. The subdirectory slug format will be
`learn/<primary-subject>/<org-name>-<course-title>.

If any of CourseRun of the course is in IN_REVIEW_STATUS or in POST_REVIEW_STATUS, then only subdirectory slug format will be used for OCM courses. Otherwise, the both slug formats will be used for OCM courses. Currently, I'm allowing both slug formats for OCM courses for any case once all OCM courses are migrated to subdirectory slug format, then we can remove the old slug format by removing check:
```python
  # TODO: remove this check once all OCM courses are migrated to subdirectory slug format
        if not valid_slug_flag:
            validators.validate_slug(url_slug)
            valid_slug_flag = True
```

https://github.com/openedx/course-discovery/pull/4000/files#diff-eadad00c3534feef2ef1587465eec30387a58cd5b0b71fecc61793e7ee8e4127R1060-R1063

Testing Instructions:
- Run the containers (discovery, frontend-app-publisher, studio, ecommerce (optional))
- Go to the `frontend-app-publisher` repo and move to `.env.development` file and set the `IS_NEW_SLUG_FORMAT_ENABLED='true'`
- Try to set new url slug format for OCM course using publisher.
- Make sure it is accepting both slug formats for OCM courses.
- Try to set course url slug format for non-OCM course using publisher.
- Make sure it is not accepting subdirectory slug format for non-OCM courses.