### PR TITLE
feat!: s/price_excl_tax/price for django oscar 3.1 upgrade

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -572,7 +572,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     def update_seat(self, course_run, product_body):
         stock_record = product_body['stockrecords'][0]
         currency_code = stock_record['price_currency']
-        price = Decimal(stock_record['price_excl_tax'])
+        price = Decimal(stock_record['price'])
         sku = stock_record['partner_sku']
 
         # For more context see ADR docs/decisions/0025-dont-sync-mobile-skus-on-discovery.rst
@@ -680,7 +680,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
 
         try:
             currency_code = stock_record['price_currency']
-            Decimal(stock_record['price_excl_tax'])
+            Decimal(stock_record['price'])
             sku = stock_record['partner_sku']
         except (KeyError, ValueError):
             msg = 'A necessary stockrecord field is missing or incorrectly set for {product} {title}'.format(
@@ -719,7 +719,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
 
         stock_record = stockrecords[0]
         currency_code = stock_record['price_currency']
-        price = Decimal(stock_record['price_excl_tax'])
+        price = Decimal(stock_record['price'])
         sku = stock_record['partner_sku']
 
         try:

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -195,7 +195,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku001",
                     }
                 ]
@@ -225,7 +225,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku002",
                     }
                 ]
@@ -242,7 +242,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price_excl_tax": "25.00",
+                        "price": "25.00",
                         "partner_sku": "sku003",
                     }
                 ]
@@ -260,7 +260,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price_excl_tax": "250.00",
+                        "price": "250.00",
                         "partner_sku": "mobile.android.sku003",
                     }
                 ]
@@ -277,7 +277,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price_excl_tax": "25.00",
+                        "price": "25.00",
                         "partner_sku": "sku004"
                     }
                 ]
@@ -304,7 +304,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku005",
                     }
                 ]
@@ -321,7 +321,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "25.00",
+                        "price": "25.00",
                         "partner_sku": "sku006",
                     }
                 ]
@@ -350,7 +350,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "250.00",
+                        "price": "250.00",
                         "partner_sku": "sku007",
                     }
                 ]
@@ -379,7 +379,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "250.00",
+                        "price": "250.00",
                         "partner_sku": "sku008",
                     }
                 ]
@@ -404,7 +404,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "123",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku009",
                     }
                 ]
@@ -429,7 +429,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku010",
                     }
                 ]

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -712,7 +712,7 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
 
         stockrecord = {
             "price_currency": alt_currency if alt_currency else "USD",
-            "price_excl_tax": "10.00",
+            "price": "10.00",
         }
         if valid_stockrecord:
             stockrecord.update({"partner_sku": "sku132"})
@@ -799,7 +799,7 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         for product in products:
             stock_record = product['stockrecords'][0]
             price_currency = stock_record['price_currency']
-            price = Decimal(stock_record['price_excl_tax'])
+            price = Decimal(stock_record['price'])
             sku = stock_record['partner_sku']
             certificate_type = Seat.AUDIT
             credit_provider = None
@@ -851,7 +851,7 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
             course = Course.objects.get(uuid=attributes['UUID'])
             stock_record = datum['stockrecords'][0]
             price_currency = stock_record['price_currency']
-            price = Decimal(stock_record['price_excl_tax'])
+            price = Decimal(stock_record['price'])
             sku = stock_record['partner_sku']
 
             mode_name = attributes['certificate_type']


### PR DESCRIPTION
## Description

