### PR TITLE
fix: explicitly add list_serializer_class

### DIFF
--- a/course_discovery/apps/api/v2/serializers.py
+++ b/course_discovery/apps/api/v2/serializers.py
@@ -48,6 +48,7 @@ class CourseSearchDocumentSerializerV2(SortFieldMixin, CourseSearchDocumentSeria
 
     class Meta(CourseSearchDocumentSerializer.Meta):
         document = CourseDocument
+        list_serializer_class = CourseSearchDocumentSerializer.Meta.list_serializer_class
         fields = CourseSearchDocumentSerializer.Meta.fields + SEARCH_INDEX_ADDITIONAL_FIELDS_V2
 
 
@@ -78,6 +79,7 @@ class LearnerPathwaySearchDocumentSerializerV2(SortFieldMixin, LearnerPathwaySea
 
     class Meta(LearnerPathwaySearchDocumentSerializer.Meta):
         document = LearnerPathwayDocument
+        list_serializer_class = LearnerPathwaySearchDocumentSerializer.Meta.list_serializer_class
         fields = LearnerPathwaySearchDocumentSerializer.Meta.fields + SEARCH_INDEX_ADDITIONAL_FIELDS_V2
 
 

--- a/course_discovery/apps/api/v2/tests/test_views/test_search.py
+++ b/course_discovery/apps/api/v2/tests/test_views/test_search.py
@@ -55,7 +55,8 @@ class AggregateSearchViewSetV2Tests(mixins.LoginMixin, ElasticsearchTestMixin, m
                 type__is_marketable=True,
                 status=CourseRunStatus.Published,
             )
-        response = self.client.get(self.list_path)
+        with self.assertNumQueries(11, threshold=2):
+            response = self.client.get(self.list_path)
         response_data = response.json()
         assert response.status_code == 200
         assert response_data["count"] == 15


### PR DESCRIPTION
[PROD-4304](https://2u-internal.atlassian.net/browse/PROD-4304)
Inheriting meta class doesn't seem to have been setting the `list_serializer_class` which ends up calling the `to_representation` of the DRF version and not our custom ListSerializers of Course and LearnerPathway documents.

This PR sets the custom list serializers correctly and rearranges the order in which these serializers are being inherited. 