### PR TITLE
perf: fix some performance issues with program admin by converting fields to search async

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -388,6 +388,10 @@ class ProgramAdmin(DjangoObjectActions, SimpleHistoryAdmin):
         'enterprise_subscription_inclusion', 'ofac_comment', 'data_modified_timestamp'
     )
     raw_id_fields = ('video',)
+    autocomplete_fields = (
+        'corporate_endorsements', 'faq', 'individual_endorsements', 'job_outlook_items',
+        'expected_learning_items',
+    )
     search_fields = ('uuid', 'title', 'marketing_slug')
     exclude = ('card_image_url',)
 
@@ -566,11 +570,14 @@ class SeatTypeAdmin(admin.ModelAdmin):
 @admin.register(Endorsement)
 class EndorsementAdmin(admin.ModelAdmin):
     list_display = ('endorser',)
+    search_fields = ('quote', 'endorser__given_name', 'endorser__family_name')
+    list_select_related = ['endorser', ]
 
 
 @admin.register(CorporateEndorsement)
 class CorporateEndorsementAdmin(admin.ModelAdmin):
     list_display = ('corporation_name',)
+    search_fields = ('corporation_name', 'statement',)
 
 
 @admin.register(FAQ)


### PR DESCRIPTION
### Description

Program admin is failing to load for some programs and is spending a lot of time rendering form widgets. The program has a few M2M fields that are rendered as multi-select form. Changing them to autocomplete so that admin page does not load all the objects and only loads the relevant objects when searching (https://stackoverflow.com/questions/24116775/why-is-a-django-model-taking-so-long-to-load-in-admin). EndorsementAdmin and CorporateEndorsementAdmin needed search_fields to be defined for search to work on program admin


#### Before
<img width="1680" alt="Screenshot 2025-01-07 at 12 59 42 PM" src="https://github.com/user-attachments/assets/f01a92e1-67b9-491d-a9c1-b5ba586fc87b" />

#### After

<img width="1680" alt="Screenshot 2025-01-07 at 1 00 04 PM" src="https://github.com/user-attachments/assets/1c918086-3c0f-4a7b-a487-ea3733f79367" />
