### PR TITLE
Revert "fix: search/all breakage"

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2554,6 +2554,9 @@ class CourseRunSearchDocumentSerializerTests(ElasticsearchTestMixin, TestCase):
             'first_enrollable_paid_seat_sku': course_run.first_enrollable_paid_seat_sku(),
             'first_enrollable_paid_seat_price': course_run.first_enrollable_paid_seat_price,
             'is_enrollable': course_run.is_enrollable,
+            'restriction_type': (
+                course_run.restricted_run.restriction_type if hasattr(course_run, 'restricted_run') else None
+            )
         }
 
 

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/course_run.py
@@ -90,6 +90,7 @@ class CourseRunSearchDocumentSerializer(DateTimeSerializerMixin, DocumentSeriali
             'transcript_languages',
             'type',
             'weeks_to_complete',
+            'restriction_type',
         )
 
 


### PR DESCRIPTION
[PROD-4101](https://2u-internal.atlassian.net/browse/PROD-4101)

In [4377](https://github.com/openedx/course-discovery/pull/4377) we removed restriction_type from the CourseRunSearchDocumentSerializer as it was causing issues due to `update_index` not having completed and hence the restriction_type field not being present in the index. Now that `update_index` has completed successfully, we are adding the field back to the serializer.