### PR TITLE
temp: add temporary exception handling in course and course run api to log the complete error

### DIFF
--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -290,7 +290,7 @@ class CourseRunViewSet(CompressedCacheResponseMixin, ValidElasticSearchQueryRequ
 
         try:
             course_run = serializer.save(**save_kwargs)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception:
             log.exception(
                 f"Exception raised when attempting to save course run {course_run.key} with arguments {save_kwargs}"
             )

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -288,7 +288,13 @@ class CourseRunViewSet(CompressedCacheResponseMixin, ValidElasticSearchQueryRequ
         if not draft and (course_run.status == CourseRunStatus.Unpublished or non_exempt_update):
             save_kwargs['status'] = CourseRunStatus.LegalReview
 
-        course_run = serializer.save(**save_kwargs)
+        try:
+            course_run = serializer.save(**save_kwargs)
+        except Exception as e:  # pylint: disable=broad-except
+            log.exception(
+                f"Exception raised when attempting to save course run {course_run.key} with arguments {save_kwargs}"
+            )
+            raise  # re-raise the exception so that it is captured by writable_request_wrapper
 
         if course_run in course_run.course.active_course_runs:
             course_run.update_or_create_seats(course_run.type, prices, upgrade_deadline_override,)

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -395,8 +395,14 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
                     _('Course edit was unsuccessful. The course URL slug ‘[{url_slug}]’ is already in use. '
                       'Please update this field and try again.').format(url_slug=url_slug))
 
-        # Then the course itself
-        course = serializer.save()
+        try:
+            # Then the course itself
+            course = serializer.save()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.exception(
+                f"Exception raised when attempting to save course {course.key} with arguments {data}"
+            )
+            raise  # re-raise the exception so that it is captured by writable_request_wrapper
         if url_slug:
             course.set_active_url_slug(url_slug)
             if course.official_version and (not draft or self._is_course_run_reviewed(course)):

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -398,7 +398,7 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         try:
             # Then the course itself
             course = serializer.save()
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception:
             logger.exception(
                 f"Exception raised when attempting to save course {course.key} with arguments {data}"
             )


### PR DESCRIPTION
### [PROD-3743](https://2u-internal.atlassian.net/browse/PROD-3743)

Temporary logs to capture the complete stack track to identify what causes course/course run save failure when called via respective API