### PR TITLE
feat: do not index retired products in elasticsearch

### DIFF
--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -15,7 +15,7 @@ from sortedm2m.fields import SortedManyToManyField
 from course_discovery.apps.core.api_client.lms import LMSAPIClient
 from course_discovery.apps.core.utils import serialize_datetime
 from course_discovery.apps.course_metadata.choices import CourseRunRestrictionType
-from course_discovery.apps.course_metadata.models import CourseRun
+from course_discovery.apps.course_metadata.models import CourseRun, CourseRunType, CourseType
 
 logger = logging.getLogger(__name__)
 
@@ -412,3 +412,17 @@ def use_request_cache(cache_name, key_func):
             return result
         return wrapper
     return inner
+
+
+@use_request_cache("retired_run_types_cache", lambda: "retired_run_types")
+def get_retired_run_type_ids():
+    return list(
+        CourseRunType.objects.filter(slug__in=settings.RETIRED_RUN_TYPES).values_list('id', flat=True)
+    )
+
+
+@use_request_cache("retired_course_types_cache", lambda: "retired_course_types")
+def get_retired_course_type_ids():
+    return list(
+        CourseType.objects.filter(slug__in=settings.RETIRED_COURSE_TYPES).values_list('id', flat=True)
+    )

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -4,6 +4,7 @@ import logging
 import math
 from urllib.parse import parse_qsl, urlencode, urljoin
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db.models.fields.related import ManyToManyField
 from django.utils.translation import gettext as _

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -1307,7 +1307,7 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
         query = 'title:Some random title'
         url = '{root}?q={query}'.format(root=reverse('api:v1:course_run-list'), query=query)
 
-        with self.assertNumQueries(25, threshold=3):
+        with self.assertNumQueries(26, threshold=3):
             response = self.client.get(url)
 
         actual_sorted = sorted(response.data['results'], key=lambda course_run: course_run['key'])

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -700,7 +700,6 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         assert set(actual_course_run_keys) == set(expected_course_run_keys)
 
     @ddt.data("course", "courserun")
-    @pytest.mark.foo
     def test_retired_courses_and_runs_not_indexed(self, content_type):
         """ Verify that courses and runs corresponding to retired types are not indexed. """
 

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -209,10 +209,10 @@ class CourseRunSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
          ['results', 0, 'program_types', 0], ProgramStatus.Unpublished, 5),
         (detailed_path,
          CourseRunSearchModelSerializer,
-         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 21),
+         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Deleted, 22),
         (detailed_path,
          CourseRunSearchModelSerializer,
-         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 22),
+         ['results', 0, 'programs', 0, 'type'], ProgramStatus.Unpublished, 23),
     )
     @ddt.unpack
     def test_exclude_unavailable_program_types(self, path, serializer, result_location_keys, program_status,
@@ -599,7 +599,7 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
             self.serialize_program_search(other_program),
         ]
 
-    @ddt.data((True, 9), (False, 9))
+    @ddt.data((True, 10), (False, 10))
     @ddt.unpack
     def test_query_count_exclude_expired_course_run(self, exclude_expired, expected_queries):
         """ Verify that there is no query explosion when excluding expired course runs. """

