### PR TITLE
fix: use "price" in ecommerce data loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: ${{ matrix.status == 'ignored' }}
       - name: Upload coverage
         if: matrix.db-version == 'mysql80'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage${{ matrix.pytest-split-group }}
           path: .coverage

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -572,7 +572,10 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     def update_seat(self, course_run, product_body):
         stock_record = product_body['stockrecords'][0]
         currency_code = stock_record['price_currency']
-        price = Decimal(stock_record['price_excl_tax'])
+        if 'price_excl_tax' in stock_record:
+            price = Decimal(stock_record['price_excl_tax'])
+        else:
+            price = Decimal(stock_record['price'])
         sku = stock_record['partner_sku']
 
         # For more context see ADR docs/decisions/0025-dont-sync-mobile-skus-on-discovery.rst

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -643,9 +643,11 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     def validate_stockrecord(self, stockrecords, title, product_class):
         """
         Argument:
-            body (dict): product data from ecommerce, either entitlement or enrollment code
+            sockrecords (list): a list of stock records to validate from ecommerce
+            title (str): product title
+            product_class (str): either entitlement or enrollment code
         Returns:
-            product sku if no exceptions, else None
+            True when all validation checks pass, else None
         """
         # Map product_class keys with how they should be displayed in the exception messages.
         product_classes = {
@@ -680,7 +682,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
 
         try:
             currency_code = stock_record['price_currency']
-            Decimal(stock_record['price_excl_tax'])
+            Decimal(stock_record.get('price_excl_tax', stock_record['price']))
             sku = stock_record['partner_sku']
         except (KeyError, ValueError):
             msg = 'A necessary stockrecord field is missing or incorrectly set for {product} {title}'.format(
@@ -719,7 +721,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
 
         stock_record = stockrecords[0]
         currency_code = stock_record['price_currency']
-        price = Decimal(stock_record['price_excl_tax'])
+        price = Decimal(stock_record.get('price_excl_tax', stock_record['price']))
         sku = stock_record['partner_sku']
 
         try:

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -572,10 +572,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     def update_seat(self, course_run, product_body):
         stock_record = product_body['stockrecords'][0]
         currency_code = stock_record['price_currency']
-        if 'price_excl_tax' in stock_record:
-            price = Decimal(stock_record['price_excl_tax'])
-        else:
-            price = Decimal(stock_record['price'])
+        price = Decimal(stock_record.get('price_excl_tax', stock_record['price']))
         sku = stock_record['partner_sku']
 
         # For more context see ADR docs/decisions/0025-dont-sync-mobile-skus-on-discovery.rst

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -247,23 +247,6 @@ ECOMMERCE_API_BODIES = [
                     }
                 ]
             },
-            {
-                "structure": "child",
-                "expires": "2017-01-01T12:00:00Z",
-                "attribute_values": [
-                    {
-                        "name": "certificate_type",
-                        "value": "verified"
-                    }
-                ],
-                "stockrecords": [
-                    {
-                        "price_currency": "EUR",
-                        "price": "25.00",
-                        "partner_sku": "sku003",
-                    }
-                ]
-            },
             # Mobile seat which we will discarded since we arn't syncing mobile skus see decicion 0025
             {
                 "structure": "child",

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -195,7 +195,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku001",
                     }
                 ]
@@ -225,7 +225,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku002",
                     }
                 ]
@@ -242,7 +242,24 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price_excl_tax": "25.00",
+                        "price": "25.00",
+                        "partner_sku": "sku003",
+                    }
+                ]
+            },
+            {
+                "structure": "child",
+                "expires": "2017-01-01T12:00:00Z",
+                "attribute_values": [
+                    {
+                        "name": "certificate_type",
+                        "value": "verified"
+                    }
+                ],
+                "stockrecords": [
+                    {
+                        "price_currency": "EUR",
+                        "price": "25.00",
                         "partner_sku": "sku003",
                     }
                 ]
@@ -260,7 +277,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price_excl_tax": "250.00",
+                        "price": "250.00",
                         "partner_sku": "mobile.android.sku003",
                     }
                 ]
@@ -277,7 +294,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price_excl_tax": "25.00",
+                        "price": "25.00",
                         "partner_sku": "sku004"
                     }
                 ]
@@ -304,7 +321,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku005",
                     }
                 ]
@@ -321,7 +338,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "25.00",
+                        "price": "25.00",
                         "partner_sku": "sku006",
                     }
                 ]
@@ -350,7 +367,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "250.00",
+                        "price": "250.00",
                         "partner_sku": "sku007",
                     }
                 ]
@@ -379,7 +396,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "250.00",
+                        "price": "250.00",
                         "partner_sku": "sku008",
                     }
                 ]
@@ -404,7 +421,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "123",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku009",
                     }
                 ]
@@ -429,7 +446,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price_excl_tax": "0.00",
+                        "price": "0.00",
                         "partner_sku": "sku010",
                     }
                 ]

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -712,7 +712,7 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
 
         stockrecord = {
             "price_currency": alt_currency if alt_currency else "USD",
-            "price_excl_tax": "10.00",
+            "price": "10.00",
         }
         if valid_stockrecord:
             stockrecord.update({"partner_sku": "sku132"})
@@ -799,7 +799,7 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         for product in products:
             stock_record = product['stockrecords'][0]
             price_currency = stock_record['price_currency']
-            price = Decimal(stock_record['price_excl_tax'])
+            price = Decimal(stock_record['price'])
             sku = stock_record['partner_sku']
             certificate_type = Seat.AUDIT
             credit_provider = None
@@ -851,7 +851,7 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
             course = Course.objects.get(uuid=attributes['UUID'])
             stock_record = datum['stockrecords'][0]
             price_currency = stock_record['price_currency']
-            price = Decimal(stock_record['price_excl_tax'])
+            price = Decimal(stock_record['price'])
             sku = stock_record['partner_sku']
 
             mode_name = attributes['certificate_type']


### PR DESCRIPTION
## Description

The Django Oscar upgrade of ecommerce changed the
item's price field from `price_excl_tax` to just `price`
causing the EcommerceApi data loader to fail.

This commit handled the exception and falls back to
the 'price' value.

Ref: https://github.com/openedx/ecommerce/pull/4050

## Additional information

The same as #4291.

## Testing instructions

### Reproduce Issue

1. Setup Tutor 18 (Redwood) dev env with the plugins `ecommerce` and `discovery` enabled
2. Clone course-discovery.
3. Add a tutor mount for the course-discovery.
4. Create a course or import the demo course.
5. Setup admin user for ecommerce and discovery
6. Add a course seat in http://ecommerce.local.edly.io:8130/courses/ for the test course
7. Run the following from Discovery Shell to set the ecommerce API url. NOTE: trying the same in Discovery admin fails due to URL validation.
    ```
    from course_discovery.apps.core.models import Partner
    p = Partner.objects.get(short_code="dev")
    p.ecommerce_api_url = "http://ecommerce:8130/api/v2/"
    p.save()
    ```
8. Run `./manage.py refresh_course_metadata --partner dev`. It should fail with the KeyError `price_excl_tax`.

### Testing the fix from PR

1. Checkout the PR branch
2. Run `./manage.py refresh_course_metadata --partner dev` again. This time, it should run successfully.