### PR TITLE
refactor: refactor Course.retrieve to prevent calling get_object twice

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -2386,12 +2386,6 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
 
         # Now with editable=1 for real
         response = self.client.get(url, {'editable': 1})
-        # This is not a no-op. Essentially, once we hit the endpoint for a course that
-        # has no entitlements, and an entitlement is created, we'll get a stale response
-        # Only when we hit it the second time do we get the updated response. This is because
-        # the entitlements are prefetched on the course object and the call to
-        # create_missing_entitlement is made after the prefetch.
-        response = self.client.get(url, {'editable': 1})
 
         assert response.status_code == 200
         assert 'entitlements' in response.json()

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -516,6 +516,7 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         course = self.get_object()
         if get_query_param(request, 'editable') and not course.entitlements.exists():
             create_missing_entitlement(course)
+            course.refresh_from_db(fields=['entitlements'])
         # Rather than call super().retrieve, we instantiate the serializer and return its
         # data ourselves. This is to prevent duplicate calls (and hence duplicate queries)
         # to self.get_object. Note that we have called get_object once already(see above).

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -516,8 +516,11 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         course = self.get_object()
         if get_query_param(request, 'editable') and not course.entitlements.exists():
             create_missing_entitlement(course)
-
-        return super().retrieve(request, *args, **kwargs)
+        # Rather than call super().retrieve, we instantiate the serializer and return its
+        # data ourselves. This is to prevent duplicate calls (and hence duplicate queries)
+        # to self.get_object. Note that we have called get_object once already(see above).
+        serializer = self.get_serializer(course)
+        return Response(serializer.data)
 
 
 class CourseRecommendationViewSet(RetrieveModelMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
## Overview
Right now, the [retrieve endpoint](https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/api/v1/views/courses.py#L516-L520) is written such that there are two calls to `get_object`. Once at line 516, and a [second one](https://github.com/encode/django-rest-framework/blob/master/rest_framework/mixins.py#L55-L58) inside of `super.retrieve` by DRF. This duplicates the database queries inside `get_object`. This PR attempts to fix that.

### [PROD-3833](https://2u-internal.atlassian.net/browse/PROD-3833)