### PR TITLE
feat: update slug for exec-ed courses

### DIFF
--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -2,10 +2,8 @@ import base64
 import functools
 import logging
 import math
-import re
 from urllib.parse import parse_qsl, urlencode, urljoin
 
-from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db.models.fields.related import ManyToManyField
 from django.utils.translation import gettext as _
@@ -15,31 +13,9 @@ from sortedm2m.fields import SortedManyToManyField
 
 from course_discovery.apps.core.api_client.lms import LMSAPIClient
 from course_discovery.apps.core.utils import serialize_datetime
-from course_discovery.apps.course_metadata.constants import SUBDIRECTORY_SLUG_FORMAT_REGEX
-from course_discovery.apps.course_metadata.models import Course, CourseRun
-from course_discovery.apps.course_metadata.utils import get_slug_for_course
+from course_discovery.apps.course_metadata.models import CourseRun
 
 logger = logging.getLogger(__name__)
-
-
-def set_subdirectory_slug_for_course(course_run):
-    """
-    Sets the active url slug for draft and non-draft courses if the current
-    slug is not validated as per the new format.
-    """
-    draft_course = Course.everything.get(key=course_run.course.key, draft=True)
-    is_slug_in_subdirectory_format = bool(re.match(SUBDIRECTORY_SLUG_FORMAT_REGEX, draft_course.active_url_slug))
-    if not is_slug_in_subdirectory_format and draft_course.product_source.slug == settings.DEFAULT_PRODUCT_SOURCE_SLUG:
-        slug, error = get_slug_for_course(draft_course)
-        if slug:
-            draft_course.set_active_url_slug(slug)
-            if draft_course.official_version:
-                draft_course.official_version.set_active_url_slug(slug)
-        else:
-            raise Exception(  # pylint: disable=broad-exception-raised
-                f"Slug generation Failed: unable to set active url slug for course: {draft_course.key} "
-                f"with error {error}"
-            )
 
 
 def cast2int(value, name):

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.db import models, transaction
 from django.db.models.functions import Lower
 from django.http.response import Http404
@@ -19,16 +18,13 @@ from course_discovery.apps.api.mixins import ValidElasticSearchQueryRequiredMixi
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.permissions import IsCourseRunEditorOrDjangoOrReadOnly
 from course_discovery.apps.api.serializers import MetadataWithRelatedChoices
-from course_discovery.apps.api.utils import (
-    StudioAPI, get_query_param, reviewable_data_has_changed, set_subdirectory_slug_for_course
-)
+from course_discovery.apps.api.utils import StudioAPI, get_query_param, reviewable_data_has_changed
 from course_discovery.apps.api.v1.exceptions import EditableAndQUnsupported
 from course_discovery.apps.core.utils import SearchQuerySetWrapper
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.constants import COURSE_RUN_ID_REGEX
 from course_discovery.apps.course_metadata.exceptions import EcommerceSiteAPIClientException
 from course_discovery.apps.course_metadata.models import Course, CourseEditor, CourseRun
-from course_discovery.apps.course_metadata.toggles import IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED
 from course_discovery.apps.course_metadata.utils import ensure_draft_world
 from course_discovery.apps.publisher.utils import is_publisher_user
 
