### PR TITLE
chore: update team to course-discovery-maintainers for reqs upgrade job

### DIFF
--- a/.github/workflows/requirements-upgrade.yml
+++ b/.github/workflows/requirements-upgrade.yml
@@ -55,7 +55,7 @@ jobs:
         --target-branch="${{ env.target_branch }}" --base-branch-name="upgrade-python-requirements" \
         --commit-message="chore: python requirements update" --pr-title="chore: python requirements update" \
         --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
-        --user-reviewers="" --team-reviewers="course-discovery-admins" --delete-old-pull-requests
+        --user-reviewers="" --team-reviewers="course-discovery-maintainers" --delete-old-pull-requests
 
     - name: Send failure notification
       if: ${{ failure() }}


### PR DESCRIPTION
### [PROD-3463](https://2u-internal.atlassian.net/browse/PROD-3463)

### Description
Update requirements upgrade job to tag https://github.com/orgs/openedx/teams/course-discovery-maintainers on PRs instead of course-discovery-admins. admins team has been deleted by Axim as part of org teams cleanup.