### PR TITLE
Add taxiform updates to trigger course data_modified_timestamp changes

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -882,6 +882,17 @@ class TaxiForm(ManageHistoryMixin, TimeStampedModel):
             return False
         return self.has_model_changed()
 
+    def update_product_data_modified_timestamp(self, bypass_has_changed=False):
+        if self.has_changed or bypass_has_changed:
+            logger.info(
+                f"TaxiForm update_product_data_modified_timestamp triggered for {self.form_id}."
+                f"Updating data modified timestamp for related courses."
+            )
+            if self.additional_metadata:
+                self.additional_metadata.related_courses.all().update(
+                    data_modified_timestamp=datetime.datetime.now(pytz.UTC)
+                )
+
     def __str__(self):
         return f"{self.title}({self.form_id})"
 

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -21,7 +21,7 @@ from course_discovery.apps.course_metadata.data_loaders.api import CoursesApiDat
 from course_discovery.apps.course_metadata.models import (
     AdditionalMetadata, CertificateInfo, Course, CourseEditor, CourseEntitlement, CourseLocationRestriction, CourseRun,
     Curriculum, CurriculumCourseMembership, CurriculumProgramMembership, Fact, GeoLocation, Organization, ProductMeta,
-    ProductValue, Program, Seat
+    ProductValue, Program, Seat, TaxiForm
 )
 from course_discovery.apps.course_metadata.publishers import ProgramMarketingSitePublisher
 from course_discovery.apps.course_metadata.salesforce import (
@@ -508,6 +508,7 @@ def connect_course_data_modified_timestamp_related_models():
         ProductValue,
         Seat,
         Fact,
+        TaxiForm,
     ]:
         pre_save.connect(data_modified_timestamp_update, sender=model)
 
@@ -528,7 +529,8 @@ def disconnect_course_data_modified_timestamp_related_models():
         ProductMeta,
         ProductValue,
         Seat,
-        Fact
+        Fact,
+        TaxiForm
     ]:
         pre_save.disconnect(data_modified_timestamp_update, sender=model)
 


### PR DESCRIPTION
### [PROD-4061](https://2u-internal.atlassian.net/browse/PROD-4061)

This update ensures that the `data_modified` timestamp for a course is updated when changes are made to the taxiform.

- The `data_modified` timestamp is now updated whenever the taxiform is updated via the admin interface.
- Additionally, changing any fields on the taxiform object also triggers an update to the `data_modified` timestamp for the associated course.

These changes ensure that the course's modified timestamp reflects updates to the taxiform.