### PR TITLE
feat: add CRUD operations for taxi form

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2059,6 +2059,7 @@ class AdditionalMetadataSerializerTests(TestCase):
             'product_status': additional_metadata.product_status,
             'external_course_marketing_type': additional_metadata.external_course_marketing_type,
             'display_on_org_page': additional_metadata.display_on_org_page,
+            'taxi_form': TaxiFormSerializer(additional_metadata.taxi_form).data,
         }
         assert serializer.data == expected
 

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -577,6 +577,7 @@ class CertificateInfoAdmin(admin.ModelAdmin):
 class AdditionalMetadataAdmin(admin.ModelAdmin):
     list_display = (
         'id', 'external_identifier', 'external_url', 'courses', 'facts_list', 'external_course_marketing_type',
+        'taxi_form',
     )
     search_fields = ('external_identifier', 'external_url')
     list_filter = ('product_status', )

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -971,7 +971,7 @@ class AdditionalMetadata(ManageHistoryMixin, TimeStampedModel):
     def has_changed(self):
         if not self.pk:
             return False
-        external_keys = [self.product_meta,]
+        external_keys = [self.product_meta, self.taxi_form]
         return self.has_model_changed(external_keys=external_keys)
 
     def update_product_data_modified_timestamp(self, bypass_has_changed=False):


### PR DESCRIPTION
[PROD-4058](https://2u-internal.atlassian.net/browse/PROD-4058)
---------
This pull request adds the taxi form to the `additional_metadata` serializer and manages the creation and updating of the `taxi_form`. Additionally, it includes the `taxi_form` field in the `discovery` admin.


<img width="416" alt="image" src="https://github.com/openedx/course-discovery/assets/78806673/2a394ae1-f016-4e1f-94c9-d7ce4e9f8aba">
---
<img width="202" alt="image" src="https://github.com/openedx/course-discovery/assets/78806673/02384502-c1c4-4c99-9191-ee7a6857c9fa">
