### PR TITLE
chore: prevent creation of retired product types from admin

### DIFF
--- a/course_discovery/apps/course_metadata/forms.py
+++ b/course_discovery/apps/course_metadata/forms.py
@@ -1,10 +1,11 @@
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.utils.translation import gettext_lazy as _
 
 from course_discovery.apps.course_metadata.choices import ProgramStatus
-from course_discovery.apps.course_metadata.models import Course, CourseRun, Pathway, Program
+from course_discovery.apps.course_metadata.models import Course, CourseRun, CourseRunType, CourseType, Pathway, Program
 from course_discovery.apps.course_metadata.widgets import SortedModelSelect2Multiple
 
 
@@ -121,6 +122,8 @@ class CourseAdminForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if self.fields.get('product_source'):
             self.fields['product_source'].required = True
+        if not self.instance.pk:
+            self.fields['type'].queryset = CourseType.objects.exclude(slug__in=settings.RETIRED_COURSE_TYPES)
 
 
 class CourseRunAdminForm(forms.ModelForm):
@@ -150,6 +153,11 @@ class CourseRunAdminForm(forms.ModelForm):
                 },
             ),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.instance.pk:
+            self.fields['type'].queryset = CourseRunType.objects.exclude(slug__in=settings.RETIRED_RUN_TYPES)
 
 
 class PathwayAdminForm(forms.ModelForm):

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -7,6 +7,7 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib.contenttypes.models import ContentType
 from django.http import HttpRequest
 from django.test import LiveServerTestCase, TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK
 from selenium import webdriver
@@ -25,7 +26,9 @@ from course_discovery.apps.course_metadata.admin import DegreeAdmin, PositionAdm
 from course_discovery.apps.course_metadata.choices import ProgramStatus
 from course_discovery.apps.course_metadata.constants import PathwayType
 from course_discovery.apps.course_metadata.forms import PathwayAdminForm, ProgramAdminForm
-from course_discovery.apps.course_metadata.models import Degree, Person, Position, Program, ProgramType, Source
+from course_discovery.apps.course_metadata.models import (
+    CourseRunType, CourseType, Degree, Person, Position, Program, ProgramType, Source
+)
 from course_discovery.apps.course_metadata.tests import factories
 
 
@@ -221,6 +224,32 @@ class AdminTests(SiteMixin, TestCase):
         assert 0 == program.courses.all().count()
         response = self.client.get(reverse('admin:course_metadata_program_change', args=(program.id,)))
         assert response.status_code == 200
+
+    @ddt.data(
+        [{'RETIRED_COURSE_TYPES': ['audit']}, False, CourseType],
+        [{'RETIRED_RUN_TYPES': ['audit']}, False, CourseRunType],
+        [{}, True, CourseType],
+        [{}, True, CourseRunType]
+    )
+    @ddt.unpack
+    @pytest.mark.doo
+    def test_retired_product_types_not_in_options(self, custom_settings, audit_in_options, type_model):
+        """ Verify that new objects (courses/courseruns) can not have a retired type"""
+        audit_type = type_model.objects.get(slug='audit')
+        url_name = (
+            "admin:course_metadata_course_add"
+            if type_model is CourseType
+            else "admin:course_metadata_courserun_add"
+        )
+        url = reverse(url_name)
+        with override_settings(**custom_settings):
+            response = self.client.get(url)
+            assert response.status_code == 200
+
+        soup = BeautifulSoup(response.content)
+        type_options = soup.find('select', {'name': 'type'}).find_all('option')
+        type_option_names = map(lambda opt: opt.get_text(), type_options)
+        assert (audit_type.name in type_option_names) == audit_in_options
 
 
 class ProgramAdminFunctionalTests(SiteMixin, LiveServerTestCase):

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -232,7 +232,6 @@ class AdminTests(SiteMixin, TestCase):
         [{}, True, CourseRunType]
     )
     @ddt.unpack
-    @pytest.mark.doo
     def test_retired_product_types_not_in_options(self, custom_settings, audit_in_options, type_model):
         """ Verify that new objects (courses/courseruns) can not have a retired type"""
         audit_type = type_model.objects.get(slug='audit')
@@ -258,7 +257,6 @@ class AdminTests(SiteMixin, TestCase):
         [{}, CourseRunType]
     )
     @ddt.unpack
-    @pytest.mark.doo
     def test_retired_product_types_in_options(self, custom_settings, type_model):
         """ Verify that objects associated to retired types keep showing it in the type dropdown """
         audit_type = type_model.objects.get(slug='audit')
@@ -269,9 +267,9 @@ class AdminTests(SiteMixin, TestCase):
             else "admin:course_metadata_courserun_change"
         )
         product = (
-            CourseFactory(type__slug='audit')
+            factories.CourseFactory(type=audit_type)
             if type_model is CourseType
-            else CourseRunFactory(type__slug='audit')
+            else factories.CourseRunFactory(type=audit_type)
         )
 
         url = reverse(url_name, args=(product.id,))


### PR DESCRIPTION
[PROD-4273](https://2u-internal.atlassian.net/browse/PROD-4273)
-------

Do not show retired course and courserun types while creating a course or courserun from the django admin.