### PR TITLE
feat: Improve DB performance by changing ES logic

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -702,7 +702,7 @@ class LimitedAggregateSearchViewSetTests(
         course_run = CourseRunFactory(course__partner=self.partner, status=CourseRunStatus.Published)
         program = ProgramFactory(partner=self.partner, status=ProgramStatus.Active)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(3):
             response = self.client.get(self.path)
         assert response.status_code == 200
         response_data = response.json()

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -1,8 +1,11 @@
+# pylint: disable=W0223
 import datetime
 
 import pytz
+from django.db import models
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
+from rest_framework.serializers import ListSerializer
 from taxonomy.choices import ProductTypes
 from taxonomy.utils import get_whitelisted_serialized_skills
 
@@ -16,6 +19,24 @@ from ..documents import CourseDocument
 from .common import DateTimeSerializerMixin, DocumentDSLSerializerMixin, ModelObjectDocumentSerializerMixin
 
 __all__ = ('CourseSearchDocumentSerializer',)
+
+
+class CourseSearchDocumentListSerializer(ModelObjectDocumentSerializerMixin, ListSerializer):
+    """
+    Custom List Serializer for CourseSearchDocument to fetch all instances at once.
+    """
+
+    def to_representation(self, data):
+        """
+        Custom list representation to fetch all the course instances at once.
+        """
+        iterable = data.all() if isinstance(data, models.Manager) else data
+        _objects = list(self.get_model_object_by_instances(iterable))
+
+        object_dict = {obj.pk: obj for obj in _objects}
+        result_tuples = [(item, object_dict.get(item.pk)) for item in iterable]
+
+        return super().to_representation(result_tuples)
 
 
 class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTimeSerializerMixin, DocumentSerializer):
@@ -120,15 +141,28 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
             self.fields.pop('outcome', None)
 
     def to_representation(self, instance):
-        _object = self.get_model_object_by_instance(instance)
-        setattr(instance, 'object', _object)  # pylint: disable=literal-used-as-attribute
-        return super().to_representation(instance)
+        """
+        Custom instance representation.
+        The instance needs to be handled differently and can be either of the two:
+
+        1. A tuple consistent of an ES Hit object and a model object to be assigned to the hit object.
+        2. A single ES Hit object
+        """
+        if isinstance(instance, tuple):
+            setattr(instance[0], 'object', instance[1])  # pylint: disable=literal-used-as-attribute
+            prepared_instance = instance[0]
+        else:
+            _object = self.get_model_object_by_instances(instance).get()
+            setattr(instance, 'object', _object)  # pylint: disable=literal-used-as-attribute
+            prepared_instance = instance
+        return super().to_representation(prepared_instance)
 
     class Meta:
         """
         Meta options.
         """
 
+        list_serializer_class = CourseSearchDocumentListSerializer
         document = CourseDocument
         ignore_fields = COMMON_IGNORED_FIELDS
         fields = BASE_SEARCH_INDEX_FIELDS + (

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/learner_pathway.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/learner_pathway.py
@@ -1,5 +1,8 @@
+# pylint: disable=W0223
+from django.db import models
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from rest_framework import serializers
+from rest_framework.serializers import ListSerializer
 
 from course_discovery.apps.api.fields import StdImageSerializerField
 from course_discovery.apps.api.serializers import ContentTypeSerializer
@@ -10,6 +13,20 @@ from ..documents import LearnerPathwayDocument
 from .common import DateTimeSerializerMixin, DocumentDSLSerializerMixin, ModelObjectDocumentSerializerMixin
 
 __all__ = ('LearnerPathwaySearchDocumentSerializer',)
+
+
+class LearnerPathwaySearchDocumentListSerializer(ModelObjectDocumentSerializerMixin, ListSerializer):
+    def to_representation(self, data):
+        """
+        Custom list representation to fetch all the learner_pathway instances at once.
+        """
+        iterable = data.all() if isinstance(data, models.Manager) else data
+        _objects = list(self.get_model_object_by_instances(iterable))
+
+        object_dict = {obj.pk: obj for obj in _objects}
+        result_tuples = [(item, object_dict.get(item.pk)) for item in iterable]
+
+        return super().to_representation(result_tuples)
 
 
 class LearnerPathwaySearchDocumentSerializer(
@@ -34,6 +51,7 @@ class LearnerPathwaySearchDocumentSerializer(
         Meta options.
         """
 
+        list_serializer_class = LearnerPathwaySearchDocumentListSerializer
         document = LearnerPathwayDocument
         ignore_fields = COMMON_IGNORED_FIELDS
         fields = (
@@ -44,9 +62,21 @@ class LearnerPathwaySearchDocumentSerializer(
         )
 
     def to_representation(self, instance):
-        _object = self.get_model_object_by_instance(instance)
-        setattr(instance, 'object', _object)  # pylint: disable=literal-used-as-attribute
-        return super().to_representation(instance)
+        """
+        Custom instance representation.
+        The instance needs to be handled differently and can be either of the two:
+
+        1. A tuple consistent of an ES Hit object and a model object to be assigned to the hit object.
+        2. A single ES Hit object
+        """
+        if isinstance(instance, tuple):
+            setattr(instance[0], 'object', instance[1])  # pylint: disable=literal-used-as-attribute
+            prepared_instance = instance[0]
+        else:
+            _object = self.get_model_object_by_instances(instance).get()
+            setattr(instance, 'object', _object)  # pylint: disable=literal-used-as-attribute
+            prepared_instance = instance
+        return super().to_representation(prepared_instance)
 
 
 class LearnerPathwaySearchModelSerializer(DocumentDSLSerializerMixin, ContentTypeSerializer, LearnerPathwaySerializer):


### PR DESCRIPTION
[PROD-3873](https://2u-internal.atlassian.net/browse/PROD-3873)
Updates the underlying ES logic for AggregateSearchSerializer which uses CourseSearchDocumentSerializer and LearnerPathwaySearchDocumentSerializers. These serializers used to fetch each item from the DB one by one. This PR will stay backward compatible along with changing only the problematic serializers to fetch all objects in one DB call. 

This results in significant reduction of DB queryes of Course and LearnerPathway along with it reducing calls to their related models (courserun, courseruntype, seattype etc). Ultimately, this will greatly improve performance for the ES endpoints like `search/all/` and `search/courses/`.

### Testing Instruction

- Update ES index on local: `./manage.py update_index --disable-change-limit`
- Verify all the following URLs and check the decreased amount of queries:

```
router.register(r'search/limited', search_views.LimitedAggregateSearchView, basename='search-limited')
router.register(r'search/all', search_views.AggregateSearchViewSet, basename='search-all')
router.register(r'search/courses', search_views.CourseSearchViewSet, basename='search-courses')
router.register(r'search/course_runs', search_views.CourseRunSearchViewSet, basename='search-course_runs')
router.register(r'search/programs', search_views.ProgramSearchViewSet, basename='search-programs')
router.register(r'search/people', search_views.PersonSearchViewSet, basename='search-people')
```
