### PR TITLE
WS-4468: add new field for algolia experiment

### DIFF
--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -80,7 +80,7 @@ class EnglishProductIndex(BaseProductIndex):
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
                     ('product_blocked_in', 'blocked_in'), 'subscription_eligible',
-                    'subscription_prices', 'learning_type',)
+                    'subscription_prices', 'learning_type', 'learning_type_exp',)
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'),
                       ('product_value_per_click_usa', 'value_per_click_usa'),
                       ('product_value_per_click_international', 'value_per_click_international'),
@@ -116,7 +116,7 @@ class EnglishProductIndex(BaseProductIndex):
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)', 'skills.skill',
             'skills.category', 'skills.subcategory', 'tags', 'subscription_eligible', 'subscription_prices',
-            'learning_type',
+            'learning_type', 'learning_type_exp',
         ],
         'customRanking': ['asc(availability_rank)', 'desc(recent_enrollment_count)']
     }
@@ -133,7 +133,7 @@ class SpanishProductIndex(BaseProductIndex):
                     ('active_languages', 'language'), ('product_type', 'product'), ('program_types', 'program_type'),
                     ('staff_slugs', 'staff'), ('product_allowed_in', 'allowed_in'),
                     ('product_blocked_in', 'blocked_in'), 'subscription_eligible',
-                    'subscription_prices', 'learning_type',)
+                    'subscription_prices', 'learning_type', 'learning_type_exp',)
     ranking_fields = ('availability_rank', ('product_recent_enrollment_count', 'recent_enrollment_count'),
                       ('product_value_per_click_usa', 'value_per_click_usa'),
                       ('product_value_per_click_international', 'value_per_click_international'),
@@ -171,7 +171,7 @@ class SpanishProductIndex(BaseProductIndex):
             'partner', 'availability', 'subject', 'level', 'language', 'product', 'program_type',
             'filterOnly(staff)', 'filterOnly(allowed_in)', 'filterOnly(blocked_in)',
             'skills.skill', 'skills.category', 'skills.subcategory', 'tags', 'subscription_eligible',
-            'subscription_prices', 'learning_type',
+            'subscription_prices', 'learning_type', 'learning_type_exp',
         ],
         'customRanking': ['desc(promoted_in_spanish_index)', 'asc(availability_rank)', 'desc(recent_enrollment_count)']
     }


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/WS-4468

Adding an alternative field for `learning_type`, with different product types grouped together into certain categories. We'll toggle which field to use on the frontend using Optimizely. Tested indexing with Algolia stage environment.

**A/C**
1. exec ed, xseries, licenses, certificates, and professional certificates bucketed under "Certificate courses"
2. micro masters and micro bachelors bucketed under "Paths to degrees"
3. masters, bachelors, doctorates bucketed under "Degrees"

**Course example**
![Screenshot 2024-03-08 at 10 56 02 AM](https://github.com/openedx/course-discovery/assets/10442143/14bd2e79-de57-4d40-a3cf-e3befe92ea27)
