### PR TITLE
perf: optimize loading of django admin program pages

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -128,6 +128,7 @@ class ProductValueAdmin(admin.ModelAdmin):
     ]
     search_fields = ('id',)
 
+
 @admin.register(Course)
 class CourseAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     form = CourseAdminForm

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -7,8 +7,9 @@ from django.db.models import Prefetch
 from django.db.utils import IntegrityError
 from django.forms import CheckboxSelectMultiple, ModelForm
 from django.http import HttpResponseRedirect
+from django.templatetags.static import static
 from django.urls import re_path, reverse
-from django.utils.html import format_html
+from django.utils.html import format_html, html_safe
 from django.utils.translation import gettext_lazy as _
 from django_object_actions import DjangoObjectActions
 from parler.admin import TranslatableAdmin
@@ -28,7 +29,6 @@ from course_discovery.apps.course_metadata.forms import (
     CourseAdminForm, CourseRunAdminForm, PathwayAdminForm, ProgramAdminForm
 )
 from course_discovery.apps.course_metadata.models import *  # pylint: disable=wildcard-import
-from course_discovery.apps.course_metadata.utils import SortableSelectJSPath
 from course_discovery.apps.course_metadata.views import (
     CourseSkillsView, RefreshCourseSkillsView, RefreshProgramSkillsView
 )
@@ -52,6 +52,13 @@ class CurriculumCourseMembershipForm(ModelForm):
         widgets = {
             'course': autocomplete.ModelSelect2(url='admin_metadata:course-autocomplete')
         }
+
+
+@html_safe
+class SortableSelectJSPath:
+    def __str__(self):
+        abs_path = static('js/sortable_select.js')
+        return f'<script src="{abs_path}" defer></script>'
 
 
 class ProgramEligibilityFilter(admin.SimpleListFilter):

--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -28,6 +28,7 @@ from course_discovery.apps.course_metadata.forms import (
     CourseAdminForm, CourseRunAdminForm, PathwayAdminForm, ProgramAdminForm
 )
 from course_discovery.apps.course_metadata.models import *  # pylint: disable=wildcard-import
+from course_discovery.apps.course_metadata.utils import SortableSelectJSPath
 from course_discovery.apps.course_metadata.views import (
     CourseSkillsView, RefreshCourseSkillsView, RefreshProgramSkillsView
 )
@@ -125,7 +126,7 @@ class ProductValueAdmin(admin.ModelAdmin):
     list_display = [
         'id', 'per_click_usa', 'per_click_international', 'per_lead_usa', 'per_lead_international'
     ]
-
+    search_fields = ('id',)
 
 @admin.register(Course)
 class CourseAdmin(DjangoObjectActions, SimpleHistoryAdmin):
@@ -390,7 +391,7 @@ class ProgramAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     raw_id_fields = ('video',)
     autocomplete_fields = (
         'corporate_endorsements', 'faq', 'individual_endorsements', 'job_outlook_items',
-        'expected_learning_items',
+        'expected_learning_items', 'in_year_value'
     )
     search_fields = ('uuid', 'title', 'marketing_slug')
     exclude = ('card_image_url',)
@@ -523,7 +524,7 @@ class ProgramAdmin(DjangoObjectActions, SimpleHistoryAdmin):
         js = (
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
             'bower_components/jquery/dist/jquery.min.js',
-            'js/sortable_select.js'
+            SortableSelectJSPath()
         )
 
 

--- a/course_discovery/apps/course_metadata/tests/test_widgets.py
+++ b/course_discovery/apps/course_metadata/tests/test_widgets.py
@@ -7,9 +7,9 @@ from course_discovery.apps.course_metadata.widgets import SortedModelSelect2Mult
 @ddt.ddt
 class SortedModelSelect2MultipleTests(TestCase):
     @ddt.data(
-        (['1', '2'], [1, 2, 3]),
-        (['2', '1'], [2, 1, 3]),
-        (['3'], [3, 1, 2]),
+        (['1', '2'], [1, 2]),
+        (['2', '1'], [2, 1]),
+        (['3'], [3,]),
     )
     @ddt.unpack
     def test_optgroups_are_sorted(self, value, result_order):

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -17,7 +17,9 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.db import models, transaction
+from django.templatetags.static import static
 from django.utils.functional import cached_property
+from django.utils.html import html_safe
 from django.utils.translation import gettext as _
 from dynamic_filenames import FilePattern
 from edx_django_utils.cache import RequestCache, get_cache_key
@@ -1264,3 +1266,10 @@ def get_course_run_statuses(statuses, course_runs):
         else:
             statuses.add(course_run.status)
     return statuses
+
+
+@html_safe
+class SortableSelectJSPath:
+    def __str__(self):
+        abs_path = static('js/sortable_select.js')
+        return f'<script src="{abs_path}" defer></script>'

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -17,9 +17,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.db import models, transaction
-from django.templatetags.static import static
 from django.utils.functional import cached_property
-from django.utils.html import html_safe
 from django.utils.translation import gettext as _
 from dynamic_filenames import FilePattern
 from edx_django_utils.cache import RequestCache, get_cache_key
@@ -1266,10 +1264,3 @@ def get_course_run_statuses(statuses, course_runs):
         else:
             statuses.add(course_run.status)
     return statuses
-
-
-@html_safe
-class SortableSelectJSPath:
-    def __str__(self):
-        abs_path = static('js/sortable_select.js')
-        return f'<script src="{abs_path}" defer></script>'

--- a/course_discovery/apps/course_metadata/widgets.py
+++ b/course_discovery/apps/course_metadata/widgets.py
@@ -29,4 +29,4 @@ class SortedModelSelect2Multiple(autocomplete.ModelSelect2Multiple):
                     ordered.append(item)
                     break
 
-        return ordered + unselected
+        return ordered


### PR DESCRIPTION
## [PROD-4274](https://2u-internal.atlassian.net/browse/PROD-4274)

### Description

Program admin pages are taking a long time to load and sometimes may even time out. Looking at the traces, most of the time is being spent in rendering the html widgets.

This PR makes the following changes:-

1. Add `in_year_value` to autocomplete_fields so that all ProductValue objects are not rendered in the html
2. While calculating `optgroups` on `SortedModelSelect2Multiple` widgets, do not include unselected options. This prevents the unselected options from being rendered in the html. `django_autocomplete_light` also appears to be [doing](https://github.com/yourlabs/django-autocomplete-light/blob/45a9ff6e95e58348b90b3c1f01f01cb6ca10b4d3/src/dal/widgets.py#L129-L133) the same thing
3. Currently, the sorting of `SortedModelSelect2Multiple` widgets is broken. We fix it by deferring the loading of `sortable_select.js`

### Before
<img width="1241" alt="Screenshot 2025-01-09 at 1 44 36 PM" src="https://github.com/user-attachments/assets/f963539e-3a38-44c0-9793-a6765c8cded9" />
<img width="576" alt="Screenshot 2025-01-09 at 1 45 11 PM" src="https://github.com/user-attachments/assets/9d24aac8-8cd9-42cc-a39e-78861d8c1cf3" />

### After

<img width="1433" alt="Screenshot 2025-01-09 at 1 43 30 PM" src="https://github.com/user-attachments/assets/fb56e941-f81e-4df9-93da-4ad92e970775" />
<img width="630" alt="Screenshot 2025-01-09 at 1 44 07 PM" src="https://github.com/user-attachments/assets/fe3d7355-d2fb-4050-8ed2-00a170490e12" />
