### PR TITLE
fix: update default database settings

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -131,7 +131,7 @@ WSGI_APPLICATION = 'course_discovery.wsgi.application'
 # Set this value in the environment-specific files (e.g. local.py, production.py, test.py)
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.',
+        'ENGINE': 'django.db.backends.mysql',
         'NAME': 'discovery',
         'USER': 'discov001',
         'PASSWORD': 'password',
@@ -140,7 +140,7 @@ DATABASES = {
         'ATOMIC_REQUESTS': False,
     },
     'read_replica': {
-        'ENGINE': 'django.db.backends.',
+        'ENGINE': 'django.db.backends.mysql',
         'NAME': 'discovery',
         'USER': 'discov001',
         'PASSWORD': 'password',


### PR DESCRIPTION
This fixes an invalid `ENGINE` setting in the default database settings in the `base.py` file.

Sets the default `ENGINE` value to `django.db.backends.mysql`, which matches default values for other IDAs.

This resolves an issue with migrations not running in development environments.