### PR TITLE
fix: [WS-4468] update learning type experiment filter

### DIFF
--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -50,6 +50,25 @@ def get_owners(entry):
     return list(filter(lambda owner: owner['logoImageUrl'] is not None, all_owners))
 
 
+def process_learning_type(product_type):
+    CERTIFICATES = _('Certificates')
+    PATHWAYS_TO_DEGREES = _('Pathways to Degrees')
+
+    product_map = {
+        'Boot Camp': _('Boot Camps'),
+        'Certificate': CERTIFICATES,
+        'License': CERTIFICATES,
+        'Professional Certificate': CERTIFICATES,
+        'XSeries': CERTIFICATES,
+        'MicroBachelors': PATHWAYS_TO_DEGREES,
+        'MicroMasters': PATHWAYS_TO_DEGREES,
+        'Bachelors': _('Bachelor’s'),
+        'Masters': _('Master’s')
+    }
+
+    return product_map.get(product_type, product_type)
+
+
 def delegate_attributes(cls):
     '''
     Class decorator. For all Algolia fields, when my_instance.attribute is accessed, get the attribute off
@@ -300,26 +319,12 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
         Temporary field used as a variant of `learning_type` for an experiment. If the experiment is successful,
         this will replace `learning_type`.
         """
-        if self.type.slug == CourseType.EXECUTIVE_EDUCATION_2U:
-            return [_('Certificate courses')]
-
+        course_type = process_learning_type(self.product_type)
         processed_program_types = []
         for program_type in self.program_types:
-            if program_type in [
-                'Certificate',
-                'License',
-                'Professional Certificate',
-                'XSeries'
-            ]:
-                processed_program_types.append(_('Certificate courses'))
-            elif program_type in ['Bachelors', 'Doctorate', 'Masters']:
-                processed_program_types.append(_('Degrees'))
-            elif program_type in ['MicroBachelors', 'MicroMasters']:
-                processed_program_types.append(_('Paths to degrees'))
-            else:
-                processed_program_types.append(program_type)
+            processed_program_types.append(process_learning_type(program_type))
 
-        return [self.product_type, *processed_program_types]
+        return [course_type, *processed_program_types]
 
     @property
     def product_card_image_url(self):
@@ -572,22 +577,7 @@ class AlgoliaProxyProgram(Program, AlgoliaBasicModelFieldsMixin):
         this will replace `learning_type`.
         """
         if self.type:
-            if self.type.slug in [
-                ProgramType.CERTIFICATE,
-                ProgramType.LICENSE,
-                ProgramType.PROFESSIONAL_CERTIFICATE,
-                ProgramType.XSERIES
-            ]:
-                return [_('Certificate courses')]
-            if self.type.slug in [
-                ProgramType.BACHELORS,
-                ProgramType.DOCTORATE,
-                ProgramType.MASTERS
-            ]:
-                return [_('Degrees')]
-            if self.type.slug in [ProgramType.MICROBACHELORS, ProgramType.MICROMASTERS]:
-                return [_('Paths to degrees')]
-            return [self.type.name_t]
+            return [process_learning_type(self.type.name_t)]
         return []
 
     @property

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -524,9 +524,9 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
             assert course.learning_type == ['Course']
 
     @ddt.data(
-        (ProgramType.PROFESSIONAL_CERTIFICATE, 'Certificate courses'),
-        (ProgramType.MASTERS, 'Degrees'),
-        (ProgramType.MICROBACHELORS, 'Paths to degrees'),
+        (ProgramType.XSERIES, 'Certificates'),
+        (ProgramType.MASTERS, 'Master’s'),
+        (ProgramType.MICROMASTERS, 'Pathways to Degrees'),
     )
     @ddt.unpack
     def test_learning_type_exp_open_course(self, program_type_slug, learning_type):
@@ -548,8 +548,8 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         assert course.learning_type == [expected_result]
 
     @ddt.data(
-        (CourseType.EXECUTIVE_EDUCATION_2U, 'Certificate courses'),
-        (CourseType.BOOTCAMP_2U, 'Boot Camp'),
+        (CourseType.EXECUTIVE_EDUCATION_2U, 'Executive Education'),
+        (CourseType.BOOTCAMP_2U, 'Boot Camps'),
     )
     @ddt.unpack
     def test_learning_type_exp_non_open_course(self, course_type_slug, expected_result):
@@ -875,9 +875,9 @@ class TestAlgoliaProxyProgram(TestAlgoliaProxyWithEdxPartner):
         assert program.learning_type == [program_type.name_t]
 
     @ddt.data(
-        (ProgramType.PROFESSIONAL_CERTIFICATE, 'Certificate courses'),
-        (ProgramType.MASTERS, 'Degrees'),
-        (ProgramType.MICROBACHELORS, 'Paths to degrees'),
+        (ProgramType.PROFESSIONAL_CERTIFICATE, 'Certificates'),
+        (ProgramType.MASTERS, 'Master’s'),
+        (ProgramType.MICROBACHELORS, 'Pathways to Degrees'),
     )
     @ddt.unpack
     def test_learning_type_exp(self, program_type_slug, learning_type):


### PR DESCRIPTION
Internal ticket: https://2u-internal.atlassian.net/browse/WS-4468

Update fields for the learning type experiment filter based on product specs, plus some code cleanup:

- Courses
- Certificates (includes "Degree" Certificates, Professional Certificates, Licenses, and XSeries)
- Executive Education
- Pathways to Degrees (includes MicroBachelors and MicroMasters)
- Boot Camps
- Bachelor’s
- Master’s
- Doctorate
