### PR TITLE
Add description fields in oc and degree exports

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/populate_product_catalog.py
+++ b/course_discovery/apps/course_metadata/management/commands/populate_product_catalog.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
 
     CATALOG_CSV_HEADERS = [
         'UUID', 'Title', 'Organizations Name', 'Organizations Logo', 'Organizations Abbr', 'Languages',
-        'Subjects', 'Subjects Spanish', 'Marketing URL', 'Marketing Image'
+        'Subjects', 'Subjects Spanish', 'Marketing URL', 'Marketing Image', 'Short Description', 'Full Description'
     ]
 
     def add_arguments(self, parser):
@@ -162,6 +162,8 @@ class Command(BaseCommand):
                 ),
                 "Languages": product.languages_codes(),
                 "Marketing Image": product.image.url if product.image else "",
+                "Short Description": product.short_description,
+                "Full Description": product.full_description,
             })
         elif product_type == 'degree':
             data.update({
@@ -172,6 +174,8 @@ class Command(BaseCommand):
                 ),
                 "Languages": ", ".join(language.code for language in product.active_languages) or 'en-us',
                 "Marketing Image": product.card_image.url if product.card_image else "",
+                "Short Description": product.subtitle,
+                "Full Description": product.overview,
             })
 
         return data

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_populate_product_catalog.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_populate_product_catalog.py
@@ -505,6 +505,8 @@ class PopulateProductCatalogCommandTests(TestCase):
             ),
             "Marketing URL": product.marketing_url,
             "Marketing Image": (product.image.url if product.image else ""),
+            "Short Description": product.short_description,
+            "Full Description": product.full_description,
         }
 
     def test_get_transformed_data_for_degree(self):
@@ -538,6 +540,8 @@ class PopulateProductCatalogCommandTests(TestCase):
             ),
             "Marketing URL": product.marketing_url,
             "Marketing Image": product.card_image.url if product.card_image else "",
+            "Short Description": product.subtitle,
+            "Full Description": product.overview,
         }
 
     @mock.patch('course_discovery.apps.course_metadata.management.commands.populate_product_catalog.GspreadClient')


### PR DESCRIPTION
### [PROD-4202](https://2u-internal.atlassian.net/browse/PROD-4202)

This update adds a description field to the OC and Degree export for the SFMC catalog.

- For OC, both the short description and full description fields are included.
- For Degrees, the subtitle has been used for the short description, and the overview field has been used for the full description.

These changes ensure that the appropriate descriptions are provided in the catalog exports.