### PR TITLE
identify and prefetch N+1 queries in search/all for learner pathways

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -763,30 +763,20 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         )
         assert expected == actual
 
-    @ddt.data(True, False)
-    def test_learner_pathway_feature_flag(self, include_learner_pathways):
+    @ddt.data((True, 10, 8), (False, 0, 4))
+    @ddt.unpack
+    def test_learner_pathway_feature_flag(self, include_learner_pathways, expected_result_count, expected_query_count):
         """ Verify the include_learner_pathways feature flag works as expected."""
-        LearnerPathwayStepFactory.create_batch(5, pathway__partner=self.partner)
+        LearnerPathwayStepFactory.create_batch(10, pathway__partner=self.partner)
         pathways = LearnerPathway.objects.all()
-        assert pathways.count() == 5
+        assert pathways.count() == 10
         query = {
             'include_learner_pathways': include_learner_pathways,
         }
 
-        if include_learner_pathways:
-            expected_result_count = pathways.count()
-            expected_query_count = 8
-        else:
-            expected_result_count = 0
-            expected_query_count = 4
-
         with self.assertNumQueries(expected_query_count):
             response = self.get_response(query, self.list_path)
 
-        response = self.get_response(
-            query,
-            self.list_path
-        )
         assert response.status_code == 200
         response_data = response.json()
 

