### PR TITLE
style: add padding to the attributes of inner tags of table

### DIFF
--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
@@ -88,8 +88,8 @@
                             {% if new_product.course_run_variant_id %}
                                 {{ new_product.course_run_variant_id }}
                             {% endif %}
-                        </td style="padding: 5px;">
-                        <td>
+                        </td>
+                        <td style="padding: 5px;">
                             {% if new_product.restriction_type %}
                                 {{ new_product.restriction_type }}
                             {% endif %}

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
@@ -50,22 +50,22 @@
             {% if product_type != "DEGREES" %}
                 <table border="2" style="padding: 5px;">
                     <tr>
-                        <th>
+                        <th style="padding: 5px;">
                             Course UUID
                         </th>
-                        <th>
+                        <th style="padding: 5px;">
                             URL Slug
                         </th>
-                        <th>
+                        <th style="padding: 5px;">
                             External Course Marketing Type
                         </th>
-                        <th>
+                        <th style="padding: 5px;">
                             Variant ID
                         </th>
-                        <th>
+                        <th style="padding: 5px;">
                             Restriction Type
                         </th>
-                        <th>
+                        <th style="padding: 5px;">
                             Rerun
                         </th>
                     </tr>

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/loader_ingestion.html
@@ -73,28 +73,28 @@
             {% for new_product in created_products %}
                 {% if product_type != "DEGREES" %}
                     <tr>
-                        <td>
+                        <td style="padding: 5px;">
                             <a href='{{publisher_url}}courses/{{new_product.uuid}}'>{{ new_product.uuid }}</a>
                         </td>
-                        <td>
+                        <td style="padding: 5px;">
                             {{ new_product.url_slug}}
                         </td>
-                        <td>
+                        <td style="padding: 5px;">
                             {% if new_product.external_course_marketing_type %}
                                 {{ new_product.external_course_marketing_type }}
                             {% endif %}
                         </td>
-                        <td>
+                        <td style="padding: 5px;">
                             {% if new_product.course_run_variant_id %}
                                 {{ new_product.course_run_variant_id }}
                             {% endif %}
-                        </td>
+                        </td style="padding: 5px;">
                         <td>
                             {% if new_product.restriction_type %}
                                 {{ new_product.restriction_type }}
                             {% endif %}
                         </td>
-                        <td>
+                        <td style="padding: 5px;">
                             {% if new_product.rerun %}
                                 Yes
                             {% else %}

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -589,7 +589,7 @@ class TestIngestionEmail(TestCase):
                 "<tr><th>Updated Products</th><td> 0 </td></tr>",
                 "<h3>New Products</h3>",
                 "<tr><th>Course UUID</th><th>URL Slug</th><th>External Course Marketing Type</th><th>Variant ID</th><th>Restriction Type</th><th>Rerun</th></tr>",
-                f"<tr><td><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td>{url_slug}</td><td></td><td>{variant_id}</td><td>None</td><td>Yes</td></tr>",
+                f"<tr><td style='padding: 5px;'><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td style='padding: 5px;'>{url_slug}</td><td style='padding: 5px;'></td><td style='padding: 5px;'>{variant_id}</td><td style='padding: 5px;'>None</td><td style='padding: 5px;'>Yes</td></tr>",
             ]
         )
         # pylint: enable=line-too-long
@@ -640,9 +640,9 @@ class TestIngestionEmail(TestCase):
                 "<tr><th>Updated Products</th><td> 0 </td></tr>",
                 "<h3>New Products</h3>",
                 "<tr><th>Course UUID</th><th>URL Slug</th><th>External Course Marketing Type</th><th>Variant ID</th><th>Restriction Type</th><th>Rerun</th></tr>",
