### PR TITLE
Move courses to published in CSVLoader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -262,8 +262,11 @@ class CSVDataLoader(AbstractDataLoader):
 
             if course_run.status == CourseRunStatus.Unpublished:
                 course_run.refresh_from_db()
+                # Pushing the run into LegalReview is necessary to ensure that the
+                # url slug is correctly generated in subdirectory format
                 course_run.status = CourseRunStatus.LegalReview
-                course_run.save(update_fields=['status'])
+                course_run.save(update_fields=['status'], send_emails=False)
+                self._complete_run_review(row, course_run)
 
             logger.info("Course and course run updated successfully for course key {}".format(course_key))  # lint-amnesty, pylint: disable=logging-format-interpolation
             self.course_uuids[str(course.uuid)] = course_title

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -340,8 +340,6 @@ class CSVLoaderMixin:
         'content_language', 'transcript_language', 'syllabus', 'frequently_asked_questions',
     ]
     BASE_EXPECTED_COURSE_DATA = {
-        # Loader does not publish newly created course or a course that has not reached published status.
-        # That's why only the draft version of the course exists.
         'draft': True,
         'verified_price': 150,
         'title': 'CSV Course',
@@ -378,10 +376,8 @@ class CSVLoaderMixin:
     }
 
     BASE_EXPECTED_COURSE_RUN_DATA = {
-        # Loader does not publish newly created course or a course that has not reached published status.
-        # That's why only the draft version of the course run exists.
         'draft': True,
-        'status': CourseRunStatus.LegalReview,
+        'status': CourseRunStatus.Published,
         'length': 10,
         'minimum_effort': 4,
         'maximum_effort': 10,

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
@@ -158,11 +158,11 @@ class TestImportCourseMetadata(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                             (LOGGER_PATH, 'INFO', 'CSV loader import flow completed.')
                         )
 
-                        assert Course.everything.count() == 1
-                        assert CourseRun.everything.count() == 1
+                        assert Course.everything.count() == 2
+                        assert CourseRun.everything.count() == 2
 
-                        course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner)
-                        course_run = CourseRun.everything.get(course=course)
+                        course = Course.everything.get(key=self.COURSE_KEY, partner=self.partner, draft=True)
+                        course_run = CourseRun.everything.get(course=course, draft=True)
                         slug_path = f'{slugify(course.authoring_organizations.first().name)}-{slugify(course.title)}'
 
                         assert course.image.read() == image_content


### PR DESCRIPTION
### [PROD-3990](https://2u-internal.atlassian.net/browse/PROD-3990)

Instead of LegalReview, move course runs to published state in csv loader

### Testing Instructions
Run ingestion on local. Verify that the course runs are pushed to Published state, and all the seats/entitlements etc. are generated correctly (draft/non-draft)