--- a/course_discovery/apps/api/v1/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_search.py
@@ -716,7 +716,7 @@ class AggregateSearchViewSetTests(mixins.SerializationMixin, mixins.LoginMixin, 
         else:
             expected = [self.serialize_course_run_search(run2), self.serialize_course_run_search(run3)]
 
-        assert sorted(response_data['results'], key = itemgetter('key')) == sorted(expected, key = itemgetter('key'))
+        assert sorted(response_data['results'], key=itemgetter('key')) == sorted(expected, key=itemgetter('key'))
 
     def test_empty_query(self):
         """ Verify, when the query (q) parameter is empty, the endpoint behaves as if the parameter

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -421,7 +421,7 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
         if self.type.slug == CourseType.EXECUTIVE_EDUCATION_2U and \
                 self.product_external_status == ExternalProductStatus.Archived:
             return False
-        
+
         if self.type.slug in settings.RETIRED_COURSE_TYPES:
             return False
 

--- a/course_discovery/apps/course_metadata/algolia_models.py
+++ b/course_discovery/apps/course_metadata/algolia_models.py
@@ -421,6 +421,9 @@ class AlgoliaProxyCourse(Course, AlgoliaBasicModelFieldsMixin):
         if self.type.slug == CourseType.EXECUTIVE_EDUCATION_2U and \
                 self.product_external_status == ExternalProductStatus.Archived:
             return False
+        
+        if self.type.slug in settings.RETIRED_COURSE_TYPES:
+            return False
 
         # WS-3723, Emeritus courses should be hidden until all features finished.
         if self.product_source and is_excluded_product_sources_check(self.product_source.slug):

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -5,6 +5,7 @@ from opaque_keys.edx.keys import CourseKey
 from taxonomy.choices import ProductTypes
 from taxonomy.utils import get_whitelisted_serialized_skills
 
+from course_discovery.apps.api.utils import get_retired_course_type_ids
 from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseType
 from course_discovery.apps.course_metadata.utils import get_product_skill_names
 
@@ -126,9 +127,7 @@ class CourseDocument(BaseCourseDocument):
     def get_queryset(self, excluded_restriction_types=None):
         if excluded_restriction_types is None:
             excluded_restriction_types = []
-        retired_type_ids = list(
-            CourseType.objects.filter(slug__in=settings.RETIRED_COURSE_TYPES).values_list('id', flat=True)
-        )
+        retired_type_ids = get_retired_course_type_ids()
 
         return super().get_queryset().exclude(type_id__in=retired_type_ids).prefetch_related(
             Prefetch('course_runs', queryset=CourseRun.objects.exclude(

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -6,7 +6,7 @@ from taxonomy.choices import ProductTypes
 from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.utils import get_retired_course_type_ids
-from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseType
+from course_discovery.apps.course_metadata.models import Course, CourseRun
 from course_discovery.apps.course_metadata.utils import get_product_skill_names
 
 from .analyzers import case_insensitive_keyword

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course.py
@@ -5,7 +5,7 @@ from opaque_keys.edx.keys import CourseKey
 from taxonomy.choices import ProductTypes
 from taxonomy.utils import get_whitelisted_serialized_skills
 
-from course_discovery.apps.course_metadata.models import Course, CourseRun
+from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseType
 from course_discovery.apps.course_metadata.utils import get_product_skill_names
 
 from .analyzers import case_insensitive_keyword
@@ -126,8 +126,11 @@ class CourseDocument(BaseCourseDocument):
     def get_queryset(self, excluded_restriction_types=None):
         if excluded_restriction_types is None:
             excluded_restriction_types = []
+        retired_type_ids = list(
+            CourseType.objects.filter(slug__in=settings.RETIRED_COURSE_TYPES).values_list('id', flat=True)
+        )
 
-        return super().get_queryset().prefetch_related(
+        return super().get_queryset().exclude(type_id__in=retired_type_ids).prefetch_related(
             Prefetch('course_runs', queryset=CourseRun.objects.exclude(
                 restricted_run__restriction_type__in=excluded_restriction_types
             ).prefetch_related(

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -5,7 +5,7 @@ from taxonomy.choices import ProductTypes
 from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
-from course_discovery.apps.course_metadata.models import CourseRun
+from course_discovery.apps.course_metadata.models import CourseRun, CourseRunType
 from course_discovery.apps.course_metadata.utils import get_product_skill_names
 
 from .analyzers import case_insensitive_keyword, html_strip
@@ -148,8 +148,12 @@ class CourseRunDocument(BaseCourseDocument):
         ]
 
     def get_queryset(self, excluded_restriction_types=None):  # pylint: disable=unused-argument
+        retired_type_ids = list(
+            CourseRunType.objects.filter(slug__in=settings.RETIRED_RUN_TYPES).values_list('id', flat=True)
+        )
         return filter_visible_runs(
             super().get_queryset()
+                   .exclude(type_id__in=retired_type_ids)
                    .select_related('course')
                    .select_related('course__type')
                    .prefetch_related('seats__type')

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -4,6 +4,7 @@ from opaque_keys.edx.keys import CourseKey
 from taxonomy.choices import ProductTypes
 from taxonomy.utils import get_whitelisted_serialized_skills
 
+from course_discovery.apps.api.utils import get_retired_run_type_ids
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.models import CourseRun, CourseRunType
 from course_discovery.apps.course_metadata.utils import get_product_skill_names
@@ -148,9 +149,7 @@ class CourseRunDocument(BaseCourseDocument):
         ]
 
     def get_queryset(self, excluded_restriction_types=None):  # pylint: disable=unused-argument
-        retired_type_ids = list(
-            CourseRunType.objects.filter(slug__in=settings.RETIRED_RUN_TYPES).values_list('id', flat=True)
-        )
+        retired_type_ids = get_retired_run_type_ids()
         return filter_visible_runs(
             super().get_queryset()
                    .exclude(type_id__in=retired_type_ids)

--- a/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
+++ b/course_discovery/apps/course_metadata/search_indexes/documents/course_run.py
@@ -6,7 +6,7 @@ from taxonomy.utils import get_whitelisted_serialized_skills
 
 from course_discovery.apps.api.utils import get_retired_run_type_ids
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
-from course_discovery.apps.course_metadata.models import CourseRun, CourseRunType
+from course_discovery.apps.course_metadata.models import CourseRun
 from course_discovery.apps.course_metadata.utils import get_product_skill_names
 
 from .analyzers import case_insensitive_keyword, html_strip

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -392,7 +392,7 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         assert course.should_index == should_index
 
     @pytest.mark.foo
-    @override_settings(RETIRED_COURSE_TYPES=['audi'])
+    @override_settings(RETIRED_COURSE_TYPES=['audit'])
     def test_retired_course_indexing(self):
         """
         Test that retired courses are not indexed

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -391,7 +391,6 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         course.additional_metadata = AdditionalMetadataFactory(product_status=external_status)
         assert course.should_index == should_index
 
-    @pytest.mark.foo
     @override_settings(RETIRED_COURSE_TYPES=['audit'])
     def test_retired_course_indexing(self):
         """

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -391,6 +391,17 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         course.additional_metadata = AdditionalMetadataFactory(product_status=external_status)
         assert course.should_index == should_index
 
+    @pytest.mark.foo
+    @override_settings(RETIRED_COURSE_TYPES=['audi'])
+    def test_retired_course_indexing(self):
+        """
+        Test that retired courses are not indexed
+        """
+        course = self.create_course_with_basic_active_course_run()
+        course.authoring_organizations.add(OrganizationFactory())
+        course.type = CourseTypeFactory(slug='audit')
+        assert course.should_index == False
+
     @ddt.data(
         (None, True),
         (CourseType.BOOTCAMP_2U, True),

--- a/course_discovery/apps/course_metadata/tests/test_algolia_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_algolia_models.py
@@ -399,7 +399,7 @@ class TestAlgoliaProxyCourse(TestAlgoliaProxyWithEdxPartner):
         course = self.create_course_with_basic_active_course_run()
         course.authoring_organizations.add(OrganizationFactory())
         course.type = CourseTypeFactory(slug='audit')
-        assert course.should_index == False
+        assert not course.should_index
 
     @ddt.data(
         (None, True),


### PR DESCRIPTION
[PROD-4261](https://2u-internal.atlassian.net/browse/PROD-4261)
-------

For retired course and course run types, do not index associated products in elasticsearch.