### PR TITLE
feat: ability to exclude by course_type

### DIFF
--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -194,7 +194,14 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         },
         'availability': {'field': 'availability.raw', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
         'content_type': {'field': 'content_type', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
-        'course_type': {'field': 'course_type', 'lookups': [LOOKUP_FILTER_TERM, LOOKUP_FILTER_TERMS]},
+        'course_type': {
+            'field': 'course_type',
+            'lookups': [
+                LOOKUP_FILTER_TERM,
+                LOOKUP_FILTER_TERMS,
+                LOOKUP_QUERY_EXCLUDE,
+            ]
+        },
         'enterprise_subscription_inclusion': {
             'field': 'enterprise_subscription_inclusion',
             'lookups': [LOOKUP_FILTER_TERM],


### PR DESCRIPTION
## Description

In order to run `"course_type__exclude": "executive-education-2u"` type queries

- https://2u-internal.atlassian.net/browse/ENT-7893