### PR TITLE
chore: using CSRF_TRUSTED_ORIGINS now. No need for extra variable.

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -772,6 +772,4 @@ NOTIFY_SLUG_UPDATE_RECIPIENTS = []
 # disable indexing on history_date
 SIMPLE_HISTORY_DATE_INDEX = False
 
-CSRF_TRUSTED_ORIGINS_WITH_SCHEME = [] # just for Django 4.2 upgrade
-
 USE_DEPRECATED_PYTZ = True

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from os import environ
 
 import certifi
-import django
 import memcache
 import MySQLdb
 import yaml
@@ -92,6 +91,3 @@ AWS_DEFAULT_ACL = 'public-read'
 
 # Convert dict keys to lowercase
 GOOGLE_SERVICE_ACCOUNT_CREDENTIALS = {k.lower(): v for k, v in GOOGLE_SERVICE_ACCOUNT_CREDENTIALS.items()}
-
-if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
-    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME


### PR DESCRIPTION
Django42 cleanup
First merge this https://github.com/edx/edx-internal/pull/9421/files
