### PR TITLE
Fix: [ENT-8400]: added transcript_languages_search_facet_names to CourseRunSerializer

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -1018,6 +1018,7 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         required=False, many=True, slug_field='code',
         queryset=LanguageTag.objects.prefetch_related('translations').order_by('name')
     )
+    transcript_languages_search_facet_names = serializers.SerializerMethodField()
     video = VideoSerializer(required=False, allow_null=True, source='get_video')
     instructors = serializers.SerializerMethodField(help_text='This field is deprecated. Use staff.')
     staff = SlugRelatedFieldWithReadSerializer(slug_field='uuid', required=False, many=True,
@@ -1066,7 +1067,8 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
             'level_type', 'mobile_available', 'hidden', 'reporting_type', 'eligible_for_financial_aid',
             'first_enrollable_paid_seat_price', 'has_ofac_restrictions', 'ofac_comment',
             'enrollment_count', 'recent_enrollment_count', 'expected_program_type', 'expected_program_name',
-            'course_uuid', 'estimated_hours', 'content_language_search_facet_name', 'enterprise_subscription_inclusion'
+            'course_uuid', 'estimated_hours', 'content_language_search_facet_name', 'enterprise_subscription_inclusion',
+            'transcript_languages_search_facet_names'
         )
         read_only_fields = ('enrollment_count', 'recent_enrollment_count', 'content_language_search_facet_name',
                             'enterprise_subscription_inclusion')
@@ -1083,6 +1085,9 @@ class CourseRunSerializer(MinimalCourseRunSerializer):
         if language is None:
             return None
         return language.get_search_facet_display(translate=True)
+
+    def get_transcript_languages_search_facet_names(self, obj):
+        return [lang.get_search_facet_display() for lang in obj.transcript_languages.all()]
 
     def update_video(self, instance, video_data):
         # A separate video object is a historical concept. These days, we really just use the link address. So

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -681,7 +681,7 @@ class CourseRunSerializerTests(MinimalCourseRunBaseTestSerializer):
             'hidden': course_run.hidden,
             'content_language': course_run.language.code,
             'content_language_search_facet_name': course_run.language.get_search_facet_display(translate=True),
-            'transcript_languages': [],
+            'transcript_languages': [lang.code for lang in course_run.transcript_languages.all()],
             'min_effort': course_run.min_effort,
             'max_effort': course_run.max_effort,
             'weeks_to_complete': course_run.weeks_to_complete,
@@ -705,12 +705,18 @@ class CourseRunSerializerTests(MinimalCourseRunBaseTestSerializer):
             'ofac_comment': course_run.ofac_comment,
             'estimated_hours': get_course_run_estimated_hours(course_run),
             'enterprise_subscription_inclusion': course_run.enterprise_subscription_inclusion,
+            'transcript_languages_search_facet_names': [
+                lang.get_search_facet_display() for lang in course_run.transcript_languages.all()
+            ]
         })
         return expected
 
     def test_data(self):
         request = make_request()
         course_run = CourseRunFactory()
+        # Adjusting transcript_languages here for CourseRunSerializerTests to avoid affecting
+        # other tests that use CourseRunFactory
+        course_run.transcript_languages.set([LanguageTag.objects.first()])
         serializer = self.serializer_class(course_run, context={'request': request})
         expected = self.get_expected_data(course_run, request)
 

--- a/course_discovery/apps/ietf_language_tags/models.py
+++ b/course_discovery/apps/ietf_language_tags/models.py
@@ -26,7 +26,7 @@ class LanguageTag(TranslatableModel):
         # All other languages are grouped by macrolanguage.
         if self.code.startswith('zh'):
             return self.name_t if translate else self.name
-        return self.translated_macrolanguage if translate else self.macrolanguage
+        return self.translated_macrolanguage if translate and self.name_t else self.macrolanguage
 
 
 class LanguageTagTranslation(TranslatedFieldsModel):


### PR DESCRIPTION
### Ticket
[ENT-8400](https://2u-internal.atlassian.net/browse/ENT-8400)

### Description
- Reapplies PR [4269](https://github.com/openedx/course-discovery/pull/4296) that was reverted and resolves the mentioned issue. 
- The error occurred because the language `Tagalog` was stored in the `LanguageTag` model without a corresponding `name_t` (Name for translation) in the `LanguageTagTranslation` model. This caused an error when the existing `get_search_facet_display` method looked for a corresponding name for translation.

### Resolution
 I've added a validation check to verify the existence of the corresponding `name_t` (Name for translation) in the `LanguageTagTranslation` model before accessing it, furthermore I have disabled the translation flag for `get_transcript_languages_search_facet_names` because we do not require translated transcript language names, and not all languages stored in transcript_languages have a corresponding name for translation stored.


```
File "/edx/app/discovery/discovery/course_discovery/apps/api/serializers.py", line 1096, in get_transcript_languages_search_facet_names
    transcript_languages_facet_names.append(language.get_search_facet_display(translate=True))
  File "/edx/app/discovery/discovery/course_discovery/apps/ietf_language_tags/models.py", line 29, in get_search_facet_display
    return self.translated_macrolanguage if translate else self.macrolanguage
  File "/edx/app/discovery/discovery/course_discovery/apps/ietf_language_tags/models.py", line 22, in translated_macrolanguage
    return self.name_t.split('-')[0].strip()
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/parler/fields.py", line 142, in __get__
    translation = instance._get_translated_model(use_fallback=True, meta=meta)
  File "/edx/app/discovery/venvs/discovery/lib/python3.8/site-packages/parler/models.py", line 620, in _get_translated_model
    raise meta.model.DoesNotExist(
parler.models.DoesNotExist: language tag does not have a translation for the current language!
language tag ID #tl, language=en (tried fallbacks en)
Attempted to read attribute name_t.
```

