### PR TITLE
fix: allow both active and marketable runs in update_course_ai_translations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: ${{ matrix.status == 'ignored' }}
       - name: Upload coverage
         if: matrix.db-version == 'mysql80'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage${{ matrix.pytest-split-group }}
           path: .coverage
@@ -60,7 +60,7 @@ jobs:
           PYTHON_VERSION: 3.12
       - name: Download all artifacts
         # Downloads coverage1, coverage2, etc.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
       - name: Run coverage
         run: make ci_coverage
       - uses: codecov/codecov-action@v1

--- a/course_discovery/apps/course_metadata/management/commands/update_course_ai_translations.py
+++ b/course_discovery/apps/course_metadata/management/commands/update_course_ai_translations.py
@@ -51,10 +51,11 @@ class Command(BaseCommand):
 
         course_runs = CourseRun.objects.all()
 
-        if options['active']:
+        if options['active'] and options['marketable']:
+            course_runs = course_runs.marketable().union(course_runs.active())
+        elif options['active']:
             course_runs = course_runs.active()
-
-        if options['marketable']:
+        elif options['marketable']:
             course_runs = course_runs.marketable()
 
         for course_run in course_runs:


### PR DESCRIPTION
[PROD-4175](https://2u-internal.atlassian.net/browse/PROD-4175)
Adding an improvement to allow filtering both active and marketable runs. 