### PR TITLE
feat: Add improvements to populate_product_catalog_command

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1709,14 +1709,28 @@ class Course(ManageHistoryMixin, DraftModelMixin, PkSearchableMixin, CachedMixin
             if course_run.language is not None
         })
 
-    @property
-    def languages_codes(self):
+    def languages_codes(self, exclude_inactive_runs=False):
         """
         Returns a string of languages codes used in this course. The languages codes are separated by comma.
         This property will ignore restricted runs and course runs with no language set.
+
+        Arguments:
+            exclude_inactive_runs (bool): whether to exclude inactive runs
         """
-        filtered_course_runs = self.active_course_runs.filter(language__isnull=False, restricted_run__isnull=True)
-        return ','.join(course_run.language.code for course_run in filtered_course_runs)
+        if exclude_inactive_runs:
+            language_codes = set(
+                course_run.language.code for course_run in self.active_course_runs.filter(
+                    language__isnull=False, restricted_run__isnull=True
+                )
+            )
+        else:
+            language_codes = set(
+                course_run.language.code for course_run in self.course_runs.filter(
+                    language__isnull=False, restricted_run__isnull=True
+                )
+            )
+
+        return ", ".join(sorted(language_codes))
 
     @property
     def first_enrollable_paid_seat_price(self):


### PR DESCRIPTION
[PROD-4167](https://2u-internal.atlassian.net/browse/PROD-4167)
------


This PR adds following improvements to management command
- Skip record if required detail is empty.
- Remove duplicates from language_code method.
- Add flag to include inactive runs' language codes in the method.
- Fix N+1 query issue.
- Remove dashes from uuid.