### PR TITLE
Fix HTML rendering issue in vertical assignment email

### DIFF
--- a/course_discovery/apps/tagging/emails.py
+++ b/course_discovery/apps/tagging/emails.py
@@ -53,6 +53,7 @@ def send_email_for_course_vertical_assignment(course, to_users):
         settings.PUBLISHER_FROM_EMAIL,
         to_users,
     )
+    email.content_subtype = "html"
 
     try:
         email.send()


### PR DESCRIPTION
Fix HTML rendering issue in vertical assignment email 

<img width="982" alt="Screenshot 2025-02-01 at 4 21 25 AM" src="https://github.com/user-attachments/assets/7f0654dd-afe5-434f-aafa-2531638e558f" />

