### PR TITLE
Use weak password hashing for testing

### DIFF
--- a/course_discovery/apps/core/tests/test_weak_password.py
+++ b/course_discovery/apps/core/tests/test_weak_password.py
@@ -1,0 +1,14 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from django.contrib.auth.hashers import make_password
+from django.test import TestCase
+
+
+class WeakPasswordTest(TestCase):
+    def test_weak_password_hashing(self):
+        weak_password = "password123"
+        hashed_password = make_password(weak_password)
+
+        # Ensure the weak password is hashed using UnsaltedMD5PasswordHasher
+        self.assertTrue(hashed_password.startswith('md5$'))

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -3,7 +3,6 @@ import tempfile
 from course_discovery.settings.base import *
 from course_discovery.settings.shared.test import *
 
-
 INSTALLED_APPS += [
     'course_discovery.apps.edx_catalog_extensions',
 ]

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -3,6 +3,7 @@ import tempfile
 from course_discovery.settings.base import *
 from course_discovery.settings.shared.test import *
 
+
 INSTALLED_APPS += [
     'course_discovery.apps.edx_catalog_extensions',
 ]
@@ -10,6 +11,10 @@ INSTALLED_APPS += [
 ALLOWED_HOSTS = ['*']
 
 DEFAULT_PARTNER_ID = 1
+
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.MD5PasswordHasher',  # Use MD5 hasher for testing
+]
 
 TEST_NON_SERIALIZED_APPS = [
     # Prevents the issue described at https://code.djangoproject.com/ticket/23727.


### PR DESCRIPTION
## Description

This pull request addresses the issue regarding slow test suite performance caused by strong password hashing during testing. To improve the test suite runtime, I have implemented a solution that uses weak password hashing specifically for testing purposes, as recommended by the Django documentation: https://docs.djangoproject.com/en/4.1/topics/testing/overview/#password-hashing

## Changes Made

- Created a new test file `course_discovery/apps/core/tests/test_weak_password.py` to implement weak password hashing for testing.
- Modified the test settings to use the weak password hashing configuration only during testing.
- Added a test case to verify that weak password hashing is applied during testing.

This change has been tested locally and successfully improves the test suite runtime while ensuring the security of strong password hashing in production.

Fixes: https://github.com/openedx/public-engineering/issues/164
