### PR TITLE
chore: increase user throttle rate

### DIFF
--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -417,7 +417,7 @@ REST_FRAMEWORK = {
         'course_discovery.apps.core.throttles.OverridableUserRateThrottle',
     ),
     'DEFAULT_THROTTLE_RATES': {
-        'user': '100/hour',
+        'user': '200/hour',
     },
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }


### PR DESCRIPTION
Increasing throttle rate to avoid 429 on Enterprise.