### PR TITLE
Revert "ENT-8400: Added transcript_languages_search_facet_names to CourseRunSerializer"

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1018,7 +1018,6 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         required=False, many=True, slug_field='code',
         queryset=LanguageTag.objects.prefetch_related('translations').order_by('name')
     )
-    transcript_languages_search_facet_names = serializers.SerializerMethodField()
     video = VideoSerializer(required=False, allow_null=True, source='get_video')
     instructors = serializers.SerializerMethodField(help_text='This field is deprecated. Use staff.')
     staff = SlugRelatedFieldWithReadSerializer(slug_field='uuid', required=False, many=True,
@@ -1067,11 +1066,10 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
             'level_type', 'mobile_available', 'hidden', 'reporting_type', 'eligible_for_financial_aid',
             'first_enrollable_paid_seat_price', 'has_ofac_restrictions', 'ofac_comment',
             'enrollment_count', 'recent_enrollment_count', 'expected_program_type', 'expected_program_name',
-            'course_uuid', 'estimated_hours', 'content_language_search_facet_name', 'enterprise_subscription_inclusion',
-            'transcript_languages_search_facet_names'
+            'course_uuid', 'estimated_hours', 'content_language_search_facet_name', 'enterprise_subscription_inclusion'
         )
         read_only_fields = ('enrollment_count', 'recent_enrollment_count', 'content_language_search_facet_name',
-                            'enterprise_subscription_inclusion', 'transcript_languages_search_facet_names')
+                            'enterprise_subscription_inclusion')
 
     def get_instructors(self, obj):  # pylint: disable=unused-argument
         # This field is deprecated. Use the staff field.
@@ -1085,17 +1083,6 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         if language is None:
             return None
         return language.get_search_facet_display(translate=True)
-
-    def get_transcript_languages_search_facet_names(self, obj):
-        transcript_languages = obj.transcript_languages.all()
-        if not transcript_languages:
-            return None
-
-        transcript_languages_facet_names = []
-        for language in transcript_languages:
-            transcript_languages_facet_names.append(language.get_search_facet_display(translate=True))
-
-        return transcript_languages_facet_names
 
     def update_video(self, instance, video_data):
         # A separate video object is a historical concept. These days, we really just use the link address. So

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -705,7 +705,6 @@ class CourseRunSerializerTests(MinimalCourseRunBaseTestSerializer):
             'ofac_comment': course_run.ofac_comment,
             'estimated_hours': get_course_run_estimated_hours(course_run),
             'enterprise_subscription_inclusion': course_run.enterprise_subscription_inclusion,
-            'transcript_languages_search_facet_names': None
         })
         return expected
 


### PR DESCRIPTION
Reverts openedx/course-discovery#4296. 

```
File "/edx/app/discovery/discovery/course_discovery/apps/api/serializers.py", line 1096, in get_transcript_languages_search_facet_names
    transcript_languages_facet_names.append(language.get_search_facet_display(translate=True))
  File "/edx/app/discovery/discovery/course_discovery/apps/ietf_language_tags/models.py", line 29, in get_search_facet_display
    return self.translated_macrolanguage if translate else self.macrolanguage
  File "/edx/app/discovery/discovery/course_discovery/apps/ietf_language_tags/models.py", line 22, in translated_macrolanguage
    return self.name_t.split('-')[0].strip()
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/parler/fields.py", line 142, in __get__
    translation = instance._get_translated_model(use_fallback=True, meta=meta)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/parler/models.py", line 620, in _get_translated_model
    raise meta.model.DoesNotExist(
parler.models.DoesNotExist: language tag does not have a translation for the current language!
language tag ID #tl, language=en (tried fallbacks en)
Attempted to read attribute name_t.
```