### PR TITLE
feat: use org short code override for bootcamps in url slug creation logic

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/tests/test_migrate_course_slugs.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_migrate_course_slugs.py
@@ -62,7 +62,8 @@ class TestMigrateCourseSlugs(TestCase):
         )
         self.exec_ed_course1.authoring_organizations.add(self.organization)
         self.bootcamp_course_1 = CourseFactory(
-            draft=True, product_source=self.external_product_source, partner=partner, type=bootcamp_type
+            draft=True, product_source=self.external_product_source, partner=partner, type=bootcamp_type,
+            organization_short_code_override=''
         )
         self.bootcamp_course_1.authoring_organizations.add(self.organization)
         self.bootcamp_course_1.subjects.add(self.subject)

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -178,7 +178,7 @@ class TestCourse(TestCase):
         Tests automate url slug restructuring for bootcamps must work under its relevant feature flag
         """
         bootcamp_type = CourseTypeFactory(slug=CourseType.BOOTCAMP_2U)
-        bootcamp_course_draft = CourseFactory(draft=True, type=bootcamp_type)
+        bootcamp_course_draft = CourseFactory(draft=True, type=bootcamp_type, organization_short_code_override='')
         draft_course_run = CourseRunFactory(draft=True, course=bootcamp_course_draft)
         subject = SubjectFactory(name='Subject1')
         org = OrganizationFactory(name='organization1')

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -1072,14 +1072,15 @@ def get_slug_for_course(course):
             logger.info(error)
             return None, error
         primary_subject_slug = course_subjects[0].slug
+        organization_short_code = course.organization_short_code_override or organization_slug
 
-        slug = f'boot-camps/{primary_subject_slug}/{organization_slug}-{course_slug}'
+        slug = f'boot-camps/{primary_subject_slug}/{organization_short_code}-{course_slug}'
         if is_existing_slug(slug, course):
             logger.info(
                 f"Bootcamp Slug '{slug}' already exists in DB, recreating slug by adding a number in course_title"
             )
             course_slug = f"{slugify(course.title)}-{get_existing_slug_count(slug) + 1}"
-            slug = f"boot-camps/{primary_subject_slug}/{organization_slug}-{course_slug}"
+            slug = f"boot-camps/{primary_subject_slug}/{organization_short_code}-{course_slug}"
         return slug, None
 
     def create_slug_for_ocm():


### PR DESCRIPTION
## Description
This PR will update logic of URL slug creation of bootcamp courses to use organization_short_code_override if exists otherwise use authoring organization code