### PR TITLE
feat: filter restricted runs on APIs

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2347,7 +2347,9 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
                 'staff': MinimalPersonSerializer(course_run.staff, many=True,
                                                  context={'request': request}).data,
                 'content_language': course_run.language.code if course_run.language else None,
-
+                'restriction_type': (
+                    course_run.restricted_run.restriction_type if hasattr(course_run, 'restricted_run') else None
+                )
             }],
             'uuid': str(course.uuid),
             'subjects': [subject.name for subject in course.subjects.all()],
@@ -2418,6 +2420,9 @@ class CourseSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase, Cour
                 'estimated_hours': get_course_run_estimated_hours(course_run),
                 'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0,
                 'is_enrollable': course_run.is_enrollable,
+                'restriction_type': (
+                    course_run.restricted_run.restriction_type if hasattr(course_run, 'restricted_run') else None
+                )
             }],
             'uuid': str(course.uuid),
             'subjects': [subject.name for subject in course.subjects.all()],
@@ -2549,6 +2554,9 @@ class CourseRunSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase):
             'first_enrollable_paid_seat_sku': course_run.first_enrollable_paid_seat_sku(),
             'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price,
             'is_enrollable': course_run.is_enrollable,
+            'restriction_type': (
+                course_run.restricted_run.restriction_type if hasattr(course_run, 'restricted_run') else None
+            )
         }
 
 
@@ -2751,7 +2759,8 @@ class TestLearnerPathwaySearchDocumentSerializer(ElasticsearchTestMixin, TestCas
             'visible_via_association': True,
             'steps': LearnerPathwayStepSerializer(
                 learner_pathway.steps.all(),
-                many=True
+                many=True,
+                context={'request': request}
             ).data,
             'created': serialize_datetime(learner_pathway.created),
         }

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -13,6 +13,7 @@ from sortedm2m.fields import SortedManyToManyField
 
 from course_discovery.apps.core.api_client.lms import LMSAPIClient
 from course_discovery.apps.core.utils import serialize_datetime
+from course_discovery.apps.course_metadata.choices import CourseRunRestrictionType
 from course_discovery.apps.course_metadata.models import CourseRun
 
 logger = logging.getLogger(__name__)
