### PR TITLE
build: fix ci-workflow migration issue

### DIFF
--- a/.github/workflows/migrations-check-mysql8.yml
+++ b/.github/workflows/migrations-check-mysql8.yml
@@ -47,6 +47,8 @@ jobs:
         lsb_release -a
         mysql -V
 
+    # pinning xmlsec to version 1.3.13 to avoid the CI error, migration checks are failing due to an issue in the latest release of python-xmlsec
+    # https://github.com/xmlsec/python-xmlsec/issues/314
     - name: Install Python dependencies
       run: |
         pip install -r requirements/pip_tools.txt
@@ -54,7 +56,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec xmlsec==1.3.13
 
     - name: Initiate Services
       run: |


### PR DESCRIPTION
`python-xmlsec`'s current version 1.3.14 is causing some issues during the dependency installation stage of `mysql8-migrations-check`. This PR is to pin it to 1.3.13 for the time being until the issue can be resolved.

https://github.com/xmlsec/python-xmlsec/issues/314

Thread Link:
https://twou.slack.com/archives/C030CC8T40N/p1713436115873339