### PR TITLE
chore: update microbachelors seat types

### DIFF
--- a/course_discovery/apps/course_metadata/migrations/0336_update_microbachelors_seat_types.py
+++ b/course_discovery/apps/course_metadata/migrations/0336_update_microbachelors_seat_types.py
@@ -1,0 +1,26 @@
+"""
+Migration to remove audit seat type from micro_bachelors program type.
+"""
+from django.db import migrations
+
+
+def update_program_type(apps, schema_editor):  # pylint: disable=unused-argument
+    ProgramType = apps.get_model('course_metadata', 'ProgramType')
+    SeatType = apps.get_model('course_metadata', 'SeatType')
+
+    micro_bachelors = ProgramType.objects.get(slug='microbachelors')
+    verified_seat_type = SeatType.objects.get(slug='verified')
+
+    # Set the applicable seat types for 'MicroBachelors' to only 'verified'
+    micro_bachelors.applicable_seat_types.set([verified_seat_type])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_metadata', '0335_migrateprogramslugconfiguration'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_program_type, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
[PROD-3518](https://2u-internal.atlassian.net/browse/PROD-3518)
Updates microbachelors program type to have only verified seat type. Previously, it had both audit and verified seat types.

# Testing Instructions
1. Expect microbatchelors to have the following seat types on your local

<img width="530" alt="Screenshot 2023-09-27 at 2 30 14 PM" src="https://github.com/openedx/course-discovery/assets/52413434/b25af0f7-9a75-4f76-a081-a05ad2339c32">

2. Run migrate
3. You can now see only verified as the seat type:

<img width="530" alt="Screenshot 2023-09-27 at 2 32 25 PM" src="https://github.com/openedx/course-discovery/assets/52413434/346ee0d5-394d-41a3-bb55-8242b1ae468c">
