### PR TITLE
perf: use taxonomy get_whitelisted_serialized_skills to utilize cached data for calculating skill_names

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -25,7 +25,7 @@ from rest_framework.metadata import SimpleMetadata
 from rest_framework.relations import ManyRelatedField
 from taggit.serializers import TaggitSerializer, TagListSerializerField
 from taxonomy.choices import ProductTypes
-from taxonomy.utils import get_whitelisted_product_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.fields import (
     HtmlField, ImageField, SlugRelatedFieldWithReadSerializer, SlugRelatedTranslatableField, StdImageSerializerField
@@ -46,7 +46,9 @@ from course_discovery.apps.course_metadata.models import (
     ProgramType, Ranking, Seat, SeatType, Source, Specialization, Subject, TaxiForm, Topic, Track, Video
 )
 from course_discovery.apps.course_metadata.toggles import IS_COURSE_RUN_VARIANT_ID_EDITABLE
-from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours, parse_course_key_fragment
+from course_discovery.apps.course_metadata.utils import (
+    get_course_run_estimated_hours, get_product_skill_names, parse_course_key_fragment
+)
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.api.serializers import GroupUserSerializer
 
@@ -1396,8 +1398,7 @@ class CourseSerializer(TaggitSerializer, MinimalCourseSerializer):
         return None
 
     def get_skill_names(self, obj):
-        course_skills = get_whitelisted_product_skills(obj.key, product_type=ProductTypes.Course)
-        return list({course_skill.skill.name for course_skill in course_skills})
+        return get_product_skill_names(obj.key, ProductTypes.Course)
 
     def get_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.key, product_type=ProductTypes.Course)
@@ -2227,8 +2228,7 @@ class ProgramSerializer(MinimalProgramSerializer):
         return [topic.name for topic in obj.topics]
 
     def get_skill_names(self, obj):
-        program_skills = get_whitelisted_product_skills(obj.uuid, product_type=ProductTypes.Program)
-        return list({program_skill.skill.name for program_skill in program_skills})
+        return get_product_skill_names(obj.uuid, ProductTypes.Program)
 
     def get_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.uuid, product_type=ProductTypes.Program)

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -462,7 +462,7 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
             self.serialize_program_search(other_program),
         ]
 
-    @ddt.data((True, 18), (False, 16))
+    @ddt.data((True, 10), (False, 10))
     @ddt.unpack
     def test_query_count_exclude_expired_course_run(self, exclude_expired, expected_queries):
         """ Verify that there is no query explosion when excluding expired course runs. """
@@ -584,7 +584,7 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         upcoming = CourseRunFactory(course__partner=self.partner, start=now + datetime.timedelta(weeks=4))
         course_run_keys = [course_run.key for course_run in [archived, current, starting_soon, upcoming]]
 
-        with self.assertNumQueries(12, threshold=5):
+        with self.assertNumQueries(5, threshold=3):
             response = self.get_response({"ordering": ordering})
         assert response.status_code == 200
         assert response.data['objects']['count'] == 4

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -2,9 +2,10 @@ from django.conf import settings
 from django_elasticsearch_dsl import Index, fields
 from opaque_keys.edx.keys import CourseKey
 from taxonomy.choices import ProductTypes
-from taxonomy.utils import get_whitelisted_product_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.course_metadata.models import Course
+from course_discovery.apps.course_metadata.utils import get_product_skill_names
 
 from .analyzers import case_insensitive_keyword
 from .common import BaseCourseDocument, filter_visible_runs
@@ -104,8 +105,7 @@ class CourseDocument(BaseCourseDocument):
         return list(set(seat_types))
 
     def prepare_skill_names(self, obj):
-        course_skills = get_whitelisted_product_skills(obj.key, product_type=ProductTypes.Course)
-        return list(set(course_skill.skill.name for course_skill in course_skills))
+        return get_product_skill_names(obj.key, ProductTypes.Course)
 
     def prepare_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.key, product_type=ProductTypes.Course)

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -2,10 +2,11 @@ from django.conf import settings
 from django_elasticsearch_dsl import Index, fields
 from opaque_keys.edx.keys import CourseKey
 from taxonomy.choices import ProductTypes
