### PR TITLE
feat: add active filter on course level 

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2230,7 +2230,7 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
         )
         course.course_runs.add(course_run)
         course.save()
-        seat = SeatFactory(course_run=course_run)
+
         course_skill = CourseSkillsFactory(
             course_key=course.key
         )
@@ -2250,9 +2250,9 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
             'subjects': [subject.name for subject in course.subjects.all()],
             'languages': [
                 serialize_language(course_run.language) for course_run in course.course_runs.all()
-                if course_run.language
+                if course_run.language and course.is_active
             ],
-            'seat_types': [seat.type.slug],
+            'seat_types': [],
             'skill_names': [course_skill.skill.name],
             'skills': [
                 {

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -123,7 +123,8 @@ class CourseDocument(BaseCourseDocument):
         return [prerequisite.name for prerequisite in obj.prerequisites.all()]
 
     def get_queryset(self):
-        return super().get_queryset().prefetch_related('course_runs__seats__type', 'course_runs__type')
+        return super().get_queryset().prefetch_related(
+            'course_runs__seats__type', 'course_runs__type', 'course_runs__language').select_related('partner')
 
     def prepare_course_type(self, obj):
         return obj.type.slug

--- a/course_discovery/apps/ietf_language_tags/tests/test_utils.py
+++ b/course_discovery/apps/ietf_language_tags/tests/test_utils.py
@@ -1,0 +1,27 @@
+import ddt
+import pytest
+from django.test import TestCase
+
+from course_discovery.apps.ietf_language_tags.models import LanguageTag
+from course_discovery.apps.ietf_language_tags.utils import serialize_language
+
+
+@ddt.ddt
+@pytest.mark.django_db
+class SerializeLanguageTest(TestCase):
+    """
+    Tests for serialize_language method
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.language_1 = LanguageTag.objects.filter(code__startswith='zh').first()
+        self.language_2 = LanguageTag.objects.filter(code__startswith='en').first()
+
+    def test_serialize_language__with_language(self):
+        """
+        Test that serialize_language method returns the language name
+        if the language code starts with 'zh' else returns the macrolanguage.
+        """
+        assert serialize_language(self.language_1) == self.language_1.name
+        assert serialize_language(self.language_2) == self.language_2.macrolanguage

--- a/course_discovery/apps/ietf_language_tags/tests/test_utils.py
+++ b/course_discovery/apps/ietf_language_tags/tests/test_utils.py
@@ -1,3 +1,5 @@
+""" Tests for the ietf_language_tags utility methods """
+
 import ddt
 import pytest
 from django.test import TestCase

--- a/course_discovery/apps/ietf_language_tags/utils.py
+++ b/course_discovery/apps/ietf_language_tags/utils.py
@@ -1,3 +1,8 @@
+"""
+This module contains utility functions for the ietf_language_tags app
+"""
+
+
 def serialize_language(language):
     """
     Given a language object, it returns the language name if the language code starts with 'zh' else returns the

--- a/course_discovery/apps/ietf_language_tags/utils.py
+++ b/course_discovery/apps/ietf_language_tags/utils.py
@@ -1,0 +1,9 @@
+def serialize_language(language):
+    """
+    Given a language object, it returns the language name if the language code starts with 'zh' else returns the
+    macrolanguage.
+    """
+    if language.code.startswith('zh'):
+        return language.name
+
+    return language.macrolanguage


### PR DESCRIPTION
This PR use existing `exculude_expired_course_run` query param to caculate the course_run related attributes on the basis of `active_course_runs`

Testing:

- Visit `http://localhost:18381/api/v1/search/all/`
- Add `{'content_type': 'course', 'exclude_expired_course_run': 'true'}` in the post request of search/all endpoint.
