### PR TITLE
feat: Loader updates for custom presentations

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -288,7 +288,9 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                             'uuid': str(course.uuid),
                             'external_course_marketing_type': 'short_course',
                             'url_slug': expected_slug,
-                            'rerun': True
+                            'rerun': True,
+                            'course_run_variant_id': str(course.course_runs.last().variant_id),
+                            'restriction_type': None,
                         }],
                         'archived_products_count': 0,
                         'archived_products': [],
@@ -370,7 +372,9 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                             'uuid': str(course.uuid),
                             'external_course_marketing_type': 'short_course',
                             'url_slug': 'csv-course',
-                            'rerun': True
+                            'rerun': True,
+                            'course_run_variant_id': str(course.course_runs.last().variant_id),
+                            'restriction_type': None,
                         }],
                         'archived_products_count': 2,
                         'errors': loader.error_logs
@@ -579,7 +583,9 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                                 'external_course_marketing_type':
                                     course.additional_metadata.external_course_marketing_type,
                                 'url_slug': course.active_url_slug,
-                                'rerun': True
+                                'rerun': True,
+                                'course_run_variant_id': str(course_run.variant_id),
+                                'restriction_type': None,
                             }],
                             'archived_products_count': 0,
                             'archived_products': [],

--- a/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/import_course_metadata.py
@@ -93,6 +93,7 @@ class Command(BaseCommand):
         for model in apps.get_app_config('course_metadata').get_models():
             for signal in (post_save, post_delete):
                 signal.disconnect(receiver=api_change_receiver, sender=model)
+
         products_json = []
         try:
             loader = CSVDataLoader(

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
@@ -47,21 +47,70 @@
 <div>
     <h3>New Products</h3>
         <ul>
+            {% if product_type != "DEGREES" %}
+                <table border="2" style="padding: 5px;">
+                    <tr>
+                        <th>
+                            Course UUID
+                        </th>
+                        <th>
+                            URL Slug
+                        </th>
+                        <th>
+                            External Course Marketing Type
+                        </th>
+                        <th>
+                            Variant ID
+                        </th>
+                        <th>
+                            Restriction Type
+                        </th>
+                        <th>
+                            Rerun
+                        </th>
+                    </tr>
+            {% endif %}
             {% for new_product in created_products %}
                 {% if product_type != "DEGREES" %}
-                    <li><a href="{{publisher_url}}courses/{{new_product.uuid}}">{{ new_product.uuid }}</a> - {{ new_product.url_slug}} 
-                        {% if new_product.external_course_marketing_type %}
-                            ({{ new_product.external_course_marketing_type }})
-                        {% endif %}
-                        {% if new_product.rerun %}
-                            A new run has been created
-                        {% endif %}
-                    </li>
+                    <tr>
+                        <td>
+                            <a href='{{publisher_url}}courses/{{new_product.uuid}}'>{{ new_product.uuid }}</a>
+                        </td>
+                        <td>
+                            {{ new_product.url_slug}}
+                        </td>
+                        <td>
+                            {% if new_product.external_course_marketing_type %}
+                                {{ new_product.external_course_marketing_type }}
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if new_product.course_run_variant_id %}
+                                {{ new_product.course_run_variant_id }}
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if new_product.restriction_type %}
+                                {{ new_product.restriction_type }}
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if new_product.rerun %}
+                                Yes
+                            {% else %}
+                                No
+                            {% endif %}
+                        </td>
+                    </tr>
                 {% else %}
                     <li>{{ new_product.uuid }}</li>
                 {% endif %}
             {% endfor %}
-        </ul>
+            {% if product_type != "DEGREES" %}
+                </table>
+            {% else %}
+                </ul>
+            {% endif %}
 </div>
 {% endif %}
 

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.txt
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.txt
@@ -12,7 +12,7 @@ Archived Products: {{ archived_products_count }}
 {% if created_products_count > 0 %}
 New Products
 {% for new_product in created_products %}
