### PR TITLE
fix: use appropriate OC course type checks for enterprise sub inclusion calculation

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1484,7 +1484,7 @@ class Course(ManageHistoryMixin, DraftModelMixin, PkSearchableMixin, CachedMixin
     def is_enterprise_catalog_allowed_course(self):
         """
         As documented in ADR docs/decisions/0012-enterprise-program-inclusion-boolean.rst, OC course types
-        are allowed in Enterprise catalog inclusion. By definition, OC types are all types excluding ExecEd and Bootcamp.
+        are allowed in Enterprise catalog inclusion. OC types are all course types excluding ExecEd and Bootcamp.
         """
         return not self.is_external_course
 

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -684,12 +684,6 @@ class CourseType(TimeStampedModel):
         """ Empty types are special - they are the default type used when we don't know a real type """
         return self.slug == self.EMPTY
 
-    @classmethod
-    def is_enterprise_catalog_course_type(cls, course_type):
-        return course_type.slug in [
-            cls.AUDIT, cls.VERIFIED_AUDIT, cls.PROFESSIONAL, cls.CREDIT_VERIFIED_AUDIT, cls.EMPTY
-        ]
-
 
 class Subject(TranslatableModel, TimeStampedModel):
     """ Subject model. """
@@ -1479,13 +1473,20 @@ class Course(ManageHistoryMixin, DraftModelMixin, PkSearchableMixin, CachedMixin
 
     def _check_enterprise_subscription_inclusion(self):
         # if false has been passed in, or it's already been set to false
-        if not CourseType.is_enterprise_catalog_course_type(self.type) or \
+        if not self.is_enterprise_catalog_allowed_course() or \
                 self.enterprise_subscription_inclusion is False:
             return False
         for org in self.authoring_organizations.all():
             if not org.enterprise_subscription_inclusion:
                 return False
         return True
+
+    def is_enterprise_catalog_allowed_course(self):
+        """
+        As documented in ADR docs/decisions/0012-enterprise-program-inclusion-boolean.rst, OC course types
+        are allowed in Enterprise catalog inclusion. By definition, OC types are all types excluding ExecEd and Bootcamp.
+        """
+        return not self.is_external_course
 
     def update_data_modified_timestamp(self):
         """

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -306,6 +306,7 @@ class CourseTypeFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = CourseType
+        django_get_or_create = ('slug',)
 
     @factory.post_generation
     def entitlement_types(self, create, extracted, **kwargs):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -485,8 +485,8 @@ class TestCourse(TestCase):
         assert course.additional_metadata.end_date == additional_metadata.end_date
         assert course.additional_metadata.product_status == ExternalProductStatus.Published
 
-    def test_enterprise_subscription_inclusion(self):
-        """ Verify the enterprise inclusion boolean is calculated as expected. """
+    def test_enterprise_subscription_inclusion__authoring_organizations(self):
+        """ Verify the enterprise inclusion boolean is calculated as expected based on authoring orgs inclusion."""
         org1 = factories.OrganizationFactory(enterprise_subscription_inclusion=True)
         org2 = factories.OrganizationFactory(enterprise_subscription_inclusion=True)
         org_list = [org1, org2]
@@ -502,6 +502,26 @@ class TestCourse(TestCase):
             authoring_organizations=org_list, enterprise_subscription_inclusion=None, type=course_type,
         )
         assert course1.enterprise_subscription_inclusion is False
+
+    @ddt.data(
+        (CourseType.VERIFIED_AUDIT, True),
+        (CourseType.AUDIT, True),
+        (CourseType.PROFESSIONAL, True),
+        (CourseType.EMPTY, True),
+        ('verified', True),
+        (CourseType.CREDIT_VERIFIED_AUDIT, True),
+        (CourseType.BOOTCAMP_2U, False),
+        (CourseType.EXECUTIVE_EDUCATION_2U, False)
+    )
+    @ddt.unpack
+    def test_enterprise_subscription_inclusion__course_type(self, course_type_slug, expected_inclusion_value):
+        """ Verify the enterprise inclusion boolean is calculated as expected based on allowed course types."""
+        org1 = factories.OrganizationFactory(enterprise_subscription_inclusion=True)
+        course_type = CourseTypeFactory(slug=course_type_slug)
+        course = factories.CourseFactory(
+            authoring_organizations=[org1], enterprise_subscription_inclusion=None, type=course_type,
+        )
+        assert course.enterprise_subscription_inclusion is expected_inclusion_value
 
     def test_set_active_url_slug__draft_only(self):
         """


### PR DESCRIPTION
### [PROD-3767](https://2u-internal.atlassian.net/browse/PROD-3767)

### Description
"Verified Only" course type was not included in the enterprise subscription inclusion checks for Course. Toggling the flag from publisher did not set the value for Course. The old code was checking against the following types:
- audit
- verified-audit
- professional
- empty
- credit-verified-audit
However, the type are the types that have their slugs in discovery codebase. Other types, like honor and verified only do not have slugs in discovery codebase and were setup directly on stage/prod. Secondly, as documented in https://github.com/openedx/course-discovery/blob/master/docs/decisions/0012-enterprise-program-inclusion-boolean.rst, OCs are eligible for enterprise inclusion. OC are all course types except ExecEd and Bootcamp. This PR updates the inclusion check for Course to take care of this details and ensures that all OC courses are unblock for setting the enterprise sub inclusion flag.