### PR TITLE
fix: update limit for es response

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -5,7 +5,6 @@ import re
 from urllib.parse import urlencode
 
 import ddt
-import pytest
 import responses
 from django.test import TestCase
 from django.utils.text import slugify
@@ -2623,9 +2622,7 @@ class PersonSearchModelSerializerTests(PersonSearchDocumentSerializerTest):
         }
 
 
-@pytest.mark.django_db
-@pytest.mark.usefixtures('elasticsearch_dsl_default_connection')
-class TestProgramSearchDocumentSerializer(TestCase):
+class TestProgramSearchDocumentSerializer(ElasticsearchTestMixin, TestCase):
     serializer_class = ProgramSearchDocumentSerializer
 
     def setUp(self):
@@ -2722,9 +2719,7 @@ class ProgramSearchModelSerializerTest(TestProgramSearchDocumentSerializer):
         return expected
 
 
-@pytest.mark.django_db
-@pytest.mark.usefixtures('elasticsearch_dsl_default_connection')
-class TestLearnerPathwaySearchDocumentSerializer(TestCase):
+class TestLearnerPathwaySearchDocumentSerializer(ElasticsearchTestMixin, TestCase):
     serializer_class = LearnerPathwaySearchDocumentSerializer
 
     def setUp(self):
@@ -2782,9 +2777,7 @@ class LearnerPathwaySearchModelSerializerTest(TestLearnerPathwaySearchDocumentSe
         return expected
 
 
-@pytest.mark.django_db
-@pytest.mark.usefixtures('elasticsearch_dsl_default_connection')
-class TestTypeaheadCourseRunSearchSerializer:
+class TestTypeaheadCourseRunSearchSerializer(ElasticsearchTestMixin, TestCase):
     serializer_class = TypeaheadCourseRunSearchSerializer
 
     @classmethod
@@ -2809,9 +2802,7 @@ class TestTypeaheadCourseRunSearchSerializer:
         return serializer
 
 
-@pytest.mark.django_db
-@pytest.mark.usefixtures('elasticsearch_dsl_default_connection')
-class TestTypeaheadProgramSearchSerializer:
+class TestTypeaheadProgramSearchSerializer(ElasticsearchTestMixin, TestCase):
     serializer_class = TypeaheadProgramSearchSerializer
 
     @classmethod

--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -72,6 +72,11 @@ class ElasticsearchUtils:
         connection.indices.update_aliases(body)
 
     @classmethod
+    def update_max_result_window(cls, connection, max_result_window, index):
+        if connection.indices.exists(index=index):
+            connection.indices.put_settings(body={"index": {"max_result_window": max_result_window}})
+
+    @classmethod
     def create_index(cls, index, conn_name='default'):
         """
         Creates a new index whose name is prefixed with the specified value.

--- a/course_discovery/apps/edx_elasticsearch_dsl_extensions/management/commands/update_index.py
+++ b/course_discovery/apps/edx_elasticsearch_dsl_extensions/management/commands/update_index.py
@@ -117,11 +117,13 @@ class Command(DjangoESDSLCommand):
                     )
                     if record_count_is_sane:
                         ElasticsearchUtils.set_alias(conn, alias, new_index_name)
+                        ElasticsearchUtils.update_max_result_window(conn, settings.MAX_RESULT_WINDOW, new_index_name)
                         indexes_pending.pop(new_index_name, None)
                     else:
                         indexes_pending[new_index_name] = index_info_string
                 else:
                     ElasticsearchUtils.set_alias(conn, alias, new_index_name)
+                    ElasticsearchUtils.update_max_result_window(conn, settings.MAX_RESULT_WINDOW, new_index_name)
                     indexes_pending.pop(new_index_name, None)
 
         for index_alias_mapper in alias_mappings:

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -461,11 +461,13 @@ SYNONYMS_MODULE = 'course_discovery.settings.synonyms'
 # (by default it uses the database driver's default setting)
 # https://docs.djangoproject.com/en/3.1/ref/models/querysets/#iterator
 # Thus set the 'chunk_size'
-ELASTICSEARCH_DSL_QUERYSET_PAGINATION = 10000
+ELASTICSEARCH_DSL_QUERYSET_PAGINATION = 15000
 
 # Defining default pagination for all requests to ElasticSearch,
 # whose parameters 'size' and 'from' are not explicitly set.
-ELASTICSEARCH_DSL_LOAD_PER_QUERY = 10000
+ELASTICSEARCH_DSL_LOAD_PER_QUERY = 15000
+
+MAX_RESULT_WINDOW = 15000
 
 ELASTICSEARCH_DSL = {
     'default': {'hosts': '127.0.0.1:9200'}

--- a/course_discovery/settings/test.py
+++ b/course_discovery/settings/test.py
@@ -157,3 +157,7 @@ COURSE_URL_SLUGS_PATTERN = {
             'error_msg': 'Course edit was unsuccessful. The course URL slug "[{url_slug}]" is an invalid format. Please ensure that the slug is in the format `boot-camps/<primary_subject>/<organization_name>-<course_title>`',
         }},
 }
+
+ELASTICSEARCH_DSL_QUERYSET_PAGINATION = 10000
+
+ELASTICSEARCH_DSL_LOAD_PER_QUERY = 10000


### PR DESCRIPTION
[PROD-3986](https://2u-internal.atlassian.net/browse/PROD-3986)
Adds a setting to `update_index`. This will increase the `max_result_window` for all existing indexes and subsequently update any newly created index as well. 

~Also updates the unit test that previously didn't support a custom value of `max_result_window` in ES related logic.~
Keeping the same limit count for unit tests as we won't reach this limit while testing.