### PR TITLE
build: pin workflows to use ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
   # Combine and upload coverage reports.
   coverage:
     needs: pytest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - run: make ci_up
@@ -70,7 +70,7 @@ jobs:
           fail_ci_if_error: true
 
   quality:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - run: make ci_up
@@ -79,7 +79,7 @@ jobs:
       - run: make ci_quality
 
   semgrep:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.12']

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
       - open-release/**
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/migrations-check-mysql8.yml
+++ b/.github/workflows/migrations-check-mysql8.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         python-version: [ 3.12 ]
 
     steps:

--- a/.github/workflows/requirements-upgrade.yml
+++ b/.github/workflows/requirements-upgrade.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   upgrade_requirements:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
## Description
- `ubuntu-latest` is causing issues in workflows due to updated `binaries` and `dependencies`.
- Pinned all workflows to use `ubuntu-22.04` by default just like we did recently in `edx-platform`.
- Example PR in edx-platform: https://github.com/openedx/edx-platform/pull/35635.