### PR TITLE
style: nav style update for vertical tagging app

### DIFF
--- a/course_discovery/apps/tagging/templates/tagging/base.html
+++ b/course_discovery/apps/tagging/templates/tagging/base.html
@@ -18,13 +18,16 @@
         <div class="container">
             <div class="d-flex justify-content-between align-items-center">
                 <div class="d-flex align-items-center">
-                    <a class="navbar-brand" href="{% url 'tagging:course_list' %}">
+                    <a class="navbar-brand me-3" href="{% url 'tagging:course_list' %}">
                         <img src="{{ HEADER_LOGO_URL }}" alt="header logo" height="30" class="d-inline-block align-middle" />
-                        <span class="fw-bold ml-2 me-3">Course Tagging</span>
                     </a>
                     <nav class="navbar navbar-expand-lg">
                         <div class="collapse navbar-collapse" id="navbarNav">
+                            
                             <ul class="navbar-nav">
+                                <li class="nav-item {% if request.resolver_match.url_name == 'course_list' %}active{% endif %}">
+                                    <a class="nav-link" href="{% url 'tagging:course_list' %}">Course Tagging</a>
+                                </li>
                                 <li class="nav-item {% if request.resolver_match.url_name == 'vertical_list' %}active{% endif %}">
                                     <a class="nav-link" href="{% url 'tagging:vertical_list' %}">Verticals</a>
                                 </li>                                

--- a/course_discovery/static/css/tagging.css
+++ b/course_discovery/static/css/tagging.css
@@ -1,5 +1,6 @@
 .site-header .active {
     border-bottom: 2px solid #454545;
+    font-weight: bold;
 }
 .page-link {
    color:  #00262b;


### PR DESCRIPTION
This PR updates the nav style for the tagging app and makes `Course Tagging` a nav item instead of an app heading

Before:
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/221f723f-66db-4128-ba27-9fa5ca22d079" />


After:
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/aff5e351-0f3a-4052-90ca-1cd3d4eceae1" />
