### PR TITLE
chore: updates version of taxonomy-connector to 1.43.3

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -886,7 +886,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.43.2
+taxonomy-connector==1.43.3
     # via -r requirements/base.in
 testfixtures==7.1.0
     # via -r requirements/test.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -642,7 +642,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.43.2
+taxonomy-connector==1.43.3
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7294](https://2u-internal.atlassian.net/browse/ENT-7294)

__Description:__
This is a version upgrade PR for `taxonomy-connector`, upgrading the version to `1.43.3`. The new version contains fixes for the logic of calculating similar jobs. [Here](https://github.com/openedx/taxonomy-connector/compare/1.43.2...1.43.3) are the exact changes included in the release.
