### PR TITLE
chore: update remaining local configs for Django v4.2

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/add_provisioning_data.py
+++ b/course_discovery/apps/course_metadata/management/commands/add_provisioning_data.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
             'short_code': 'edx',
             'site': self.site,
             'organizations_api_url': "http://edx.devstack.lms:18000/api/organizations/v0/",
-            'studio_url': "http://edx.devstack.studio:18010/"
+            'studio_url': "http://edx.devstack.cms:18010/"
         })
         self.org, _ = Organization.objects.get_or_create(key="edX", defaults={
             'partner': self.partner,

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -775,3 +775,11 @@ SIMPLE_HISTORY_DATE_INDEX = False
 
 USE_DEPRECATED_PYTZ = True
 ORGANIC_MARKETING_EMAIL = None
+
+CSRF_TRUSTED_ORIGINS = (
+    'http://localhost:8734',  # frontend-app-learner-portal-enterprise
+    'http://localhost:1991',  # frontend-app-admin-portal
+    'http://localhost:18400',  # frontend-app-publisher
+    'http://localhost:18450',  # frontend-app-support-tools
+    'http://localhost:2000',  # frontend-app-learning
+)

--- a/course_discovery/settings/local.py
+++ b/course_discovery/settings/local.py
@@ -57,14 +57,6 @@ JWT_AUTH.update({
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 })
 
-CSRF_TRUSTED_ORIGINS = (
-    'http://localhost:8734',  # frontend-app-learner-portal-enterprise
-    'http://localhost:1991',  # frontend-app-admin-portal
-    'http://localhost:18400',  # frontend-app-publisher
-    'http://localhost:18450',  # frontend-app-support-tools
-    'http://localhost:2000',  # frontend-app-learning
-)
-
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/course_discovery/settings/local.py
+++ b/course_discovery/settings/local.py
@@ -57,6 +57,14 @@ JWT_AUTH.update({
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 })
 
+CSRF_TRUSTED_ORIGINS = (
+    'http://localhost:8734',  # frontend-app-learner-portal-enterprise
+    'http://localhost:1991',  # frontend-app-admin-portal
+    'http://localhost:18400',  # frontend-app-publisher
+    'http://localhost:18450',  # frontend-app-support-tools
+    'http://localhost:2000',  # frontend-app-learning
+)
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):


### PR DESCRIPTION
[PROD-3864](https://2u-internal.atlassian.net/browse/PROD-3864)
-------------
This PR adds the local configs for `CSRF_TRUSTED_ORIGINS` to whitelist them and update the `STUDIO URL` from to `http://edx.devstack.cms:18010/` (from `http://edx.devstack.studio:18010/`) for the edX partner provisioned in devstack.
