### PR TITLE
feat: send variant_id from discovery to ecommerce

### DIFF
--- a/course_discovery/apps/course_metadata/toggles.py
+++ b/course_discovery/apps/course_metadata/toggles.py
@@ -65,3 +65,16 @@ IS_SUBDIRECTORY_SLUG_FORMAT_FOR_BOOTCAMP_ENABLED = WaffleSwitch(
 IS_COURSE_RUN_VARIANT_ID_EDITABLE = WaffleSwitch(
     'course_metadata.is_course_run_variant_id_editable', __name__
 )
+# .. toggle_name: course_metadata.is_course_run_variant_id_ecommerce_consumable
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Enable the sending of the course run's variant_id to the ecommerce for external courses,
+# .. rather than retrieving it from the additional metadata of the course.
+# .. toggle_use_cases: open_edx
+# .. toggle_type: temporary
+# .. toggle_creation_date: 2023-11-17
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: PROD-3733
+IS_COURSE_RUN_VARIANT_ID_ECOMMERCE_CONSUMABLE = WaffleSwitch(
+    'course_metadata.is_course_run_variant_id_ecommerce_consumable', __name__
+)


### PR DESCRIPTION
[PROD-3752]()
--------

This PR enables sending of variant_id (taken from course_run) along with seat info from ecommerce to discovery. Keeping both the flows ongoing.
Currently, the enterprise is utilizing the `variant_id` from the Course Entitlements model in the ecommerce. Given the shift towards a multiple course runs approach for Executive Education courses in Discovery, we will temporarily include `variant_id` in Seat along with both Course Entitlements. Once enterprise will be done with their changes on ecommerce and enterprise side, we will remove `variant_id` from course level and stop sending it to ecommerce from entitlements data.