### PR TITLE
feat: add searching functionality in FAQ and add index to sorted m2m fields

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -524,7 +524,8 @@ class CorporateEndorsementAdmin(admin.ModelAdmin):
 
 @admin.register(FAQ)
 class FAQAdmin(admin.ModelAdmin):
-    list_display = ('question',)
+    list_display = ('id', 'question', 'answer')
+    search_fields = ('id', 'question',)
 
 
 @admin.register(Ranking)

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -3192,7 +3192,7 @@ class FAQ(TimeStampedModel):
         ordering = ['created']
 
     def __str__(self):
-        return self.question
+        return f'{self.pk}: {self.question}'
 
 
 class Program(ManageHistoryMixin, PkSearchableMixin, TimeStampedModel):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -3802,7 +3802,7 @@ class FAQTests(TestCase):
     def test_str(self):
         question = 'test question'
         faq = FAQ.objects.create(question=question, answer='test')
-        assert str(faq) == question
+        assert str(faq) == f'{faq.id}: {faq.question}'
 
 
 class RankingTests(TestCase):


### PR DESCRIPTION
[PROD-3233](https://2u-internal.atlassian.net/browse/PROD-3233)
--------
This PR adds search functionality to the `FAQ` model, allowing searches by `id` and `question` text. As many questions in the course_discovery can share the same text, I have added the primary key `id` to the admin list display for easier identification.

Additionally, I updated the `__str__` method to include the index number alongside the question text in multiple select fields:
https://forum.djangoproject.com/t/rendering-with-checkboxselectmultiple/16410

Explored `SortedCheckboxSelectMultiple` from `sortedm2m`, but it doesn't have built-in functionality to include links with the rendered options. It simply uses the model's `__str__` method for choices.

### Screenshot:

Before:
No search before:
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/10b60318-a52e-4ee7-8443-935fdd944e3a">


After:
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/da8a8c22-3560-4769-9c74-898cb79aaf57">

After:
Before: I was simply question text with no index no.
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/61c6305b-6acf-475a-a645-84fb132cff4a">

