### PR TITLE
Revert "fix: strip off the spaces in mktg url"

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -3303,8 +3303,8 @@ class Program(ManageHistoryMixin, PkSearchableMixin, TimeStampedModel):
     @property
     def marketing_url(self):
         if self.marketing_slug:
-            path = f'{self.type.slug.lower().strip()}/{self.marketing_slug.strip()}'
-            return urljoin(self.partner.marketing_site_url_root.strip(), path)
+            path = f'{self.type.slug.lower()}/{self.marketing_slug}'
+            return urljoin(self.partner.marketing_site_url_root, path)
 
         return None
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2454,18 +2454,6 @@ class ProgramTests(TestCase):
         query = 'title:' + self.program.title
         self.assertSetEqual({Program.search(query).first()}, {self.program})
 
-    def test_spaces_must_be_stripped_off_from_marketing_url(self):
-        """
-        Validate that the spaces in the marketing slug must be stripped off while generating marketing url
-        """
-        # updating the attrs with trailing spaces
-        self.program.marketing_slug = 'test-slug-0 '
-        self.program.type.slug = 'test '
-        site_root = self.program.partner.marketing_site_url_root
-        self.program.partner.marketing_site_url_root = site_root + ' '
-
-        assert self.program.marketing_url.find(' ') == -1
-
     def test_subject_search(self):
         """
         Verify that the program endpoint correctly handles elasticsearch queries on the subject uuid


### PR DESCRIPTION
Reverts openedx/course-discovery#4087

Reverting this change because of locating few instances with empty marketing root. Calling `strip()` on them raises exception which ultimately sets the flag `should_index` to `True`.It results in indexing unwanted instances on algolia, maybe it is the possible reason of build failure of prospectus.