### PR TITLE
perf: optimise queryset of ES

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -1091,7 +1091,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(45, threshold=3):
+        with self.assertNumQueries(25, threshold=3):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])

--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -97,12 +97,13 @@ class CourseRunViewSet(CompressedCacheResponseMixin, ValidElasticSearchQueryRequ
             queryset = self.queryset
 
         if q:
-            qs = SearchQuerySetWrapper(CourseRun.search(q).filter('term', partner=partner.short_code))
-            # This is necessary to avoid issues with the filter backend.
-            qs.model = self.queryset.model
-            return qs
+            queryset = SearchQuerySetWrapper(
+                CourseRun.search(q).filter('term', partner=partner.short_code),
+                model=queryset.model
+            )
+        else:
+            queryset = queryset.filter(course__partner=partner)
 
-        queryset = queryset.filter(course__partner=partner)
         return self.get_serializer_class().prefetch_queryset(queryset=queryset)
 
     def get_serializer_context(self):

--- a/course_discovery/apps/core/tests/test_utils.py
+++ b/course_discovery/apps/core/tests/test_utils.py
@@ -111,7 +111,7 @@ class SearchQuerySetWrapperTests(TestCase):
         CourseRunFactory.create_batch(3, title=title)
         self.search_queryset = CourseRunDocument().search().query('query_string', query=query)
         self.course_runs = [e.object for e in self.search_queryset]
-        self.wrapper = SearchQuerySetWrapper(self.search_queryset)
+        self.wrapper = SearchQuerySetWrapper(self.search_queryset, CourseRunFactory)
 
     def test_count(self):
         assert self.search_queryset.count() == self.wrapper.count()

--- a/course_discovery/apps/core/tests/test_utils.py
+++ b/course_discovery/apps/core/tests/test_utils.py
@@ -121,3 +121,9 @@ class SearchQuerySetWrapperTests(TestCase):
 
     def test_getitem(self):
         assert self.course_runs[0] == self.wrapper[0]
+
+    def test_prefetch_related_count(self):
+        assert self.search_queryset.count() == self.wrapper.prefetch_related().count()
+
+    def test_select_related_count(self):
+        assert self.search_queryset.count() == self.wrapper.select_related().count()

--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -164,7 +164,7 @@ class SearchQuerySetWrapper:
     def prefetch_related(self, *lookups):
         """Same as QuerySet.prefetch_related()"""
         clone = self._chain()
-        if lookups == (None,):
+        if not lookups or lookups == (None,):
             clone._prefetch_related_lookups = ()  # pylint: disable=protected-access
         else:
             clone._prefetch_related_lookups += lookups
@@ -173,7 +173,7 @@ class SearchQuerySetWrapper:
     def select_related(self, *lookups):
         """Will work same as .prefetch_related()"""
         clone = self._chain()
-        if lookups == (None,):
+        if not lookups or lookups == (None,):
             clone._select_related_lookups = ()  # pylint: disable=protected-access
         else:
             clone._select_related_lookups += lookups

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -977,14 +977,18 @@ class CourseRunTests(OAuth2Mixin, TestCase):
         title = 'Some random title'
         course_runs = factories.CourseRunFactory.create_batch(3, title=title)
         query = 'title:' + title
-        actual_sorted = sorted(SearchQuerySetWrapper(CourseRun.search(query)), key=lambda course_run: course_run.key)
+        actual_sorted = sorted(
+            SearchQuerySetWrapper(CourseRun.search(query), CourseRunFactory), key=lambda course_run: course_run.key
+        )
         expected_sorted = sorted(course_runs, key=lambda course_run: course_run.key)
         assert actual_sorted == expected_sorted
 
     def test_wildcard_search(self):
         """ Verify the method returns an unfiltered queryset of course runs. """
         course_runs = factories.CourseRunFactory.create_batch(3)
-        actual_sorted = sorted(SearchQuerySetWrapper(CourseRun.search('*')), key=lambda course_run: course_run.key)
+        actual_sorted = sorted(
+            SearchQuerySetWrapper(CourseRun.search('*'), CourseRunFactory), key=lambda course_run: course_run.key
+        )
         expected_sorted = sorted(course_runs + [self.course_run], key=lambda course_run: course_run.key)
         assert actual_sorted == expected_sorted
 


### PR DESCRIPTION
After making the above changes query count is reduced to its half i.e. Before this change query count was around ~85 queries and after this change it is dropped to ~45 queries.
Following are the screenshots:

**Before this change:**
<img width="1326" alt="Screenshot 2024-02-15 at 4 00 50 PM" src="https://github.com/openedx/course-discovery/assets/15120237/bf7b06d3-93e1-471d-9877-e62c40cf3713">

**After this change:**
<img width="1317" alt="Screenshot 2024-02-15 at 3 57 20 PM" src="https://github.com/openedx/course-discovery/assets/15120237/6e6097d7-ecd2-4fb0-8c61-a0f7f1554594">

The above statistics can be observed by hitting the rest api of the course runs with query param so that it will go the Elasticsearch.

**Steps to Reproduce:**

- Go to http://localhost:18381/api/v1/course_runs/?q=*
- Refresh 2 to 3 times so that caches are populated to make a stable response.
- Observe the Django tool bar, specifically Time and SQL queries.

Follow the above steps first on master branch and then on this PR to notice the drop in query count.

**Note:** One can also observe a drop in the response time of upto ~400ms. Also set the `edit_mode` to `False` directly in the codebase so that rest api with ES query can be loaded efficiently.

- file path: **course_discovery/apps/api/v1/views/course_runs.py**
- after line 85, explicitly set `edit_mode=False`