### PR TITLE
fix: add pymemcache requirement in local.txt

### DIFF
--- a/requirements/local.in
+++ b/requirements/local.in
@@ -11,3 +11,4 @@ docker-compose
 edx-i18n-tools
 pytest-split
 pywatchman                                 # For devserver code reloading
+pymemcache

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -666,6 +666,8 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
+pymemcache==4.0.0
+    # via -r requirements/test.in
 pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0


### PR DESCRIPTION
## Description
- CI tests require the `local.txt` to also be updated with latest dependencies. 
- The `Python Requirements Upgrade` job is currently broken due to token permission issue so manually upgrading `local.txt` to resolve blocker in testing the issue. 
- Avoided upgrading other dependencies in the same PR to make the change simple to review. 