### PR TITLE
chore: configure Renovate to tag team on PR creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,9 @@
   "schedule": [
     "every weekday"
   ],
+  "reviewers": [
+    "team:2u-phoenix"
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["node", "npm"],


### PR DESCRIPTION
Configure Renovate to tag team on PR creation