### PR TITLE
feat: add missing pieces for Course data modified timestamp workflow

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/load_program_fixture.py
+++ b/course_discovery/apps/course_metadata/management/commands/load_program_fixture.py
@@ -17,9 +17,9 @@ from course_discovery.apps.course_metadata.models import (
 )
 from course_discovery.apps.course_metadata.signals import (
     check_curriculum_for_cycles, check_curriculum_program_membership_for_cycles,
-    connect_course_data_modified_timestamp_related_models, course_run_m2m_changed,
-    disconnect_course_data_modified_timestamp_related_models, ensure_external_key_uniqueness__course_run,
-    ensure_external_key_uniqueness__curriculum, ensure_external_key_uniqueness__curriculum_course_membership
+    connect_course_data_modified_timestamp_signal_handlers, disconnect_course_data_modified_timestamp_signal_handlers,
+    ensure_external_key_uniqueness__course_run, ensure_external_key_uniqueness__curriculum,
+    ensure_external_key_uniqueness__curriculum_course_membership
 )
 
 logger = logging.getLogger(__name__)
@@ -64,23 +64,18 @@ def disconnect_program_signals():
             'signal': ensure_external_key_uniqueness__curriculum_course_membership,
             'sender': CurriculumCourseMembership,
         },
-        {
-            'action': db.models.signals.m2m_changed,
-            'signal': course_run_m2m_changed,
-            'sender': CourseRun.transcript_languages.through,
-        }
     ]
 
     for signal in signals_list:
         signal['action'].disconnect(signal['signal'], sender=signal['sender'])
-    disconnect_course_data_modified_timestamp_related_models()
+    disconnect_course_data_modified_timestamp_signal_handlers()
 
     try:
         yield
     finally:
         for signal in signals_list:
             signal['action'].connect(signal['signal'], sender=signal['sender'])