-{{ new_product.uuid }} - {{ new_product.url_slug}} {% if new_product.external_course_marketing_type %} ({{ new_product.external_course_marketing_type }}) {% endif %} {% if new_product.rerun %} A new run has been created {% endif %}
+{{ new_product.uuid }} - {{ new_product.url_slug}} {% if new_product.external_course_marketing_type %} ({{ new_product.external_course_marketing_type }}) {% endif %} {% if new_product.rerun %} (rerun: True) {% endif %} {% if new_product.course_run_variant_id %} (variant: {{ new_product.course_run_variant_id }}) {% endif %} {% if new_product.restriction_type %} (restriction_type: {{ new_product.restriction_type }}) {% endif %}
 {% endfor %}
 {% endif %}
 {% if created_products_count > 0 %}

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -557,6 +557,7 @@ class TestIngestionEmail(TestCase):
         Verify the email content for new products.
         """
         uuid = str(uuid4())
+        variant_id = str(uuid4())
         url_slug = 'course-slug-1'
         emails.send_ingestion_email(
             self.partner, self.EMAIL_SUBJECT, self.USER_EMAILS, self.EXEC_ED_PRODUCT, self.source,
@@ -571,11 +572,14 @@ class TestIngestionEmail(TestCase):
                         'external_course_marketing_type': None,
                         'url_slug': url_slug,
                         'rerun': True,
+                        'course_run_variant_id': variant_id,
+                        'restriction_type': 'None',
                     }
                 ],
             }
         )
 
+        # pylint: disable=line-too-long
         self._assert_email_content(
             self.EMAIL_SUBJECT,
             [
@@ -584,10 +588,11 @@ class TestIngestionEmail(TestCase):
                 "<tr><th>New Products</th><td> 1 </td></tr>",
                 "<tr><th>Updated Products</th><td> 0 </td></tr>",
                 "<h3>New Products</h3>",
-                f"<li><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a> - {url_slug} "
-                f"A new run has been created</li>"
+                "<tr><th>Course UUID</th><th>URL Slug</th><th>External Course Marketing Type</th><th>Variant ID</th><th>Restriction Type</th><th>Rerun</th></tr>",
+                f"<tr><td><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td>{url_slug}</td><td></td><td>{variant_id}</td><td>None</td><td>Yes</td></tr>",
             ]
         )
+        # pylint: enable=line-too-long
 
     def test_email_new_exec_ed_products(self):
         """
@@ -625,6 +630,7 @@ class TestIngestionEmail(TestCase):
             }
         )
 
+        # pylint: disable=line-too-long
         self._assert_email_content(
             self.EMAIL_SUBJECT,
             [
@@ -633,14 +639,13 @@ class TestIngestionEmail(TestCase):
                 "<tr><th>New Products</th><td> 3 </td></tr>",
                 "<tr><th>Updated Products</th><td> 0 </td></tr>",
                 "<h3>New Products</h3>",
-                f"<li><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a> - {url_slug} "
-                f"(sprint) A new run has been created</li>"
-                f"<li><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a> - {url_slug} "
-                f"(course_stack) A new run has been created</li>"
-                f"<li><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a> - {url_slug} "
-                f"(short_course) A new run has been created</li>"
+                "<tr><th>Course UUID</th><th>URL Slug</th><th>External Course Marketing Type</th><th>Variant ID</th><th>Restriction Type</th><th>Rerun</th></tr>",
+                f"<tr><td><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td>{url_slug}</td><td>sprint</td><td></td><td></td><td>Yes</td></tr>",
+                f"<tr><td><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td>{url_slug}</td><td>course_stack</td><td></td><td></td><td>Yes</td></tr>",
+                f"<tr><td><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td>{url_slug}</td><td>short_course</td><td></td><td></td><td>Yes</td></tr>",
             ]
         )
+        # pylint: enable=line-too-long
 
     def test_email_ingestion_failures(self):
         """


### PR DESCRIPTION
[PROD-4007](https://2u-internal.atlassian.net/browse/PROD-4007)
-------
This PR carries CSV loader updates to handle b2b-custom representations. Now the CSV loader can handle the creation/update of multiple variants in a single ingestion. This also handles loader ingestion report email updates for multiple variants.

Testing Instructions:
---------
- Download the dummy json file from the given [link](https://drive.google.com/file/d/1KSQOpz1Q8q6tFcYFb98S-1xM5_Oriss5/view?usp=sharing)
- Place this in `course-discovery` root folder.
- Run `populate_executive_education_data_csv` command
```bash
./manage.py populate_executive_education_data_csv --product_source=2u --output_csv=output.csv --dev_input_json=dev.json --use_getsmarter_api_client=True
```
- Then, finally, run the import_course_metadata command: 
```bash
./manage.py import_course_metadata --partner_code=edx --csv_path=output.csv --product_type=EXECUTIVE_EDUCATION --product_source=2u
```


(Make sure to update the slug format dict in base.py; otherwise, it might raise an error.)