-from taxonomy.utils import get_whitelisted_product_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.models import CourseRun
+from course_discovery.apps.course_metadata.utils import get_product_skill_names
 
 from .analyzers import case_insensitive_keyword, html_strip
 from .common import BaseCourseDocument, filter_visible_runs
@@ -118,8 +119,7 @@ class CourseRunDocument(BaseCourseDocument):
         return [seat_type.slug for seat_type in obj.seat_types]
 
     def prepare_skill_names(self, obj):
-        course_skills = get_whitelisted_product_skills(obj.course.key, product_type=ProductTypes.Course)
-        return list(set(course_skill.skill.name for course_skill in course_skills))
+        return get_product_skill_names(obj.course.key, ProductTypes.Course)
 
     def prepare_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.course.key, product_type=ProductTypes.Course)

--- a/course_discovery/apps/course_metadata/search_indexes/documents/program.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/program.py
@@ -1,10 +1,11 @@
 from django.conf import settings
 from django_elasticsearch_dsl import Index, fields
 from taxonomy.choices import ProductTypes
-from taxonomy.utils import get_whitelisted_product_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.models import Degree, Program
+from course_discovery.apps.course_metadata.utils import get_product_skill_names
 
 from .analyzers import case_insensitive_keyword, edge_ngram_completion, html_strip, synonym_text
 from .common import BaseDocument, OrganizationsMixin
@@ -97,8 +98,7 @@ class ProgramDocument(BaseDocument, OrganizationsMixin):
         return [seat_type.slug for seat_type in obj.seat_types]
 
     def prepare_skill_names(self, obj):
-        program_skills = get_whitelisted_product_skills(obj.uuid, product_type=ProductTypes.Program)
-        return list(set(program_skill.skill.name for program_skill in program_skills))
+        return get_product_skill_names(obj.uuid, ProductTypes.Program)
 
     def prepare_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.uuid, product_type=ProductTypes.Program)

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -4,11 +4,11 @@ import pytz
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
 from taxonomy.choices import ProductTypes
-from taxonomy.utils import get_whitelisted_product_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.api import serializers as cd_serializers
 from course_discovery.apps.api.serializers import ContentTypeSerializer, CourseWithProgramsSerializer
-from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours
+from course_discovery.apps.course_metadata.utils import get_course_run_estimated_hours, get_product_skill_names
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.serializers import BaseDjangoESDSLFacetSerializer
 
 from ..constants import BASE_SEARCH_INDEX_FIELDS, COMMON_IGNORED_FIELDS
@@ -98,8 +98,7 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
         return list(set(seat_types))
 
     def get_skill_names(self, result):
-        course_skills = get_whitelisted_product_skills(result.key, product_type=ProductTypes.Course)
-        return list(set(course_skill.skill.name for course_skill in course_skills))
+        return get_product_skill_names(result.key, ProductTypes.Course)
 
     def get_skills(self, result):
         return get_whitelisted_serialized_skills(result.key, product_type=ProductTypes.Course)

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
@@ -1,9 +1,10 @@
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
 from taxonomy.choices import ProductTypes
-from taxonomy.utils import get_whitelisted_product_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.serializers import ContentTypeSerializer, CourseRunWithProgramsSerializer
+from course_discovery.apps.course_metadata.utils import get_product_skill_names
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.serializers import BaseDjangoESDSLFacetSerializer
 
 from ..constants import BASE_SEARCH_INDEX_FIELDS, COMMON_IGNORED_FIELDS
@@ -38,8 +39,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
         return self.handle_datetime_field(obj.enrollment_end)
 
     def get_skill_names(self, result):
-        course_skills = get_whitelisted_product_skills(result.course_key, product_type=ProductTypes.Course)
-        return list(set(course_skill.skill.name for course_skill in course_skills))
+        return get_product_skill_names(result.course_key, ProductTypes.Course)
 
     def get_skills(self, result):
         return get_whitelisted_serialized_skills(result.course_key, product_type=ProductTypes.Course)

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/program.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/program.py
@@ -3,9 +3,10 @@ import json
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
 from taxonomy.choices import ProductTypes
