### PR TITLE
fix: Give a default to CSRF_TRUSTED_ORIGINS_WITH_SCHEME to unbreak devstack

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -768,3 +768,5 @@ JOB_TO_JOB_DESCRIPTION_PROMPT = 'How can a {current_job_name} switch to {future_
 OPENAI_API_KEY = 'I am an api key'
 
 NOTIFY_SLUG_UPDATE_RECIPIENTS = []
+
+CSRF_TRUSTED_ORIGINS_WITH_SCHEME = [] # just for Django 4.2 upgrade


### PR DESCRIPTION
Not tested in devstack, but see https://github.com/openedx/devstack/actions/runs/6325325801/job/17176599210 for error.