### PR TITLE
chore: upgraded taxonomy-connector to 1.43.2

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -74,9 +74,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.28.15
+boto3==1.28.17
     # via django-ses
-botocore==1.31.15
+botocore==1.31.17
     # via
     #   boto3
     #   s3transfer
@@ -145,7 +145,7 @@ coverage[toml]==7.2.7
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.3
     # via
     #   paramiko
     #   pyjwt
@@ -402,7 +402,7 @@ edx-opaque-keys[django]==2.3.0
     #   edx-drf-extensions
     #   openedx-events
     #   taxonomy-connector
-edx-rest-api-client==5.5.2
+edx-rest-api-client==5.6.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
@@ -472,7 +472,7 @@ google-auth-httplib2==0.1.0
     #   google-api-python-client
 google-auth-oauthlib==1.0.0
     # via gspread
-googleapis-common-protos==1.59.1
+googleapis-common-protos==1.60.0
     # via google-api-core
 gspread==5.10.0
     # via -r requirements/base.in
@@ -592,9 +592,10 @@ pillow==9.5.0
     #   -r requirements/base.in
     #   cairosvg
     #   django-stdimage
-platformdirs==3.10.0
+platformdirs==3.8.1
     # via
     #   pylint
+    #   snowflake-connector-python
     #   virtualenv
     #   zeep
 pluggy==1.2.0
@@ -786,7 +787,7 @@ requests-toolbelt==0.10.1
     # via
     #   -c requirements/constraints.txt
     #   zeep
-responses==0.23.1
+responses==0.23.3
     # via
     #   -r requirements/test.in
     #   pytest-responses
@@ -800,7 +801,7 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 s3transfer==0.6.1
     # via boto3
-selenium==4.10.0
+selenium==4.11.2
     # via -r requirements/test.in
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -840,7 +841,7 @@ sniffio==1.3.0
     # via trio
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.0.4
+snowflake-connector-python==3.1.0
     # via -r requirements/base.in
 social-auth-app-django==5.2.0
     # via
@@ -885,7 +886,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.43.1
+taxonomy-connector==1.43.2
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in
@@ -904,7 +905,9 @@ tomli==2.0.1
     #   pytest
     #   tox
 tomlkit==0.12.1
-    # via pylint
+    # via
+    #   pylint
+    #   snowflake-connector-python
 tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
@@ -961,7 +964,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.2
+virtualenv==20.24.1
     # via tox
 walrus==0.9.3
     # via edx-event-bus-redis

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -49,9 +49,9 @@ beautifulsoup4==4.12.2
     #   taxonomy-connector
 billiard==4.1.0
     # via celery
-boto3==1.28.15
+boto3==1.28.17
     # via django-ses
-botocore==1.31.15
+botocore==1.31.17
     # via
     #   boto3
     #   s3transfer
@@ -102,7 +102,7 @@ code-annotations==1.5.0
     # via edx-toggles
 contentful==2.1.1
     # via -r requirements/base.in
-cryptography==40.0.2
+cryptography==41.0.3
     # via
     #   pyjwt
     #   pyopenssl
@@ -329,7 +329,7 @@ edx-opaque-keys[django]==2.3.0
     #   edx-drf-extensions
     #   openedx-events
     #   taxonomy-connector
-edx-rest-api-client==5.5.2
+edx-rest-api-client==5.6.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
@@ -381,7 +381,7 @@ google-auth-httplib2==0.1.0
     #   google-api-python-client
 google-auth-oauthlib==1.0.0
     # via gspread
-googleapis-common-protos==1.59.1
+googleapis-common-protos==1.60.0
     # via google-api-core
 greenlet==2.0.2
     # via gevent
@@ -470,8 +470,10 @@ pillow==9.5.0
     #   -r requirements/base.in
     #   cairosvg
     #   django-stdimage
-platformdirs==3.10.0
-    # via zeep
+platformdirs==3.8.1
+    # via
+    #   snowflake-connector-python
+    #   zeep
 prompt-toolkit==3.0.39
     # via click-repl
 protobuf==4.23.4
@@ -619,7 +621,7 @@ six==1.16.0
     #   requests-file
 slumber==0.7.1
     # via edx-rest-api-client
-snowflake-connector-python==3.0.4
+snowflake-connector-python==3.1.0
     # via -r requirements/base.in
 social-auth-app-django==5.2.0
     # via
@@ -640,7 +642,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.43.1
+taxonomy-connector==1.43.2
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -648,6 +650,8 @@ tinycss2==1.2.1
     # via
     #   cairosvg
     #   cssselect2
+tomlkit==0.12.1
+    # via snowflake-connector-python
 tqdm==4.65.0
     # via openai
 typing-extensions==4.7.1


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7294](https://2u-internal.atlassian.net/browse/ENT-7294)

__ Description:__
This is a version upgrade PR for `taxonomy-connector`, upgrading the version to `1.43.1`. The new version contains optimizations for `reindex_algolia` management command. [Here](https://github.com/openedx/taxonomy-connector/compare/1.43.1...1.43.2) are the exact changes included in the release.

**Note:** There is one major upgrade for [cryptography](https://github.com/openedx/course-discovery/compare/master...saleem-latif:course-discovery:saleem-latif/ENT-7294-more-updates?expand=1#diff-eec14310e29cef9d8ae421c606788e73774112c68cda8ab743ad4257ff73d156R148) 
``` diff
- cryptography==40.0.2
+ cryptography==41.0.3
``` 