### PR TITLE
fix: send users list in vertical tagging email

### DIFF
--- a/course_discovery/apps/tagging/emails.py
+++ b/course_discovery/apps/tagging/emails.py
@@ -41,7 +41,7 @@ def send_email_for_course_vertical_assignment(course, to_users):
     Sends an email to specified users requesting action to assign vertical and sub-vertical
     for a given course, but only to those who have email notifications enabled.
     """
-    email_enabled_users = [user.email for user in to_users if is_email_notification_enabled(user)]
+    email_enabled_users = [user for user in to_users if is_email_notification_enabled(user)]
     if not email_enabled_users:
         logger.exception(
             f"Failed to send vertical assignment email for course '{course.title}' (UUID: {course.uuid})"
@@ -70,5 +70,5 @@ def send_email_for_course_vertical_assignment(course, to_users):
     except Exception as e:  # pylint: disable=broad-except
         logger.exception(
             f"Failed to send vertical assignment email for course '{course.title}' (UUID: {course.uuid}) to "
-            f"recipients {', '.join(email_enabled_users)}. Error: {str(e)}"
+            f"recipients {', '.join(list(map(lambda user: user.email, email_enabled_users)))}. Error: {str(e)}"
         )

--- a/course_discovery/apps/tagging/tests/test_emails.py
+++ b/course_discovery/apps/tagging/tests/test_emails.py
@@ -31,7 +31,7 @@ class VerticalAssignmentEmailTests(TestCase):
         self.assertEqual(len(mail.outbox), 1)
 
         email = mail.outbox[0]
-        self.assertEqual(email.to, [self.user1.email, self.user2.email])
+        self.assertEqual(email.to, [self.user1, self.user2])
         expected_subject = f"Action Required: Assign Vertical and Sub-vertical for Course '{self.course.title}'"
         self.assertEqual(email.subject, expected_subject)
 


### PR DESCRIPTION
Followup to https://github.com/openedx/course-discovery/pull/4574 and fixes the email method by sending users instead of user emails.