### PR TITLE
fix: put settings through index/_settings endpoint

### DIFF
--- a/course_discovery/apps/core/utils.py
+++ b/course_discovery/apps/core/utils.py
@@ -74,7 +74,7 @@ class ElasticsearchUtils:
     @classmethod
     def update_max_result_window(cls, connection, max_result_window, index):
         if connection.indices.exists(index=index):
-            connection.indices.put_settings(body={"index": {"max_result_window": max_result_window}})
+            connection.indices.put_settings(index=index, body={"index": {"max_result_window": max_result_window}})
 
     @classmethod
     def create_index(cls, index, conn_name='default'):


### PR DESCRIPTION
Seeing "Your request: '/_settings' is not allowed." on stage. It seems like AWS adds a bunch of constraints on ES endpoints and using plain `/_settings` has a very limited usage. 
We're changing our logic [like this](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html#update-index-settings-api-request)
