### PR TITLE
perf: fix N+1 in program serializers that is impacting pathways serializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1991,7 +1991,10 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
         # Explicitly check if the queryset is None before selecting related
         queryset = queryset if queryset is not None else Program.objects.filter(partner=partner)
 
-        return queryset.select_related('type', 'partner').prefetch_related(
+        return queryset.select_related(
+            'type', 'partner', 'degree', 'language_override', 'level_type_override', 'primary_subject_override',
+            'degree__additional_metadata'
+        ).prefetch_related(
             'excluded_course_runs',
             # `type` is serialized by a third-party serializer. Providing this field name allows us to
             # prefetch `applicable_seat_types`, a m2m on `ProgramType`, through `type`, a foreign key to
@@ -1999,9 +2002,16 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
             'type__applicable_seat_types',
             'type__translations',
             'authoring_organizations',
-            'degree',
+            'degree__costs',
+            'degree__deadlines',
             'curricula',
             'subscription__prices__currency',
+            'primary_subject_override__translations',
+            'level_type_override__translations',
+            'degree__specializations',
+            'degree__rankings',
+            'degree__quick_facts',
+            'labels',
             Prefetch('courses', queryset=MinimalProgramCourseSerializer.prefetch_queryset()),
         )
 

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1893,7 +1893,7 @@ class DegreeSerializer(BaseModelSerializer):
     micromasters_background_image = StdImageSerializerField()
     micromasters_path = serializers.SerializerMethodField()
     additional_metadata = DegreeAdditionalMetadataSerializer(required=False)
-    specializations = serializers.SerializerMethodField()
+    specializations = serializers.StringRelatedField(many=True)
 
     class Meta:
         model = Degree
@@ -1915,9 +1915,6 @@ class DegreeSerializer(BaseModelSerializer):
             return url.sub('', degree.micromasters_url)
         else:
             return degree.micromasters_url
-
-    def get_specializations(self, degree):
-        return list(degree.specializations.values_list('value', flat=True))
 
 
 class ProgramSubscriptionPriceSerializer(BaseModelSerializer):

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -214,7 +214,7 @@ class TestProgramViewSet(SerializationMixin):
         """ Verify the endpoint returns a list of all programs. """
         expected = [self.create_program() for __ in range(3)]
 
-        self.assert_list_results(self.list_path, expected, 41)
+        self.assert_list_results(self.list_path, expected, 26)
 
     def test_extended_query_param_fields(self):
         """ Verify that the `extended` query param will result in an extended amount of fields returned. """
@@ -258,7 +258,7 @@ class TestProgramViewSet(SerializationMixin):
         program_type_name = 'foo'
         program = ProgramFactory(type__name_t=program_type_name, partner=self.partner)
         url = self.list_path + '?type=' + program_type_name
-        self.assert_list_results(url, [program], 21)
+        self.assert_list_results(url, [program], 17)
 
         url = self.list_path + '?type=bar'
         self.assert_list_results(url, [], 5)
@@ -272,7 +272,7 @@ class TestProgramViewSet(SerializationMixin):
         # Create a third program, which should be filtered out.
         ProgramFactory(partner=self.partner)
 
-        self.assert_list_results(url, expected, 27)
+        self.assert_list_results(url, expected, 18)
 
     def test_filter_by_timestamp(self):
         """
@@ -311,13 +311,13 @@ class TestProgramViewSet(SerializationMixin):
         # Create a third program, which should be filtered out.
         ProgramFactory(partner=self.partner)
 
-        self.assert_list_results(url, expected, 27)
+        self.assert_list_results(url, expected, 18)
 
     @pytest.mark.parametrize(
         'status,is_marketable,expected_query_count',
         (
             (ProgramStatus.Unpublished, False, 5),
-            (ProgramStatus.Active, True, 34),
+            (ProgramStatus.Active, True, 19),
         )
     )
     def test_filter_by_marketable(self, status, is_marketable, expected_query_count):
@@ -336,13 +336,13 @@ class TestProgramViewSet(SerializationMixin):
         retired = ProgramFactory(status=ProgramStatus.Retired, partner=self.partner)
 
         url = self.list_path + '?status=active'
-        self.assert_list_results(url, [active], 21)
+        self.assert_list_results(url, [active], 17)
 
         url = self.list_path + '?status=retired'
-        self.assert_list_results(url, [retired], 21)
+        self.assert_list_results(url, [retired], 17)
 
         url = self.list_path + '?status=active&status=retired'
-        self.assert_list_results(url, [active, retired], 27)
+        self.assert_list_results(url, [active, retired], 18)
 
     def test_filter_by_hidden(self):
         """ Endpoint should filter programs by their hidden attribute value. """
@@ -350,16 +350,16 @@ class TestProgramViewSet(SerializationMixin):
         not_hidden = ProgramFactory(hidden=False, partner=self.partner)
 
         url = self.list_path + '?hidden=True'
-        self.assert_list_results(url, [hidden], 21)
+        self.assert_list_results(url, [hidden], 17)
 
         url = self.list_path + '?hidden=False'
-        self.assert_list_results(url, [not_hidden], 21)
+        self.assert_list_results(url, [not_hidden], 17)
 
         url = self.list_path + '?hidden=1'
-        self.assert_list_results(url, [hidden], 21)
+        self.assert_list_results(url, [hidden], 17)
 
         url = self.list_path + '?hidden=0'
-        self.assert_list_results(url, [not_hidden], 21)
+        self.assert_list_results(url, [not_hidden], 17)
 
     def test_filter_by_marketing_slug(self):
         """ The endpoint should support filtering programs by marketing slug. """
@@ -375,13 +375,13 @@ class TestProgramViewSet(SerializationMixin):
         program.marketing_slug = SLUG
         program.save()
 
-        self.assert_list_results(url, [program], 28)
+        self.assert_list_results(url, [program], 24)
 
     def test_list_exclude_utm(self):
         """ Verify the endpoint returns marketing URLs without UTM parameters. """
         url = self.list_path + '?exclude_utm=1'
         program = self.create_program()
-        self.assert_list_results(url, [program], 27, extra_context={'exclude_utm': 1})
+        self.assert_list_results(url, [program], 23, extra_context={'exclude_utm': 1})
 
     def test_minimal_serializer_use(self):
         """ Verify that the list view uses the minimal serializer. """


### PR DESCRIPTION
### [PROD-3487](https://2u-internal.atlassian.net/browse/PROD-3487)

### [PROD-3895](https://2u-internal.atlassian.net/browse/PROD-3895)


Fix N+1 issues with Program serializer. Serializer used by Pathway listing includes Program details, thus leaking Program N+1 issues to Pathway

#### Testing

- Ensure you have programs, degrees, and pathways on your local. You can use factories for this
- Checkout master and run discovery. Hit http://localhost:18381/api/v1/pathways and http://localhost:18381/api/v1/programs. Note the query count
- Checkout this branch and hit both urls. Verify the query count changes. 