### PR TITLE
fix: avoid span tags overlapping

### DIFF
--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -807,6 +807,8 @@ class UtilsTests(TestCase):
         ('<p><span lang="en">with lang</span></p>', '<p><span lang="en">with lang</span></p>'),
         ('<p><span class="body" lang="en">lang and class</span></p>', '<p><span lang="en">lang and class</span></p>'),
         ('<p><span class="body">class only</span></p>', '<p>class only</p>'),
+        ('<p dir="rtl"><span lang="en">1 span tag inside RTL p</span></p>', '<p dir="rtl"><span lang="en">1 span tag inside RTL p</span></p>'),
+        ('<p dir="rtl"><span lang="en"><span lang="en"><span lang="en">multiple span tags inside RTL p</span></span></span></p>', '<p dir="rtl"><span lang="en">multiple span tags inside RTL p</span></p>'),
 
         # A sample text from real life when pasting from Microsoft Word into a rich text editor
         # pylint: disable=line-too-long

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -732,7 +732,7 @@ class HTML2TextWithLangSpans(html2text.HTML2Text):
         if not self.is_p_tag_with_dir:
             super().handle_tag(tag, attrs, start)
 
-        elif tag not in HTML_TAGS_ATTRIBUTE_WHITELIST:
+        elif tag not in HTML_TAGS_ATTRIBUTE_WHITELIST and tag != 'span':
             if start:
                 self.outtextf(f'<{tag}')
                 if attrs:
@@ -743,7 +743,7 @@ class HTML2TextWithLangSpans(html2text.HTML2Text):
                 self.outtextf(f'</{tag}>')
 
         if tag == 'span':
-            if attrs and start and 'lang' in dict(attrs):
+            if attrs and start and not self.in_lang_span and 'lang' in dict(attrs):
                 self.outtextf(f'<span lang="{dict(attrs)["lang"]}">')
                 self.in_lang_span = True
             if not start and self.in_lang_span:


### PR DESCRIPTION
[PROD-4016](https://2u-internal.atlassian.net/browse/PROD-4016)
Updates the logic to avoid adding multiple span tags around span tags after each time `handle_tag` is called for one of the richtext fields on Publisher. Filters out extra span tags as well.

It used to add extra span tags for a richtext having `dir="rtl"` like this:
`'<p dir="rtl"><span lang="en"><span lang="en">lang and class</span></span></p>'`
And after any subsequent save call to any of the fields using it, it will multiply the `span` tags to something like:
`'<p dir="rtl"><span lang="en"><span lang="en"><span lang="en">lang and class</span></span></span></p>'`