### PR TITLE
fix: update only relevant fields in analytics loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/analytics_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/analytics_api.py
@@ -58,7 +58,7 @@ class AnalyticsAPIDataLoader(AbstractDataLoader):
             program = program_dict['program']
             program.enrollment_count = program_dict['count']
             program.recent_enrollment_count = program_dict['recent_count']
-            program.save(suppress_publication=True)
+            program.save(update_fields=['enrollment_count', 'recent_enrollment_count'], suppress_publication=True)
             logger.info('Updating program: %s', program.uuid)
 
     def _process_course_run_summary(self, course_run_summary):
@@ -76,7 +76,7 @@ class AnalyticsAPIDataLoader(AbstractDataLoader):
         # Update course run counts
         course_run.enrollment_count = course_run_count
         course_run.recent_enrollment_count = course_run_recent_count
-        course_run.save(suppress_publication=True)
+        course_run.save(update_fields=['enrollment_count', 'recent_enrollment_count'], suppress_publication=True)
 
         # Add course run total to course total in dictionary
         if course.uuid in self.course_dictionary:


### PR DESCRIPTION
[PROD-3899](https://2u-internal.atlassian.net/browse/PROD-3899)

Currently, in the analytics loader, program objects may be "cached" in memory until all course runs and courses have been processed, and then eventually be saved. The processing for all courses and courseruns may take a considerable amount of time. Hence any updates to the cached program objects during this time will be lost. This PR "fixes" the program save call to only modify the enrollment_count and recent_enrollment_count fields. We have also done the same for the courserun save, even though the chances of a lost update there are tiny, as they are saved immediately after being fetched.

A similar fix was done for courses in [4487](https://github.com/openedx/course-discovery/pull/4487/files)