### PR TITLE
perf: add CompressedCacheResponseMixin to CourseRecommendations ViewSet

### DIFF
--- a/course_discovery/apps/api/cache.py
+++ b/course_discovery/apps/api/cache.py
@@ -154,14 +154,14 @@ class CompressedCacheResponseMixin():
     list_cache_timeout = settings.REST_FRAMEWORK_EXTENSIONS['DEFAULT_CACHE_RESPONSE_TIMEOUT']
 
     @conditional_decorator(
-        settings.USE_API_CACHING,
+        lambda: settings.USE_API_CACHING,
         compressed_cache_response(key_func=list_cache_key_func, timeout=list_cache_timeout),
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
     @conditional_decorator(
-        settings.USE_API_CACHING,
+        lambda: settings.USE_API_CACHING,
         compressed_cache_response(key_func=object_cache_key_func, timeout=object_cache_timeout),
     )
     def retrieve(self, request, *args, **kwargs):

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -129,11 +129,19 @@ def reviewable_data_has_changed(obj, new_key_vals, exempt_fields=None):
     return changed_fields
 
 
-def conditional_decorator(condition, decorator):
+def conditional_decorator(condition_getter, decorator):
     """
-    Util decorator that allows for only using the given decorator arg if the condition passes
+    Util decorator that applies the given decorator only if the condition passes.
+    The condition is evaluated at runtime via the `condition_getter` callable, allowing dynamic condition checking.
+    If callable evaluates to `True`, the provided decorator is applied, otherwise, the function remains unmodified.
     """
-    return decorator if condition else lambda x: x
+    def wrapper(func):
+        def wrapped(*args, **kwargs):
+            if condition_getter():
+                return decorator(func)(*args, **kwargs)
+            return func(*args, **kwargs)
+        return wrapped
+    return wrapper
 
 
 def decode_image_data(image_data):

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -530,7 +530,7 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class CourseRecommendationViewSet(RetrieveModelMixin, viewsets.GenericViewSet):
+class CourseRecommendationViewSet(CompressedCacheResponseMixin, RetrieveModelMixin, viewsets.GenericViewSet):
     filter_backends = (DjangoFilterBackend, )
     lookup_field = 'key'
     lookup_value_regex = COURSE_ID_REGEX


### PR DESCRIPTION
[PROD-3562](https://2u-internal.atlassian.net/browse/PROD-3562)
-------

This PR adds `CompressedCacheResponseMixin` to `CourseRecommendationsViewSet`. `CompressedCacheResponseMixin` adds the functionality of key-value based caching.

Testing:
- On master branch, hit `course-recommendations` endpoint after commenting the following line
https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/api/cache.py#L101 
- Look into query count from django toolbar. Hit course_run endpoint again. Query count will not decrease.
- Checkout to `afaq/prod-3562` and hit `course-recommendations` endpoint. You will notice Query count decreases.

`http://localhost:18381/api/v1/course_recommendations/{course-key}`


1st Call:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/150e3e4b-e2f8-408c-abeb-c9fa93b3261e">


2nd Call:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/35308665-6e1b-4b49-a421-3e45ad4021e9">

