### PR TITLE
Fix: renovate bot auto merging PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "extends": [
     "config:base",
-    ":automergeLinters",
-    ":automergeTesters",
-    ":automergeMinor",
     ":noUnscheduledUpdates",
     ":semanticCommits"
   ],


### PR DESCRIPTION
This PR disables the automerge feature in Renovate Bot configuration. By doing so, Renovate will now assign reviewers and assignees when opening PRs, ensuring proper visibility and involvement in the review process.

When auto merge is **enabled**, Renovate skips adding **reviewers** and **assignees** at PR creation, which can reduce notification noise but may lead to less awareness for important changes.

For reference: [Renovate Bot Auto Merge - Assignees and Reviewers](https://docs.renovatebot.com/key-concepts/automerge/#assignees-and-reviewers)