### PR TITLE
feat: add capabilty in queryset method to exclude hidden runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,10 @@ jobs:
         uses: actions/download-artifact@v4
       - name: Run coverage
         run: make ci_coverage
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   quality:
     runs-on: ubuntu-latest

--- a/course_discovery/apps/course_metadata/management/commands/populate_product_catalog.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_product_catalog.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
         ]
 
         if product_type in ['executive_education', 'bootcamp', 'ocm_course']:
-            queryset = Course.objects.available().select_related('partner', 'type')
+            queryset = Course.objects.available(exclude_hidden_runs=True).select_related('partner', 'type')
 
             if product_type == 'ocm_course':
                 queryset = queryset.filter(type__slug__in=ocm_course_catalog_types)


### PR DESCRIPTION
[PROD-4177](https://2u-internal.atlassian.net/browse/PROD-4177)
--------
This PR adds the capability in `populate_product_catalog` command to exclude hidden available runs from the queryset.

Testing:
- Create a run from publisher and publish it. Make it hidden from django admin (both darft and non-draft)
- Run the following command from discovery shell.  
```bash
python manage.py populate_product_catalog --product_type={product_type} --output_csv=/path/to/output.csv --product_source={product_source}
```
- Verify Course having only hidden published runs are excluded from the catalog