### PR TITLE
feat: include all PCs in review emails

### DIFF
--- a/course_discovery/apps/course_metadata/emails.py
+++ b/course_discovery/apps/course_metadata/emails.py
@@ -44,7 +44,7 @@ def log_missing_project_coordinator(key, org, template_name):
 
 
 def get_project_coordinator(org):
-    """ Get the registered project coordinator for an organization.
+    """ Get the registered project coordinators for an organization.
 
         Only returns the first one. Technically the database supports multiple. But in practice, we only use one.
         Requires a OrganizationUserRole to be set up first.
@@ -53,7 +53,7 @@ def get_project_coordinator(org):
             org (Object): Organization object
 
         Returns:
-            Object: a User object or None if no project coordinator is registered
+            list(Object): a list of User objects or None if no project coordinator is registered
     """
     # Model imports here to avoid a circular import
     from course_discovery.apps.publisher.models import OrganizationUserRole  # pylint: disable=import-outside-toplevel
@@ -61,13 +61,20 @@ def get_project_coordinator(org):
     if not org:
         return None
 
-    role = OrganizationUserRole.objects.filter(organization=org,
-                                               role=InternalUserRole.ProjectCoordinator.value).first()
-    return role.user if role else None
+    are_project_coordinators_present = OrganizationUserRole.objects.filter(
+        organization=org, role=InternalUserRole.ProjectCoordinator.value
+    ).exists()
+
+    if not are_project_coordinators_present:
+        return None
+    project_coordinators = [pc.user for pc in OrganizationUserRole.objects.filter(
+        organization=org, role=InternalUserRole.ProjectCoordinator.value
+    ).select_related('user')]
+    return project_coordinators
 
 
 def send_email(template_name, subject, to_users, recipient_name,
-               course_run=None, course=None, context=None, project_coordinator=None):
+               course_run=None, course=None, context=None, project_coordinators=None):
     """ Send an email template out to the given users with some standard context variables.
 
         Arguments:
@@ -78,13 +85,13 @@ def send_email(template_name, subject, to_users, recipient_name,
             course_run (Object): CourseRun object
             course (Object): Course object
             context (dict): additional context for the template
-            project_coordinator (Object): optional optimization if you have the PC User already, to prevent a lookup
+            project_coordinators (list): optional optimization if you have the PC User(s) already, to prevent a lookup
     """
     course = course or course_run.course
     partner = course.partner
     org = course.authoring_organizations.first()
-    project_coordinator = project_coordinator or get_project_coordinator(org)
-    if not project_coordinator:
+    project_coordinators = project_coordinators or get_project_coordinator(org)
+    if not project_coordinators:
         log_missing_project_coordinator(course.key, org, template_name)
         return
 
@@ -115,7 +122,7 @@ def send_email(template_name, subject, to_users, recipient_name,
             'recipient_name': recipient_name,
             'platform_name': settings.PLATFORM_NAME,
             'org_name': org.name,
-            'contact_us_email': project_coordinator.email,
+            'contact_us_emails': [project_coordinator.email for project_coordinator in project_coordinators],
             'course_page_url': review_url,
             'studio_url': run_studio_url,
             'preview_url': course_run.marketing_url,
@@ -127,7 +134,7 @@ def send_email(template_name, subject, to_users, recipient_name,
             'recipient_name': recipient_name,
             'platform_name': settings.PLATFORM_NAME,
             'org_name': org.name,
-            'contact_us_email': project_coordinator.email,
+            'contact_us_emails': [project_coordinator.email for project_coordinator in project_coordinators],
         })
     if context:
         base_context.update(context)
@@ -178,14 +185,13 @@ def send_email_to_project_coordinator(course_run, template_name, subject, contex
             context (dict): additional context for the template
     """
     org = course_run.course.authoring_organizations.first()
-    project_coordinator = get_project_coordinator(org)
-    if not project_coordinator:
+    project_coordinators = get_project_coordinator(org)
+    if not project_coordinators:
         log_missing_project_coordinator(course_run.course.key, org, template_name)
         return
 
-    recipient_name = project_coordinator.full_name or project_coordinator.username
-    send_email(template_name, subject, [project_coordinator], recipient_name, context=context,
-               project_coordinator=project_coordinator, course_run=course_run)
+    send_email(template_name, subject, project_coordinators, _('Project Coordinator team'), context=context,
+               project_coordinators=project_coordinators, course_run=course_run)
 
 
 def send_email_to_editors(course_run, template_name, subject, context=None):
@@ -321,10 +327,10 @@ def send_email_for_comment(comment, course, author):
     )
 
     org = course.authoring_organizations.first()
-    project_coordinator = get_project_coordinator(org)
+    project_coordinators = get_project_coordinator(org)
     recipients = list(CourseEditor.course_editors(course))
-    if project_coordinator:
-        recipients.append(project_coordinator)
+    if project_coordinators:
+        recipients.extend(project_coordinators)
 
     # remove email of comment owner if exists
     recipients = filter(lambda x: x.email != author.email, recipients)
