### PR TITLE
feat: allow uuid in Contentful to be null

### DIFF
--- a/course_discovery/apps/course_metadata/contentful_utils.py
+++ b/course_discovery/apps/course_metadata/contentful_utils.py
@@ -401,10 +401,13 @@ def fetch_and_transform_degree_contentful_data():
     transformed_degree_data = {}
 
     for degree_entry in contentful_degree_page_entries:
-        product_uuid = degree_entry.uuid
+        product_uuid = getattr(degree_entry, 'uuid', None)
         if product_uuid in transformed_degree_data:
             continue
         uuid_list = getattr(degree_entry, 'uuid_list', [])
+        if product_uuid is None:
+            # add all the transformed data against the first uuid in uuid_list.
+            product_uuid = uuid_list[0]
         excluded_from_search = getattr(degree_entry, 'excluded_from_search', False)
         excluded_from_seo = getattr(degree_entry, 'excluded_from_seo', False)
         page_title = degree_entry.seo.page_title

--- a/course_discovery/apps/course_metadata/tests/contentful_utils/contentful_mock_data.py
+++ b/course_discovery/apps/course_metadata/tests/contentful_utils/contentful_mock_data.py
@@ -35,7 +35,7 @@ class MockContenfulDegreeResponse:
     degree_transformed_data = None
     mock_contentful_degree_entry = None
 
-    def __init__(self):
+    def __init__(self, uuid):
         seo_entry = create_contentful_entry('seo', {
             'pageTitle': 'SEO Page Title',
             'pageDescription': 'SEO Page Description',
@@ -106,9 +106,9 @@ class MockContenfulDegreeResponse:
                 })
             ]
         })
-        self.mock_contentful_degree_entry = create_contentful_entry('degreeDetailPage', {
+
+        degree_contentful_entry = {
             'internalName': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-            'uuid': 'test-uuid',
             'uuid_list': ['test-uuid1', 'test-uuid2', 'test-uuid3'],
             'excluded_from_search': False,
             'excluded_from_seo': False,
@@ -120,23 +120,22 @@ class MockContenfulDegreeResponse:
                 placement_about_section_entry,
                 featured_products_entry
             ]
-        })
+        }
 
-        self.mock_contentful_degree_missing_rich_text = create_contentful_entry('degreeDetailPage', {
-            'internalName': 'Degree Missing Rich Text',
-            'uuid': 'test-uuid',
-            'uuid_list': ['test-uuid1', 'test-uuid2', 'test-uuid3'],
-            'excluded_from_search': False,
-            'excluded_from_seo': False,
-            'seo': seo_entry,
-            'hero': hero_entry,
-            'modules': [
-                about_the_program_entry,
-                faq_entry,
-                placement_about_section_entry,
-                featured_products_entry__missing_rich_text
-            ]
-        })
+        if uuid:
+            degree_contentful_entry['uuid'] = uuid
+
+        self.mock_contentful_degree_entry = create_contentful_entry('degreeDetailPage', degree_contentful_entry)
+
+        degree_contentful_entry['modules'] = [
+            about_the_program_entry,
+            faq_entry,
+            placement_about_section_entry,
+            featured_products_entry__missing_rich_text
+        ]
+
+        self.mock_contentful_degree_missing_rich_text = create_contentful_entry(
+            'degreeDetailPage', degree_contentful_entry)
 
         self.degree_sample_contentful_entry = {
             'page_title': 'SEO Page Title',
@@ -170,15 +169,19 @@ class MockContenfulDegreeResponse:
         }
 
         self.degree_transformed_data = {
-            'test-uuid': self.degree_sample_contentful_entry,
             'test-uuid1': self.degree_sample_contentful_entry,
             'test-uuid2': self.degree_sample_contentful_entry,
             'test-uuid3': self.degree_sample_contentful_entry
         }
 
