### PR TITLE
chore: update dockerfile for newer versions of mysqlclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN apt update && \
   python3.8-distutils \
   libmysqlclient-dev \
   libssl-dev \
+  # mysqlclient >= 2.2.0 requires pkg-config.
+  pkg-config \
   libcairo2-dev && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description
mysqlclient versions >= `2.2.0` require `pkg-config` to install properly. Add it to the dockerfile
Note that we are already on mysqlclient==2.2.0. This does not cause an error because `pkg-config` is a dependency of a dependency of `libcairo`, which we install already.