### PR TITLE
fix: avoids call to DB when checking for queryset

### DIFF
--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1183,7 +1183,8 @@ class SearchAfterMixin:
             QuerySet
         """
         query = clean_query(query)
-        queryset = queryset or cls.objects.all()
+        if queryset is None:
+            queryset = cls.objects.all()
 
         if query == '(*)':
             # Early-exit optimization. Wildcard searching is very expensive in elasticsearch. And since we just


### PR DESCRIPTION
Fixes the v2 endpoint slowness using `is None` instead of checking it using a boolean expression. 