### PR TITLE
feat: use `atlas` in `make pull_translations`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:focal as app
 ENV DEBIAN_FRONTEND noninteractive
 # System requirements.
 RUN apt update && \
-  apt-get install -qy \ 
+  apt-get install -qy \
   curl \
+  gettext \
   # required by bower installer
   git \
   language-pack-en \

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,19 @@ extract_translations: ## Extract strings to be translated, outputting .po and .m
 	cd course_discovery && PYTHONPATH="..:${PYTHONPATH}" django-admin.py compilemessages
 
 # This Make target should not be removed since it is relied on by a Jenkins job (`edx-internal/tools-edx-jenkins/translation-jobs.yml`), using `ecommerce-scripts/transifex`.
+ifeq ($(OPENEDX_ATLAS_PULL),)
 pull_translations: ## Pull translations from Transifex
 	tx pull -a -f -t --mode reviewed --minimum-perc=1
+else
+# Experimental: OEP-58 Pulls translations using atlas
+pull_translations:
+	find course_discovery/conf/locale -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
+	atlas pull $(OPENEDX_ATLAS_ARGS) translations/course-discovery/course_discovery/conf/locale:course_discovery/conf/locale
+	python manage.py compilemessages
+
+	@echo "Translations pulled from Transifex and compiled."
+	@echo "'make static' or 'make static.dev' is required to update the js i18n files."
+endif
 
 # This Make target should not be removed since it is relied on by a Jenkins job (`edx-internal/tools-edx-jenkins/translation-jobs.yml`), using `ecommerce-scripts/transifex`.
 push_translations: ## Push source translation files (.po) to Transifex

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -65,6 +65,7 @@ html2text
 lxml
 jsonfield
 markdown
+openedx-atlas
 pillow
 pycountry
 python-dateutil

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -558,6 +558,8 @@ oauthlib==3.2.2
     #   social-auth-core
 openai==0.27.8
     # via taxonomy-connector
+openedx-atlas==0.4.4
+    # via -r requirements/base.in
 openedx-events==8.5.0
     # via
     #   edx-event-bus-kafka

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -447,6 +447,8 @@ oauthlib==3.2.2
     #   social-auth-core
 openai==0.27.8
     # via taxonomy-connector
+openedx-atlas==0.4.4
+    # via -r requirements/base.in
 openedx-events==8.5.0
     # via
     #   edx-event-bus-kafka


### PR DESCRIPTION
## Changes

 - Add new `ATLAS_PULL_LANGS` variable similar to the deprecated `transifex_langs` variable in other repos.
 - Add `atlas` into `make pull_translations` when `OPENEDX_ATLAS_PULL` environment variable is set.

Testing
-------

Mostly the following commands needs to be run, I won't go into super detailed steps though:

```
# Rebuild the image and restart the devstack
course-discovery $ docker build --target=dev -t edxops/discovery-dev:latest .

# Then run the pull command with `static.dev`
devstack $ make dev.shell.discovery
discovery $ OPENEDX_ATLAS_PULL=yes make pull_translations static.dev
```

 - [x] Test pulled translations
   * Deletes the existing language
   * Pulls new language files from the the openedx-translations repo: https://github.com/openedx/openedx-translations/tree/main/translations/course-discovery/course_discovery/conf/locale (See latest comments for testing log)

 - [x] Quick QA for translated content ([source po file](https://github.com/openedx/openedx-translations/blob/e5d771f466b3dffcb815e139f02b6ece71d3e8e0/translations/course-discovery/course_discovery/conf/locale/ar/LC_MESSAGES/django.po#L2264-L2279)):
   ![image](https://github.com/openedx/course-discovery/assets/645156/21e4a17c-d75a-41e3-8893-81d32f4d5876)



References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes:

**For XBlocks and Python projects:**
 - The standard translation path must be `conf/locale`.
 - At the end of the project, a clear change log will be added and all translations will be handled by Atlas. Thus, the local translation will be removed from the repo.
 - A notification for the community will be published to ensure that everyone knows why translations directories are removed from all repos.
