### PR TITLE
feat: appropriate handling of language labels for ai transcription languages

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/tests/test_update_course_ai_languages.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_update_course_ai_languages.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the `update_course_ai_languages` management command.
 """
+import copy
 import datetime
 from unittest.mock import patch
 
@@ -8,9 +9,12 @@ import ddt
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 from django.utils.timezone import now
+from testfixtures import LogCapture
 
-from course_discovery.apps.course_metadata.models import CourseRun, CourseRunType
+from course_discovery.apps.course_metadata.models import CourseRun, CourseRunType, LanguageTag
 from course_discovery.apps.course_metadata.tests.factories import CourseRunFactory, PartnerFactory, SeatFactory
+
+LOGGER_PATH = 'course_discovery.apps.course_metadata.management.commands.update_course_ai_languages'
 
 
 @ddt.ddt
@@ -34,6 +38,8 @@ class UpdateCourseAiLanguagesTests(TestCase):
     def setUp(self):
         self.partner = PartnerFactory()
         self.course_run = CourseRunFactory()
+        LanguageTag.objects.get_or_create(code='da', name='Danish')
+        LanguageTag.objects.get_or_create(code='fr', name='French')
 
     def assert_ai_langs(self, run, data):
         self.assertListEqual(
@@ -41,8 +47,13 @@ class UpdateCourseAiLanguagesTests(TestCase):
             data['available_translation_languages']
         )
         self.assertListEqual(
-            run.ai_languages['transcription_languages'],
-            [{'code': lang_code, 'label': lang_code} for lang_code in data.get('transcription_languages', [])]
+            run.ai_languages["transcription_languages"],
+            [
+                {
+                    "code": lang_code, "label": LanguageTag.objects.get(code__iexact=lang_code.replace("_", "-")).name,
+                }
+                for lang_code in data.get("transcription_languages", [])
+            ],
         )
 
     @ddt.data(AI_LANGUAGES_DATA, AI_LANGUAGES_DATA_WITH_TRANSCRIPTIONS)
@@ -66,7 +77,6 @@ class UpdateCourseAiLanguagesTests(TestCase):
             draft=True, end=now() + datetime.timedelta(days=10)
         )
         course_run = CourseRunFactory(draft=False, draft_version_id=draft_course_run.id)
-
         call_command('update_course_ai_languages', partner=self.partner.name)
 
         course_run.refresh_from_db()
@@ -100,9 +110,44 @@ class UpdateCourseAiLanguagesTests(TestCase):
 
         active_course_run.refresh_from_db()
         non_active_course_run.refresh_from_db()
-
         self.assert_ai_langs(active_course_run, mock_data)
         assert non_active_course_run.ai_languages is None
+
+    def test_command__language_tag_missing(self, mock_get_translations_and_transcriptions):
+        """ Test the command with a language code that does not have a corresponding language tag """
+        mock_data = copy.deepcopy(self.AI_LANGUAGES_DATA_WITH_TRANSCRIPTIONS)
+        mock_data['transcription_languages'] = ['da', 'fr', 'gf']
+        mock_get_translations_and_transcriptions.return_value = mock_data
+
+        course_run = CourseRunFactory(end=now() + datetime.timedelta(days=10), ai_languages=None)
+        with LogCapture(LOGGER_PATH) as log_capture:
+            call_command('update_course_ai_languages', partner=self.partner.name)
+
+            course_run.refresh_from_db()
+            assert course_run.ai_languages['transcription_languages'] == [
+                {'code': 'da', 'label': 'Danish'},
+                {'code': 'fr', 'label': 'French'},
+            ]
+            log_capture.check_present(
+                (LOGGER_PATH, 'ERROR', 'Error: Missing language label for gf'),
+            )
+
+    def test_command__deprecated_language_code(self, mock_get_translations_and_transcriptions):
+        """ Test the command with a deprecated language code """
+        deprecated_code = 'iw'
+        deprecated_label = 'Hebrew'
+        mock_data = copy.deepcopy(self.AI_LANGUAGES_DATA_WITH_TRANSCRIPTIONS)
+        mock_data['transcription_languages'] = ['da', 'fr', deprecated_code]
+        mock_get_translations_and_transcriptions.return_value = mock_data
+        course_run = CourseRunFactory(end=now() + datetime.timedelta(days=10), ai_languages=None)
+        call_command('update_course_ai_languages', partner=self.partner.name)
+
+        course_run.refresh_from_db()
+        assert course_run.ai_languages['transcription_languages'] == [
+            {'code': 'da', 'label': 'Danish'},
+            {'code': 'fr', 'label': 'French'},
+            {'code': deprecated_code, 'label': deprecated_label},
+        ]
 
     @ddt.data(AI_LANGUAGES_DATA, AI_LANGUAGES_DATA_WITH_TRANSCRIPTIONS)
     def test_command_with_marketable_flag(self, mock_data, mock_get_translations_and_transcriptions):


### PR DESCRIPTION
[PROD-4313](https://2u-internal.atlassian.net/browse/PROD-4313)
-------
This PR adds the name of the language to the dictionary for the `attr` key in `transcription_languages` list. Currently, both the `code` and `label` keys has their values set to the language code