@@ -341,7 +347,7 @@ def send_email_for_comment(comment, course, author):
 
     try:
         send_email('course_metadata/email/comment', subject, recipients, '',
-                   course=course, context=context, project_coordinator=project_coordinator)
+                   course=course, context=context, project_coordinators=project_coordinators)
     except Exception:  # pylint: disable=broad-except
         logger.exception('Failed to send email notifications for comment on course %s', course.uuid)
 

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/go_live.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/go_live.html
@@ -28,12 +28,18 @@
 </p>
 
 <p>
-    {% blocktrans trimmed asvar tmsg %}
-        Note: This email address is unable to receive replies. For questions or comments, please contact {link_start}{contact_us_email}{link_middle}your Project Coordinator{link_end}.
-    {% endblocktrans %}
-    {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>'|safe contact_us_email=contact_us_email|safe %}
-</p
->
+    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator(s):
+    {% for contact_us_email in contact_us_emails %}
+        {% blocktrans trimmed asvar tmsg %}
+        {link_start}{contact_us_email}{link_middle}{contact_us_email}{link_end}
+        {% endblocktrans %}
+        {% if forloop.last %}
+        {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>'|safe contact_us_email=contact_us_email|safe %}
+        {% else %}
+        {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>, '|safe contact_us_email=contact_us_email|safe %}
+        {% endif %}
+    {% endfor %}
+</p>
 
 <!-- End Message Body -->
 {% endblock body %}

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/go_live.txt
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/go_live.txt
@@ -13,5 +13,5 @@
 {% endblocktrans %}
 
 {% blocktrans trimmed %}
-    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator at {{ contact_us_email }}.
-{% endblocktrans %}
+    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator(s):
+{% endblocktrans %}{% for contact_us_email in contact_us_emails %}{% if forloop.last %}{{ contact_us_email }}{% else %}{{ contact_us_email }},{% endif %}{% endfor %}

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/legal_review.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/legal_review.html
@@ -18,10 +18,17 @@
     {% interpolate_html tmsg link_start='<a href="'|safe link_middle='">'|safe link_end='</a>'|safe org_name=org_name|safe course_name=course_name|safe course_page_url=course_page_url|safe %}
 </p>
 <p>
-    {% blocktrans trimmed asvar tmsg %}
-        Note: This email address is unable to receive replies. For questions or comments, please contact {link_start}{contact_us_email}{link_middle}the Project Coordinator{link_end}.
-    {% endblocktrans %}
-    {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>'|safe contact_us_email=contact_us_email|safe  %}
+    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator(s):
+    {% for contact_us_email in contact_us_emails %}
+        {% blocktrans trimmed asvar tmsg %}
+        {link_start}{contact_us_email}{link_middle}{contact_us_email}{link_end}
+        {% endblocktrans %}
+        {% if forloop.last %}
+        {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>'|safe contact_us_email=contact_us_email|safe %}
+        {% else %}
+        {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>, '|safe contact_us_email=contact_us_email|safe %}
+        {% endif %}
+    {% endfor %}
 </p>
 
 <!-- End Message Body -->

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/legal_review.txt
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/legal_review.txt
@@ -13,5 +13,5 @@
 {% endblocktrans %}
 
 {% blocktrans trimmed %}
-    Note: This email address is unable to receive replies. For questions or comments, please contact the Project Coordinator at {{ contact_us_email }}.
-{% endblocktrans %}
+    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator(s):
+{% endblocktrans %}{% for contact_us_email in contact_us_emails %}{% if forloop.last %}{{ contact_us_email }}{% else %}{{ contact_us_email }},{% endif %}{% endfor %}

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/reviewed.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/reviewed.html
@@ -33,10 +33,17 @@
 </p>
 
 <p>
-    {% blocktrans trimmed asvar tmsg %}
-        Note: This email address is unable to receive replies. For questions or comments, please contact {link_start}{contact_us_email}{link_middle}your Project Coordinator{link_end}.
-    {% endblocktrans %}
-    {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>'|safe contact_us_email=contact_us_email|safe %}
+    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator(s):
+    {% for contact_us_email in contact_us_emails %}
+        {% blocktrans trimmed asvar tmsg %}
+        {link_start}{contact_us_email}{link_middle}{contact_us_email}{link_end}
+        {% endblocktrans %}
+        {% if forloop.last %}
+        {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>'|safe contact_us_email=contact_us_email|safe %}
+        {% else %}
+        {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>, '|safe contact_us_email=contact_us_email|safe %}
+        {% endif %}
+    {% endfor %}
 </p>
 
 <!-- End Message Body -->

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/reviewed.txt
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/reviewed.txt
@@ -23,5 +23,5 @@
 {% endblocktrans %}
 
 {% blocktrans trimmed %}
-    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator at {{ contact_us_email }}.
-{% endblocktrans %}
+    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator(s):
+{% endblocktrans %}{% for contact_us_email in contact_us_emails %}{% if forloop.last %}{{ contact_us_email }}{% else %}{{ contact_us_email }},{% endif %}{% endfor %}

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -78,7 +78,6 @@ class EmailTests(TestCase):
         for regex in both_regexes or []:
             self.assertRegex(text, regex)
             self.assertRegex(html, regex)
-
         for regex in text_regexes or []:
             self.assertRegex(text, regex)
 
@@ -128,6 +127,10 @@ class EmailTests(TestCase):
         """
         Verify that send_email_for_legal_review's happy path works as expected
         """
+        project_coordinator_2 = self.make_user(email='pc2@test.com')
+        OrganizationUserRoleFactory(
+            user=project_coordinator_2, organization=self.org, role=InternalUserRole.ProjectCoordinator.value
+        )
         self.assertEmailSent(
             emails.send_email_for_legal_review,
             f'^Legal review requested: {self.course_run.title}$',
@@ -139,12 +142,13 @@ class EmailTests(TestCase):
             ],
             html_regexes=[
                 '<a href="%s">View this course run in Publisher</a> to determine OFAC status.' % self.publisher_url,
-                'For questions or comments, please contact '
-                '<a href="mailto:pc@example.com">the Project Coordinator</a>.',
+                r'For questions or comments, please contact your Project Coordinator\(s\):',
+                '<a href="mailto:pc@example.com">pc@example.com</a>, ',
+                '<a href="mailto:pc2@test.com">pc2@test.com</a>',
             ],
             text_regexes=[
                 '%s\nView this course run in Publisher above to determine OFAC status.' % self.publisher_url,
-                'For questions or comments, please contact the Project Coordinator at pc@example.com.',
+                r'For questions or comments, please contact your Project Coordinator\(s\):pc@example.com,pc2@test.com'
             ],
         )
 
@@ -184,7 +188,7 @@ class EmailTests(TestCase):
             f'^Review requested: {re.escape(self.course_run.key)} - {self.course_run.title}$',
             [self.pc],
             both_regexes=[
-                'Dear %s,' % self.pc.full_name,
+                'Dear Project Coordinator team,',
                 'MyOrg has submitted %s for review.' % re.escape(self.course_run.key),
             ],
             html_regexes=[
@@ -218,14 +222,14 @@ class EmailTests(TestCase):
             html_regexes=[
                 'The <a href="%s">%s course run</a> of %s has been reviewed and approved by %s.' %
                 (self.publisher_url, self.run_num, self.course_run.title, settings.PLATFORM_NAME),
-                'For questions or comments, please contact '
-                '<a href="mailto:pc@example.com">your Project Coordinator</a>.',
+                r'For questions or comments, please contact your Project Coordinator\(s\):',
+                '<a href="mailto:pc@example.com">pc@example.com</a>',
             ],
             text_regexes=[
                 'The %s course run of %s has been reviewed and approved by %s.' %
                 (self.run_num, self.course_run.title, settings.PLATFORM_NAME),
                 '\n\nView the course run in Publisher: %s\n' % self.publisher_url,
-                'For questions or comments, please contact your Project Coordinator at pc@example.com.',
+                r'For questions or comments, please contact your Project Coordinator\(s\):pc@example.com'
             ],
         )
 
@@ -241,12 +245,12 @@ class EmailTests(TestCase):
             ],
             'html_regexes': [
                 '<a href="%s">View this About page.</a>' % self.course_run.marketing_url,
-                'For questions or comments, please contact '
-                '<a href="mailto:pc@example.com">your Project Coordinator</a>.',
+                r'For questions or comments, please contact your Project Coordinator\(s\):',
+                '<a href="mailto:pc@example.com">pc@example.com</a>',
             ],
             'text_regexes': [
                 '\n\nView this About page. %s\n' % self.course_run.marketing_url,
-                'For questions or comments, please contact your Project Coordinator at pc@example.com.',
+                r'For questions or comments, please contact your Project Coordinator\(s\):pc@example.com'
             ],
         }
 


### PR DESCRIPTION
### [PROD-3365](https://2u-internal.atlassian.net/browse/PROD-3365)

### Description
- Send emails to all PCs when PCs are notified via email
- Replace contact us email of PCs with contact_us_emails for all PCs.
- Update PC email template to remove the name and add default "Project Coordinator team"

### Testing
In send_email method in emails.py, add `    open(f"{str(datetime.datetime.now())}.html", 'w').write(html_content)
` before email_msg.send() call. On local, the emails are not sent. However, this will render the email content in an HTML file. 

- Ensure you have two or more PCs for an organization in http://localhost:18381/admin/publisher/organizationuserrole/
- Create a new course in publisher and send it to legal review after adding the data. Notice the test html. Ensure the content includes email for both PCs
- Move to PC review and ensure the PC email does not include pc name
- Move to scheduled/published and verify the pc emails are present in the content

### Screenshots
<img width="977" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/a520ef10-59e1-41c6-acde-c6c0894ffcbf">

<img width="1241" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/a9788e24-c309-461c-b231-06be99ae024c">

<img width="1241" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/cc2ff6d6-1bd9-46d2-ad8c-b0d3f4c617f8">

<img width="1241" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/59a3550d-076b-4fee-af1e-26121a3a3b5e">
