### PR TITLE
perf: fix some N+1 issues in program related serializers

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1047,6 +1047,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         return queryset.select_related(
             'course__level_type',
             'course__video__image',
+            'course__additional_metadata',
             'language',
             'video',
             'expected_program_type'
@@ -2002,7 +2003,6 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
             # `ProgramType` on `Program`.
             'type__applicable_seat_types',
             'type__translations',
-            'authoring_organizations',
             'degree__costs',
             'degree__deadlines',
             'curricula',
@@ -2014,6 +2014,7 @@ class MinimalProgramSerializer(TaggitSerializer, FlexFieldsSerializerMixin, Base
             'degree__quick_facts',
             'labels',
             Prefetch('courses', queryset=MinimalProgramCourseSerializer.prefetch_queryset()),
+            Prefetch('authoring_organizations', queryset=OrganizationSerializer.prefetch_queryset(partner)),
         )
 
     class Meta:
@@ -2218,17 +2219,33 @@ class ProgramSerializer(MinimalProgramSerializer):
             'geolocation',
             'in_year_value',
             'product_source',
-            'location_restriction'
+            'location_restriction',
+            'degree',
+            'language_override',
+            'level_type_override',
+            'primary_subject_override',
+            'degree__additional_metadata'
         ).prefetch_related(
             'excluded_course_runs',
-            'expected_learning_items',
-            'faq',
-            'job_outlook_items',
-            'instructor_ordering',
             # `type` is serialized by a third-party serializer. Providing this field name allows us to
             # prefetch `applicable_seat_types`, a m2m on `ProgramType`, through `type`, a foreign key to
             # `ProgramType` on `Program`.
             'type__applicable_seat_types',
+            'type__translations',
+            'degree__costs',
+            'degree__deadlines',
+            'curricula',
+            'subscription__prices__currency',
+            'primary_subject_override__translations',
+            'level_type_override__translations',
+            'degree__specializations',
+            'degree__rankings',
+            'degree__quick_facts',
+            'labels',
+            'expected_learning_items',
+            'faq',
+            'job_outlook_items',
+            'instructor_ordering',
             # We need the full Course prefetch here to get CourseRun information that methods on the Program
             # model iterate across (e.g. language). These fields aren't prefetched by the minimal Course serializer.
             Prefetch('courses', queryset=CourseSerializer.prefetch_queryset(partner=partner)),

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -131,7 +131,7 @@ class TestProgramViewSet(SerializationMixin):
         program = self.create_program(courses=[])
         self.create_curriculum(program)
 
-        with django_assert_num_queries(FuzzyInt(56, 3)):
+        with django_assert_num_queries(FuzzyInt(52, 3)):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 
@@ -188,7 +188,7 @@ class TestProgramViewSet(SerializationMixin):
         """ Verify the endpoint returns data for a program even if the program's courses have no course runs. """
         course = CourseFactory(partner=self.partner)
         program = ProgramFactory(courses=[course], partner=self.partner)
-        with django_assert_num_queries(FuzzyInt(43, 2)):
+        with django_assert_num_queries(FuzzyInt(40, 2)):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
 


### PR DESCRIPTION
### [PROD-3895](https://2u-internal.atlassian.net/browse/PROD-3895)

### Description

Fixes N+1 issues in MinimalExtendedProgramSerializer for programs api. This serializer is used for data representation in programs api when ?extended=true is passed. 

- Ensure you have programs with courses
- Run http://localhost:18381/api/v1/programs/?extended=true. Ensure the programs with course runs are listed there.
- Note the query count
- Run  http://localhost:18381/api/v1/programs/<uuid> and notice the query count
- Checkout to this branch and hit URLs again. Note the decrease in query count
