### PR TITLE
fix: add setting variable to determine request scheme

### DIFF
--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -94,3 +94,10 @@ GOOGLE_SERVICE_ACCOUNT_CREDENTIALS = {
     k.lower(): (v.replace("\\n", "\n") if k.lower() == "private_key" else v)
     for (k, v) in GOOGLE_SERVICE_ACCOUNT_CREDENTIALS.items()
 }
+
+# IMPORTANT: With this enabled, the server must always be behind a proxy that
+# strips the header X_FORWARDED_PROTO from client requests. Otherwise,
+# a user can fool our server into thinking it was an https connection.
+# See https://docs.djangoproject.com/en/5.1/ref/settings/#secure-proxy-ssl-header
+# for other warnings.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
[PROD 4118 ](https://2u-internal.atlassian.net/browse/PROD-4118)

When we have paginated list endpoints, the "next" page URL is mistakenly HTTP. We suspect this is because the URL is constructed based on the current request scheme.  edx-platform seems to workaround this issue by setting [SECURE_PROXY_SSL_HEADER](https://github.com/openedx/edx-platform/blob/c27d55a25383c08363671c2a847442b7a816b54c/lms/envs/production.py#L60) which overrides the current request scheme when DRF tries to fetch it to construct a next URL, so this PR is mimicking that behavior.

Enterprise also does the [same](https://github.com/openedx/enterprise-catalog/pull/896), and that is where we mostly copy-pasted this PR from.

## Internal Slack discussions for more context

https://twou.slack.com/archives/C04ACDVM6A1/p1720630664588599

https://twou.slack.com/archives/C049BVC75J7/p1720627508164049
