### PR TITLE
feat!: Django 4.0 and above, CSRF_TRUSTED_ORIGINS must include schemes.

### DIFF
--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -4,6 +4,7 @@ import warnings
 from copy import deepcopy
 from os import environ
 
+import django
 import certifi
 import memcache
 import MySQLdb
@@ -91,3 +92,6 @@ AWS_DEFAULT_ACL = 'public-read'
 
 # Convert dict keys to lowercase
 GOOGLE_SERVICE_ACCOUNT_CREDENTIALS = {k.lower(): v for k, v in GOOGLE_SERVICE_ACCOUNT_CREDENTIALS.items()}
+
+if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
+    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -4,8 +4,8 @@ import warnings
 from copy import deepcopy
 from os import environ
 
-import django
 import certifi
+import django
 import memcache
 import MySQLdb
 import yaml


### PR DESCRIPTION
https://github.com/edx/edx-arch-experiments/issues/459

django4.0 = https://docs.djangoproject.com/en/4.0/ref/settings/#csrf-trusted-origins

django3.2 = https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins


Internal PR
https://github.com/edx/edx-internal/pull/9272/files