-                f"<tr><td><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td>{url_slug}</td><td>sprint</td><td></td><td></td><td>Yes</td></tr>",
-                f"<tr><td><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td>{url_slug}</td><td>course_stack</td><td></td><td></td><td>Yes</td></tr>",
-                f"<tr><td><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td>{url_slug}</td><td>short_course</td><td></td><td></td><td>Yes</td></tr>",
+                f"<tr><td style='padding: 5px;'><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td style='padding: 5px;'>{url_slug}</td><td style='padding: 5px;'>sprint</td><td style='padding: 5px;'></td><td style='padding: 5px;'></td><td style='padding: 5px;'>Yes</td></tr>",
+                f"<tr><td style='padding: 5px;'><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td style='padding: 5px;'>{url_slug}</td><td style='padding: 5px;'>course_stack</td><td style='padding: 5px;'></td><td style='padding: 5px;'></td><td style='padding: 5px;'>Yes</td></tr>",
+                f"<tr><td style='padding: 5px;'><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td style='padding: 5px;'>{url_slug}</td><td style='padding: 5px;'>short_course</td><td style='padding: 5px;'></td><td style='padding: 5px;'></td><td style='padding: 5px;'>Yes</td></tr>",
             ]
         )
         # pylint: enable=line-too-long

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -588,7 +588,7 @@ class TestIngestionEmail(TestCase):
                 "<tr><th>New Products</th><td> 1 </td></tr>",
                 "<tr><th>Updated Products</th><td> 0 </td></tr>",
                 "<h3>New Products</h3>",
-                "<tr><th>Course UUID</th><th>URL Slug</th><th>External Course Marketing Type</th><th>Variant ID</th><th>Restriction Type</th><th>Rerun</th></tr>",
+                "<tr><th style='padding: 5px;'>Course UUID</th><th style='padding: 5px;'>URL Slug</th><th style='padding: 5px;'>External Course Marketing Type</th><th style='padding: 5px;'>Variant ID</th><th style='padding: 5px;'>Restriction Type</th><th style='padding: 5px;'>Rerun</th></tr>",
                 f"<tr><td style='padding: 5px;'><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td style='padding: 5px;'>{url_slug}</td><td style='padding: 5px;'></td><td style='padding: 5px;'>{variant_id}</td><td style='padding: 5px;'>None</td><td style='padding: 5px;'>Yes</td></tr>",
             ]
         )
@@ -639,7 +639,7 @@ class TestIngestionEmail(TestCase):
                 "<tr><th>New Products</th><td> 3 </td></tr>",
                 "<tr><th>Updated Products</th><td> 0 </td></tr>",
                 "<h3>New Products</h3>",
-                "<tr><th>Course UUID</th><th>URL Slug</th><th>External Course Marketing Type</th><th>Variant ID</th><th>Restriction Type</th><th>Rerun</th></tr>",
+                "<tr><th style='padding: 5px;'>Course UUID</th><th style='padding: 5px;'>URL Slug</th><th style='padding: 5px;'>External Course Marketing Type</th><th style='padding: 5px;'>Variant ID</th><th style='padding: 5px;'>Restriction Type</th><th style='padding: 5px;'>Rerun</th></tr>",
                 f"<tr><td style='padding: 5px;'><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td style='padding: 5px;'>{url_slug}</td><td style='padding: 5px;'>sprint</td><td style='padding: 5px;'></td><td style='padding: 5px;'></td><td style='padding: 5px;'>Yes</td></tr>",
                 f"<tr><td style='padding: 5px;'><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td style='padding: 5px;'>{url_slug}</td><td style='padding: 5px;'>course_stack</td><td style='padding: 5px;'></td><td style='padding: 5px;'></td><td style='padding: 5px;'>Yes</td></tr>",
                 f"<tr><td style='padding: 5px;'><a href='{self.partner.publisher_url}courses/{uuid}'>{uuid}</a></td><td style='padding: 5px;'>{url_slug}</td><td style='padding: 5px;'>short_course</td><td style='padding: 5px;'></td><td style='padding: 5px;'></td><td style='padding: 5px;'>Yes</td></tr>",


### PR DESCRIPTION
This PR adds the padding to the table data `<td>` tag of the table in the email_ingestion template.
<img width="1399" alt="image" src="https://github.com/openedx/course-discovery/assets/78806673/1d465de5-59e5-45d0-83d8-b4b00b63d349">

