### PR TITLE
feat: autogeneration of bootcamp url slug

### DIFF
--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -12,6 +12,7 @@ SUBDIRECTORY_SLUG_FORMAT_REGEX = (
     r'boot-camps\/[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+$'
 )
 SLUG_FORMAT_REGEX = r'[a-zA-Z0-9-_]+$'
+
 DEFAULT_SLUG_FORMAT_ERROR_MSG = 'Enter a valid “slug” consisting of letters, numbers, underscores or hyphens.'
 
 MASTERS_PROGRAM_TYPE_SLUG = 'masters'

--- a/course_discovery/apps/course_metadata/constants.py
+++ b/course_discovery/apps/course_metadata/constants.py
@@ -12,7 +12,6 @@ SUBDIRECTORY_SLUG_FORMAT_REGEX = (
     r'boot-camps\/[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+$'
 )
 SLUG_FORMAT_REGEX = r'[a-zA-Z0-9-_]+$'
-
 DEFAULT_SLUG_FORMAT_ERROR_MSG = 'Enter a valid “slug” consisting of letters, numbers, underscores or hyphens.'
 
 MASTERS_PROGRAM_TYPE_SLUG = 'masters'

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -55,7 +55,8 @@ from course_discovery.apps.course_metadata.publishers import (
 )
 from course_discovery.apps.course_metadata.query import CourseQuerySet, CourseRunQuerySet, ProgramQuerySet
 from course_discovery.apps.course_metadata.toggles import (
-    IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED, IS_SUBDIRECTORY_SLUG_FORMAT_FOR_EXEC_ED_ENABLED
+    IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED, IS_SUBDIRECTORY_SLUG_FORMAT_FOR_BOOTCAMP_ENABLED,
+    IS_SUBDIRECTORY_SLUG_FORMAT_FOR_EXEC_ED_ENABLED
 )
 from course_discovery.apps.course_metadata.utils import (
     UploadToFieldNamePath, clean_query, custom_render_variations, get_slug_for_course, is_ocm_course,
@@ -1862,10 +1863,13 @@ class Course(DraftModelMixin, PkSearchableMixin, CachedMixin, TimeStampedModel):
         """
         is_slug_in_subdirectory_format = bool(re.match(SUBDIRECTORY_SLUG_FORMAT_REGEX, self.active_url_slug))
         is_exec_ed_course = self.type.slug == CourseType.EXECUTIVE_EDUCATION_2U
+        is_bootcamp_course = self.type.slug == CourseType.BOOTCAMP_2U
         if is_exec_ed_course and not IS_SUBDIRECTORY_SLUG_FORMAT_FOR_EXEC_ED_ENABLED.is_enabled():
             return
+        if is_bootcamp_course and not IS_SUBDIRECTORY_SLUG_FORMAT_FOR_BOOTCAMP_ENABLED.is_enabled():
+            return
         is_open_course = is_ocm_course(self)
-        if not is_slug_in_subdirectory_format and (is_exec_ed_course or is_open_course):
+        if not is_slug_in_subdirectory_format and (is_exec_ed_course or is_open_course or is_bootcamp_course):
             slug, error = get_slug_for_course(self)
             if slug:
                 self.set_active_url_slug(slug)

--- a/course_discovery/apps/course_metadata/toggles.py
+++ b/course_discovery/apps/course_metadata/toggles.py
@@ -43,3 +43,14 @@ IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED = WaffleSwitch(
 IS_SUBDIRECTORY_SLUG_FORMAT_FOR_EXEC_ED_ENABLED = WaffleSwitch(
     'course_metadata.is_subdirectory_slug_format_for_exec_ed_enabled', __name__
 )
+# .. toggle_name: course_metadata.is_subdirectory_slug_format_for_bootcamp_enabled
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Enable to use subdirectory slug format for bootcamp courses.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-09-05
+# .. toggle_target_removal_date: 2023-09-20
+# .. toggle_tickets: PROD-3611
+IS_SUBDIRECTORY_SLUG_FORMAT_FOR_BOOTCAMP_ENABLED = WaffleSwitch(
+    'course_metadata.is_subdirectory_slug_format_for_bootcamp_enabled', __name__
+)


### PR DESCRIPTION
[PROD-3611](https://2u-internal.atlassian.net/browse/PROD-3611)
------------------
This PR covers autogeneration of bootcamps subdirectory format url slug when course is transitioned to submit for review status.

**Note: This PR also adds some duplicate changes from this PR to test the functionality https://github.com/openedx/course-discovery/pull/4075**