### PR TITLE
feat: add fixed_usd_price to CourseRunSerializer and CRUD updates

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -968,10 +968,10 @@ class MinimalCourseRunSerializer(FlexFieldsSerializerMixin, TimestampModelSerial
 
     class Meta:
         model = CourseRun
-        fields = ('key', 'uuid', 'title', 'external_key', 'image', 'short_description', 'marketing_url',
-                  'seats', 'start', 'end', 'go_live_date', 'enrollment_start', 'enrollment_end', 'weeks_to_complete',
-                  'pacing_type', 'type', 'restriction_type', 'run_type', 'status', 'is_enrollable', 'is_marketable',
-                  'term', 'availability', 'variant_id')
+        fields = ('key', 'uuid', 'title', 'external_key', 'fixed_price_usd', 'image', 'short_description',
+                  'marketing_url', 'seats', 'start', 'end', 'go_live_date', 'enrollment_start', 'enrollment_end',
+                  'weeks_to_complete', 'pacing_type', 'type', 'restriction_type', 'run_type', 'status', 'is_enrollable',
+                  'is_marketable', 'term', 'availability', 'variant_id')
 
     def get_marketing_url(self, obj):
         include_archived = self.context.get('include_archived')

--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -638,6 +638,7 @@ class MinimalCourseRunBaseTestSerializer(TestCase):
             'is_marketable': course_run.is_marketable,
             'availability': course_run.availability,
             'variant_id': str(course_run.variant_id),
+            'fixed_price_usd': str(course_run.fixed_price_usd),
             'restriction_type': (
                 course_run.restricted_run.restriction_type
                 if hasattr(course_run, 'restricted_run')

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -173,6 +173,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
             'course': ['This field is required.'],
         })
         variant_id = str(uuid.uuid4())
+        fixed_price_usd = 500
         # Send minimum requested
         response = self.client.post(url, {
             'course': course.key,
@@ -180,6 +181,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
             'end': '2001-01-01T00:00:00Z',
             'run_type': str(self.course_run_type.uuid),
             'variant_id': variant_id,
+            'fixed_price_usd': fixed_price_usd,
         }, format='json')
         assert response.status_code == 201
         new_course_run = CourseRun.everything.get(key=new_key)
@@ -189,6 +191,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         # default we provide
         assert str(new_course_run.end) == '2001-01-01 00:00:00+00:00'
         assert str(new_course_run.variant_id) == variant_id
+        assert new_course_run.fixed_price_usd == round(fixed_price_usd, 2)
         # spot check that input made it
         assert new_course_run.draft
 
@@ -562,13 +565,15 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
 
         expected_min_effort = 867
         expected_max_effort = 5309
+        fixed_price_usd = 500
         prev_variant_id = self.draft_course_run.variant_id
         variant_id = str(uuid.uuid4())
         data = {
             'max_effort': expected_max_effort,
             'min_effort': expected_min_effort,
             'variant_id': variant_id,
-            'restriction_type': CourseRunRestrictionType.CustomB2BEnterprise.value
+            'restriction_type': CourseRunRestrictionType.CustomB2BEnterprise.value,
+            'fixed_price_usd': fixed_price_usd,
         }
 
         # Update this course_run with the new info
@@ -582,6 +587,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         assert self.draft_course_run.max_effort == expected_max_effort
         assert self.draft_course_run.min_effort == expected_min_effort
         assert self.draft_course_run.variant_id == prev_variant_id
+        assert self.draft_course_run.fixed_price_usd == round(fixed_price_usd, 2)
         assert self.draft_course_run.restricted_run == RestrictedCourseRun.everything.get()
 
     def test_partial_update_with_waffle_switch_variant_id_editable_enable(self):
@@ -594,11 +600,13 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
 
         expected_min_effort = 867
         expected_max_effort = 5309
+        fixed_price_usd = 500
         variant_id = str(uuid.uuid4())
         data = {
             'max_effort': expected_max_effort,
             'min_effort': expected_min_effort,
             'variant_id': variant_id,
+            'fixed_price_usd': fixed_price_usd,
         }
 
         # Update this course_run with the new info
@@ -612,6 +620,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         assert self.draft_course_run.max_effort == expected_max_effort
         assert self.draft_course_run.min_effort == expected_min_effort
         assert str(self.draft_course_run.variant_id) == variant_id
+        assert self.draft_course_run.fixed_price_usd == round(fixed_price_usd, 2)
 
     def test_partial_update_no_studio_url(self):
         """ Verify we skip pushing when no studio url is set. """

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -281,7 +281,7 @@ class CourseRunAdmin(SimpleHistoryAdmin):
     raw_id_fields = ('course', 'draft_version',)
     readonly_fields = [
         'enrollment_count', 'recent_enrollment_count', 'hidden', 'key', 'enterprise_subscription_inclusion',
-        'variant_id'
+        'variant_id', 'fixed_price_usd'
     ]
     search_fields = ('uuid', 'key', 'title_override', 'course__title', 'slug', 'external_key', 'variant_id')
     save_error = False

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -37,6 +37,7 @@ class CourseRunDocument(BaseCourseDocument):
     end = fields.DateField()
     enrollment_start = fields.DateField()
     enrollment_end = fields.DateField()
+    fixed_price_usd = fields.FloatField()
     first_enrollable_paid_seat_sku = fields.TextField()
     go_live_date = fields.DateField()
     has_enrollable_seats = fields.BooleanField()


### PR DESCRIPTION
[PROD-4126](https://2u-internal.atlassian.net/browse/PROD-4126)
--------

This PR adds `fixed_usd_price` to CourseRunSerializer and CRUD updates. Additionally, this PR adds `fixed_usd_price` in search/all endpoint utilizing `elastic-search`.

Screenshots:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/08e2a1d6-9152-4c06-9884-a1a2e153862e">

<img width="722" alt="image" src="https://github.com/user-attachments/assets/b1548047-c127-475f-907e-cf9b4ff31563">

Commands to refresh es_index:
```bash
./manage.py search_index --disable-change-limit --create
./manage.py search_index --disable-change-limit --populate
```
