### PR TITLE
chore:  Add CompressedCacheResponseMixin to CourseRun Viewset

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -38,6 +38,7 @@ LOGGER_NAME = 'course_discovery.apps.api.utils'
 
 
 @ddt.ddt
+@pytest.mark.usefixtures('django_cache')
 class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin, APITestCase):
     def setUp(self):
         super().setUp()

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -14,6 +14,7 @@ from rest_framework.permissions import SAFE_METHODS, IsAuthenticated
 from rest_framework.response import Response
 
 from course_discovery.apps.api import filters, serializers
+from course_discovery.apps.api.cache import CompressedCacheResponseMixin
 from course_discovery.apps.api.mixins import ValidElasticSearchQueryRequiredMixin
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.permissions import IsCourseRunEditorOrDjangoOrReadOnly
@@ -49,7 +50,7 @@ def writable_request_wrapper(method):
 
 
 # pylint: disable=useless-super-delegation
-class CourseRunViewSet(ValidElasticSearchQueryRequiredMixin, viewsets.ModelViewSet):
+class CourseRunViewSet(CompressedCacheResponseMixin, ValidElasticSearchQueryRequiredMixin, viewsets.ModelViewSet):
     """ CourseRun resource. """
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filterset_class = filters.CourseRunFilter


### PR DESCRIPTION
[PROD-3627](https://2u-internal.atlassian.net/browse/PROD-3627)
-------
This PR adds `CompressedCacheResponseMixin` to `CourseRunViewSet`. `CompressedCacheResponseMixin` adds the functionality of key-value based caching.

Testing:
- On master branch, hit course_run endpoint after commenting the following line
https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/api/cache.py#L101 
- Look into query count from django toolbar. Hit course_run endpoint again. Query count will not decrease.
- Checkout to `afaq/prod-3627` and hit course_run endpoint. You will notice Query count decreases to (1-3) queries (until you update or edit some model instance)

1st Call:
<img width="842" alt="image" src="https://github.com/openedx/course-discovery/assets/78806673/265be69e-5764-4462-9a7d-122b116088e2">

2nd Call:
<img width="842" alt="image" src="https://github.com/openedx/course-discovery/assets/78806673/fb4090d9-ccc9-4039-ae13-64654ca5e25b">