-        connect_course_data_modified_timestamp_related_models()
+        connect_course_data_modified_timestamp_signal_handlers()
 
 
 class Command(BaseCommand):

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_migrate_course_slugs.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_migrate_course_slugs.py
@@ -30,7 +30,8 @@ class TestMigrateCourseSlugs(TestCase):
         self.course2.subjects.add(self.subject)
 
         self.course3_draft = CourseFactory(
-            draft=True, product_source=product_source, partner=partner, url_slug='test_course'
+            draft=True, product_source=product_source, partner=partner, url_slug='test_course',
+            title='test_course'
         )
         course_url_slug = CourseUrlSlugFactory(
             url_slug='test_slug', is_active=True, partner=partner, course=self.course3_draft
@@ -40,7 +41,7 @@ class TestMigrateCourseSlugs(TestCase):
         self.course3_draft.subjects.add(self.subject)
 
         self.course3_non_draft = CourseFactory(
-            draft=False, draft_version_id=self.course3_draft.id, uuid=self.course3_draft.uuid,
+            draft=False, draft_version=self.course3_draft, uuid=self.course3_draft.uuid,
             product_source=product_source, partner=partner, title='test_course'
         )
         self.course3_non_draft.url_slug_history.add(course_url_slug)

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -8,6 +8,7 @@ import pytest
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db.models.signals import m2m_changed
 from django.test import TestCase, override_settings
 from factory.django import DjangoModelFactory
 from opaque_keys.edx.keys import CourseKey
@@ -23,15 +24,23 @@ from course_discovery.apps.course_metadata.algolia_models import (
 )
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.models import (
-    BackfillCourseRunSlugsConfig, BackpopulateCourseTypeConfig, BulkModifyProgramHookConfig, BulkUpdateImagesConfig,
-    BulkUploadTagsConfig, CourseEditor, CourseRun, CSVDataLoaderConfiguration, Curriculum, CurriculumProgramMembership,
-    DataLoaderConfig, DeduplicateHistoryConfig, DeletePersonDupsConfig, DrupalPublishUuidConfig, LevelTypeTranslation,
-    MigrateCourseSlugConfiguration, MigratePublisherToCourseMetadataConfig, ProfileImageDownloadConfig, Program,
-    ProgramTypeTranslation, RemoveRedirectsConfig, SubjectTranslation, TagCourseUuidsConfig, TopicTranslation
+    AdditionalMetadata, BackfillCourseRunSlugsConfig, BackpopulateCourseTypeConfig, BulkModifyProgramHookConfig,
+    BulkUpdateImagesConfig, BulkUploadTagsConfig, Course, CourseEditor, CourseRun, CSVDataLoaderConfiguration,
+    Curriculum, CurriculumProgramMembership, DataLoaderConfig, DeduplicateHistoryConfig, DeletePersonDupsConfig,
+    DrupalPublishUuidConfig, LevelTypeTranslation, MigrateCourseSlugConfiguration,
+    MigratePublisherToCourseMetadataConfig, ProductMeta, ProfileImageDownloadConfig, Program, ProgramTypeTranslation,
+    RemoveRedirectsConfig, SubjectTranslation, TagCourseUuidsConfig, TopicTranslation
 )
-from course_discovery.apps.course_metadata.signals import _duplicate_external_key_message, update_course_data_from_event
+from course_discovery.apps.course_metadata.signals import (
+    _duplicate_external_key_message, additional_metadata_facts_changed,
+    connect_course_data_modified_timestamp_signal_handlers, course_collaborators_changed, course_run_staff_changed,
+    course_run_transcript_languages_changed, course_subjects_changed, course_topics_taggable_changed,
+    disconnect_course_data_modified_timestamp_signal_handlers, product_meta_taggable_changed,
+    update_course_data_from_event
+)
 from course_discovery.apps.course_metadata.tests import factories
 from course_discovery.apps.course_metadata.tests.factories import CourseEditorFactory, CourseFactory
+from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.tests.factories import GroupFactory, OrganizationExtensionFactory
 
 LOGGER_NAME = 'course_discovery.apps.course_metadata.signals'
@@ -1004,14 +1013,31 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
     This test suite is meant for testing various signal handlers that update data modified timestamps on
     Course & Program.
 
-      * course_taggable_manager_changed
       * additional_metadata_facts_changed
+      * course_run_staff_changed
+      * course_run_transcript_languages_changed
+      * course_collaborators_changed
+      * course_subjects_changed
+      * product_meta_taggable_changed
+      * course_topics_taggable_changed
     """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        disconnect_course_data_modified_timestamp_signal_handlers()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        connect_course_data_modified_timestamp_signal_handlers()
+        super().tearDownClass()
+
     def test_product_meta_keywords_change(self):
         """
         Verify that updating the keywords on ProductMeta triggers the update_data_modified_timestamp
         for ProductMeta and updates data_modified_timestamp for related courses.
         """
+        m2m_changed.connect(product_meta_taggable_changed, sender=ProductMeta.keywords.through)
         product_meta = factories.ProductMetaFactory()
         course = factories.CourseFactory(
             draft=True,
@@ -1034,12 +1060,43 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
                 f"{product_meta.keywords.through} has been updated for ProductMeta {product_meta.pk}."
             )
         )
+        m2m_changed.disconnect(product_meta_taggable_changed, sender=ProductMeta.keywords.through)
+
+    def test_course_topics_taggable_change(self):
+        """
+        Verify that updating the keywords on ProductMeta triggers the update_data_modified_timestamp
+        for ProductMeta and updates data_modified_timestamp for related courses.
+        """
+        m2m_changed.connect(course_topics_taggable_changed, sender=Course.topics.through)
+        course = factories.CourseFactory(draft=True)
+        course_timestamp = course.data_modified_timestamp
+
+        with LogCapture(LOGGER_NAME) as log:
+            course.topics.set(['keyword_1', 'keyword_2'])
+
+        course.refresh_from_db()
+        assert course_timestamp < course.data_modified_timestamp
+
+        log.check_present(
+            (
+                LOGGER_NAME,
+                'INFO',
+                f"{course.topics.through} has been updated for Course {course.key}."
+            )
+        )
+        # Attempting to set the same keywords does not update the timestamp
+        course_timestamp = course.data_modified_timestamp
+        course.topics.set(['keyword_1', 'keyword_2'])
+        course.refresh_from_db()
+        assert course_timestamp == course.data_modified_timestamp
+        m2m_changed.connect(course_topics_taggable_changed, sender=Course.topics.through)
 
     def test_additional_metadata_fact_addition(self):
         """
         Verify that adding Fact objects on AdditionalMetadata triggers the update_data_modified_timestamp
         for AdditionalMetadata and updates data_modified_timestamp for related courses.
         """
+        m2m_changed.connect(additional_metadata_facts_changed, sender=AdditionalMetadata.facts.through)
         additional_metadata = factories.AdditionalMetadataFactory()
         course = factories.CourseFactory(
             draft=True,
@@ -1060,3 +1117,199 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
                 f"AdditionalMetadata {additional_metadata.pk}."
             )
         )
+        m2m_changed.disconnect(additional_metadata_facts_changed, sender=AdditionalMetadata.facts.through)
+
+    def test_course_collaborators_change__non_draft_present(self):
+        """
+        Verify the change in course collaborators will update the data timestamp for Course if the non-draft version
+        of the course is present.
+        """
+        m2m_changed.connect(course_collaborators_changed, sender=Course.collaborators.through)
+
+        draft_course = CourseFactory(draft=True)
+        non_draft_course = CourseFactory(draft_version=draft_course, key=draft_course.key)
+        course_timestamp = draft_course.data_modified_timestamp
+        collaborator_1 = factories.CollaboratorFactory()
+        collaborator_2 = factories.CollaboratorFactory()
+        collaborator_3 = factories.CollaboratorFactory()
+        non_draft_course.collaborators.add(collaborator_1, collaborator_2, collaborator_3)
+
+        with LogCapture(LOGGER_NAME) as log:
+            draft_course.collaborators.set((collaborator_1, collaborator_2))
+        draft_course.refresh_from_db()
+        assert course_timestamp < draft_course.data_modified_timestamp
+        log.check_present(
+            (
+                LOGGER_NAME,
+                'INFO',
+                f"Collaborator M2M relation has been updated for course {draft_course.key}."
+            )
+        )
+        m2m_changed.disconnect(course_collaborators_changed, sender=Course.collaborators.through)
+
+    def test_course_collaborators_change__non_draft_missing(self):
+        """
+        Verify the change in course collaborators will not update the data timestamp for Course if course does not
+        have a non-draft version.
+        """
+        m2m_changed.connect(course_collaborators_changed, sender=Course.collaborators.through)
+
+        course = CourseFactory(draft=True)
+        course_timestamp = course.data_modified_timestamp
+        collaborator_1 = factories.CollaboratorFactory()
+        collaborator_2 = factories.CollaboratorFactory()
+
+        with LogCapture(LOGGER_NAME) as log:
+            course.collaborators.set((collaborator_1, collaborator_2))
+        course.refresh_from_db()
+        assert course_timestamp == course.data_modified_timestamp
+        with self.assertRaises(AssertionError):
+            log.check_present(
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    f"Collaborator M2M relation has been updated for course {course.key}."
+                )
+            )
+
+        m2m_changed.disconnect(course_collaborators_changed, sender=Course.collaborators.through)
+
+    def test_course_subjects_change__non_draft_present(self):
+        """
+        Verify the change in course subjects will update the data timestamp for Course if the non-draft version
+        of the course is present.
+        """
+        m2m_changed.connect(course_subjects_changed, sender=Course.subjects.through)
+
+        draft_course = CourseFactory(draft=True)
+        non_draft_course = CourseFactory(draft_version=draft_course, key=draft_course.key)
+        course_timestamp = draft_course.data_modified_timestamp
+        subject_1 = factories.SubjectFactory()
+        subject_2 = factories.SubjectFactory()
+        subject_3 = factories.SubjectFactory()
+        non_draft_course.subjects.add(subject_1, subject_2, subject_3)
+
+        with LogCapture(LOGGER_NAME) as log:
+            draft_course.subjects.set((subject_1, subject_2))
+        draft_course.refresh_from_db()
+        assert course_timestamp < draft_course.data_modified_timestamp
+
+        log.check_present(
+            (
+                LOGGER_NAME,
+                'INFO',
+                f"Subject M2M relation has been updated for course {draft_course.key}."
+            )
+        )
+        m2m_changed.disconnect(course_subjects_changed, sender=Course.subjects.through)
+
+    def test_course_subjects_change__non_draft_missing(self):
+        """
+        Verify the change in course subjects will not update the data timestamp for Course if course does not
+        have a non-draft version.
+        """
+        m2m_changed.connect(course_subjects_changed, sender=Course.subjects.through)
+        course = CourseFactory(draft=True)
+        course_timestamp = course.data_modified_timestamp
+        subject_1 = factories.SubjectFactory()
+        subject_2 = factories.SubjectFactory()
+
+        with LogCapture(LOGGER_NAME) as log:
+            course.subjects.set((subject_1, subject_2))
+        course.refresh_from_db()
+        assert course_timestamp == course.data_modified_timestamp
+        with self.assertRaises(AssertionError):
+            log.check_present(
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    f"Subject M2M relation has been updated for course {course.key}."
+                )
+            )
+
+        m2m_changed.disconnect(course_subjects_changed, sender=Course.subjects.through)
+
+    def test_course_run_transcript_language_changed(self):
+        """
+        Verify the change of transcript language relationship updates the data modified timestamp for related Course.
+        """
+        m2m_changed.connect(course_run_transcript_languages_changed, sender=CourseRun.transcript_languages.through)
+        course = CourseFactory(draft=True)
+        course_run = factories.CourseRunFactory(course=course, draft=True)
+        language_tags = LanguageTag.objects.all()[:2]
+        course_timestamp = course.data_modified_timestamp
+
+        with LogCapture(LOGGER_NAME) as log:
+            course_run.transcript_languages.set(language_tags)
+
+        course.refresh_from_db()
+        assert course_timestamp < course.data_modified_timestamp
+        log.check_present(
+            (
+                LOGGER_NAME,
+                'INFO',
+                f"{course_run.transcript_languages.through} has been updated for course run {course_run.key}."
+            )
+        )
+
+        m2m_changed.disconnect(course_run_transcript_languages_changed, sender=CourseRun.transcript_languages.through)
+
+    def test_course_run_staff_changed__non_draft_present(self):
+        """
+        Verify the staff relation change in course run updates the timestamp for course if a non-draft course run
+        is present.
+        """
+        m2m_changed.connect(course_run_staff_changed, sender=CourseRun.staff.through)
+        draft_course = CourseFactory(draft=True)
+        non_draft_course = CourseFactory(draft_version=draft_course, key=draft_course.key)
+        draft_course_run = factories.CourseRunFactory(draft=True, course=draft_course)
+        non_draft_course_run = factories.CourseRunFactory(
+            course=non_draft_course, draft_version=draft_course_run, key=draft_course_run.key
+        )
+        staff1 = factories.PersonFactory()
+        staff2 = factories.PersonFactory()
+        staff3 = factories.PersonFactory()
+        course_timestamp = draft_course.data_modified_timestamp
+
+        non_draft_course_run.staff.add(staff1, staff2, staff3)
+
+        with LogCapture(LOGGER_NAME) as log:
+            draft_course_run.staff.set((staff1, staff2))
+
+        draft_course.refresh_from_db()
+        assert course_timestamp < draft_course.data_modified_timestamp
+        log.check_present(
+            (
+                LOGGER_NAME,
+                'INFO',
+                f"Staff M2M relation has been updated for course run {draft_course_run.key}."
+            )
+        )
+        m2m_changed.disconnect(course_run_staff_changed, sender=CourseRun.staff.through)
+
+    def test_course_run_staff_changed__non_draft_missing(self):
+        """
+        Verify the staff relation change in course run does not update the timestamp for course if non-draft course run
+        is not present.
+        """
+        m2m_changed.connect(course_run_staff_changed, sender=CourseRun.staff.through)
+        draft_course = CourseFactory(draft=True)
+        draft_course_run = factories.CourseRunFactory(draft=True, course=draft_course)
+        staff1 = factories.PersonFactory()
+        staff2 = factories.PersonFactory()
+        course_timestamp = draft_course.data_modified_timestamp
+
+        with LogCapture(LOGGER_NAME) as log:
+            draft_course_run.staff.set((staff1, staff2))
+
+        draft_course.refresh_from_db()
+        assert course_timestamp == draft_course.data_modified_timestamp
+        with self.assertRaises(AssertionError):
+            log.check_present(
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    f"Staff M2M relation has been updated for course run {draft_course_run.key}."
+                )
+            )
+        m2m_changed.disconnect(course_run_staff_changed, sender=CourseRun.staff.through)


### PR DESCRIPTION
### [PROD-3408](https://2u-internal.atlassian.net/browse/PROD-3408)

### Description
This PR is a followup work from the PR https://github.com/openedx/course-discovery/pull/3976. This PR adds the necessary elements to complete course data modified timestamp update flow.

#### Seat Model
Seat model is linked with CourseRun and contains information about seat pricing and upgrade deadline override (this field is available on publisher in CourseRunForm section). Appropriate field tracker  based signal handler is added to update course data modified timestamp when seat related attrs are changed.

#### Course url slug
Course url slug and its history are maintained in CourseUrlSlug model. The slug handling also differs if the course is draft or non-draft. The draft->non-draft changes are not managed via set_official_state util. Instead, set_active_url_slug method is responsible for appropriate slug and history updates. Therefore,  in the method,  the mechanism to update course data modified timestamp has been added in the method set_active_url_slug. **That method did not have any unit tests, so I had to add them as well to verify the timestamp updates are working as expected.**

#### M2M relationships 

Following two categories of M2M relationships were not covered before:
- SortedM2M Field
- Taggable Manager

The details of the M2M relationship complexity can be seen in the internal doc https://2u-internal.atlassian.net/wiki/spaces/CAT/pages/356156060/Timestamp+Based+Data+Query. However, I am adding some concise context here.

Rest framework’s serializer [update() method use M2M field’s .set()](https://github.com/encode/django-rest-framework/blob/master/rest_framework/serializers.py#L1010) method to add M2M relationship after updating the instance object The set() method in [M2MField in Django](https://github.com/django/django/blob/main/django/db/models/fields/related_descriptors.py#L895) varies the m2m setting behavior based on clear flag. However, for SortedM2M, the clear is[ always set to True](https://github.com/jazzband/django-sortedm2m/blob/e646aafa81416c7888a7d358c7293bd4f707a25f/sortedm2m/fields.py#L47-L50), to maintain the ordering of the objects in M2M relationship.  **The workaround here is to get M2M relationship pks from non-draft versions of Course/CourseRun and then compare those Pks with values being added in m2m_relationship.**

Taggable manager in django-taggit uses [TaggedItem](https://github.com/jazzband/django-taggit/blob/master/taggit/models.py#L185) to store information on which tags are assigned to which Django model (via content type). TaggedItem is the [default](https://github.com/jazzband/django-taggit/blob/master/taggit/managers.py#L440) through value if it is not defined explicitly. In Discovery course_metadata app, the value for through is not defined whenever TaggableManager is used (be it Org, Course, ProductMeta, Program, etc). Now, to receive m2m_changed signal, we need to specify the sender. The sender is i[ntermediate or through model ](https://docs.djangoproject.com/en/4.2/ref/signals/#m2m-changed)(which is TaggedItem for tag manager). So, therefore, when m2m_changed is attempted to be set only for Course.topics.through, since through=TaggedItem, whenever m2m for tags is changed on any other model, say ProductMeta, the m2m_changed handler is called because through is the same for Course & ProductMeta. **Explicit model label checks helped curate the proper handler for each taggable manager**

#### Product Value & Location Restriction
In Course api, the handling for product value & location restriction is updated to rely on calling save() instead of .filter().update() to enforce pre_save signal handler execution.

### Testing

- Make sure you have one ExecEd course in your local discovery for complete flow testinng
- Check out this branch.
- Run the latest publisher on your local. 
- Go to any course. 
- Edit its url slug. Ensure the slug is changed and the timestamp is updated.  Verify for both draft & non-draft versions
- Edit the course collaborators (both add/remove) and verify the timestamp updates
- Edit the course subjects (both add/remove) and verify the timestamp updates
- Edit product value and verify data timestamp updates
- Add/Edit location restriction and verify data timestamp updates
- In course run form, update verified upgrade deadline (only for Verified types) and verify the course timestamp is updated
- Edit the course run staff (both add/remove) and verify the timestamp updates
- For last step in testing, edit any field in Course/CourseRun form and ensure the data timestamp is updated. If any field change does not do that, flag that during review.
