### PR TITLE
fix: bold active navbar item

### DIFF
--- a/course_discovery/static/css/tagging.css
+++ b/course_discovery/static/css/tagging.css
@@ -1,6 +1,6 @@
 .site-header .active {
     border-bottom: 2px solid #454545;
-    font-weight: bold;
+    font-weight: bold !important;
 }
 .page-link {
    color:  #00262b;


### PR DESCRIPTION
For some reason, the active navbar item didn’t become bold on stage, so I’m attempting to apply `font-weight` to bold the active nav item by using `!important`

<img width="1399" alt="image" src="https://github.com/user-attachments/assets/24b1c3de-874c-4d2f-b5ca-b5c5b042d149" />
