### PR TITLE
feat: changes related to python 3.12 upgrade

### DIFF
--- a/course_discovery/apps/catalogs/models.py
+++ b/course_discovery/apps/catalogs/models.py
@@ -1,4 +1,4 @@
-from collections import Iterable  # lint-amnesty, pylint: disable=deprecated-class, no-name-in-module
+from collections.abc import Iterable
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _


### PR DESCRIPTION
This PR is required to close this [issue](https://github.com/overhangio/tutor-discovery/issues/62) in tutor-discovery.
With this change course-discovery is compatible with python 3 (including 3.8 to 3.12). The previous line of code was only compatible with python 2.7 which is no longer supported.