### PR TITLE
temp: decrease pagination size to 10k

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -461,11 +461,11 @@ SYNONYMS_MODULE = 'course_discovery.settings.synonyms'
 # (by default it uses the database driver's default setting)
 # https://docs.djangoproject.com/en/3.1/ref/models/querysets/#iterator
 # Thus set the 'chunk_size'
-ELASTICSEARCH_DSL_QUERYSET_PAGINATION = 15000
+ELASTICSEARCH_DSL_QUERYSET_PAGINATION = 10000
 
 # Defining default pagination for all requests to ElasticSearch,
 # whose parameters 'size' and 'from' are not explicitly set.
-ELASTICSEARCH_DSL_LOAD_PER_QUERY = 15000
+ELASTICSEARCH_DSL_LOAD_PER_QUERY = 10000
 
 MAX_RESULT_WINDOW = 15000
 


### PR DESCRIPTION
Removes the pagination size to avoid breaking ES endpoints until the `max_result_window` increases.