### PR TITLE
feat: prefetch course run type

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -214,7 +214,7 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         ([{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True}], 7),
         ([{'title': 'Software Testing', 'excluded': False}, {'title': 'Software Testing 2', 'excluded': False}], 7),
         ([{'title': 'Software Testing', 'excluded': True}, {'title': 'Software Testing 2', 'excluded': True},
-          {'title': 'Software Testing 3', 'excluded': False}], 9),
+          {'title': 'Software Testing 3', 'excluded': False}], 8),
     )
     @ddt.unpack
     def test_excluded_course_run(self, course_runs, expected_queries):
@@ -462,7 +462,7 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
             self.serialize_program_search(other_program),
         ]
 
-    @ddt.data((True, 10), (False, 10))
+    @ddt.data((True, 7), (False, 7))
     @ddt.unpack
     def test_query_count_exclude_expired_course_run(self, exclude_expired, expected_queries):
         """ Verify that there is no query explosion when excluding expired course runs. """

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -123,7 +123,7 @@ class CourseDocument(BaseCourseDocument):
         return [prerequisite.name for prerequisite in obj.prerequisites.all()]
 
     def get_queryset(self):
-        return super().get_queryset().prefetch_related('course_runs__seats__type')
+        return super().get_queryset().prefetch_related('course_runs__seats__type', 'course_runs__type')
 
     def prepare_course_type(self, obj):
         return obj.type.slug


### PR DESCRIPTION
[PROD-3841](https://2u-internal.atlassian.net/browse/PROD-3841)
The PR fixes the only problem it has currently i.e. prefetching course run type for each run beforehand.

Updates the query from:
SELECT ••• FROM `course_metadata_courseruntype` WHERE `course_metadata_courseruntype`.`id` = 1
to
SELECT ••• FROM `course_metadata_courseruntype` WHERE `course_metadata_courseruntype`.`id` IN (1)