### PR TITLE
Migrate renovate bot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,10 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     ":noUnscheduledUpdates",
     ":semanticCommits"
   ],
-  "rebaseStalePrs": true,
+  "rebaseWhen": "behind-base-branch",
   "schedule": [
     "every weekday"
   ],


### PR DESCRIPTION
This PR addresses the warnings issued by the Renovate Bot configuration validator.

Renovate Bot has updated its default configuration preset from `config:base` to `config:recommended` starting from version 36.0.0 (released on August 23, 2023). 
**Reference:** https://github.com/renovatebot/renovate/pull/21136

<img width="1100" alt="Screenshot 2024-10-14 at 5 59 32 PM" src="https://github.com/user-attachments/assets/44bc13fb-5937-445f-9f93-5bc0805b81f1">
