### PR TITLE
ENT-7294:  Updated the version of taxonomy-connector to 1.43.1

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -885,7 +885,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.42.3
+taxonomy-connector==1.43.1
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -640,7 +640,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.42.3
+taxonomy-connector==1.43.1
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7294](https://2u-internal.atlassian.net/browse/ENT-7294)

__ Description:__
This is a version upgrade PR for `taxonomy-connector`, upgrading the version to `1.43.1`. The new version contains memory optimizations for `reindex_algolia` management command. [Here](https://github.com/openedx/taxonomy-connector/compare/1.42.3...1.43.1) are the exact changes included in the release.