### PR TITLE
perf: N+1 fixes

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -1019,7 +1019,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         """ Verify the endpoint returns a list of all course runs. """
         url = reverse('api:v1:course_run-list')
 
-        with self.assertNumQueries(17, threshold=3):
+        with self.assertNumQueries(14, threshold=3):
             response = self.client.get(url)
 
         assert response.status_code == 200
@@ -1032,7 +1032,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         """ Verify the endpoint returns a list of all course runs sorted by start date. """
         url = '{root}?ordering=start'.format(root=reverse('api:v1:course_run-list'))
 
-        with self.assertNumQueries(17, threshold=3):
+        with self.assertNumQueries(14, threshold=3):
             response = self.client.get(url)
 
         assert response.status_code == 200


### PR DESCRIPTION
## [PROD-3626](https://2u-internal.atlassian.net/browse/PROD-3626)

This PR fixes most of the N+1 issues on CourseRun.List endpoint.

### Comparison
<img width="308" alt="Screenshot 2023-09-19 at 3 31 16 PM" src="https://github.com/openedx/course-discovery/assets/87228907/0d372a38-9443-4a72-9fd0-4851ee99e67b">
<img width="289" alt="Screenshot 2023-09-19 at 3 36 45 PM" src="https://github.com/openedx/course-discovery/assets/87228907/4b969827-0ec5-4360-b603-6fe27a6eafe2">