@@ -279,7 +275,6 @@ class CourseRunViewSet(ValidElasticSearchQueryRequiredMixin, viewsets.ModelViewS
         save_kwargs = {}
         # If changes are made after review and before publish, revert status to unpublished.
         # Unless we're just switching the status
-        product_source = course_run.course.product_source
         non_exempt_update = changed and course_run.status == CourseRunStatus.Reviewed
         if non_exempt_update:
             save_kwargs['status'] = CourseRunStatus.Unpublished
@@ -291,9 +286,6 @@ class CourseRunViewSet(ValidElasticSearchQueryRequiredMixin, viewsets.ModelViewS
         # back into legal review if a non exempt field was changed (expected_program_name and expected_program_type)
         if not draft and (course_run.status == CourseRunStatus.Unpublished or non_exempt_update):
             save_kwargs['status'] = CourseRunStatus.LegalReview
-            if IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED.is_enabled() and \
-                    product_source.slug == settings.DEFAULT_PRODUCT_SOURCE_SLUG:
-                set_subdirectory_slug_for_course(course_run)
 
         course_run = serializer.save(**save_kwargs)
 

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -432,7 +432,7 @@ class CSVDataLoader(AbstractDataLoader):
             'draft': is_draft,
             'key': course.key,
             'uuid': str(course.uuid),
-            'url_slug': data.get('slug') or course.active_url_slug,
+            'url_slug': course.active_url_slug,
             'type': str(course.type.uuid),
             'subjects': subjects,
             'collaborators': collaborator_uuids,

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -189,8 +189,8 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                     )
 
     @data(
-        ('csv-course-custom-slug', 'csv-course-custom-slug'),
-        ('custom-slug-2', 'custom-slug-2'),
+        ('csv-course-custom-slug', 'csv-course'),
+        ('custom-slug-2', 'csv-course'),
         ('', 'csv-course')  # No slug in CSV corresponds to default slug mechanism
     )
     @unpack

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
@@ -6,6 +6,8 @@ from unittest import mock
 import responses
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import CommandError, call_command
+from edx_toggles.toggles.testutils import override_waffle_switch
+from slugify import slugify
 from testfixtures import LogCapture
 
 from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
@@ -15,6 +17,7 @@ from course_discovery.apps.course_metadata.data_loaders.tests import mock_data
 from course_discovery.apps.course_metadata.data_loaders.tests.mixins import CSVLoaderMixin
 from course_discovery.apps.course_metadata.models import Course, CourseRun
 from course_discovery.apps.course_metadata.tests.factories import CSVDataLoaderConfigurationFactory
+from course_discovery.apps.course_metadata.toggles import IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED
 
 LOGGER_PATH = 'course_discovery.apps.course_metadata.management.commands.import_course_metadata'
 
@@ -128,36 +131,39 @@ class TestImportCourseMetadata(CSVLoaderMixin, OAuth2Mixin, APITestCase):
 
         _ = CSVDataLoaderConfigurationFactory.create(enabled=True, csv_file=self.csv_file)
 
-        with LogCapture(LOGGER_PATH) as log_capture:
-            with mock.patch.object(
-                    CSVDataLoader,
-                    '_call_course_api',
-                    self.mock_call_course_api
-            ):
-                call_command(
-                    'import_course_metadata',
-                    '--partner_code', self.partner.short_code,
-                    '--product_type', 'EXECUTIVE_EDUCATION',
-                    '--product_source', self.source.slug,
-                )
-                log_capture.check_present(
-                    (
-                        LOGGER_PATH,
-                        'INFO',
-                        'Starting CSV loader import flow for partner {}'.format(self.partner.short_code)
+        with override_waffle_switch(IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED, active=True):
+            with LogCapture(LOGGER_PATH) as log_capture:
+                with mock.patch.object(
+                        CSVDataLoader,
+                        '_call_course_api',
+                        self.mock_call_course_api
+                ):
+                    call_command(
+                        'import_course_metadata',
+                        '--partner_code', self.partner.short_code,
+                        '--product_type', 'EXECUTIVE_EDUCATION',
+                        '--product_source', self.source.slug,
                     )
-                )
-                log_capture.check_present(
-                    (LOGGER_PATH, 'INFO', 'CSV loader import flow completed.')
-                )
+                    log_capture.check_present(
+                        (
+                            LOGGER_PATH,
+                            'INFO',
+                            'Starting CSV loader import flow for partner {}'.format(self.partner.short_code)
+                        )
+                    )
+                    log_capture.check_present(
+                        (LOGGER_PATH, 'INFO', 'CSV loader import flow completed.')
+                    )
 
-                assert Course.everything.count() == 1
-                assert CourseRun.everything.count() == 1
+                    assert Course.everything.count() == 1
+                    assert CourseRun.everything.count() == 1
 
-                course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
-                course_run = CourseRun.everything.get(course=course)
+                    course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
+                    course_run = CourseRun.everything.get(course=course)
+                    slug_path = f'{slugify(course.authoring_organizations.first().name)}-{slugify(course.title)}'
 
-                assert course.image.read() == image_content
-                self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)
-                self._assert_course_run_data(course_run, self.BASE_EXPECTED_COURSE_RUN_DATA)
-                email_patch.assert_called_once()
+                    assert course.image.read() == image_content
+                    assert course.active_url_slug == f'executive-education/{slug_path}'
+                    self._assert_course_data(course, self.BASE_EXPECTED_COURSE_DATA)
+                    self._assert_course_run_data(course_run, self.BASE_EXPECTED_COURSE_RUN_DATA)
+                    email_patch.assert_called_once()

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -44,7 +44,7 @@ from course_discovery.apps.course_metadata.choices import (
     CertificateType, CourseLength, CourseRunPacing, CourseRunStatus, ExternalCourseMarketingType, ExternalProductStatus,
     PayeeType, ProgramStatus, ReportingType
 )
-from course_discovery.apps.course_metadata.constants import PathwayType
+from course_discovery.apps.course_metadata.constants import SUBDIRECTORY_SLUG_FORMAT_REGEX, PathwayType
 from course_discovery.apps.course_metadata.fields import AutoSlugWithSlashesField, HtmlField, NullHtmlField
 from course_discovery.apps.course_metadata.managers import DraftManager
 from course_discovery.apps.course_metadata.model_utils import has_model_changed
@@ -53,9 +53,10 @@ from course_discovery.apps.course_metadata.publishers import (
     CourseRunMarketingSitePublisher, ProgramMarketingSitePublisher
 )
 from course_discovery.apps.course_metadata.query import CourseQuerySet, CourseRunQuerySet, ProgramQuerySet
+from course_discovery.apps.course_metadata.toggles import IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED
 from course_discovery.apps.course_metadata.utils import (
-    UploadToFieldNamePath, clean_query, custom_render_variations, push_to_ecommerce_for_course_run,
-    push_tracks_to_lms_for_course_run, set_official_state, subtract_deadline_delta
+    UploadToFieldNamePath, clean_query, custom_render_variations, get_slug_for_course, is_ocm_course,
+    push_to_ecommerce_for_course_run, push_tracks_to_lms_for_course_run, set_official_state, subtract_deadline_delta
 )
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.utils import VALID_CHARS_IN_COURSE_NUM_AND_ORG_KEY
@@ -1838,6 +1839,26 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
                 seen.add(course)
         return deduped
 
+    def set_subdirectory_slug(self):
+        """
+        Sets the active url slug for draft and non-draft courses if the current
+        slug is not validated as per the new format.
+        """
+        is_slug_in_subdirectory_format = bool(re.match(SUBDIRECTORY_SLUG_FORMAT_REGEX, self.active_url_slug))
+        is_exec_ed_course = self.type.slug == CourseType.EXECUTIVE_EDUCATION_2U
+        is_open_course = is_ocm_course(self)
+        if not is_slug_in_subdirectory_format and (is_exec_ed_course or is_open_course):
+            slug, error = get_slug_for_course(self)
+            if slug:
+                self.set_active_url_slug(slug)
+                if self.official_version:
+                    self.official_version.set_active_url_slug(slug)
+            else:
+                raise Exception(  # pylint: disable=broad-exception-raised
+                    f"Slug generation Failed: unable to set active url slug for course: {self.key} "
+                    f"with error {error}"
+                )
+
 
 class CourseEditor(TimeStampedModel):
     """
@@ -2548,6 +2569,9 @@ class CourseRun(DraftModelMixin, CachedMixin, TimeStampedModel):
 
         if self.status == CourseRunStatus.LegalReview:
             email_method = emails.send_email_for_legal_review
+
+            if IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED.is_enabled():
+                self.course.set_subdirectory_slug()
 
         elif self.status == CourseRunStatus.InternalReview:
             email_method = emails.send_email_for_internal_review

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -971,6 +971,25 @@ def is_valid_slug_format(val):
     return bool(re.match(valid_slug_pattern, val))
 
 
+def is_ocm_course(course):
+    """
+    Checks whether a given course is an OCM or not
+
+    Args:
+        course: a course instance
+
+    Returns:
+        True for all edx courses other than exec-ed and bootcamps
+    """
+    # to avoid circular dependency
+    from course_discovery.apps.course_metadata.models import CourseType  # pylint: disable=import-outside-toplevel
+
+    non_ocm_types = [CourseType.EXECUTIVE_EDUCATION_2U, CourseType.BOOTCAMP_2U]
+    is_ocm_course_type = course.type.slug not in non_ocm_types
+    is_default_product_source = course.product_source.slug == settings.DEFAULT_PRODUCT_SOURCE_SLUG
+    return is_ocm_course_type and is_default_product_source
+
+
 def get_slug_for_course(course):
     """
     Given a course it will return slug and error if there is any'


### PR DESCRIPTION
### [PROD-3494](https://2u-internal.atlassian.net/browse/PROD-3494)

### Description
The PR adds the support for the slug generation in sub-directory format for all the Executive Education courses offered by 2U.In addition to it, the code-base is also refactored related to the slug generation of the OCM in sub-directory format.

### Context
When the newly created courses including 2U's exec-ed and ocm's are transitioned to Legal review, their slug will be updated to the sub-directory format if it is not in it already. Its roll out demands operational preventive measures for its successful deplyment to the production environment that is why it is implemented under a feature flag named `IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED`.

### Tests
The test cases related to the added features in this PR are also updated.