### PR TITLE
feat: add active filter to search/all endpoint

### DIFF
--- a/course_discovery/apps/api/v1/views/search.py
+++ b/course_discovery/apps/api/v1/views/search.py
@@ -127,6 +127,9 @@ class CourseRunSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumentVie
         'subjects': {'field': 'subjects.raw', 'enabled': True},
         'transcript_languages': {'field': 'transcript_languages.raw', 'enabled': True},
         'content_type': {'field': 'content_type', 'enabled': True},
+        'active': {
+            'field': 'is_active', 'enabled': True
+        },
     }
 
 
@@ -164,6 +167,9 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
         'external_course_marketing_type': {'field': 'external_course_marketing_type', 'enabled': True},
         'product_source': {'field': 'product_source', 'enabled': True},
         'first_enrollable_paid_seat_price': {'field': 'first_enrollable_paid_seat_price', 'enabled': True},
+        'active': {
+            'field': 'is_active', 'enabled': True
+        },
         'language': {'field': 'language.raw', 'enabled': True},
         'level_type': {'field': 'level_type.raw', 'enabled': True},
         'mobile_available': {'field': 'mobile_available', 'enabled': True},
@@ -223,6 +229,9 @@ class BaseAggregateSearchViewSet(FacetQueryFieldsMixin, BaseElasticsearchDocumen
                 LOOKUP_QUERY_LTE,
                 LOOKUP_FILTER_TERMS,
             ],
+        },
+        'active': {
+            'field': 'is_active', 'lookups': [LOOKUP_FILTER_TERM],
         },
         'end': {'field': 'end', 'lookups': [LOOKUP_QUERY_GT, LOOKUP_QUERY_GTE, LOOKUP_QUERY_LT, LOOKUP_QUERY_LTE]},
         'end_date': {

--- a/course_discovery/apps/course_metadata/search_indexes/documents/common.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/common.py
@@ -150,6 +150,14 @@ class BaseDocument(Document, metaclass=DocumentMeta):
             return language.get_search_facet_display()
         return None
 
+    def _prepare_is_active(self, obj):
+        """
+        Returns True if the object is `is_marketable` and `is_enrollable` and active.
+        - is_marketable`, `is_enrollable`: properties of the CourseRun Model
+        - `has_ended()`: methods of the CourseRun Model to check if the course end date has passed.
+        """
+        return obj.is_marketable and obj.is_enrollable and not obj.has_ended()
+
     object = property(_get_object, _set_object)
 
     def prepare_authoring_organization_uuids(self, obj):

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -40,6 +40,7 @@ class CourseRunDocument(BaseCourseDocument):
     first_enrollable_paid_seat_sku = fields.TextField()
     go_live_date = fields.DateField()
     has_enrollable_seats = fields.BooleanField()
+    is_active = fields.BooleanField()
     has_enrollable_paid_seats = fields.BooleanField()
     hidden = fields.BooleanField()
     is_enrollable = fields.BooleanField()
@@ -88,6 +89,9 @@ class CourseRunDocument(BaseCourseDocument):
 
     def prepare_first_enrollable_paid_seat_sku(self, obj):
         return obj.first_enrollable_paid_seat_sku()
+
+    def prepare_is_active(self, obj):
+        return self._prepare_is_active(obj)
 
     def prepare_is_current_and_still_upgradeable(self, obj):
         return obj.is_current_and_still_upgradeable()


### PR DESCRIPTION
### [PROD-3952](https://2u-internal.atlassian.net/browse/PROD-3952) & [ENT-8528](https://2u-internal.atlassian.net/browse/ENT-8528)
-----
This PR adds a new new filter to filter out the active runs from the course' course runs

### Testing:
- Visit `http://localhost:18381/api/v1/search/all/`
- Add `{"active" : "true"}` in post request.
- Notice you'll have now only active runs of the course