### PR TITLE
feat: update event-bus-kafka to bring in new client.id

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -391,7 +391,7 @@ edx-django-utils==5.10.1
     #   taxonomy-connector
 edx-drf-extensions==9.1.2
     # via -r requirements/base.in
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/base.in
 edx-event-bus-redis==0.3.2
     # via -r requirements/base.in
@@ -565,7 +565,7 @@ openai==0.28.1
     #   taxonomy-connector
 openedx-atlas==0.6.0
     # via -r requirements/base.in
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   edx-event-bus-kafka
     #   edx-event-bus-redis

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -312,7 +312,7 @@ edx-django-utils==5.10.1
     #   taxonomy-connector
 edx-drf-extensions==9.1.2
     # via -r requirements/base.in
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/base.in
 edx-event-bus-redis==0.3.2
     # via -r requirements/base.in
@@ -447,7 +447,7 @@ openai==0.28.1
     #   taxonomy-connector
 openedx-atlas==0.6.0
     # via -r requirements/base.in
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   edx-event-bus-kafka
     #   edx-event-bus-redis


### PR DESCRIPTION
Uses the EVENTS_SERVICE_NAME variable, set in https://github.com/edx/edx-internal/blob/0e4a237e89c4621e00b73c10d99d0d639e0f0474/argocd/applications/course-discovery/prod-config.yaml#L174