### PR TITLE
ENT-8059 Open AI version 1.0.0 dropped support for APIs in use, so pinning the version.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -51,3 +51,6 @@ django-debug-toolbar < 4.2.0
 
 # selenium==4.13.0 causing test failures
 selenium==4.12.0
+
+# Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise.
+openai<=0.28.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,6 +6,10 @@
 #
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
+aiohttp==3.9.1
+    # via openai
+aiosignal==1.3.1
+    # via aiohttp
 alabaster==0.7.13
     # via sphinx
 algoliasearch==1.20.0
@@ -19,12 +23,6 @@ algoliasearch-django==1.7.3
     #   -r requirements/base.in
 amqp==5.2.0
     # via kombu
-annotated-types==0.6.0
-    # via pydantic
-anyio==3.7.1
-    # via
-    #   httpx
-    #   openai
 asgiref==3.7.2
     # via
     #   django
@@ -37,9 +35,12 @@ astroid==3.0.1
     #   pylint
     #   pylint-celery
 async-timeout==4.0.3
-    # via redis
+    # via
+    #   aiohttp
+    #   redis
 attrs==21.4.0
     # via
+    #   aiohttp
     #   glom
     #   jsonschema
     #   openedx-events
@@ -98,8 +99,6 @@ celery==5.3.5
 certifi==2023.11.17
     # via
     #   elasticsearch
-    #   httpcore
-    #   httpx
     #   requests
     #   selenium
     #   snowflake-connector-python
@@ -175,9 +174,7 @@ dill==0.3.7
 distlib==0.3.7
     # via virtualenv
 distro==1.8.0
-    # via
-    #   docker-compose
-    #   openai
+    # via docker-compose
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -431,7 +428,6 @@ elasticsearch-dsl==7.4.1
     #   django-elasticsearch-dsl-drf
 exceptiongroup==1.1.3
     # via
-    #   anyio
     #   pytest
     #   trio
     #   trio-websocket
@@ -452,6 +448,10 @@ filelock==3.13.1
     #   virtualenv
 freezegun==1.2.2
     # via -r requirements/test.in
+frozenlist==1.4.0
+    # via
+    #   aiohttp
+    #   aiosignal
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.in
 glom==22.1.0
@@ -478,26 +478,19 @@ googleapis-common-protos==1.61.0
 gspread==5.12.0
     # via -r requirements/base.in
 h11==0.14.0
-    # via
-    #   httpcore
-    #   wsproto
+    # via wsproto
 html2text==2020.1.16
     # via -r requirements/base.in
-httpcore==1.0.2
-    # via httpx
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-httpx==0.25.1
-    # via openai
 idna==3.4
     # via
-    #   anyio
-    #   httpx
     #   requests
     #   snowflake-connector-python
     #   trio
+    #   yarl
 imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.8.0
@@ -548,6 +541,10 @@ mock==5.1.0
     # via -r requirements/test.in
 more-itertools==10.1.0
     # via simple-salesforce
+multidict==6.0.4
+    # via
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.0
     # via -r requirements/test.in
 newrelic==9.2.0
@@ -557,8 +554,10 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openai==1.3.3
-    # via taxonomy-connector
+openai==0.28.1
+    # via
+    #   -c requirements/constraints.txt
+    #   taxonomy-connector
 openedx-atlas==0.5.0
     # via -r requirements/base.in
 openedx-events==9.2.0
@@ -630,10 +629,6 @@ pycountry==22.3.5
     # via -r requirements/base.in
 pycparser==2.21
     # via cffi
-pydantic==2.5.1
-    # via openai
-pydantic-core==2.14.3
-    # via pydantic
 pydata-sphinx-theme==0.14.3
     # via sphinx-book-theme
 pygments==2.17.1
@@ -771,6 +766,7 @@ requests==2.31.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   google-api-core
+    #   openai
     #   requests-file
     #   requests-oauthlib
     #   requests-toolbelt
@@ -840,10 +836,7 @@ six==1.16.0
 slumber==0.7.1
     # via edx-rest-api-client
 sniffio==1.3.0
-    # via
-    #   anyio
-    #   httpx
-    #   trio
+    # via trio
 snowballstemmer==2.2.0
     # via sphinx
 snowflake-connector-python==3.5.0
@@ -928,16 +921,12 @@ trio-websocket==0.11.1
     # via selenium
 typing-extensions==4.8.0
     # via
-    #   annotated-types
     #   asgiref
     #   astroid
     #   django-countries
     #   edx-opaque-keys
     #   faker
     #   kombu
-    #   openai
-    #   pydantic
-    #   pydantic-core
     #   pydata-sphinx-theme
     #   pylint
     #   semgrep
@@ -989,6 +978,8 @@ wsproto==1.2.0
     # via trio-websocket
 xss-utils==0.5.0
     # via -r requirements/base.in
+yarl==1.9.3
+    # via aiohttp
 zeep==4.2.1
     # via simple-salesforce
 zipp==3.17.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --output-file=requirements/production.txt requirements/production.in
 #
