### PR TITLE
feat: use finalRegCloseDate for reading enrollment end from GEAG

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -346,7 +346,9 @@ class Command(BaseCommand):
             'secondary_subject': partially_filled_csv_dict.get('secondary_subject', ''),
             'tertiary_subject': partially_filled_csv_dict.get('tertiary_subject', ''),
             'start_date': partially_filled_csv_dict.get('start_date') or product_dict['variant']['startDate'],
-            'reg_close_date': partially_filled_csv_dict.get('regCloseDate') or product_dict['variant']['regCloseDate'],
+            'reg_close_date': partially_filled_csv_dict.get(
+                'reg_close_date'
+            ) or product_dict['variant']['finalRegCloseDate'],
             'minimum_effort': minimum_effort,
             'maximum_effort': maximum_effort,
             'organization_logo_override': utils.format_base64_strings(product_dict['logoUrl']),

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_executive_education_data_csv.py
@@ -61,6 +61,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                     "finalPrice": "1998",
                     "startDate": "2022-03-06",
                     "regCloseDate": "2022-02-06",
+                    "finalRegCloseDate": "2022-02-15",
                 },
                 "curriculum": {
                     "heading": "Course curriculum",
@@ -179,6 +180,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
                 assert data_row['Long Description'] == 'Very short description\n' \
                                                        'This is supposed to be a long description'
                 assert data_row['End Time'] == '23:59:59'
+                assert data_row['Reg Close Date'] == '01/25/2050'
                 assert data_row['Course Enrollment Track'] == 'Executive Education(2U)'
                 assert data_row['Course Run Enrollment Track'] == 'Unpaid Executive Education'
                 assert data_row['Length'] == '10'
@@ -346,6 +348,7 @@ class TestPopulateExecutiveEducationDataCsv(CSVLoaderMixin, TestCase):
         assert data_row['Start Date'] == '2022-03-06'
         assert data_row['End Time'] == '23:59:59'
         assert data_row['End Date'] == '2022-05-06'
+        assert data_row['Reg Close Date'] == '2022-02-15'
         assert data_row['Verified Price'] == '1998'
         assert data_row['Short Description'] == 'A short description for CSV course'
         assert data_row['Long Description'] == 'Very short description\n' \

--- a/course_discovery/apps/course_metadata/tests/constants.py
+++ b/course_discovery/apps/course_metadata/tests/constants.py
@@ -38,6 +38,7 @@ MOCK_PRODUCTS_DATA = [
                 "finalPrice": "1998",
                 "startDate": "2022-03-06",
                 "regCloseDate": "2022-02-06",
+                "finalRegCloseDate": "2022-02-15",
         },
         "curriculum": {
             "heading": "Course curriculum",


### PR DESCRIPTION
### [PROD-3891](https://2u-internal.atlassian.net/browse/PROD-3891)

Use finalRegCloseDate to read enrollment end date from GEAG variant