### PR TITLE
fix: use case insensitive check in populate exec ed command

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -329,7 +329,7 @@ class Command(BaseCommand):
             'end_date': product_dict['variant']['endDate'],
             'restriction_type': (
                 CourseRunRestrictionType.CustomB2BEnterprise.value
-                if product_dict['variant'].get('websiteVisibility', None).lower() == 'private'
+                if product_dict['variant'].get('websiteVisibility', 'None').lower() == 'private'
                 else None
             ),
             'length': product_dict['durationWeeks'],

--- a/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_executive_education_data_csv.py
@@ -329,7 +329,7 @@ class Command(BaseCommand):
             'end_date': product_dict['variant']['endDate'],
             'restriction_type': (
                 CourseRunRestrictionType.CustomB2BEnterprise.value
-                if product_dict['variant'].get('websiteVisibility', None) == 'private'
+                if product_dict['variant'].get('websiteVisibility', None).lower() == 'private'
                 else None
             ),
             'length': product_dict['durationWeeks'],


### PR DESCRIPTION
### [PROD-4029](https://2u-internal.atlassian.net/browse/PROD-4029)

### Description

websiteVisibility has 'Private' in API response but the code was checking against 'private'. The change makes the API value lower to avoid case sensitivity. 