### PR TITLE
fix: temporarily remove anonymous throttling

### DIFF
--- a/course_discovery/apps/taxonomy_support/api/v1/views.py
+++ b/course_discovery/apps/taxonomy_support/api/v1/views.py
@@ -14,7 +14,6 @@ class CourseRecommendationsAPIView(AnonymousUserThrottleAuthenticatedEndpointMix
     Example:
         GET /taxonomy/api/v1/course_recommendations/edX+DemoX/
     """
-    anonymous_user_throttle_class = CourseRecommendationsViewAnonymousUserThrottle
     permission_classes = (permissions.IsAuthenticated,)
     queryset = Course.objects.all()
     serializer_class = CourseRecommendationsSerializer


### PR DESCRIPTION
[PROD-3994](https://2u-internal.atlassian.net/browse/PROD-3994)

Temporarily removing the `AnonymousUserThrottleAuthenticatedEndpointMixin` to unblock the course recommendations endpoint for Enterprise.