### PR TITLE
feat: add anon user rate limiting for taxonomy recommendation endpoint

### DIFF
--- a/course_discovery/apps/api/tests/test_mixins.py
+++ b/course_discovery/apps/api/tests/test_mixins.py
@@ -1,0 +1,101 @@
+from django.test.utils import override_settings
+from django.urls import path, reverse
+from mock import patch
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+from rest_framework.test import APITestCase
+from rest_framework.throttling import AnonRateThrottle
+from rest_framework.views import APIView
+
+from course_discovery.apps.api.mixins import AnonymousUserThrottleAuthenticatedEndpointMixin
+from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
+
+
+class TestAPIView(AnonymousUserThrottleAuthenticatedEndpointMixin, APIView):
+    anonymous_user_throttle_class = None
+    permission_classes = ()
+    authentication_classes = ()
+
+    def get(self, request, *_args, **_kwargs):  # pylint: disable=unused-argument
+        return Response(
+            status=status.HTTP_200_OK,
+            data="Hello, World"
+        )
+
+
+class TestThrottle(AnonRateThrottle):
+    rate = '5/hour'
+
+
+# Replaces the built url with the urlpatterns defined in the test file so that TestView can be accessed
+# via an url
+urlpatterns = [
+    path('test', TestAPIView.as_view(), name='test-view'),
+]
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class TestAnonymousUserThrottleMixin(APITestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('test-view')
+
+    def make_requests(self, count=5):
+        """
+        Make multiple requests until the throttle's limit is exceeded.
+        """
+        for __ in range(count - 1):
+            response = self.client.get(self.url)
+            assert response.status_code != 429
+        response = self.client.get(self.url)
+        return response
+
+    def test_throttle_authenticated_user(self):
+        """
+        Verify that anonymous user throttle does not apply to authenticated users.
+        """
+        auth_user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=auth_user.username, password=USER_PASSWORD)
+        with patch.object(TestAPIView, 'anonymous_user_throttle_class', TestThrottle):
+            with patch.object(
+                    TestAPIView, 'authentication_classes', api_settings.DEFAULT_AUTHENTICATION_CLASSES
+            ):
+                response = self.make_requests(10)
+        assert response.status_code == 200
+        assert response.data == "Hello, World"
+        self.client.logout()
+
+    def test_throttle_limit__authentication_classes(self):
+        """
+        Verify that endpoint is throttled against unauthenticated users when requests are greater than limit.
+        """
+        with patch.object(TestAPIView, 'anonymous_user_throttle_class', TestThrottle):
+            with patch.object(
+                    TestAPIView, 'authentication_classes', api_settings.DEFAULT_AUTHENTICATION_CLASSES
+            ):
+                response = self.make_requests(6)
+        assert response.status_code == 429
+
+    def test_throttle_limit__no_authentication_permission(self):
+        """
+        Verify that anonymous user throttle does not execute if the view does not have auth defined via
+        authentication_classes or IsAuthenticated permission.
+        """
+        with patch.object(TestAPIView, 'anonymous_user_throttle_class', TestThrottle):
+            response = self.make_requests(10)
+        assert response.status_code != 429
+
+    def test_throttle_limit__authentication_permissions(self):
+        """
+        Verify that endpoint is throttled against unauthenticated users when IsAuthenticated permission is present
+        on API endpoint.
+        """
+        with patch.object(TestAPIView, 'anonymous_user_throttle_class', TestThrottle):
+            with patch.object(
+                    TestAPIView, 'permission_classes', (IsAuthenticated, )
+            ):
+                response = self.make_requests(6)
+        assert response.status_code == 429

--- a/course_discovery/apps/taxonomy_support/api/v1/views.py
+++ b/course_discovery/apps/taxonomy_support/api/v1/views.py
@@ -2,16 +2,19 @@ from rest_framework import permissions
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 
+from course_discovery.apps.api.mixins import AnonymousUserThrottleAuthenticatedEndpointMixin
 from course_discovery.apps.course_metadata.models import Course
 from course_discovery.apps.taxonomy_support.api.v1.serializers import CourseRecommendationsSerializer
+from course_discovery.apps.taxonomy_support.throttles import CourseRecommendationsViewAnonymousUserThrottle
 
 
-class CourseRecommendationsAPIView(ListAPIView):
+class CourseRecommendationsAPIView(AnonymousUserThrottleAuthenticatedEndpointMixin, ListAPIView):
     """
     Course recommendations API.
     Example:
-        GET discovery.edx.org/taxonomy/api/v1/course_recommendations/edX+DemoX/
+        GET /taxonomy/api/v1/course_recommendations/edX+DemoX/
     """
+    anonymous_user_throttle_class = CourseRecommendationsViewAnonymousUserThrottle
     permission_classes = (permissions.IsAuthenticated,)
     queryset = Course.objects.all()
     serializer_class = CourseRecommendationsSerializer

--- a/course_discovery/apps/taxonomy_support/tests/test_throttles.py
+++ b/course_discovery/apps/taxonomy_support/tests/test_throttles.py
@@ -1,0 +1,39 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+class ThrottleTest(APITestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('taxonomy_support:course_recommendations', args=('NO+COURSE',))
+
+    def _make_requests(self, count=11):
+        """
+        Make multiple requests until the throttle's limit is exceeded.
+        """
+        for __ in range(count - 1):
+            response = self.client.get(self.url)
+            assert response.status_code != 429
+        response = self.client.get(self.url)
+        return response
+
+    def assert_rate_limited(self, count=11):
+        """
+        Asserts that the throttle's rate limit exceeded and 429 error was raised.
+        """
+        response = self._make_requests(count)
+        assert response.status_code == 429
+
+    def test_rate_limit_not_exceeded(self):
+        """
+        Asserts that requests below throttle rate do not encounter 429.
+        """
+        response = self._make_requests(9)
+        assert response.status_code != 429
+
+    def test_rate_limiting(self):
+        """
+        Verify the API responds with HTTP 429 if the request goes over the rate limit.
+        """
+        self.assert_rate_limited(count=11)

--- a/course_discovery/apps/taxonomy_support/throttles.py
+++ b/course_discovery/apps/taxonomy_support/throttles.py
@@ -1,0 +1,9 @@
+
+from rest_framework.throttling import AnonRateThrottle
+
+
+class CourseRecommendationsViewAnonymousUserThrottle(AnonRateThrottle):
+    """
+    Throttling for Anonymous users against CourseRecommendationsAPIView endpoint.
+    """
+    rate = '10/h'


### PR DESCRIPTION
### [PROD-3836](https://2u-internal.atlassian.net/browse/PROD-3836)

### Description

This PR adds rate limiting for unauthenticated requests against Taxonomy Support Recommendation endpoint. This endpoint is being hit with unauth requests aggressively and is causing issues. The throttling is aggressive for a while and might be increased in the future if needed (via settings variable).

Due to how DRF works, the anon throttle does not work for APIs that require authentication (See https://github.com/encode/django-rest-framework/issues/5234). Therefore, this PR adds a Mixin that overrides dispatch and then handle throttling there. 

- https://docs.djangoproject.com/en/4.2/topics/testing/tools/#urlconf-configuration
- https://github.com/encode/django-rest-framework/issues/5234
- https://stackoverflow.com/questions/75365158/django-unable-to-apply-function-view-decorator-to-class-based-view


### Testing
- Checkout this branch and start discovery
- Go to /taxonomy/api/v1/course_recommendations/edX+DemoX/ in an incognito tab/ logged out session
- Hit it 10 times, the 11th should show 429 error and also showcasing the retry-after/wait point
