### PR TITLE
chore: add partner field to PersonSearchDocumentSerializer

### DIFF
--- a/course_discovery/apps/api/tests/test_serializers.py
+++ b/course_discovery/apps/api/tests/test_serializers.py
@@ -2593,6 +2593,7 @@ class PersonSearchDocumentSerializerTest(ElasticsearchTestMixin, TestCase):
             'profile_image_url': person.get_profile_image_url,
             'full_name': person.full_name,
             'organizations': [],
+            'partner': person.partner.short_code,
         }
 
     def test_data(self):

--- a/course_discovery/apps/course_metadata/search_indexes/serializers/person.py
+++ b/course_discovery/apps/course_metadata/search_indexes/serializers/person.py
@@ -37,6 +37,7 @@ class PersonSearchDocumentSerializer(DocumentSerializer):
             'profile_image_url',
             'position',
             'organizations',
+            'partner'
         )
 
 


### PR DESCRIPTION
## [PROD-4240](https://2u-internal.atlassian.net/browse/PROD-4240)

This PR adds the partner field to PersonSearchDocumentSerializer. This is the remaining part of [4497](https://github.com/openedx/course-discovery/pull/4497).