-from taxonomy.utils import get_whitelisted_product_skills, get_whitelisted_serialized_skills
+from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.serializers import ContentTypeSerializer, ProgramSerializer
+from course_discovery.apps.course_metadata.utils import get_product_skill_names
 from course_discovery.apps.edx_elasticsearch_dsl_extensions.serializers import BaseDjangoESDSLFacetSerializer
 
 from ..constants import BASE_PROGRAM_FIELDS, BASE_SEARCH_INDEX_FIELDS, COMMON_IGNORED_FIELDS
@@ -29,8 +30,7 @@ class ProgramSearchDocumentSerializer(DocumentSerializer):
         return [json.loads(organization) for organization in organizations] if organizations else []
 
     def get_skill_names(self, program):
-        program_skills = get_whitelisted_product_skills(program.uuid, product_type=ProductTypes.Program)
-        return list(set(program_skill.skill.name for program_skill in program_skills))
+        return get_product_skill_names(program.uuid, ProductTypes.Program)
 
     def get_skills(self, program):
         return get_whitelisted_serialized_skills(program.uuid, product_type=ProductTypes.Program)

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -23,6 +23,7 @@ from edx_django_utils.cache import RequestCache, get_cache_key
 from getsmarter_api_clients.geag import GetSmarterEnterpriseApiClient
 from slugify import slugify
 from stdimage.models import StdImageFieldFile
+from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.core.models import SalesforceConfiguration
 from course_discovery.apps.core.utils import serialize_datetime
@@ -1230,3 +1231,11 @@ def clear_slug_request_cache_for_course(course_uuid):
     active_url_cache = RequestCache("active_url_cache")
     active_url_cache.delete(get_cache_key(course_uuid=course_uuid, draft=True))
     active_url_cache.delete(get_cache_key(course_uuid=course_uuid, draft=False))
+
+
+def get_product_skill_names(product_identifier, product_type):
+    """
+    Util method to get list of skill names associated with a product (course/program).
+    """
+    product_skills = get_whitelisted_serialized_skills(product_identifier, product_type=product_type)
+    return list({product_skill['name'] for product_skill in product_skills})


### PR DESCRIPTION
### [PROD-3842](https://2u-internal.atlassian.net/browse/PROD-3842)

### Description
There are also some duplicate calls to Taxonomy models within Discovery. The repeated calls to Taxonomy for each course/program entry are expected because there is no direct DB relation between the models and a lookup needs to be done from Taxonomy models using course/program uuid. In various APIs, there are two fields present; skills and skill_names. Both are fetched via different methods. Taxonomy offers various methods to fetch product skills, and not all use cache.
- Skill_names → get_whitelisted_product_skills
- skills → get_whitelisted_serialized_skills (this method has Tiered cache enabled)

This PR adds a util to get skill_names using get_whitelisted_serialized_skills so that duplicate calls to Taxonomy for each course/program are avoided and use cached response. 

The change impacts various APIs and removes the duplicate calls from each one of them:
- api/v1/courses/
- api/v1/programs/
- api/v1/search/all
- api/v1/search/courses
- api/v1/search/course_runs
- api/v1/search/programs
- api/v1/catalogs/1/courses/

Two tests had their query count decreased. They are ES related tests where document creation creates skills data (and caches them) and skips the DB call when hitting the endpoint. 


### Testing
- Make sure there are courses and programs with skills data (you might need to add manually)
- Checkout master
- Go to any of the relevant endpoints mentioned above and ensure the response has skills information. Note the query count
- Check out this branch and hit the endpoint again. Note the decrease in query count. 


### Screenshots

#### Before

<img width="1680" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/46bba02a-f729-40f2-8cca-da86ba562f88">

<img width="1680" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/017b52d6-fc3d-43f8-a3e9-08ed66e8d723">

<img width="1680" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/69d54be1-8871-4d94-8142-6b56122f8c04">

<img width="1680" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/8f12231d-24f2-4c0a-b44c-ede2f736d474">

#### After

<img width="1680" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/64d4ac7f-350b-438c-9b50-372df778b2e2">

<img width="1680" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/f2776da0-faee-479f-8b49-a0ab11a9684a">

<img width="1680" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/8e7e2443-449a-4beb-89e6-860deedb1b40">

<img width="1680" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/80e54a33-98cc-4f00-a8f3-b7b45a9b3d4b">

