### PR TITLE
perf: improving database queries for CourseRecommendations endpoint

### DIFF
--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -525,4 +525,4 @@ class CourseRecommendationViewSet(RetrieveModelMixin, viewsets.GenericViewSet):
     lookup_value_regex = COURSE_ID_REGEX
     permission_classes = (IsAuthenticated, IsCourseEditorOrReadOnly,)
     serializer_class = serializers.CourseWithRecommendationsSerializer
-    queryset = serializers.MinimalCourseSerializer.prefetch_queryset()
+    queryset = Course.objects.all()


### PR DESCRIPTION
[PROD-3561](https://2u-internal.atlassian.net/browse/PROD-3561)
------------------------

This PR fixes most of the N+1 issues on CourseRecommendations endpoint. 

### Screenshots
These are particular changes from an endpoint on my machine. The effects on prod will probably be significantly different, and most likely not this significant, due to the type and size of the data over there.
#### Before
<img width="240" alt="Screenshot 2023-08-10 at 12 21 26 PM" src="https://github.com/openedx/course-discovery/assets/87228907/be5bc4c2-e779-484b-8910-1a2a80338eb6">

#### After
<img width="237" alt="Screenshot 2023-08-10 at 12 23 31 PM" src="https://github.com/openedx/course-discovery/assets/87228907/d13e01dd-78e2-4fa8-9f1f-7c56ed701af0">

### Testing
- Go to /api/v1/course_recommendations/<course_key> for a particular course on local
- Note the query count and Time in Django Debug Toolbar
- Pull these changes
- Go to the the same course_recommendations endpoint
- Note the query count and Time again. They should both decrease.
