### PR TITLE
fix: use correct request type in anon throttle mixin

### DIFF
--- a/course_discovery/apps/api/mixins.py
+++ b/course_discovery/apps/api/mixins.py
@@ -182,7 +182,8 @@ class AnonymousUserThrottleAuthenticatedEndpointMixin:
     See https://github.com/encode/django-rest-framework/issues/5234 for more context.
     """
     def dispatch(self, request, *args, **kwargs):
-        user = request.user
+        initialized_request = self.initialize_request(request, *args, **kwargs)
+        user = initialized_request.user
         if isinstance(user, AnonymousUser) and (
                 self.authentication_classes or (self.permission_classes and IsAuthenticated in self.permission_classes)
         ):
@@ -194,7 +195,7 @@ class AnonymousUserThrottleAuthenticatedEndpointMixin:
                 wait = math.ceil(throttle_instance.wait())
                 self.args = args
                 self.kwargs = kwargs
-                self.request = self.initialize_request(request, *args, **kwargs)
+                self.request = initialized_request
                 self.headers = {**self.default_response_headers, 'Retry-After': wait}
                 self.format_kwarg = self.get_format_suffix(**kwargs)
                 response = Response(


### PR DESCRIPTION
### [PROD-3994](https://2u-internal.atlassian.net/browse/PROD-3994)

### Description

Moves request_initialization at start of dispatch so that WSGIRequest --> DRFRequest conversion can take place and request.user does DRF authentication

### Testing
- You need Postman to test this out (for JWT Authentication ease)
- Go to LMS /admin/oauth2_provider/application/ and setup a new OAuth app. It should be set to Client Credentials public app.
- Go to postman and make POST request against http://localhost:18000/oauth2/access_token. See pic below for body of request. It should return JWT token
<img width="1249" alt="image" src="https://github.com/openedx/course-discovery/assets/40599381/70679464-a56f-4678-be41-45ade9a8f9a1">

- Go to discovery and ensure there are recommendation entries at http://localhost:18381/admin/taxonomy_support/courserecommendation/
- In a new Postman tab, make GET request against http://localhost:18381/taxonomy/api/v1/course_recommendations/<key>. Add Authorization: JWT <token> header. 
- For easy testing, you can set CourseRecommendationsViewAnonymousUserThrottle rate to 2/h to ensure that more than 2 requests by JWT Auth does not get throttled.