--- a/course_discovery/apps/learner_pathway/api/serializers.py
+++ b/course_discovery/apps/learner_pathway/api/serializers.py
@@ -3,8 +3,6 @@ Serializers for learner_pathway app.
 """
 from rest_framework import serializers
 
-from course_discovery.apps.api.utils import get_excluded_restriction_types
-from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.learner_pathway import models
 
 
@@ -20,12 +18,7 @@ class LearnerPathwayCourseMinimalSerializer(serializers.ModelSerializer):
         fields = ('key', 'course_runs')
 
     def get_course_runs(self, obj):
-        excluded_restriction_types = get_excluded_restriction_types(self.context['request'])
-        return list(obj.course.course_runs.filter(
-            status=CourseRunStatus.Published
-        ).exclude(
-            restricted_run__restriction_type__in=excluded_restriction_types
-        ).values('key'))
+        return [{'key': course_run.key} for course_run in obj.course.course_runs.all()]
 
 
 class LearnerPathwayCourseSerializer(LearnerPathwayCourseMinimalSerializer):
@@ -87,8 +80,7 @@ class LearnerPathwayProgramSerializer(LearnerPathwayProgramMinimalSerializer):
         return program.card_image_url
 
     def get_courses(self, obj):
-        excluded_restriction_types = get_excluded_restriction_types(self.context['request'])
-        return obj.get_linked_courses_and_course_runs(excluded_restriction_types=excluded_restriction_types)
+        return obj.get_linked_courses_and_course_runs()
 
 
 class LearnerPathwayBlockSerializer(serializers.ModelSerializer):

--- a/course_discovery/apps/learner_pathway/api/v1/urls.py
+++ b/course_discovery/apps/learner_pathway/api/v1/urls.py
@@ -4,7 +4,7 @@ from rest_framework import routers
 from course_discovery.apps.learner_pathway.api.v1 import views
 
 router = routers.SimpleRouter()
-router.register(r'learner-pathway', views.LearnerPathwayViewSet)
+router.register(r'learner-pathway', views.LearnerPathwayViewSet, basename='learner-pathway')
 router.register(r'learner-pathway-step', views.LearnerPathwayStepViewSet)
 router.register(r'learner-pathway-course', views.LearnerPathwayCourseViewSet, basename='learner-pathway-course')
 router.register(r'learner-pathway-program', views.LearnerPathwayProgramViewSet, basename='learner-pathway-program')

--- a/course_discovery/apps/learner_pathway/api/v1/urls.py
+++ b/course_discovery/apps/learner_pathway/api/v1/urls.py
@@ -6,8 +6,8 @@ from course_discovery.apps.learner_pathway.api.v1 import views
 router = routers.SimpleRouter()
 router.register(r'learner-pathway', views.LearnerPathwayViewSet)
 router.register(r'learner-pathway-step', views.LearnerPathwayStepViewSet)
-router.register(r'learner-pathway-course', views.LearnerPathwayCourseViewSet)
-router.register(r'learner-pathway-program', views.LearnerPathwayProgramViewSet)
+router.register(r'learner-pathway-course', views.LearnerPathwayCourseViewSet, basename='learner-pathway-course')
+router.register(r'learner-pathway-program', views.LearnerPathwayProgramViewSet, basename='learner-pathway-program')
 router.register(r'learner-pathway-block', views.LearnerPathwayBlocViewSet)
 
 urlpatterns = router.urls

--- a/course_discovery/apps/learner_pathway/api/v1/urls.py
+++ b/course_discovery/apps/learner_pathway/api/v1/urls.py
@@ -5,7 +5,7 @@ from course_discovery.apps.learner_pathway.api.v1 import views
 
 router = routers.SimpleRouter()
 router.register(r'learner-pathway', views.LearnerPathwayViewSet, basename='learner-pathway')
-router.register(r'learner-pathway-step', views.LearnerPathwayStepViewSet)
+router.register(r'learner-pathway-step', views.LearnerPathwayStepViewSet, basename='learner-pathway-step')
 router.register(r'learner-pathway-course', views.LearnerPathwayCourseViewSet, basename='learner-pathway-course')
 router.register(r'learner-pathway-program', views.LearnerPathwayProgramViewSet, basename='learner-pathway-program')
 router.register(r'learner-pathway-block', views.LearnerPathwayBlocViewSet)

--- a/course_discovery/apps/learner_pathway/models.py
+++ b/course_discovery/apps/learner_pathway/models.py
@@ -15,7 +15,6 @@ from taxonomy.choices import ProductTypes
 from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.core.models import Partner
-from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.models import Course, Program
 from course_discovery.apps.course_metadata.utils import UploadToFieldNamePath
 from course_discovery.apps.learner_pathway import constants
@@ -299,23 +298,15 @@ class LearnerPathwayProgram(LearnerPathwayNode):
 
         return program_skills
 
-    def get_linked_courses_and_course_runs(self, excluded_restriction_types=None) -> [dict]:
+    def get_linked_courses_and_course_runs(self):
         """
         Returns list of dict where each dict contains a course key linked with program and all its course runs
         """
-        if excluded_restriction_types is None:
-            excluded_restriction_types = []
 
         courses = []
         for course in self.program.courses.all():
-            course_runs = list(
-                course.course_runs.filter(
-                    status=CourseRunStatus.Published
-                ).exclude(
-                    restricted_run__restriction_type__in=excluded_restriction_types
-                ).values('key')
-            )
-            courses.append({"key": course.key, "course_runs": course_runs})
+            course_runs = [{'key': course_run.key} for course_run in course.course_runs.all()]
+            courses.append({'key': course.key, 'course_runs': course_runs})
         return courses
 
     def __str__(self):


### PR DESCRIPTION
### [PROD-3888](https://2u-internal.atlassian.net/browse/PROD-3888)

### TL;DR
This PR addresses the need for optimized query fetching in the `/api/v1/search/all/?include_learner_pathways=true` endpoint by implementing `prefetch_related` for `LearnerPathway` data.

1. Fixes N+1 issues in `LearnerPathwayViewSet`
2. Fixes N+1 issues in `LearnerPathwayStepViewSet`
3. Fixes N+1 issues in `LearnerPathwayCourseViewSet`
4. Fixed N+1 issues in `LearnerPathwayProgramViewSet`
5. Removes unnecessary eager loading of `learnerpathwayblock_set` 

### Details
The `get_linked_courses_and_course_runs` model method is only used in `LearnerPathwayProgramSerializer`.
The `LearnerPathwayProgramSerializer` is used by the `LearnerPathwayProgramViewSet` and the `LearnerPathwayStepSerializer`, which is then used in the `LearnerPathwaySearchDocumentSerializer`.
Even if we apply `prefetch_related` in the `LearnerPathwayDocument's` `get_queryset`, the filtering in `get_linked_courses_and_course_runs` bypasses the prefetched results and runs additional queries.

To solve this issue: I have moved the filtering logic to `LearnerPathwayProgramViewSet's` `get_queryset` and `LearnerPathwayDocument's``get_queryset` method

Since we are already overriding the `LearnerPathwayProgramViewSet's` `get_queryset`, I have also fixed the existing N+1 issue in the viewset.

Similarly for courses, `LearnerPathwayCourseMinimalSerializer's` `get_course_runs` method was causing additional queries because of filters.
`LearnerPathwayCourseMinimalSerializer` is used by `LearnerPathwayCourseSerializer`
which is used by `LearnerPathwayCourseViewSet` and `LearnerPathwayStepSerializer` (used in the `LearnerPathwaySearchDocumentSerializer`)
To solve this issue: I have moved the filtering logic to `LearnerPathwayCourseViewSet's` `get_queryset` and LearnerPathwayDocument's `get_queryset` method
Since we are already overriding the `LearnerPathwayCourseViewSet's` `get_queryset`, I have also fixed the existing N+1 issue in the viewset.

