### PR TITLE
fix: add items call to loop over attrs dict

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -660,7 +660,10 @@ class UtilsTests(TestCase):
 
         # Make sure text remains bold if p tag has rtl direction
         ('<p dir="rtl"><strong>Directed paragraph</strong></p>', '<p dir="rtl"><strong>Directed paragraph</strong></p>'),
-
+        (
+                '<p lang="en" style="font-size: 11pt; color: #000000; background-color: transparent; font-weight: 400;">Test</p>',
+                '<p>Test</p>'
+        ),
         # Make sure that only spans with lang tags are preserved in the saved string
         ('<p><span lang="en">with lang</span></p>', '<p><span lang="en">with lang</span></p>'),
         ('<p><span class="body" lang="en">lang and class</span></p>', '<p><span lang="en">lang and class</span></p>'),

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -660,10 +660,8 @@ class UtilsTests(TestCase):
 
         # Make sure text remains bold if p tag has rtl direction
         ('<p dir="rtl"><strong>Directed paragraph</strong></p>', '<p dir="rtl"><strong>Directed paragraph</strong></p>'),
-        (
-                '<p lang="en" style="font-size: 11pt; color: #000000; background-color: transparent; font-weight: 400;">Test</p>',
-                '<p>Test</p>'
-        ),
+        # Make sure the attributes on nested p tags remain as it is.
+        ('<p dir="rtl"><strong lang="en" style="font-size: 11pt; color: #000000; background-color: transparent; font-weight: 400;">Test</strong></p>', '<p dir="rtl"><strong lang="en" style="font-size: 11pt; color: #000000; background-color: transparent; font-weight: 400;">Test</strong></p>'),
         # Make sure that only spans with lang tags are preserved in the saved string
         ('<p><span lang="en">with lang</span></p>', '<p><span lang="en">with lang</span></p>'),
         ('<p><span class="body" lang="en">lang and class</span></p>', '<p><span lang="en">lang and class</span></p>'),

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -707,7 +707,7 @@ class HTML2TextWithLangSpans(html2text.HTML2Text):
                 self.outtextf(f'<{tag}')
                 if attrs:
                     self.outtextf(' ')
-                    self.outtextf(' '.join(f'{attr}="{value}"' for attr, value in attrs))
+                    self.outtextf(' '.join(f'{attr}="{value}"' for attr, value in attrs.items()))
                 self.outtextf('>')
             else:
                 self.outtextf(f'</{tag}>')


### PR DESCRIPTION
### [PROD-3701](https://2u-internal.atlassian.net/browse/PROD-3701)

### Description
Use items() call to parse HTML tags and attributes inside a directional p,  non-whitelisted tag. When encountering a tag inside a `<p>` tag with the directional attribute, the iteration of attrs on the nested tags was missing items() and thus causing issues when attempting to loop over the attrs dict.