### PR TITLE
Add default product source in Courses Api Data Loader

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -739,6 +739,12 @@ class SalesforceTests(TestCase):
 
 
 class TestCourseDataUpdateSignal(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        factories.SourceFactory(slug=settings.DEFAULT_PRODUCT_SOURCE_SLUG)
+
     def setUp(self):
         self.course_key = CourseKey.from_string('course-v1:SC+BreadX+3T2015')
         self.scheduling_data = CourseScheduleData(


### PR DESCRIPTION
## [PROD-3452](https://2u-internal.atlassian.net/browse/PROD-3452)

## Testing Instructions

1. Checkout this branch
2. Create a course in studio
3. Run RCM
4. Verify that the course you created in studio is visible in discovery and has the default product source assigned.
