### PR TITLE
temp: add function_trace temporarily to breakdown queryset fetch in pathways api

### DIFF
--- a/course_discovery/apps/api/v1/views/pathways.py
+++ b/course_discovery/apps/api/v1/views/pathways.py
@@ -1,4 +1,5 @@
 """ Views for accessing Pathway data """
+from edx_django_utils.monitoring import function_trace
 from rest_framework import viewsets
 
 from course_discovery.apps.api import serializers
@@ -10,6 +11,7 @@ class PathwayViewSet(CompressedCacheResponseMixin, viewsets.ReadOnlyModelViewSet
     permission_classes = (ReadOnlyByPublisherUser,)
     serializer_class = serializers.PathwaySerializer
 
+    @function_trace('pathways_api_queryset')
     def get_queryset(self):
         queryset = self.get_serializer_class().prefetch_queryset(partner=self.request.site.partner)
         return queryset.order_by('created')


### PR DESCRIPTION
Adds a function_trace on pathway serializer fetch to breakdown various parts and potentially see the memcached internal usage. There can be small consequences, as the docs mention avoid adding where the calls are excessive. The aim is to test it out on stage and revert if problematic/does not yield expected results.

https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/monitoring/internal/transactions.py#L45
https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/functiontrace-python-agent-api/