### PR TITLE
fix: do not push runs without seats to ecommerce in data loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -174,7 +174,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
             self._update_verified_deadline_for_course_run(official_run)
             self._update_verified_deadline_for_course_run(draft_run)
             has_upgrade_deadline_override = run.seats.filter(upgrade_deadline_override__isnull=False)
-            if not has_upgrade_deadline_override and official_run:
+            if not has_upgrade_deadline_override and official_run and official_run.seats.count():
                 push_to_ecommerce_for_course_run(official_run)
 
         logger.info(f'Processed course run with UUID [{run.uuid}] and key [{run.key}].')

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -379,12 +379,14 @@ class CoursesApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         self.assert_api_called(4)
         runs = CourseRun.objects.all()
 
+        # Change a run's end date to make it different from the one in studio. This
+        # is needed to trigger the push_to_ecommerce flow in the the loader, which is only
+        # done in case the end dates differ or a certain waffle flag is set.
         run = runs[0]
         run.end = datetime.datetime.now(pytz.UTC)
         run.save()
         assert run.seats.count() == 0
 
-        # Verify the CourseRuns were created correctly
         expected_num_course_runs = len(api_data)
         assert CourseRun.objects.count() == expected_num_course_runs
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -382,6 +382,7 @@ class CoursesApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         run = runs[0]
         run.end = datetime.datetime.now(pytz.UTC)
         run.save()
+        assert run.seats.count() == 0
 
         # Verify the CourseRuns were created correctly
         expected_num_course_runs = len(api_data)


### PR DESCRIPTION
[PROD-4171](https://2u-internal.atlassian.net/browse/PROD-4171)
--------

In the courses data loader, we push to ecommerce if the run has an updated end date. This is primarily to push seat upgrade deadline changes (which depend on run end date) to ecommerce. However, in case a run is newly created and has no seats so far, a push to ecommerce will convince ecommerce that the run does not have any seats. Hence, even if we add seats to the draft version of the run, the Ecommerce Data loader might [delete](https://github.com/openedx/course-discovery/blob/dba582d05b72afe3f9ca408626e0dfddf55e16d1/course_discovery/apps/course_metadata/data_loaders/api.py#L569-L571) the seats from discovery if the seats have not been pushed to the non-draft version and ecommerce before the time that the ecomm loader runs.

This PR attempts to circumvent the above issue by only pushing a run to ecommerce in the courses data loader if it has a non-zero number of associated seats.