### PR TITLE
feat: add CRUD support for RestrictedCourseRun in CourseRun Api

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -922,6 +922,7 @@ class MinimalCourseRunSerializer(FlexFieldsSerializerMixin, TimestampModelSerial
                                             queryset=CourseRunType.objects.all())
     term = serializers.CharField(required=False, write_only=True)
     variant_id = serializers.UUIDField(allow_null=True, required=False)
+    restriction_type = serializers.CharField(source='restricted_run.restriction_type', read_only=True)
 
     @classmethod
     def prefetch_queryset(cls, queryset=None):
@@ -932,6 +933,7 @@ class MinimalCourseRunSerializer(FlexFieldsSerializerMixin, TimestampModelSerial
         return queryset.select_related('course', 'type').prefetch_related(
             '_official_version',
             'course__partner',
+            'restricted_run',
             Prefetch('seats', queryset=SeatSerializer.prefetch_queryset()),
         )
 
@@ -939,8 +941,8 @@ class MinimalCourseRunSerializer(FlexFieldsSerializerMixin, TimestampModelSerial
         model = CourseRun
         fields = ('key', 'uuid', 'title', 'external_key', 'image', 'short_description', 'marketing_url',
                   'seats', 'start', 'end', 'go_live_date', 'enrollment_start', 'enrollment_end', 'weeks_to_complete',
-                  'pacing_type', 'type', 'run_type', 'status', 'is_enrollable', 'is_marketable', 'term', 'availability',
-                  'variant_id')
+                  'pacing_type', 'type', 'restriction_type', 'run_type', 'status', 'is_enrollable', 'is_marketable',
+                  'term', 'availability', 'variant_id')
 
     def get_marketing_url(self, obj):
         include_archived = self.context.get('include_archived')

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -638,6 +638,11 @@ class MinimalCourseRunBaseTestSerializer(TestCase):
             'is_marketable': course_run.is_marketable,
             'availability': course_run.availability,
             'variant_id': str(course_run.variant_id),
+            'restriction_type': (
+                course_run.restricted_run.restriction_type
+                if hasattr(course_run, 'restricted_run')
+                else None
+            )
         }
 
 


### PR DESCRIPTION
[PROD-4004](https://2u-internal.atlassian.net/browse/PROD-4004)
-------
This PR adds support for marking CourseRuns as restricted through the CourseRun Api

Testing Instructions:
---------
You can test it by hitting the API directly with postman or any other tool and provide the `restriction_type` parameter. Then verify that the RestrictedCourseRun objects are added/updated appropriately in the database.

Here's how I have been doing it though.
- Apply the attached patch to Publisher [restriction.patch](https://github.com/openedx/course-discovery/files/15028761/restriction.patch)
- Create/Update runs as you would normally.
- However, just before clicking the Create/Update button, set `window.restriction_type` to whatever restriction_type you want to set. 
- Observe that the objects are created/updated properly in the backend.
