### PR TITLE
fix: use correct course_key in case of a key_for_rerun in RCM

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/__init__.py
+++ b/course_discovery/apps/course_metadata/data_loaders/__init__.py
@@ -3,7 +3,7 @@ import abc
 from dateutil.parser import parse
 from edx_rest_framework_extensions.auth.jwt.decoder import configured_jwt_decode_handler
 
-from course_discovery.apps.course_metadata.models import Image, Video
+from course_discovery.apps.course_metadata.models import Course, Image, Video
 
 
 class AbstractDataLoader(metaclass=abc.ABCMeta):
@@ -80,16 +80,18 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
     @classmethod
     def get_course_key_from_course_run_key(cls, course_run_key):
         """
-        Given a serialized course run key, return the corresponding
-        serialized course key.
+        Given a serialized course run key, return the corresponding serialized course key.
+        If the course key is a 'key_for_rerun', return the original course's key.
 
         Args:
             course_run_key (CourseKey): Course run key.
 
         Returns:
-            str
+            str: The corresponding course key.
         """
-        return f'{course_run_key.org}+{course_run_key.course}'
+        course_key = f'{course_run_key.org}+{course_run_key.course}'
+        # Check if this course key is a rerun and return the original course key if it is
+        return Course.objects.filter(key_for_reruns=course_key).values_list('key', flat=True).first() or course_key
 
     @classmethod
     def _get_or_create_media(cls, media_type, url):

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -202,6 +202,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
     def get_or_create_course(self, body):
         course_run_key = CourseKey.from_string(body['id'])
         course_key = self.get_course_key_from_course_run_key(course_run_key)
+
         defaults = self.format_course_data(body)
         # We need to add the key to the defaults because django ignores kwargs with __
         # separators when constructing the create request


### PR DESCRIPTION
[PROD-4133](https://2u-internal.atlassian.net/browse/PROD-4133)

Updates the logic behind bringing the courses from studio in case a course is created in Studio and not in Discovery. Previous logic used to create a course_run from Studio into Discovery with whatever was present in the key. In case a course has a value in `key_for_reruns`, it used to assign those course_runs to the key equal to `key_for_reruns`.

Now, it finds if a course has a `key_for_reruns`, it will assign this course_run to the correct course that has the custom `key_for_reruns` value. 