### PR TITLE
fix: adding status to minimal serializers

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1175,6 +1175,7 @@ class MinimalCourseSerializer(FlexFieldsSerializerMixin, TimestampModelSerialize
     url_slug = serializers.SerializerMethodField()
     course_type = serializers.SerializerMethodField()
     enterprise_subscription_inclusion = serializers.BooleanField(required=False)
+    course_run_statuses = serializers.ReadOnlyField()
 
     @classmethod
     def prefetch_queryset(cls, queryset=None, course_runs=None):
@@ -1212,7 +1213,7 @@ class MinimalCourseSerializer(FlexFieldsSerializerMixin, TimestampModelSerialize
         model = Course
         fields = ('key', 'uuid', 'title', 'course_runs', 'entitlements', 'owners', 'image',
                   'short_description', 'type', 'url_slug', 'course_type', 'enterprise_subscription_inclusion',
-                  'excluded_from_seo', 'excluded_from_search')
+                  'excluded_from_seo', 'excluded_from_search', 'course_run_statuses')
 
 
 class CourseEditorSerializer(serializers.ModelSerializer):
@@ -1969,6 +1970,7 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
     degree = DegreeSerializer()
     curricula = CurriculumSerializer(many=True)
     card_image_url = serializers.SerializerMethodField()
+    course_run_statuses = serializers.ReadOnlyField()
     organization_short_code_override = serializers.CharField(required=False, allow_blank=True)
     organization_logo_override_url = serializers.SerializerMethodField()
     primary_subject_override = SubjectSerializer()
@@ -2012,8 +2014,8 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
             'total_hours_of_effort', 'recent_enrollment_count', 'organization_short_code_override',
             'organization_logo_override_url', 'primary_subject_override', 'level_type_override', 'language_override',
             'labels', 'taxi_form', 'program_duration_override', 'data_modified_timestamp',
-            'excluded_from_search', 'excluded_from_seo', 'subscription', 'has_ofac_restrictions', 'ofac_comment'
-
+            'excluded_from_search', 'excluded_from_seo', 'subscription', 'has_ofac_restrictions', 'ofac_comment',
+            'course_run_statuses',
         )
         read_only_fields = (
             'uuid', 'marketing_url', 'banner_image', 'data_modified_timestamp', 'has_ofac_restrictions', 'ofac_comment'
@@ -2197,7 +2199,6 @@ class ProgramSerializer(MinimalProgramSerializer):
     skill_names = serializers.SerializerMethodField()
     skills = serializers.SerializerMethodField()
     product_source = SourceSerializer(required=False, read_only=True)
-    course_run_statuses = serializers.ReadOnlyField()
 
     @classmethod
     def prefetch_queryset(cls, partner, queryset=None):
@@ -2259,7 +2260,7 @@ class ProgramSerializer(MinimalProgramSerializer):
             'staff', 'credit_redemption_overview', 'applicable_seat_types', 'instructor_ordering',
             'enrollment_count', 'topics', 'credit_value', 'enterprise_subscription_inclusion', 'geolocation',
             'location_restriction', 'is_2u_degree_program', 'in_year_value', 'skill_names', 'skills',
-            'product_source', 'excluded_from_search', 'excluded_from_seo', 'course_run_statuses',
+            'product_source', 'excluded_from_search', 'excluded_from_seo',
         )
         read_only_fields = ('enterprise_subscription_inclusion', 'product_source',)
 

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -145,6 +145,7 @@ class MinimalCourseSerializerTests(SiteMixin, TestCase):
             'course_type': course.type.slug,
             'enterprise_subscription_inclusion': course.enterprise_subscription_inclusion,
             'url_slug': None,
+            'course_run_statuses': course.course_run_statuses,
         }
 
     def test_data(self):
@@ -1095,10 +1096,12 @@ class MinimalProgramSerializerTests(TestCase):
             'ofac_comment': program.ofac_comment,
             'subscription_eligible': None,
             'subscription_prices': [],
+            'course_run_statuses': program.course_run_statuses,
         }
 
     def test_data(self):
         request = make_request()
+        self.maxDiff = None
         program = self.create_program()
         serializer = self.serializer_class(program, context={'request': request})
         expected = self.get_expected_data(program, request)

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -1101,7 +1101,6 @@ class MinimalProgramSerializerTests(TestCase):
 
     def test_data(self):
         request = make_request()
-        self.maxDiff = None
         program = self.create_program()
         serializer = self.serializer_class(program, context={'request': request})
         expected = self.get_expected_data(program, request)

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -1037,7 +1037,6 @@ class TypeaheadSearchViewTests(mixins.TypeaheadSerializationMixin, mixins.LoginM
 
     def test_typeahead_org_course_runs_come_up_first(self):
         """ Test typeahead response to ensure org is taken into account. """
-        self.maxDiff = None
         MITx = OrganizationFactory(key='MITx')
         HarvardX = OrganizationFactory(key='HarvardX')
         mit_run = CourseRunFactory(

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -842,7 +842,6 @@ class UtilsTests(TestCase):
     @ddt.unpack
     def test_clean_html(self, content, expected):
         """ Verify the method removes unnecessary HTML attributes. """
-        self.maxDiff = None
         assert clean_html(content) == expected
 
     def test_skill_data_transformation(self):

--- a/course_discovery/apps/taxonomy_support/api/v1/tests/test_serializers.py
+++ b/course_discovery/apps/taxonomy_support/api/v1/tests/test_serializers.py
@@ -42,7 +42,6 @@ class TestsCourseRecommendationsSerializer(TestCase):
         """
         Tests serializer Data.
         """
-        self.maxDiff = None
         recommendation = CourseRecommendationFactory()
         serializer = self.serializer_class(recommendation)
         expected = self.get_expected_data(recommendation)


### PR DESCRIPTION
[With the previous PR](https://github.com/openedx/course-discovery/pull/4248), I was confused as to why the addition of course_run_statuses could be seen in discovery but not in the endpoint I was querying. Looking into the details, it turns out that the endpoint is using the MinimalProgramSerializer so it wasn't picking up the new field - hence this change. 
https://2u-internal.atlassian.net/browse/ENT-8236

