### PR TITLE
ENT-7294: Version upgrade for taxonomy-connector.

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -74,9 +74,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.28.9
+boto3==1.28.10
     # via django-ses
-botocore==1.31.9
+botocore==1.31.10
     # via
     #   boto3
     #   s3transfer
@@ -225,7 +225,7 @@ django-appconf==1.0.5
     # via django-compressor
 django-autocomplete-light==3.9.7
     # via -r requirements/base.in
-django-choices==1.7.2
+django-choices==2.0.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
@@ -233,7 +233,7 @@ django-compressor==4.4
     # via
     #   -r requirements/base.in
     #   django-libsass
-django-config-models==2.3.0
+django-config-models==2.4.0
     # via -r requirements/base.in
 django-contrib-comments==2.2.0
     # via -r requirements/base.in
@@ -367,11 +367,11 @@ edx-auth-backends==4.1.0
     # via -r requirements/base.in
 edx-ccx-keys==1.2.1
     # via -r requirements/base.in
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.0.0
     # via -r requirements/base.in
-edx-django-utils==5.5.0
+edx-django-utils==5.6.0
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -812,7 +812,6 @@ simple-salesforce==1.12.4
 six==1.16.0
     # via
     #   django-autocomplete-light
-    #   django-choices
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
     #   djangorestframework-csv
@@ -885,7 +884,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.42.2
+taxonomy-connector==1.42.3
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in
@@ -961,7 +960,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.1
+virtualenv==20.24.2
     # via tox
 walrus==0.9.3
     # via edx-event-bus-redis

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -49,9 +49,9 @@ beautifulsoup4==4.12.2
     #   taxonomy-connector
 billiard==4.1.0
     # via celery
-boto3==1.28.9
+boto3==1.28.10
     # via django-ses
-botocore==1.31.9
+botocore==1.31.10
     # via
     #   boto3
     #   s3transfer
@@ -171,7 +171,7 @@ django-appconf==1.0.5
     # via django-compressor
 django-autocomplete-light==3.9.7
     # via -r requirements/base.in
-django-choices==1.7.2
+django-choices==2.0.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
@@ -179,7 +179,7 @@ django-compressor==4.4
     # via
     #   -r requirements/base.in
     #   django-libsass
-django-config-models==2.3.0
+django-config-models==2.4.0
     # via -r requirements/base.in
 django-contrib-comments==2.2.0
     # via -r requirements/base.in
@@ -298,11 +298,11 @@ edx-auth-backends==4.1.0
     # via -r requirements/base.in
 edx-ccx-keys==1.2.1
     # via -r requirements/base.in
-edx-django-release-util==1.2.0
+edx-django-release-util==1.3.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.0.0
     # via -r requirements/base.in
-edx-django-utils==5.5.0
+edx-django-utils==5.6.0
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -600,7 +600,6 @@ simple-salesforce==1.12.4
 six==1.16.0
     # via
     #   django-autocomplete-light
-    #   django-choices
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
     #   djangorestframework-csv
@@ -640,7 +639,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.42.2
+taxonomy-connector==1.42.3
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7294](https://2u-internal.atlassian.net/browse/ENT-7294)

__Description:__
This is a version upgrade PR for taxonomy connector. New version of taxonomy connector contains [these changes](https://github.com/openedx/taxonomy-connector/compare/1.42.2...1.42.3).

**Note:** There is one major upgrade added by the `make upgrade` command i.e. [django-choices==2.0.0](https://github.com/openedx/course-discovery/compare/master...saleem-latif:course-discovery:saleem-latif/ENT-7294?expand=1#diff-1d2bcb4fd89e4be6fc7473578c6072c90d9ef1a25f1ac3527c50d5d23696fc85R174)