The Django Oscar 3.1 upgrade renames column `partner_stockrecord.price_excl_tax` to `partner_stockrecord.price`. [[migration in openedx/ecommerce](https://github.com/openedx/ecommerce/blob/8cd7c39689954a16694d89eefe850fc6bca2462a/ecommerce/extensions/partner/migrations/0019_auto_20231108_1355.py#L44-L48)]

This PR mirrors the rename in course-discovery.

## Deployment Instructions

⚠️ If using openedx/ecommerce, deploy this change only AFTER deploying the Django 3.1 upgrade in https://github.com/openedx/ecommerce/pull/4050 to production.

## Additional Information

* See also: https://github.com/openedx/ecommerce/pull/4050

## Testing Instructions

<details>
<summary>Error if not present on devstack</summary>

Without this rename, I get `KeyError: 'price_excl_tax'` on devstack when trying to run the `refresh_course_metadata` management command:

```
(workarea) devstack % make dev.shell.discovery    
docker compose exec discovery env TERM=xterm-256color bash -c '/bin/bash'
root@discovery:/edx/app/discovery/discovery# ./manage.py refresh_course_metadata
2024-03-15 18:56:05,711 INFO 200 [algoliasearch_django.registration] /edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/algoliasearch_django/registration.py:77 - REGISTER <class 'course_discovery.apps.course_metadata.algolia_models.AlgoliaProxyProduct'>
System check identified some issues:

WARNINGS:
course_metadata.Course.collaborators: (fields.W340) null has no effect on ManyToManyField.
course_metadata.Degree.specializations: (fields.W340) null has no effect on ManyToManyField.
course_metadata.SearchDefaultResultsConfiguration.courses: (fields.W340) null has no effect on ManyToManyField.
course_metadata.SearchDefaultResultsConfiguration.programs: (fields.W340) null has no effect on ManyToManyField.
taxonomy.JobPostings.job: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
	HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
taxonomy.SkillsQuiz.skills: (fields.W340) null has no effect on ManyToManyField.
2024-03-15 18:56:06,775 INFO 200 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:134 - Command is not using threads to write data.
2024-03-15 18:56:06,783 INFO 200 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:178 - Executing Loader CoursesApiDataLoader, url: http://edx.devstack.lms:18000/api/courses/v1/
2024-03-15 18:56:06,936 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:57 - Refreshing Courses and CourseRuns from http://edx.devstack.lms:18000/api/courses/v1/...
2024-03-15 18:56:06,938 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:103 - Requesting course run page 1...
2024-03-15 18:56:07,104 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:111 - Retrieved 3 course runs...
2024-03-15 18:56:07,104 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:119 - Starting course processing for id course-v1:edX+DemoX+Demo_Course
2024-03-15 18:56:07,125 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:180 - Processed course run with UUID [405b556e-ff2f-4ac6-94b7-d0b4c681f4d9] and key [course-v1:edX+DemoX+Demo_Course].
2024-03-15 18:56:07,125 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:119 - Starting course processing for id course-v1:edX+M12+1T2024
2024-03-15 18:56:07,137 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:180 - Processed course run with UUID [9dc02218-a45b-4e16-b67c-05b7f68c5d08] and key [course-v1:edX+M12+1T2024].
2024-03-15 18:56:07,138 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:119 - Starting course processing for id course-v1:SimpleX+SC101+2021_T1
2024-03-15 18:56:07,149 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:180 - Processed course run with UUID [424a6eb8-4bf3-4b42-924e-51195d5cac68] and key [course-v1:SimpleX+SC101+2021_T1].
2024-03-15 18:56:07,149 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:66 - Looping to request all 1 pages...
2024-03-15 18:56:07,149 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:83 - Retrieved 3 course runs from http://edx.devstack.lms:18000/api/courses/v1/.
2024-03-15 18:56:07,150 INFO 200 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:178 - Executing Loader EcommerceApiDataLoader, url: http://edx.devstack.ecommerce:18130/api/v2/
2024-03-15 18:56:07,151 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:347 - Refreshing ecommerce data from http://edx.devstack.ecommerce:18130/api/v2/...
2024-03-15 18:56:31,718 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:481 - Retrieved 3 course seats...
2024-03-15 18:56:31,723 INFO 200 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/backoff/_common.py:105 - Backing off run_loader(...) for 0.6s (KeyError: 'price_excl_tax')
2024-03-15 18:56:32,311 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:347 - Refreshing ecommerce data from http://edx.devstack.ecommerce:18130/api/v2/...
2024-03-15 18:56:57,263 INFO 200 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:481 - Retrieved 3 course seats...
2024-03-15 18:56:57,270 ERROR 200 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/backoff/_common.py:120 - Giving up run_loader(...) after 2 tries (KeyError: 'price_excl_tax')
2024-03-15 18:56:57,271 ERROR 200 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:40 - EcommerceApiDataLoader failed!
Traceback (most recent call last):
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py", line 37, in execute_loader
    run_loader()
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/backoff/_sync.py", line 105, in retry
    ret = target(*args, **kwargs)
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py", line 34, in run_loader
    return loader_class(*loader_args).ingest()
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py", line 348, in ingest
    self._load_ecommerce_data()
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py", line 370, in _load_ecommerce_data
    self._process_course_runs(course_runs)
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py", line 488, in _process_course_runs
    self.update_seats(body)
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py", line 553, in update_seats
    self.update_seat(course_run, product_body)
  File "/edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py", line 575, in update_seat
    price = Decimal(stock_record['price_excl_tax'])
KeyError: 'price_excl_tax'
CommandError: One or more of the data loaders above failed.
root@discovery:/edx/app/discovery/discovery# 
```
</details>

<details>
<summary>Successful run of refresh_course_metadata if present on devstack</summary>

The command succeeds after this commit:

```
root@discovery:/edx/app/discovery/discovery# ./manage.py refresh_course_metadata
2024-03-15 19:19:08,461 INFO 300 [algoliasearch_django.registration] /edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/algoliasearch_django/registration.py:77 - REGISTER <class 'course_discovery.apps.course_metadata.algolia_models.AlgoliaProxyProduct'>
System check identified some issues:

WARNINGS:
course_metadata.Course.collaborators: (fields.W340) null has no effect on ManyToManyField.
course_metadata.Degree.specializations: (fields.W340) null has no effect on ManyToManyField.
course_metadata.SearchDefaultResultsConfiguration.courses: (fields.W340) null has no effect on ManyToManyField.
course_metadata.SearchDefaultResultsConfiguration.programs: (fields.W340) null has no effect on ManyToManyField.
taxonomy.JobPostings.job: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
	HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
taxonomy.SkillsQuiz.skills: (fields.W340) null has no effect on ManyToManyField.
2024-03-15 19:19:10,266 INFO 300 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:134 - Command is not using threads to write data.
2024-03-15 19:19:10,276 INFO 300 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:178 - Executing Loader CoursesApiDataLoader, url: http://edx.devstack.lms:18000/api/courses/v1/
2024-03-15 19:19:10,284 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:57 - Refreshing Courses and CourseRuns from http://edx.devstack.lms:18000/api/courses/v1/...
2024-03-15 19:19:10,285 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:103 - Requesting course run page 1...
2024-03-15 19:19:10,492 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:111 - Retrieved 3 course runs...
2024-03-15 19:19:10,492 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:119 - Starting course processing for id course-v1:edX+DemoX+Demo_Course
2024-03-15 19:19:10,506 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:180 - Processed course run with UUID [405b556e-ff2f-4ac6-94b7-d0b4c681f4d9] and key [course-v1:edX+DemoX+Demo_Course].
2024-03-15 19:19:10,507 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:119 - Starting course processing for id course-v1:edX+M12+1T2024
2024-03-15 19:19:10,514 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:180 - Processed course run with UUID [9dc02218-a45b-4e16-b67c-05b7f68c5d08] and key [course-v1:edX+M12+1T2024].
2024-03-15 19:19:10,514 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:119 - Starting course processing for id course-v1:SimpleX+SC101+2021_T1
2024-03-15 19:19:10,524 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:180 - Processed course run with UUID [424a6eb8-4bf3-4b42-924e-51195d5cac68] and key [course-v1:SimpleX+SC101+2021_T1].
2024-03-15 19:19:10,525 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:66 - Looping to request all 1 pages...
2024-03-15 19:19:10,525 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:83 - Retrieved 3 course runs from http://edx.devstack.lms:18000/api/courses/v1/.
2024-03-15 19:19:10,525 INFO 300 [course_discovery.apps.course_metadata.management.commands.refresh_course_metadata] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py:178 - Executing Loader EcommerceApiDataLoader, url: http://edx.devstack.ecommerce:18130/api/v2/
2024-03-15 19:19:10,526 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:347 - Refreshing ecommerce data from http://edx.devstack.ecommerce:18130/api/v2/...
2024-03-15 19:19:46,295 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:481 - Retrieved 3 course seats...
2024-03-15 19:19:46,444 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:641 - Created seat for course with key [course-v1:edX+DemoX+Demo_Course] and sku [8CF08E5].
2024-03-15 19:19:46,501 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:641 - Created seat for course with key [course-v1:edX+DemoX+Demo_Course] and sku [68EFFFF].
2024-03-15 19:19:46,585 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:641 - Created seat for course with key [course-v1:edX+M12+1T2024] and sku [D634FAB].
2024-03-15 19:19:46,645 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:641 - Created seat for course with key [course-v1:edX+M12+1T2024] and sku [AC474C5].
2024-03-15 19:19:46,698 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:641 - Created seat for course with key [course-v1:SimpleX+SC101+2021_T1] and sku [D31BF39].
2024-03-15 19:19:46,745 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:641 - Created seat for course with key [course-v1:SimpleX+SC101+2021_T1] and sku [957B33F].
2024-03-15 19:19:46,760 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:492 - Retrieved 0 course entitlements...
2024-03-15 19:19:46,760 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:504 - Retrieved 3 course enrollment codes...
2024-03-15 19:19:46,776 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:824 - Creating enrollment code Enrollment code for verified seat in Differential Equations with sku 27920CF for partner edX
2024-03-15 19:19:46,826 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:824 - Creating enrollment code Enrollment code for verified seat in Simple Course (Instructor FBE) with sku A3BA6CB for partner edX
2024-03-15 19:19:46,877 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:824 - Creating enrollment code Enrollment code for verified seat in edX Demonstration Course with sku A5B6DBE for partner edX
2024-03-15 19:19:46,900 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:421 - Expected 3 course seats, 0 course entitlements, and 3 enrollment codes from http://edx.devstack.ecommerce:18130/api/v2/.
2024-03-15 19:19:46,900 INFO 300 [course_discovery.apps.course_metadata.data_loaders.api] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/api.py:425 - Actually Received 3 course seats, 0 course entitlements, and 3 enrollment codes from http://edx.devstack.ecommerce:18130/api/v2/.
2024-03-15 19:19:47,098 INFO 300 [course_discovery.apps.course_metadata.data_loaders.course_type] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/course_type.py:90 - Course edX+DemoX (1) matched type Verified and Audit
2024-03-15 19:19:47,452 INFO 300 [course_discovery.apps.course_metadata.data_loaders.course_type] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/course_type.py:90 - Course edX+M12 (4) matched type Verified and Audit
2024-03-15 19:19:47,818 INFO 300 [course_discovery.apps.course_metadata.data_loaders.course_type] /edx/app/discovery/discovery/course_discovery/apps/course_metadata/data_loaders/course_type.py:90 - Course SimpleX+SC101 (5) matched type Verified and Audit
root@discovery:/edx/app/discovery/discovery# 
```
</details>