### PR TITLE
build: update docker-compose to docker compose on CI and other places

### DIFF
--- a/.ci/docker.mk
+++ b/.ci/docker.mk
@@ -1,9 +1,9 @@
 ci_up: ## Create containers used to run tests on CI
-	docker-compose -f .ci/docker-compose-ci.yml up -d
+	docker compose -f .ci/docker-compose-ci.yml up -d
 .PHONY: ci_up
 
 ci_start: ## Start containers stopped by `ci_stop`
-	docker-compose -f .ci/docker-compose-ci.yml start
+	docker compose -f .ci/docker-compose-ci.yml start
 .PHONY: ci_start
 
 ci_test: ## Run tests on Docker containers, as on CI
@@ -24,9 +24,9 @@ ci_semgrep:
 .PHONY: ci_semgrep
 
 ci_stop: ## Stop running containers created by `ci_up` without removing them
-	docker-compose -f .ci/docker-compose-ci.yml stop
+	docker compose -f .ci/docker-compose-ci.yml stop
 .PHONY: ci_stop
 
 ci_down: ## Stop and remove containers and other resources created by `ci_up`
-	docker-compose -f .ci/docker-compose-ci.yml down
+	docker compose -f .ci/docker-compose-ci.yml down
 .PHONY: ci_down

--- a/Makefile
+++ b/Makefile
@@ -117,13 +117,13 @@ push_translations: ## Push source translation files (.po) to Transifex
 	tx push -s
 
 start-devstack: ## Run a local development copy of the server
-	docker-compose up
+	docker compose up
 
 stop-devstack: ## Shutdown the local development server
-	docker-compose down
+	docker compose down
 
 open-devstack: ## Open a shell on the server started by start-devstack
-	docker-compose up -d
+	docker compose up -d
 	docker exec -it course-discovery env TERM=$(TERM) /edx/app/discovery/devstack.sh open
 
 accept: ## Run acceptance tests

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -57,6 +57,6 @@ This will install some dependencies in addition to running all tests. After the 
 
 .. code-block:: bash
 
-    $ docker-compose -f .ci/docker-compose-ci.yml exec discovery bash -c 'cd /edx/app/discovery/discovery && .tox/py38-django22/bin/pytest course_discovery/apps/api/v1/tests/test_views/test_programs.py'
+    $ docker compose -f .ci/docker-compose-ci.yml exec discovery bash -c 'cd /edx/app/discovery/discovery && .tox/py38-django22/bin/pytest course_discovery/apps/api/v1/tests/test_views/test_programs.py'
 
 When you're done, take down the services you brought up with ``make ci_down``.


### PR DESCRIPTION
docker compose v1 has been removed from GA runners since April 1st, v2 is the default option. 

https://github.com/actions/runner-images/issues/9557

https://docs.docker.com/compose/migrate/