### PR TITLE
temp: update organic email group to handle both list and str

### DIFF
--- a/course_discovery/apps/course_metadata/emails.py
+++ b/course_discovery/apps/course_metadata/emails.py
@@ -243,7 +243,12 @@ def send_email_to_notify_course_watchers_and_marketing(course, course_run_publis
     if course.watchers:
         to_users.extend(course.watchers)
     if settings.ORGANIC_MARKETING_EMAIL:
-        to_users.append(settings.ORGANIC_MARKETING_EMAIL)
+        # Temporary: Allow both string and list email groups for backwards compatibility
+        to_users.append(
+            settings.ORGANIC_MARKETING_EMAIL
+        ) if isinstance(settings.ORGANIC_MARKETING_EMAIL, str) else to_users.extend(
+            settings.ORGANIC_MARKETING_EMAIL
+        )
     if not to_users:
         logger.info("Skipping send email to the course watchers and marketing because to_users list is empty")
         return
@@ -261,6 +266,7 @@ def send_email_to_notify_course_watchers_and_marketing(course, course_run_publis
 
     try:
         email_msg.send()
+        logger.info(f"Email sent to the course watchers and marketing group {to_users} for course {course.title}")
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception(
             f'Failed to send email notification with subject "{subject}" to users {to_users}. Error: {exc}'

--- a/course_discovery/apps/course_metadata/emails.py
+++ b/course_discovery/apps/course_metadata/emails.py
@@ -244,11 +244,11 @@ def send_email_to_notify_course_watchers_and_marketing(course, course_run_publis
         to_users.extend(course.watchers)
     if settings.ORGANIC_MARKETING_EMAIL:
         # Temporary: Allow both string and list email groups for backwards compatibility
-        to_users.append(
-            settings.ORGANIC_MARKETING_EMAIL
-        ) if isinstance(settings.ORGANIC_MARKETING_EMAIL, str) else to_users.extend(
-            settings.ORGANIC_MARKETING_EMAIL
-        )
+        organic_marketing_users = settings.ORGANIC_MARKETING_EMAIL
+        if isinstance(organic_marketing_users, str):
+            organic_marketing_users = [organic_marketing_users]
+        to_users.extend(organic_marketing_users)
+
     if not to_users:
         logger.info("Skipping send email to the course watchers and marketing because to_users list is empty")
         return


### PR DESCRIPTION
### [PROD-3770](https://2u-internal.atlassian.net/browse/PROD-3770)

### Description

- Update ORGANIC_MARKETING_EMAIL handling in send_email_to_notify_course_watchers_and_marketing to cater for both str and list. This is for backward compatibility and the plan is to update ORGANIC_MARKETING_EMAIL to list only.
- Add info log when email is sent successfully.

Related edx-internal PR https://github.com/edx/edx-internal/pull/9719