### PR TITLE
fix: add pymemcache dependency

### DIFF
--- a/requirements/production.in
+++ b/requirements/production.in
@@ -10,4 +10,5 @@ gunicorn
 mysqlclient
 newrelic
 python-memcached
+pymemcache
 PyYAML

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -509,6 +509,8 @@ pyjwt[crypto]==2.8.0
     #   simple-salesforce
     #   snowflake-connector-python
     #   social-auth-core
+pymemcache==4.0.0
+    # via -r requirements/production.in
 pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -10,6 +10,7 @@ mock
 mysqlclient
 pycodestyle
 python-memcached
+pymemcache
 pytest
 pytest-cov
 pytest-django


### PR DESCRIPTION
## Description
- Under the issue https://github.com/edx/edx-arch-experiments/issues/433, adding `pymemcache` to dependencies as first step to replace cache backend in follow up PRs.