### PR TITLE
chore: Version upgrade for taxonomy-connector

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,7 +18,7 @@ certifi==2023.7.22
     # via
     #   elasticsearch
     #   requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.1
     # via requests
 django-elasticsearch-dsl==7.4
     # via -r requirements/docs.in
@@ -93,7 +93,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 typing-extensions==4.8.0
     # via pydata-sphinx-theme
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   elasticsearch
     #   requests

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -31,7 +31,7 @@ asn1crypto==1.5.1
     # via
     #   oscrypto
     #   snowflake-connector-python
-astroid==2.15.8
+astroid==3.0.1
     # via
     #   pylint
     #   pylint-celery
@@ -75,9 +75,9 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.28.63
+boto3==1.28.69
     # via django-ses
-botocore==1.31.63
+botocore==1.31.69
     # via
     #   boto3
     #   s3transfer
@@ -107,7 +107,7 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.3.0
+charset-normalizer==3.3.1
     # via
     #   aiohttp
     #   requests
@@ -286,7 +286,9 @@ django-nested-admin==4.0.2
 django-nine==0.2.7
     # via django-elasticsearch-dsl-drf
 django-object-actions==4.2.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   taxonomy-connector
 django-parler==2.3
     # via -r requirements/base.in
 django-ses==3.5.0
@@ -382,7 +384,7 @@ edx-django-utils==5.7.0
     #   edx-toggles
     #   getsmarter-api-clients
     #   taxonomy-connector
-edx-drf-extensions==8.11.1
+edx-drf-extensions==8.12.0
     # via -r requirements/base.in
 edx-event-bus-kafka==5.5.0
     # via -r requirements/base.in
@@ -390,7 +392,7 @@ edx-event-bus-redis==0.3.2
     # via -r requirements/base.in
 edx-i18n-tools==1.3.0
     # via -r requirements/local.in
-edx-lint==5.3.4
+edx-lint==5.3.6
     # via -r requirements/test.in
 edx-opaque-keys[django]==2.5.1
     # via
@@ -431,7 +433,7 @@ face==22.0.0
     # via glom
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==19.10.0
+faker==19.11.0
     # via factory-boy
 fastavro==1.8.4
     # via openedx-events
@@ -452,7 +454,7 @@ glom==22.1.0
     # via semgrep
 google-api-core==2.12.0
     # via google-api-python-client
-google-api-python-client==2.103.0
+google-api-python-client==2.104.0
     # via -r requirements/base.in
 google-auth==2.23.3
     # via
@@ -469,7 +471,7 @@ google-auth-oauthlib==1.1.0
     # via gspread
 googleapis-common-protos==1.61.0
     # via google-api-core
-gspread==5.11.3
+gspread==5.12.0
     # via -r requirements/base.in
 h11==0.14.0
     # via wsproto
@@ -518,8 +520,6 @@ jsonschema==3.2.0
     #   semgrep
 kombu==5.3.2
     # via celery
-lazy-object-proxy==1.9.0
-    # via astroid
 libsass==0.22.0
     # via django-libsass
 lxml==4.9.3
@@ -543,10 +543,8 @@ multidict==6.0.4
     #   yarl
 mysqlclient==2.2.0
     # via -r requirements/test.in
-newrelic==9.1.0
+newrelic==9.1.1
     # via edx-django-utils
-numpy==1.24.4
-    # via pandas
 oauthlib==3.2.2
     # via
     #   getsmarter-api-clients
@@ -563,7 +561,7 @@ openedx-events==9.0.0
     #   taxonomy-connector
 oscrypto==1.3.0
     # via snowflake-connector-python
-outcome==1.2.0
+outcome==1.3.0
     # via trio
 packaging==21.3
     # via
@@ -576,8 +574,6 @@ packaging==21.3
     #   snowflake-connector-python
     #   sphinx
     #   tox
-pandas==2.0.3
-    # via taxonomy-connector
 paramiko==3.3.1
     # via docker
 path==16.7.1
@@ -647,7 +643,7 @@ pyjwt[crypto]==2.8.0
     #   simple-salesforce
     #   snowflake-connector-python
     #   social-auth-core
-pylint==2.17.7
+pylint==3.0.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -655,7 +651,7 @@ pylint==2.17.7
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.3
+pylint-django==2.5.5
     # via edx-lint
 pylint-plugin-utils==0.8.2
     # via
@@ -708,7 +704,6 @@ python-dateutil==2.8.2
     #   elasticsearch-dsl
     #   faker
     #   freezegun
-    #   pandas
     #   pendulum
 python-dotenv==0.21.1
     # via docker-compose
@@ -734,7 +729,6 @@ pytz==2023.3.post1
     #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
-    #   pandas
     #   snowflake-connector-python
     #   taxonomy-connector
     #   zeep
@@ -798,7 +792,7 @@ rjsmin==1.2.1
     # via django-compressor
 rsa==4.9
     # via google-auth
-ruamel-yaml==0.17.35
+ruamel-yaml==0.17.40
     # via semgrep
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
@@ -842,9 +836,9 @@ sniffio==1.3.0
     # via trio
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python==3.3.0
+snowflake-connector-python==3.3.1
     # via -r requirements/base.in
