### PR TITLE
fix: add url slug presence checks when checking slug format

### DIFF
--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -288,13 +288,7 @@ class CourseRunViewSet(CompressedCacheResponseMixin, ValidElasticSearchQueryRequ
         if not draft and (course_run.status == CourseRunStatus.Unpublished or non_exempt_update):
             save_kwargs['status'] = CourseRunStatus.LegalReview
 
-        try:
-            course_run = serializer.save(**save_kwargs)
-        except Exception:
-            log.exception(
-                f"Exception raised when attempting to save course run {course_run.key} with arguments {save_kwargs}"
-            )
-            raise  # re-raise the exception so that it is captured by writable_request_wrapper
+        course_run = serializer.save(**save_kwargs)
 
         if course_run in course_run.course.active_course_runs:
             course_run.update_or_create_seats(course_run.type, prices, upgrade_deadline_override,)

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -395,14 +395,9 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
                     _('Course edit was unsuccessful. The course URL slug ‘[{url_slug}]’ is already in use. '
                       'Please update this field and try again.').format(url_slug=url_slug))
 
-        try:
-            # Then the course itself
-            course = serializer.save()
-        except Exception:
-            logger.exception(
-                f"Exception raised when attempting to save course {course.key} with arguments {data}"
-            )
-            raise  # re-raise the exception so that it is captured by writable_request_wrapper
+        # Then the course itself
+        course = serializer.save()
+
         if url_slug:
             course.set_active_url_slug(url_slug)
             if course.official_version and (not draft or self._is_course_run_reviewed(course)):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1915,7 +1915,9 @@ class Course(ManageHistoryMixin, DraftModelMixin, PkSearchableMixin, CachedMixin
         Sets the active url slug for draft and non-draft courses if the current
         slug is not validated as per the new format.
         """
-        is_slug_in_subdirectory_format = bool(re.match(SUBDIRECTORY_SLUG_FORMAT_REGEX, self.active_url_slug))
+        is_slug_in_subdirectory_format = bool(
+            re.match(SUBDIRECTORY_SLUG_FORMAT_REGEX, self.active_url_slug)
+        ) if self.active_url_slug else False  # Unless assigned, the active slug is None for Studio created courses.
         is_exec_ed_course = self.type.slug == CourseType.EXECUTIVE_EDUCATION_2U
         is_bootcamp_course = self.type.slug == CourseType.BOOTCAMP_2U
         if is_exec_ed_course and not IS_SUBDIRECTORY_SLUG_FORMAT_FOR_EXEC_ED_ENABLED.is_enabled():

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -243,9 +243,7 @@ class TestCourse(TestCase):
             course = draft_course_run.course
             official_version = draft_course_run.update_or_create_official_version()
             course.refresh_from_db()
-            assert course.active_url_slug.startswith('learn/')
             assert course.active_url_slug == f'learn/{subject.slug}/{org.name}-{slugify(course.title)}'
-            assert official_version.course.active_url_slug.startswith('learn/')
             assert official_version.course.active_url_slug == f'learn/{subject.slug}/{org.name}-{slugify(course.title)}'
 
     @ddt.data(


### PR DESCRIPTION
### [PROD-3743](https://2u-internal.atlassian.net/browse/PROD-3743)

### Description

Studio generated courses do not get a default slug generated using course title. Due to that, active_url_slug is None for such courses. Because of missing slug, the error is raised when attempting to generate the new url slug. The checks against old slugs fail as the slug is not present.

```
Exception raised when attempting to save course run course-v1:RCMx+RC101+2023 with arguments {'status': CourseRunStatus.LegalReview}
Traceback (most recent call last):
  File "/edx/app/discovery/discovery/course_discovery/apps/api/v1/views/course_runs.py", line 292, in _update_course_run
    course_run = serializer.save(**save_kwargs)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/rest_framework/serializers.py", line 207, in save
    self.instance = self.update(self.instance, validated_data)
  File "/edx/app/discovery/discovery/course_discovery/apps/api/serializers.py", line 1086, in update
    return super().update(instance, validated_data)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/rest_framework/serializers.py", line 1006, in update
    instance.save()
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/models.py", line 2703, in save
    self.handle_status_change(send_emails)
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/models.py", line 2650, in handle_status_change
    self.course.set_subdirectory_slug()
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/models.py", line 1918, in set_subdirectory_slug
    is_slug_in_subdirectory_format = bool(re.match(SUBDIRECTORY_SLUG_FORMAT_REGEX, self.active_url_slug))
  File "/usr/lib/python3.8/re.py", line 191, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```

PR fixes the above error and removes the temporary logs added in PR https://github.com/openedx/course-discovery/pull/4167