+aiohttp==3.9.1
+    # via openai
+aiosignal==1.3.1
+    # via aiohttp
 algoliasearch==1.20.0
     # via
     #   -c requirements/constraints.txt
@@ -15,12 +19,6 @@ algoliasearch-django==1.7.3
     #   -r requirements/base.in
 amqp==5.2.0
     # via kombu
-annotated-types==0.6.0
-    # via pydantic
-anyio==3.7.1
-    # via
-    #   httpx
-    #   openai
 asgiref==3.7.2
     # via
     #   django
@@ -29,9 +27,12 @@ asgiref==3.7.2
 asn1crypto==1.5.1
     # via snowflake-connector-python
 async-timeout==4.0.3
-    # via redis
+    # via
+    #   aiohttp
+    #   redis
 attrs==23.1.0
     # via
+    #   aiohttp
     #   openedx-events
     #   zeep
 backoff==2.2.1
@@ -70,8 +71,6 @@ certifi==2023.11.17
     # via
     #   -r requirements/production.in
     #   elasticsearch
-    #   httpcore
-    #   httpx
     #   requests
     #   snowflake-connector-python
 cffi==1.16.0
@@ -117,8 +116,6 @@ defusedxml==0.7.1
     #   djangorestframework-xml
     #   python3-openid
     #   social-auth-core
-distro==1.8.0
-    # via openai
 django==4.2.7
     # via
     #   -c requirements/constraints.txt
@@ -346,12 +343,14 @@ elasticsearch-dsl==7.4.1
     #   -r requirements/base.in
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
-exceptiongroup==1.1.3
-    # via anyio
 fastavro==1.9.0
     # via openedx-events
 filelock==3.13.1
     # via snowflake-connector-python
+frozenlist==1.4.0
+    # via
+    #   aiohttp
+    #   aiosignal
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.in
 gevent==23.9.1
@@ -381,24 +380,17 @@ gspread==5.12.0
     # via -r requirements/base.in
 gunicorn==21.2.0
     # via -r requirements/production.in
-h11==0.14.0
-    # via httpcore
 html2text==2020.1.16
     # via -r requirements/base.in
-httpcore==1.0.2
-    # via httpx
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-httpx==0.25.1
-    # via openai
 idna==3.4
     # via
-    #   anyio
-    #   httpx
     #   requests
     #   snowflake-connector-python
+    #   yarl
 importlib-metadata==6.8.0
     # via
     #   -r requirements/base.in
@@ -429,6 +421,10 @@ markupsafe==2.1.3
     # via jinja2
 more-itertools==10.1.0
     # via simple-salesforce
+multidict==6.0.4
+    # via
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.0
     # via -r requirements/production.in
 newrelic==9.2.0
@@ -440,8 +436,10 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openai==1.3.3
-    # via taxonomy-connector
+openai==0.28.1
+    # via
+    #   -c requirements/constraints.txt
+    #   taxonomy-connector
 openedx-atlas==0.5.0
     # via -r requirements/base.in
 openedx-events==9.2.0
@@ -488,10 +486,6 @@ pycountry==22.3.5
     # via -r requirements/base.in
 pycparser==2.21
     # via cffi
-pydantic==2.5.1
-    # via openai
-pydantic-core==2.14.3
-    # via pydantic
 pyjwt[crypto]==2.8.0
     # via
     #   drf-jwt
@@ -565,6 +559,7 @@ requests==2.31.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   google-api-core
+    #   openai
     #   requests-file
     #   requests-oauthlib
     #   requests-toolbelt
@@ -610,10 +605,6 @@ six==1.16.0
     #   requests-file
 slumber==0.7.1
     # via edx-rest-api-client
-sniffio==1.3.0
-    # via
-    #   anyio
-    #   httpx
 snowflake-connector-python==3.5.0
     # via -r requirements/base.in
 social-auth-app-django==5.4.0
@@ -649,14 +640,10 @@ tqdm==4.66.1
     # via openai
 typing-extensions==4.8.0
     # via
-    #   annotated-types
     #   asgiref
     #   django-countries
     #   edx-opaque-keys
     #   kombu
-    #   openai
-    #   pydantic
-    #   pydantic-core
     #   snowflake-connector-python
 tzdata==2023.3
     # via
@@ -689,6 +676,8 @@ webencodings==0.5.1
     #   tinycss2
 xss-utils==0.5.0
     # via -r requirements/base.in
+yarl==1.9.3
+    # via aiohttp
 zeep==4.2.1
     # via simple-salesforce
 zipp==3.17.0


### PR DESCRIPTION
__Jira Ticket:__ [ENT-8059](https://2u-internal.atlassian.net/browse/ENT-8059)

__Description:__
Open AI version 1.0.0 dropped support for openai.ChatCompletion which is currently in use in enterprise, pinning the version to `0.28.1` to as quick fix. We will implement a better solution as part of https://2u-internal.atlassian.net/browse/ENT-8060