### PR TITLE
Fix: 500 error during opening program certificate page

### DIFF
--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -68,6 +68,27 @@ class ProgramAdminForm(forms.ModelForm):
 
         return self.cleaned_data
 
+    def clean_authoring_organizations(self):
+        """
+        Checks the presence of images of logos of certificates of author orgs.
+
+        Iterates through authoring organizations and throws a ValidationError
+        if any organization does not have a certificate logo image.
+        """
+        authoring_organizations = self.cleaned_data.get('authoring_organizations')
+        orgs_with_empty_certificate_logo_image = []
+
+        for organization in authoring_organizations:
+            if not organization.certificate_logo_image:
+                orgs_with_empty_certificate_logo_image.append(organization.name)
+
+        if orgs_with_empty_certificate_logo_image:
+            error_message = f'Certificate logo image cannot be empty for organizations: ' \
+                            f'{", ".join(orgs_with_empty_certificate_logo_image)}.'
+            raise ValidationError(error_message)
+
+        return authoring_organizations
+
 
 class CourseRunSelectionForm(forms.ModelForm):
     class Meta:

--- a/course_discovery/apps/course_metadata/tests/test_forms.py
+++ b/course_discovery/apps/course_metadata/tests/test_forms.py
@@ -1,0 +1,72 @@
+from django.test import TestCase
+
+from course_discovery.apps.api.tests.mixins import SiteMixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from course_discovery.apps.course_metadata.choices import ProgramStatus
+from course_discovery.apps.course_metadata.forms import ProgramAdminForm
+from course_discovery.apps.course_metadata.tests import factories
+
+
+class ProgramAdminFormTests(SiteMixin, TestCase):
+    """ Tests ProgramAdminForm. """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = UserFactory(is_staff=True, is_superuser=True)
+        cls.course_runs = factories.CourseRunFactory.create_batch(3)
+        cls.courses = [course_run.course for course_run in cls.course_runs]
+        cls.product_source = factories.SourceFactory()
+
+        cls.excluded_course_run = factories.CourseRunFactory(course=cls.courses[0])
+        cls.program = factories.ProgramFactory(
+            courses=cls.courses,
+            excluded_course_runs=[cls.excluded_course_run],
+            partner=cls.partner,
+        )
+        cls.org_1 = factories.OrganizationFactory(certificate_logo_image=None)
+        cls.org_2 = factories.OrganizationFactory(certificate_logo_image=None)
+        cls.org_3 = factories.OrganizationFactory()
+
+    def setUp(self):
+        super().setUp()
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+
+    def _post_data(self, status=ProgramStatus.Unpublished, marketing_slug='/foo'):
+        return {
+            'title': 'some test title',
+            'courses': [self.courses[0].id],
+            'type': self.program.type.id,
+            'status': status,
+            'marketing_slug': marketing_slug,
+            'partner': self.program.partner.id,
+            'product_source': self.product_source.id,
+            'authoring_organizations': [self.org_1.id, self.org_2.id, self.org_3.id],
+        }
+
+    def test_clean_authoring_organizations_with_empty_certificate_logo_image(self):
+        """
+        Test verifies that the form is invalid if certificate_logo_image
+        is empty for any of the authoring_organizations.
+        """
+        data = self._post_data()
+        form = ProgramAdminForm(data=data)
+        self.assertFalse(form.is_valid())
+        expected_error_message = f'Certificate logo image cannot be empty for organizations: ' \
+                                 f'{self.org_1.name}, {self.org_2.name}.'
+
+        self.assertEqual(form.errors['authoring_organizations'][0], expected_error_message)
+
+    def test_clean_authoring_organizations_with_non_empty_certificate_logo_image(self):
+        """
+        Test verifies that the form is valid only if certificate_logo_image
+        is not empty for all authoring_organizations.
+        """
+        self.org_1.certificate_logo_image = 'logo1.jpg'
+        self.org_1.save()
+        self.org_2.certificate_logo_image = 'logo2.jpg'
+        self.org_2.save()
+        data = self._post_data()
+        form = ProgramAdminForm(data=data)
+
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
This is [backport](https://github.com/openedx/course-discovery/pull/4182) from the master.

### Description:
Error 500 occurs when going to the Program certificate page if an organization is connected to the `Authoring organizations` field with an empty field `Certificate logo image`: 
<img width="1310" alt="screen_105" src="https://github.com/openedx/course-discovery/assets/98233552/872f45f9-8d0e-4855-bd0b-2a3e9d174f2a">

---
#### Steps to Reproduce:
1. The program is created.
2. In the Discovery admin panel, connect an organization in the `Authoring organizations` field that does not have an image loaded for the `Certificate logo image field`:
<img width="1232" alt="screen_106" src="https://github.com/openedx/course-discovery/assets/98233552/f80e2a40-6c34-433c-8f7a-6f63a50eddf6">

<img width="1435" alt="screen_107" src="https://github.com/openedx/course-discovery/assets/98233552/654790cb-3df4-4ae7-847b-726939cafc98">

3. Earn a program certificate as a user.
4. Go to the program certificate page.

I propose that before saving the program, verify if the Certificate logo image field of the associated organizations is empty. Also, make the certificate_logo_image field required to be filled in the admin panel, but not in the model, to prevent unnecessary migrations.

On the **Program page** `https://<discovery>/admin/course_metadata/program/`:
<img width="1158" alt="screen_220" src="https://github.com/openedx/course-discovery/assets/98233552/dda37cb8-71d9-44fc-a064-1597f76278cf">

On the **Organization page** `https://<discovery>/admin/course_metadata/organization/`:
<img width="1097" alt="screen_221" src="https://github.com/openedx/course-discovery/assets/98233552/d727e0c9-aaa7-4ed3-8f00-cf3f67794184">