### PR TITLE
fix: typo in `make pull_translation` for atlas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ pull_translations:
 	atlas pull $(OPENEDX_ATLAS_ARGS) translations/course-discovery/course_discovery/conf/locale:course_discovery/conf/locale
 	python manage.py compilemessages
 
-	@echo "Translations pulled from Transifex and compiled."
+	@echo "Translations have been pulled via Atlas and compiled."
 	@echo "'make static' or 'make static.dev' is required to update the js i18n files."
 endif
 


### PR DESCRIPTION
It doesn't pull from Transifex, therefore Transifex shouldn't be mentioned.

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).
