### PR TITLE
build: add atlas support in discovery docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ARG DISCOVERY_CODE_DIR="${DISCOVERY_APP_DIR}/${DISCOVERY_SERVICE_NAME}"
 ARG DISCOVERY_NODEENV_DIR="${DISCOVERY_APP_DIR}/nodeenvs/${DISCOVERY_SERVICE_NAME}"
 
 ENV PATH "${DISCOVERY_VENV_DIR}/bin:${DISCOVERY_NODEENV_DIR}/bin:$PATH"
-ENV DISCOVERY_CFG "/edx/etc/discovery.yml"
+ENV DISCOVERY_CFG "minimal.yml"
 ENV DISCOVERY_CODE_DIR "${DISCOVERY_CODE_DIR}"
 ENV DISCOVERY_APP_DIR "${DISCOVERY_APP_DIR}"
 
@@ -63,6 +63,8 @@ ENV DJANGO_SETTINGS_MODULE "course_discovery.settings.production"
 
 RUN pip install -r ${DISCOVERY_CODE_DIR}/requirements/production.txt
 
+RUN make OPENEDX_ATLAS_PULL=true pull_translations
+
 CMD gunicorn --bind=0.0.0.0:8381 --workers 2 --max-requests=1000 -c course_discovery/docker_gunicorn_configuration.py course_discovery.wsgi:application
 
 FROM app as dev
@@ -71,6 +73,8 @@ ENV DJANGO_SETTINGS_MODULE "course_discovery.settings.devstack"
 
 RUN pip install -r ${DISCOVERY_CODE_DIR}/requirements/django.txt
 RUN pip install -r ${DISCOVERY_CODE_DIR}/requirements/local.txt
+
+RUN make OPENEDX_ATLAS_PULL=true pull_translations
 
 # Devstack related step for backwards compatibility
 RUN touch ${DISCOVERY_APP_DIR}/discovery_env

--- a/minimal.yml
+++ b/minimal.yml
@@ -1,0 +1,19 @@
+# WARNING: Experimental
+#
+# This is the minimal settings you need to set to be able to get django to
+# load when using the production.py settings files. It's useful to point
+# DISCOVERY_CFG to this file to be able to run various paver commands
+# without needing a full docker setup.
+#
+# Follow up work will likely be done as a part of
+# https://github.com/openedx/wg-developer-experience/issues/136
+---
+
+SECRET_KEY: dummy secret key
+TRACKING_BACKENDS: {}
+EVENT_TRACKING_BACKENDS: {}
+JWT_AUTH: {}
+CELERY_QUEUES: {}
+MKTG_URL_LINK_MAP: {}
+MKTG_URL_OVERRIDES: {}
+REST_FRAMEWORK: {}


### PR DESCRIPTION
[PROD-3932](https://2u-internal.atlassian.net/browse/PROD-3932)
Adds the pull translation logic during the creation of docker image. Adds a minimal.yml to be used for running the `python manage.py compilemessages` command during the creation of docker image.
## Testing Instructions

1. Create docker image: `docker build . -t temp -f Dockerfile`
2. Run `docker images` and note the IMAGE ID.
3. Run `docker run -it <IMAGE_ID> /bin/bash`
4. Verify that the translation configs are created exactly how we want in [`edx/app/discovery/discovery/course_discovery/conf/locale`](https://github.com/openedx/openedx-translations/tree/main/translations/course-discovery/course_discovery/conf/locale)

<img width="943" alt="Screenshot 2024-03-19 at 8 01 04 PM" src="https://github.com/openedx/course-discovery/assets/52413434/448fb5db-10f3-4e06-a7ec-a4617268724e">
