### PR TITLE
chore: upgrade package

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -388,7 +388,7 @@ edx-django-utils==5.8.0
     #   edx-toggles
     #   getsmarter-api-clients
     #   taxonomy-connector
-edx-drf-extensions==8.13.1
+edx-drf-extensions==9.0.1
     # via -r requirements/base.in
 edx-event-bus-kafka==5.5.0
     # via -r requirements/base.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -309,7 +309,7 @@ edx-django-utils==5.8.0
     #   edx-toggles
     #   getsmarter-api-clients
     #   taxonomy-connector
-edx-drf-extensions==8.13.1
+edx-drf-extensions==9.0.1
     # via -r requirements/base.in
 edx-event-bus-kafka==5.5.0
     # via -r requirements/base.in


### PR DESCRIPTION
## Overview
Upgrade edx-drf-extensions

## Methodology
Apply @robrap's [patch](https://gist.github.com/robrap/ef412a48a24454bbe2d75da6a19b49de). Looks like `event-bus-kafka` is already at `5.5.0`, hence it's not in the diff.