-social-auth-app-django==5.3.0
+social-auth-app-django==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
@@ -887,9 +881,9 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.44.3
+taxonomy-connector==1.46.0
     # via -r requirements/base.in
-testfixtures==7.2.0
+testfixtures==7.2.2
     # via -r requirements/test.in
 text-unidecode==1.3
     # via python-slugify
@@ -941,7 +935,6 @@ tzdata==2023.3
     # via
     #   backports-zoneinfo
     #   celery
-    #   pandas
 ujson==5.8.0
     # via python-lsp-jsonrpc
 unicodecsv==0.14.1
@@ -950,7 +943,7 @@ uritemplate==4.1.1
     # via
     #   drf-yasg
     #   google-api-python-client
-urllib3[socks]==1.26.17
+urllib3[socks]==1.26.18
     # via
     #   botocore
     #   docker
@@ -965,7 +958,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via tox
 walrus==0.9.3
     # via edx-event-bus-redis
@@ -981,8 +974,6 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wrapt==1.15.0
-    # via astroid
 wsproto==1.2.0
     # via trio-websocket
 xss-utils==0.5.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.41.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.1
     # via -r requirements/pip.in
 setuptools==68.2.2
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -50,9 +50,9 @@ beautifulsoup4==4.12.2
     #   taxonomy-connector
 billiard==4.1.0
     # via celery
-boto3==1.28.63
+boto3==1.28.69
     # via django-ses
-botocore==1.31.63
+botocore==1.31.69
     # via
     #   boto3
     #   s3transfer
@@ -80,7 +80,7 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.3.0
+charset-normalizer==3.3.1
     # via
     #   aiohttp
     #   requests
@@ -225,7 +225,9 @@ django-nested-admin==4.0.2
 django-nine==0.2.7
     # via django-elasticsearch-dsl-drf
 django-object-actions==4.2.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   taxonomy-connector
 django-parler==2.3
     # via -r requirements/base.in
 django-ses==3.5.0
@@ -309,7 +311,7 @@ edx-django-utils==5.7.0
     #   edx-toggles
     #   getsmarter-api-clients
     #   taxonomy-connector
-edx-drf-extensions==8.11.1
+edx-drf-extensions==8.12.0
     # via -r requirements/base.in
 edx-event-bus-kafka==5.5.0
     # via -r requirements/base.in
@@ -357,7 +359,7 @@ gevent==23.9.1
     # via -r requirements/production.in
 google-api-core==2.12.0
     # via google-api-python-client
-google-api-python-client==2.103.0
+google-api-python-client==2.104.0
     # via -r requirements/base.in
 google-auth==2.23.3
     # via
@@ -376,7 +378,7 @@ googleapis-common-protos==1.61.0
     # via google-api-core
 greenlet==3.0.0
     # via gevent
-gspread==5.11.3
+gspread==5.12.0
     # via -r requirements/base.in
 gunicorn==21.2.0
     # via -r requirements/production.in
@@ -427,12 +429,10 @@ multidict==6.0.4
     #   yarl
 mysqlclient==2.2.0
     # via -r requirements/production.in
-newrelic==9.1.0
+newrelic==9.1.1
     # via
     #   -r requirements/production.in
     #   edx-django-utils
-numpy==1.24.4
-    # via pandas
 oauthlib==3.2.2
     # via
     #   getsmarter-api-clients
@@ -455,8 +455,6 @@ packaging==23.2
     #   drf-yasg
     #   gunicorn
     #   snowflake-connector-python
-pandas==2.0.3
-    # via taxonomy-connector
 pbr==5.11.1
     # via stevedore
 pendulum==2.1.2
@@ -518,7 +516,6 @@ python-dateutil==2.8.2
     #   celery
     #   contentful
     #   elasticsearch-dsl
-    #   pandas
     #   pendulum
 python-memcached==1.59
     # via -r requirements/production.in
@@ -539,7 +536,6 @@ pytz==2023.3.post1
     #   djangorestframework
     #   drf-yasg
     #   getsmarter-api-clients
-    #   pandas
     #   snowflake-connector-python
     #   taxonomy-connector
     #   zeep
@@ -613,9 +609,9 @@ six==1.16.0
     #   requests-file
 slumber==0.7.1
     # via edx-rest-api-client
-snowflake-connector-python==3.3.0
+snowflake-connector-python==3.3.1
     # via -r requirements/base.in
-social-auth-app-django==5.3.0
+social-auth-app-django==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
@@ -634,7 +630,7 @@ stevedore==5.1.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==1.44.3
+taxonomy-connector==1.46.0
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -657,14 +653,13 @@ tzdata==2023.3
     # via
     #   backports-zoneinfo
     #   celery
-    #   pandas
 unicodecsv==0.14.1
     # via djangorestframework-csv
 uritemplate==4.1.1
     # via
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.17
+urllib3==1.26.18
     # via
     #   botocore
     #   elasticsearch


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7622](https://2u-internal.atlassian.net/browse/ENT-7622)

__Description:__
This is a version upgrade PR for taxonomy-connector. Version upgrade deploys [these changes](https://github.com/openedx/taxonomy-connector/compare/1.44.3...1.46.0) to production. It has a new feature that enables admins to blacklist job skills.