### PR TITLE
fix: handle draft only courses properly in archive_courses command

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/archive_courses.py
+++ b/course_discovery/apps/course_metadata/management/commands/archive_courses.py
@@ -75,9 +75,9 @@ class Command(BaseCommand):
             conf = ArchiveCoursesConfig.current()
             mangle_end_date = conf.mangle_end_date
             mangle_title = conf.mangle_title
-            courses = Course.objects.filter(uuid__in=self.get_uuids_from_database())
+            courses = Course.objects.filter_drafts(uuid__in=self.get_uuids_from_database())
         elif course_type:
-            courses = Course.objects.filter(
+            courses = Course.objects.filter_drafts(
                 type__in=[CourseType.objects.get(slug__in=[course_type, course_type.lower()])]
             )
         else:
@@ -90,8 +90,8 @@ class Command(BaseCommand):
             course_title = course.title
             try:
                 self.archive(course, mangle_end_date, mangle_title)
-                if course.draft_version:
-                    self.archive(course.draft_version, mangle_end_date, mangle_title)
+                if course.official_version:
+                    self.archive(course.official_version, mangle_end_date, mangle_title)
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 self.report['failures'].append(
                     {

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_archive_courses.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_archive_courses.py
@@ -90,7 +90,7 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
     @ddt.unpack
     @responses.activate
     def test_success(self, from_db, mangle_title, mangle_end_date, draft_only):
-    # draft_only specifies the case when the objects only have draft versions
+        # draft_only specifies the case when the objects only have draft versions
         for model in [Course, CourseRun]:
             assert model.objects.count() == 2
             assert model.everything.count() == 4
@@ -120,7 +120,7 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
         call_command('archive_courses', *args)
 
         course1_or_its_draft = Course.everything.get(uuid=self.course1.uuid, draft=draft_only)
-        course2_or_its_draft = Course.everything.get(uuid=self.course2.uuid, draft=draft_only) 
+        course2_or_its_draft = Course.everything.get(uuid=self.course2.uuid, draft=draft_only)
         course1_or_its_draft.refresh_from_db()
         course2_or_its_draft.refresh_from_db()
         self.verify_archived(course1_or_its_draft, mangle_title, mangle_end_date, not draft_only)

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_archive_courses.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_archive_courses.py
@@ -64,6 +64,7 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
         return args
 
     def verify_archived(self, course, mangle_title, mangle_end_date, is_official=True):
+        # is_official specifies if the course is an official version
         for c in ([course, course.draft_version] if is_official else [course]):
             assert c.additional_metadata.product_status == ExternalProductStatus.Archived
             assert c.additional_metadata.end_date < timezone.now() + timedelta(minutes=1)
@@ -76,6 +77,7 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
             assert is_end_date_mangled if mangle_end_date else not is_end_date_mangled
 
     def verify_not_archived(self, course, is_official=True):
+        # is_official specifies if the course is an official version
         for c in ([course, course.draft_version] if is_official else [course]):
             assert c.additional_metadata.product_status == ExternalProductStatus.Published
             assert c.additional_metadata.end_date > timezone.now() + timedelta(minutes=1)
@@ -119,12 +121,12 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
             args = ['--from-db']
         call_command('archive_courses', *args)
 
-        course1_or_its_draft = Course.everything.get(uuid=self.course1.uuid, draft=draft_only)
-        course2_or_its_draft = Course.everything.get(uuid=self.course2.uuid, draft=draft_only)
-        course1_or_its_draft.refresh_from_db()
-        course2_or_its_draft.refresh_from_db()
-        self.verify_archived(course1_or_its_draft, mangle_title, mangle_end_date, not draft_only)
-        self.verify_not_archived(course2_or_its_draft, not draft_only)
+        course1 = Course.everything.get(uuid=self.course1.uuid, draft=draft_only)
+        course2 = Course.everything.get(uuid=self.course2.uuid, draft=draft_only)
+        course1.refresh_from_db()
+        course2.refresh_from_db()
+        self.verify_archived(course1, mangle_title, mangle_end_date, not draft_only)
+        self.verify_not_archived(course2, not draft_only)
 
         mangle_call_count = 1 if draft_only else 2
         if mangle_end_date:

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_archive_courses.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_archive_courses.py
@@ -63,8 +63,8 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
             args.append('--mangle-end-date')
         return args
 
-    def verify_archived(self, course, mangle_title, mangle_end_date):
-        for c in [course, course.draft_version]:
+    def verify_archived(self, course, mangle_title, mangle_end_date, is_official=True):
+        for c in ([course, course.draft_version] if is_official else [course]):
             assert c.additional_metadata.product_status == ExternalProductStatus.Archived
             assert c.additional_metadata.end_date < timezone.now() + timedelta(minutes=1)
             assert c.course_runs.last().status == CourseRunStatus.Unpublished
@@ -75,8 +75,8 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
             is_end_date_mangled = c.course_runs.first().end < timezone.now() + timedelta(minutes=1)
             assert is_end_date_mangled if mangle_end_date else not is_end_date_mangled
 
-    def verify_not_archived(self, course):
-        for c in [course, course.draft_version]:
+    def verify_not_archived(self, course, is_official=True):
+        for c in ([course, course.draft_version] if is_official else [course]):
             assert c.additional_metadata.product_status == ExternalProductStatus.Published
             assert c.additional_metadata.end_date > timezone.now() + timedelta(minutes=1)
             assert c.course_runs.last().status == CourseRunStatus.Published
@@ -85,15 +85,22 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
             assert not c.course_runs.first().end < timezone.now() + timedelta(minutes=1)
 
     @ddt.data(
-        *list(product([0, 1], repeat=3))
+        *list(product([0, 1], repeat=4))
     )
     @ddt.unpack
     @responses.activate
-    def test_success(self, from_db, mangle_title, mangle_end_date):
-        # Some sanity checks on counts
+    def test_success(self, from_db, mangle_title, mangle_end_date, draft_only):
+    # draft_only specifies the case when the objects only have draft versions
         for model in [Course, CourseRun]:
             assert model.objects.count() == 2
             assert model.everything.count() == 4
+
+        if draft_only:
+            self.course1.delete()
+            self.course2.delete()
+            for model in [Course, CourseRun]:
+                assert model.objects.count() == 0
+                assert model.everything.count() == 2
 
         if from_db:
             ArchiveCoursesConfigFactory.create(
@@ -112,13 +119,16 @@ class ArchiveCoursesCommandTests(TestCase, OAuth2Mixin):
             args = ['--from-db']
         call_command('archive_courses', *args)
 
-        self.course1.refresh_from_db()
-        self.course2.refresh_from_db()
-        self.verify_archived(self.course1, mangle_title, mangle_end_date)
-        self.verify_not_archived(self.course2)
+        course1_or_its_draft = Course.everything.get(uuid=self.course1.uuid, draft=draft_only)
+        course2_or_its_draft = Course.everything.get(uuid=self.course2.uuid, draft=draft_only) 
+        course1_or_its_draft.refresh_from_db()
+        course2_or_its_draft.refresh_from_db()
+        self.verify_archived(course1_or_its_draft, mangle_title, mangle_end_date, not draft_only)
+        self.verify_not_archived(course2_or_its_draft, not draft_only)
 
+        mangle_call_count = 1 if draft_only else 2
         if mangle_end_date:
-            assert responses.assert_call_count(self.courserun1_studio_url, 2) is True
+            assert responses.assert_call_count(self.courserun1_studio_url, mangle_call_count) is True
         else:
             assert responses.assert_call_count(self.courserun1_studio_url, 0) is True
 


### PR DESCRIPTION
## [PROD-4289](https://2u-internal.atlassian.net/browse/PROD-4289)

Currently the `archive_course` command ignores courses without official versions. We change the behavior so that they are not.