### PR TITLE
feat: expose ofac fields in program api

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1975,10 +1975,12 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
             'total_hours_of_effort', 'recent_enrollment_count', 'organization_short_code_override',
             'organization_logo_override_url', 'primary_subject_override', 'level_type_override', 'language_override',
             'labels', 'taxi_form', 'program_duration_override', 'data_modified_timestamp',
-            'excluded_from_search', 'excluded_from_seo', 'subscription',
+            'excluded_from_search', 'excluded_from_seo', 'subscription', 'has_ofac_restrictions', 'ofac_comment'
 
         )
-        read_only_fields = ('uuid', 'marketing_url', 'banner_image', 'data_modified_timestamp')
+        read_only_fields = (
+            'uuid', 'marketing_url', 'banner_image', 'data_modified_timestamp', 'has_ofac_restrictions', 'ofac_comment'
+        )
 
     def get_courses(self, program):
         course_runs = list(program.course_runs)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1091,6 +1091,8 @@ class MinimalProgramSerializerTests(TestCase):
             'program_duration_override': program.program_duration_override,
             'excluded_from_seo': program.excluded_from_seo,
             'excluded_from_search': program.excluded_from_search,
+            'has_ofac_restrictions': program.has_ofac_restrictions,
+            'ofac_comment': program.ofac_comment,
             'subscription_eligible': None,
             'subscription_prices': [],
         }

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -375,8 +375,8 @@ class ProgramAdmin(DjangoObjectActions, admin.ModelAdmin):
         'instructor_ordering', 'enrollment_count', 'recent_enrollment_count', 'credit_value',
         'organization_short_code_override', 'organization_logo_override', 'primary_subject_override',
         'level_type_override', 'language_override', 'enterprise_subscription_inclusion', 'in_year_value', 'labels',
-        'geolocation', 'program_duration_override', 'ofac_comment', 'data_modified_timestamp', 'excluded_from_search',
-        'excluded_from_seo'
+        'geolocation', 'program_duration_override', 'has_ofac_restrictions', 'ofac_comment', 'data_modified_timestamp',
+        'excluded_from_search', 'excluded_from_seo'
     )
     change_actions = ('refresh_program_skills', )
 

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -336,7 +336,7 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
             'field-credit_value', 'field-organization_short_code_override', 'field-organization_logo_override',
             'field-primary_subject_override', 'field-level_type_override', 'field-language_override',
             'field-enterprise_subscription_inclusion', 'field-in_year_value', 'field-labels', 'field-geolocation',
-            'field-program_duration_override','field-has_ofac_restrictions', 'field-ofac_comment',
+            'field-program_duration_override', 'field-has_ofac_restrictions', 'field-ofac_comment',
             'field-data_modified_timestamp', 'field-excluded_from_search', 'field-excluded_from_seo'
         ]
         assert actual == expected

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -336,8 +336,8 @@ class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):
             'field-credit_value', 'field-organization_short_code_override', 'field-organization_logo_override',
             'field-primary_subject_override', 'field-level_type_override', 'field-language_override',
             'field-enterprise_subscription_inclusion', 'field-in_year_value', 'field-labels', 'field-geolocation',
-            'field-program_duration_override', 'field-ofac_comment', 'field-data_modified_timestamp',
-            'field-excluded_from_search', 'field-excluded_from_seo'
+            'field-program_duration_override','field-has_ofac_restrictions', 'field-ofac_comment',
+            'field-data_modified_timestamp', 'field-excluded_from_search', 'field-excluded_from_seo'
         ]
         assert actual == expected
 


### PR DESCRIPTION
### [PROD-3307](https://2u-internal.atlassian.net/browse/PROD-3307)

### Description
The PR adds ofac restriction & ofac comment fields in Program API and program admin.

On local, either hit listing http://localhost:18381/api/v1/programs/ or fetch a specific program http://localhost:18381/api/v1/programs/<uuid>. Ofac fields should be in response.