### PR TITLE
build: migrate ci cache backend

### DIFF
--- a/.ci/docker-compose-ci.yml
+++ b/.ci/docker-compose-ci.yml
@@ -55,7 +55,7 @@ services:
       - "es"
       - "memcached"
     environment:
-      CACHE_BACKEND: "django.core.cache.backends.memcached.MemcachedCache"
+      CACHE_BACKEND: "django.core.cache.backends.memcached.PyMemcacheCache"
       CACHE_LOCATION: "memcached:11211"
       CONN_MAX_AGE: 60
       DB_ENGINE: "django.db.backends.mysql"


### PR DESCRIPTION
## Description
- Migrating the Cache Backend in the docker-compose.yml file to use latest `PyMemcacheCache` backend when running CI tests.
- This'll fix the CI failure with Django 42 tests in Django upgrade PRs. 