@@ -197,6 +198,11 @@ def increment_character(character):
     Given a character and it will return its next character using ASCII code
     """
     return chr(ord(character) + 1) if character != 'z' else 'a'
+
+
+def get_excluded_restriction_types(request):
+    include_restricted = request.query_params.get('include_restricted', '').split(',')
+    return list(set(CourseRunRestrictionType.values) - set(include_restricted))
 
 
 class StudioAPI:

--- a/course_discovery/apps/api/v1/views/catalogs.py
+++ b/course_discovery/apps/api/v1/views/catalogs.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from course_discovery.apps.api import filters, serializers
 from course_discovery.apps.api.pagination import ProxiedPagination
 from course_discovery.apps.api.renderers import CourseRunCSVRenderer
-from course_discovery.apps.api.utils import check_catalog_api_access
+from course_discovery.apps.api.utils import check_catalog_api_access, get_excluded_restriction_types
 from course_discovery.apps.catalogs.models import Catalog
 from course_discovery.apps.course_metadata.models import CourseRun, CourseType
 
@@ -105,7 +105,8 @@ class CatalogViewSet(viewsets.ModelViewSet):
         if not catalog.include_archived:
             queryset = queryset.available()
             course_runs = course_runs.active().enrollable().marketable()
-
+        excluded_restriction_types = get_excluded_restriction_types(request)
+        course_runs = course_runs.exclude(restricted_run__restriction_type__in=excluded_restriction_types)
         queryset = serializers.CatalogCourseSerializer.prefetch_queryset(
             self.request.site.partner,
             queryset=queryset,

--- a/course_discovery/apps/course_metadata/index.py
+++ b/course_discovery/apps/course_metadata/index.py
@@ -23,11 +23,11 @@ class BaseProductIndex(AlgoliaIndex):
 
         bootcamp_contentful_data = fetch_and_transform_bootcamp_contentful_data()
         qs1 = [AlgoliaProxyProduct(course, self.language, contentful_data=bootcamp_contentful_data)
-               for course in AlgoliaProxyCourse.objects.all()]
+               for course in AlgoliaProxyCourse.prefetch_queryset()]
 
         degree_contentful_data = fetch_and_transform_degree_contentful_data()
         qs2 = [AlgoliaProxyProduct(program, self.language, contentful_data=degree_contentful_data)
-               for program in AlgoliaProxyProgram.objects.all()]
+               for program in AlgoliaProxyProgram.prefetch_queryset()]
 
         return qs1 + qs2
 

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -65,6 +65,7 @@ class CourseRunDocument(BaseCourseDocument):
     })
     status = fields.KeywordField()
     start = fields.DateField()
+    restriction_type = fields.KeywordField()
     slug = fields.TextField()
     staff_uuids = fields.KeywordField(multi=True)
     type = fields.TextField(
@@ -125,6 +126,11 @@ class CourseRunDocument(BaseCourseDocument):
     def prepare_skill_names(self, obj):
         return get_product_skill_names(obj.course.key, ProductTypes.Course)
 
+    def prepare_restriction_type(self, obj):
+        if hasattr(obj, "restricted_run"):
+            return obj.restricted_run.restriction_type
+        return None
+
     def prepare_skills(self, obj):
         return get_whitelisted_serialized_skills(obj.course.key, product_type=ProductTypes.Course)
 
@@ -137,7 +143,7 @@ class CourseRunDocument(BaseCourseDocument):
             for language in obj.transcript_languages.all()
         ]
 
-    def get_queryset(self):
+    def get_queryset(self, excluded_restriction_types=None):  # pylint: disable=unused-argument
         return filter_visible_runs(
             super().get_queryset()
                    .select_related('course')

--- a/course_discovery/apps/course_metadata/search_indexes/documents/learner_pathway.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/learner_pathway.py
@@ -50,10 +50,10 @@ class LearnerPathwayDocument(BaseDocument, OrganizationsMixin):
     def prepare_published(self, obj):
         return obj.status == PathwayStatus.Active
 
-    def get_queryset(self):
+    def get_queryset(self, excluded_restriction_types=None):  # pylint: disable=unused-argument
         return super().get_queryset().prefetch_related(
             'steps', 'steps__learnerpathwaycourse_set', 'steps__learnerpathwayprogram_set',
-            'steps__learnerpathwayblock_set'
+            'steps__learnerpathwayblock_set',
         )
 
     def prepare_skill_names(self, obj):

--- a/course_discovery/apps/course_metadata/search_indexes/documents/person.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/person.py
@@ -47,7 +47,7 @@ class PersonDocument(BaseDocument):
             return []
         return [position.title, position.organization_override]
 
-    def get_queryset(self):
+    def get_queryset(self, excluded_restriction_types=None):  # pylint: disable=unused-argument
         return super().get_queryset().select_related('bio_language')
 
     class Django:

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course.py
@@ -71,6 +71,9 @@ class CourseSearchDocumentSerializer(ModelObjectDocumentSerializerMixin, DateTim
             'estimated_hours': get_course_run_estimated_hours(course_run),
             'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price or 0.0,
             'is_enrollable': course_run.is_enrollable,
+            'restriction_type': (
+                course_run.restricted_run.restriction_type if hasattr(course_run, 'restricted_run') else None
+            ),
         }
         if detail_fields:
             course_run_detail.update(
@@ -228,7 +231,6 @@ class CourseSearchModelSerializer(DocumentDSLSerializerMixin, ContentTypeSeriali
     """
     Serializer for course model elasticsearch document.
     """
-
     class Meta(CourseWithProgramsSerializer.Meta):
         document = CourseDocument
         fields = ContentTypeSerializer.Meta.fields + CourseWithProgramsSerializer.Meta.fields

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
@@ -90,6 +90,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
             'transcript_languages',
             'type',
             'weeks_to_complete',
+            'restriction_type',
         )
 
 

--- a/course_discovery/apps/learner_pathway/api/v1/views.py
+++ b/course_discovery/apps/learner_pathway/api/v1/views.py
@@ -34,7 +34,7 @@ class LearnerPathwayViewSet(ReadOnlyModelViewSet):
     @action(detail=True)
     def snapshot(self, request, uuid):
         pathway = get_object_or_404(self.queryset, uuid=uuid, status=PathwayStatus.Active.value)
-        serializer = serializers.LearnerPathwaySerializer(pathway, many=False)
+        serializer = serializers.LearnerPathwaySerializer(pathway, many=False, context={'request': self.request})
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=False)

--- a/course_discovery/apps/learner_pathway/models.py
+++ b/course_discovery/apps/learner_pathway/models.py
@@ -299,13 +299,22 @@ class LearnerPathwayProgram(LearnerPathwayNode):
 
         return program_skills
 
-    def get_linked_courses_and_course_runs(self) -> [dict]:
+    def get_linked_courses_and_course_runs(self, excluded_restriction_types=None) -> [dict]:
         """
         Returns list of dict where each dict contains a course key linked with program and all its course runs
         """
+        if excluded_restriction_types is None:
+            excluded_restriction_types = []
+
         courses = []
         for course in self.program.courses.all():
-            course_runs = list(course.course_runs.filter(status=CourseRunStatus.Published).values('key'))
+            course_runs = list(
+                course.course_runs.filter(
+                    status=CourseRunStatus.Published
+                ).exclude(
+                    restricted_run__restriction_type__in=excluded_restriction_types
+                ).values('key')
+            )
             courses.append({"key": course.key, "course_runs": course_runs})
         return courses
 


### PR DESCRIPTION
Internal tickets: [PROD-4005](https://2u-internal.atlassian.net/browse/PROD-4005) + [PROD-4006](https://2u-internal.atlassian.net/browse/PROD-4006)

Hide restricted runs across APIs by default. Also do not include them when calculating fields like course_run_statuses. If a query-param `include_restricted=<some_value>` is present, do not hide them

# Testing
1. Create restricted runs in your system and link them with courses, programs, etc.
2. Run `update_index`
3. Verify that runs are hidden on all APIs by default and are revealed on adding the query params.