+        if uuid:
+            self.degree_transformed_data[uuid] = self.degree_sample_contentful_entry
+
 
 def create_bootcamp_mock_response_data():
-
+    """
+    Creates bootcamp mock response data.
+    """
     seo_entry = create_contentful_entry('seo', {
         'pageTitle': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
         'pageDescription': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',

--- a/course_discovery/apps/course_metadata/tests/test_contentful_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_contentful_utils.py
@@ -145,7 +145,7 @@ class TestContentfulUtils(TestCase):
             mock_bootcamp_response.bootcamp_transformed_data, 'test-uuid') == expected_data
 
     def test_get_aggregated_data_from_contentful__degree(self):
-        mock_degree_response = MockContenfulDegreeResponse()
+        mock_degree_response = MockContenfulDegreeResponse(uuid='test-uuid')
         expected_data = 'faq question Lorem ipsum dolor sit amet, consectetur adipiscing elit ' \
                         'Lorem ipsum dolor sit amet, consectetur adipiscing elit ' \
                         'Lorem ipsum dolor sit amet, consectetur adipiscing elit ' \
@@ -163,24 +163,24 @@ class TestContentfulUtils(TestCase):
             mock_degree_response.degree_transformed_data, 'test-uuid') == expected_data
 
     @mock.patch('course_discovery.apps.course_metadata.contentful_utils.get_data_from_contentful',
-                return_value=[MockContenfulDegreeResponse().mock_contentful_degree_entry])
+                return_value=[MockContenfulDegreeResponse(uuid='test-uuid').mock_contentful_degree_entry])
     def test_transform_degree_contentful_data(self, *args):
         """
         Test transform_degree_contentful_data given a mocked entry from contentful.
         """
-        mock_degree_response = MockContenfulDegreeResponse()
+        mock_degree_response = MockContenfulDegreeResponse(uuid='test-uuid')
         transformed_data = fetch_and_transform_degree_contentful_data()
         self.assertDictEqual(
             transformed_data, mock_degree_response.degree_transformed_data)
 
     @mock.patch('course_discovery.apps.course_metadata.contentful_utils.get_data_from_contentful',
-                return_value=[MockContenfulDegreeResponse().mock_contentful_degree_missing_rich_text])
+                return_value=[MockContenfulDegreeResponse(uuid='test-uuid').mock_contentful_degree_missing_rich_text])
     def test_transform_degree_contentful_data__missing_rich_text(self, *args):
         """
         Test transform_degree_contentful_data fall backs to introduction if rich text intro is not present.
         """
         expected_response = {}
-        for key, transformed_data in MockContenfulDegreeResponse().degree_transformed_data.items():
+        for key, transformed_data in MockContenfulDegreeResponse(uuid='test-uuid').degree_transformed_data.items():
             expected_response[key] = {
                 **transformed_data,
                 'featured_products': {
@@ -195,3 +195,14 @@ class TestContentfulUtils(TestCase):
 
         transformed_data = fetch_and_transform_degree_contentful_data()
         self.assertDictEqual(expected_response, transformed_data)
+
+    @mock.patch('course_discovery.apps.course_metadata.contentful_utils.get_data_from_contentful',
+                return_value=[MockContenfulDegreeResponse(uuid=None).mock_contentful_degree_entry])
+    def test_transform_degree_contentful_data_no_uuid(self, *args):
+        """
+        Test transform_degree_contentful_data given a mocked entry not having uuid from contentful.
+        """
+        mock_degree_response = MockContenfulDegreeResponse(uuid=None)
+        transformed_data = fetch_and_transform_degree_contentful_data()
+        self.assertDictEqual(
+            transformed_data, mock_degree_response.degree_transformed_data)


### PR DESCRIPTION
[PROD-3476](https://2u-internal.atlassian.net/browse/PROD-3476)

Fixing errors while Algolia is fetching Contentful. A degree entry can have a uuid-list and the uuid field can be empty. In that  case, we should take all the uuids from uuid-list.