### PR TITLE
feat: data_modified_timestamp updates for related fields of Programs and Degrees

### DIFF
--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -552,8 +552,8 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
 
         assert mock_logger.call_count == 1
         assert mock_logger.call_args_list[0] == \
-               mock.call('An error occurred while setting the course run image for [{key}] in studio. All other fields '
-                         'were successfully saved in Studio.'.format(key=new_key))
+            mock.call('An error occurred while setting the course run image for [{key}] in studio. All other fields '
+                      'were successfully saved in Studio.'.format(key=new_key))
 
     @responses.activate
     def test_update_operates_on_drafts(self):
@@ -1454,15 +1454,15 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
 
         data = response.data['actions']['PUT']
         assert data['level_type']['choices'] == \
-               [{'display_name': self.course_run.level_type.name_t,
-                 'value': self.course_run.level_type.name_t},
-                {'display_name': self.course_run_2.level_type.name_t,
-                 'value': self.course_run_2.level_type.name_t},
-                {'display_name': self.draft_course_run.level_type.name_t,
-                 'value': self.draft_course_run.level_type.name_t}]
+            [{'display_name': self.course_run.level_type.name_t,
+              'value': self.course_run.level_type.name_t},
+             {'display_name': self.course_run_2.level_type.name_t,
+              'value': self.course_run_2.level_type.name_t},
+             {'display_name': self.draft_course_run.level_type.name_t,
+             'value': self.draft_course_run.level_type.name_t}]
 
         assert data['content_language']['choices'] == \
-               [{'display_name': x.name, 'value': x.code} for x in LanguageTag.objects.all().order_by('name')]
+            [{'display_name': x.name, 'value': x.code} for x in LanguageTag.objects.all().order_by('name')]
         assert LanguageTag.objects.count() > 0
 
     def test_editable_list_gives_drafts(self):

--- a/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_course_runs.py
@@ -26,7 +26,7 @@ from course_discovery.apps.core.tests.mixins import ElasticsearchTestMixin
 from course_discovery.apps.course_metadata.choices import CourseRunRestrictionType, CourseRunStatus, ProgramStatus
 from course_discovery.apps.course_metadata.models import CourseRun, CourseRunType, RestrictedCourseRun, Seat, SeatType
 from course_discovery.apps.course_metadata.signals import (
-    connect_course_data_modified_timestamp_signal_handlers, disconnect_course_data_modified_timestamp_signal_handlers
+    connect_product_data_modified_timestamp_signal_handlers, disconnect_product_data_modified_timestamp_signal_handlers
 )
 from course_discovery.apps.course_metadata.tests.factories import (
     CourseEditorFactory, CourseFactory, CourseRunFactory, CourseRunTypeFactory, CourseTypeFactory, OrganizationFactory,
@@ -66,11 +66,11 @@ class CourseRunViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mi
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_signal_handlers()
+        disconnect_product_data_modified_timestamp_signal_handlers()
 
     @classmethod
     def tearDownClass(cls) -> None:
-        connect_course_data_modified_timestamp_signal_handlers()
+        connect_product_data_modified_timestamp_signal_handlers()
         super().tearDownClass()
 
     def mock_patch_to_studio(self, key, access_token=True, status=200, body=None):

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -31,8 +31,8 @@ from course_discovery.apps.course_metadata.models import (
     RestrictedCourseRun, Seat, Source, TaxiForm
 )
 from course_discovery.apps.course_metadata.signals import (
-    additional_metadata_facts_changed, connect_course_data_modified_timestamp_signal_handlers,
-    disconnect_course_data_modified_timestamp_signal_handlers, product_meta_taggable_changed
+    additional_metadata_facts_changed, connect_product_data_modified_timestamp_signal_handlers,
+    disconnect_product_data_modified_timestamp_signal_handlers, product_meta_taggable_changed
 )
 from course_discovery.apps.course_metadata.tests.factories import (
     CourseEditorFactory, CourseEntitlementFactory, CourseFactory, CourseLocationRestrictionFactory, CourseRunFactory,
@@ -79,11 +79,11 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_signal_handlers()
+        disconnect_product_data_modified_timestamp_signal_handlers()
 
     @classmethod
     def tearDownClass(cls) -> None:
-        connect_course_data_modified_timestamp_signal_handlers()
+        connect_product_data_modified_timestamp_signal_handlers()
         super().tearDownClass()
 
     def mock_ecommerce_publication(self):

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -2375,8 +2375,8 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         }, format='json')
         assert response.status_code == 400
         assert response.data == \
-               ('Switching entitlement types after being reviewed is not supported. Please reach out to your '
-                'project coordinator for additional help if necessary.')
+            ('Switching entitlement types after being reviewed is not supported. Please reach out to your '
+             'project coordinator for additional help if necessary.')
 
     def test_update_fails_if_manual_slug_exists(self):
         response = self.create_course()
@@ -2642,14 +2642,14 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
 
         data = response.json()['actions']['PUT']
         assert data['level_type']['choices'] == \
-               [{'display_name': self.course.level_type.name_t, 'value': self.course.level_type.name_t}]
+            [{'display_name': self.course.level_type.name_t, 'value': self.course.level_type.name_t}]
 
         assert data['entitlements']['child']['children']['mode']['choices'] == \
-               [{'display_name': 'Audit', 'value': 'audit'},
-                {'display_name': 'Credit', 'value': 'credit'},
-                {'display_name': 'Honor', 'value': 'honor'},
-                {'display_name': 'Professional', 'value': 'professional'},
-                {'display_name': 'Verified', 'value': 'verified'}]
+            [{'display_name': 'Audit', 'value': 'audit'},
+             {'display_name': 'Credit', 'value': 'credit'},
+             {'display_name': 'Honor', 'value': 'honor'},
+             {'display_name': 'Professional', 'value': 'professional'},
+             {'display_name': 'Verified', 'value': 'verified'}]
 
         assert data['subjects']['child']['choices'] == [{'display_name': 'Subject1', 'value': 'subject1'}]
         assert 'choices' not in data['partner']

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -79,6 +79,7 @@ class TestProgramViewSet(SerializationMixin):
             type=program_type,
         )
         program.labels.add(topic)
+        program.refresh_from_db()
         return program
 
     def create_curriculum(self, parent_program):

--- a/course_discovery/apps/api/v1/tests/test_views/test_programs.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_programs.py
@@ -134,7 +134,7 @@ class TestProgramViewSet(SerializationMixin):
     def test_retrieve_basic_curriculum(self, django_assert_num_queries):
         program = self.create_program(courses=[])
         self.create_curriculum(program)
-
+        program.refresh_from_db()
         with django_assert_num_queries(FuzzyInt(52, 3)):
             response = self.assert_retrieve_success(program)
         assert response.data == self.serialize_program(program)
@@ -153,7 +153,7 @@ class TestProgramViewSet(SerializationMixin):
             program=child_program2,
             curriculum=curriculum
         )
-
+        parent_program.refresh_from_db()
         with django_assert_num_queries(FuzzyInt(85, 3)):
             response = self.assert_retrieve_success(parent_program)
         assert response.data == self.serialize_program(parent_program)

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -933,13 +933,12 @@ class ProgramsApiDataLoader(AbstractDataLoader):
         # The course_code key field is technically useless, so we must build the course list from the
         # associated course runs.
         courses = Course.objects.filter(course_runs__key__in=course_run_keys).distinct()
-        program.courses.clear()
-        program.courses.add(*courses)
+        program.courses.set(courses)
 
         # Do a diff of all the course runs and the explicitly-associated course runs to determine
         # which course runs should be explicitly excluded.
         excluded_course_runs = CourseRun.objects.filter(course__in=courses).exclude(key__in=course_run_keys)
-        program.excluded_course_runs.set(*excluded_course_runs)
+        program.excluded_course_runs.set(excluded_course_runs)
 
     def _update_program_organizations(self, body, program):
         uuid = self._get_uuid(body)
@@ -949,8 +948,7 @@ class ProgramsApiDataLoader(AbstractDataLoader):
         if len(org_keys) != organizations.count():
             logger.error('Organizations for program [%s] are invalid!', uuid)
 
-        program.authoring_organizations.clear()
-        program.authoring_organizations.add(*organizations)
+        program.authoring_organizations.set(organizations)
 
     def _get_banner_image_url(self, body):
         image_key = f'w{self.image_width}h{self.image_height}'

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -939,8 +939,7 @@ class ProgramsApiDataLoader(AbstractDataLoader):
         # Do a diff of all the course runs and the explicitly-associated course runs to determine
         # which course runs should be explicitly excluded.
         excluded_course_runs = CourseRun.objects.filter(course__in=courses).exclude(key__in=course_run_keys)
-        program.excluded_course_runs.clear()
-        program.excluded_course_runs.add(*excluded_course_runs)
+        program.excluded_course_runs.set(*excluded_course_runs)
 
     def _update_program_organizations(self, body, program):
         uuid = self._get_uuid(body)

--- a/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/degrees_loader.py
@@ -301,8 +301,7 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         """
         Handle organization data for a degree.
         """
-        degree.authoring_organizations.clear()
-        degree.authoring_organizations.add(org)
+        degree.authoring_organizations.set([org])
 
     def _handle_image_fields(self, data, degree):
         """
@@ -373,13 +372,14 @@ class DegreeCSVDataLoader(AbstractDataLoader):
         """
         specializations_data = data.get('specializations', '')
         if specializations_data:
-            degree.specializations.clear()
             specializations_data = specializations_data.split('|')
+            new_specializations = []
             for specialization in specializations_data:
                 specialization = specialization.strip()
                 if specialization:
                     specialization_obj, _ = Specialization.objects.get_or_create(value=specialization)
-                    degree.specializations.add(specialization_obj)
+                    new_specializations.append(specialization_obj)
+            degree.specializations.set(new_specializations)
 
     def _get_object(self, model, key, value, degree_slug):
         """

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_analytics_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_analytics_api.py
@@ -47,7 +47,7 @@ class AnalyticsAPIDataLoaderTests(DataLoaderTestMixin, TestCase):
 
         # Create a program with all of the courses we created
         program = ProgramFactory()
-        program.courses.set(courses.values())
+        program.courses.set(list(courses.values()))
 
     def _mock_course_summaries(self, data):
         url = f'{self.api_url}course_summaries/'

--- a/course_discovery/apps/course_metadata/management/commands/load_program_fixture.py
+++ b/course_discovery/apps/course_metadata/management/commands/load_program_fixture.py
@@ -17,7 +17,7 @@ from course_discovery.apps.course_metadata.models import (
 )
 from course_discovery.apps.course_metadata.signals import (
     check_curriculum_for_cycles, check_curriculum_program_membership_for_cycles,
-    connect_course_data_modified_timestamp_signal_handlers, disconnect_course_data_modified_timestamp_signal_handlers,
+    connect_product_data_modified_timestamp_signal_handlers, disconnect_product_data_modified_timestamp_signal_handlers,
     ensure_external_key_uniqueness__course_run, ensure_external_key_uniqueness__curriculum,
     ensure_external_key_uniqueness__curriculum_course_membership
 )
@@ -68,14 +68,14 @@ def disconnect_program_signals():
 
     for signal in signals_list:
         signal['action'].disconnect(signal['signal'], sender=signal['sender'])
-    disconnect_course_data_modified_timestamp_signal_handlers()
+    disconnect_product_data_modified_timestamp_signal_handlers()
 
     try:
         yield
     finally:
         for signal in signals_list:
             signal['action'].connect(signal['signal'], sender=signal['sender'])
-        connect_course_data_modified_timestamp_signal_handlers()
+        connect_product_data_modified_timestamp_signal_handlers()
 
 
 class Command(BaseCommand):

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -4444,7 +4444,10 @@ class Curriculum(ManageHistoryMixin, TimeStampedModel):
 
     def update_product_data_modified_timestamp(self, bypass_has_changed=False):
         if self.has_changed or bypass_has_changed:
-            assoc_prog = [pk for pk in [self.field_tracker.previous('program_id'), self.program.pk] if pk is not None]
+            assoc_prog = [self.field_tracker.previous('program_id')]
+            if self.program:
+                assoc_prog.append(self.program.id)
+            assoc_prog = filter(lambda x: x is not None, assoc_prog)
             Program.objects.filter(id__in=assoc_prog).update(
                 data_modified_timestamp=datetime.datetime.now()
             )

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -868,7 +868,6 @@ class ProductMeta(ManageHistoryMixin, TimeStampedModel):
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
 
-
     def __str__(self):
         return self.title
 
@@ -910,7 +909,6 @@ class TaxiForm(ManageHistoryMixin, TimeStampedModel):
                 self.additional_metadata.related_courses.all().update(
                     data_modified_timestamp=datetime.datetime.now(pytz.UTC)
                 )
-                
                 Program.objects.filter(
                     courses__in=self.additional_metadata.related_courses.all()
                 ).update(data_modified_timestamp=datetime.datetime.now(pytz.UTC))
@@ -1024,7 +1022,6 @@ class AdditionalMetadata(ManageHistoryMixin, TimeStampedModel):
             Program.objects.filter(
                 courses__in=self.related_courses.all()
             ).update(data_modified_timestamp=datetime.datetime.now(pytz.UTC))
-
 
     def __str__(self):
         return f"{self.external_url} - {self.external_identifier}"
@@ -1337,8 +1334,8 @@ class ProductValue(ManageHistoryMixin, TimeStampedModel):
                 courses__in=self.courses.all()
             ).update(data_modified_timestamp=datetime.datetime.now(pytz.UTC))
 
-
             self.programs.all().update(data_modified_timestamp=datetime.datetime.now(pytz.UTC))
+
 
 class GeoLocation(ManageHistoryMixin, TimeStampedModel):
     """
@@ -1400,7 +1397,6 @@ class GeoLocation(ManageHistoryMixin, TimeStampedModel):
             Program.objects.filter(
                 courses__in=self.courses.all()
             ).update(data_modified_timestamp=datetime.datetime.now(pytz.UTC))
-
 
             self.programs.all().update(data_modified_timestamp=datetime.datetime.now(pytz.UTC))
 
@@ -4243,7 +4239,7 @@ class DegreeAdditionalMetadata(ManageHistoryMixin, TimeStampedModel):
     @property
     def has_changed(self):
         return self.has_model_changed()
-    
+
     def update_product_data_modified_timestamp(self):
         if self.has_changed:
             Degree.objects.filter(id__in=[self.degree_id]).update(
@@ -4296,7 +4292,6 @@ class IconTextPairing(ManageHistoryMixin, TimeStampedModel):
 
     class Meta:
         verbose_name_plural = "IconTextPairings"
-
 
     @property
     def has_changed(self):
@@ -4466,7 +4461,6 @@ class CurriculumProgramMembership(ManageHistoryMixin, TimeStampedModel):
             Program.objects.filter(id__in=[self.curriculum.program_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
-            
 
     class Meta(TimeStampedModel.Meta):
         unique_together = (
@@ -4498,7 +4492,6 @@ class CurriculumCourseMembership(ManageHistoryMixin, TimeStampedModel):
             Program.objects.filter(id__in=[self.curriculum.program_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
-
 
     class Meta(TimeStampedModel.Meta):
         unique_together = (
@@ -4763,6 +4756,7 @@ class ProgramLocationRestriction(ManageHistoryMixin, AbstractLocationRestriction
             Program.objects.filter(id__in=[self.program_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
+
 
 class CSVDataLoaderConfiguration(ConfigurationModel):
     """

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -4050,6 +4050,10 @@ class Ranking(ManageHistoryMixin, TimeStampedModel):
 
     def update_product_data_modified_timestamp(self):
         if self.has_changed:
+            logger.info(
+                f"Changes detected in Ranking {self.pk}, updating data modified "
+                f"timestamps for related programs."
+            )
             Degree.objects.filter(rankings=self).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
@@ -4068,6 +4072,10 @@ class Specialization(ManageHistoryMixin, AbstractValueModel):
 
     def update_product_data_modified_timestamp(self):
         if self.has_changed:
+            logger.info(
+                f"Changes detected in Specialization {self.pk}, updating data modified "
+                f"timestamps for related products."
+            )
             Degree.objects.filter(specializations=self).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
@@ -4242,6 +4250,10 @@ class DegreeAdditionalMetadata(ManageHistoryMixin, TimeStampedModel):
 
     def update_product_data_modified_timestamp(self):
         if self.has_changed:
+            logger.info(
+                f"Changes detected in DegreeAdditionalMetadata {self.pk}, updating data modified "
+                f"timestamps for related degree {self.degree_id}."
+            )
             Degree.objects.filter(id__in=[self.degree_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
@@ -4299,6 +4311,10 @@ class IconTextPairing(ManageHistoryMixin, TimeStampedModel):
 
     def update_product_data_modified_timestamp(self):
         if self.has_changed:
+            logger.info(
+                f"Changes detected in IconTextPairing {self.pk}, updating data modified "
+                f"timestamps for related degree {self.degree_id}."
+            )
             Degree.objects.filter(id__in=[self.degree_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
@@ -4343,6 +4359,10 @@ class DegreeDeadline(ManageHistoryMixin, TimeStampedModel):
 
     def update_product_data_modified_timestamp(self):
         if self.has_changed:
+            logger.info(
+                f"Changes detected in DegreeDeadline {self.pk}, updating data modified "
+                f"timestamps for related degree {self.degree_id}."
+            )
             Degree.objects.filter(id__in=[self.degree_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
@@ -4378,6 +4398,10 @@ class DegreeCost(ManageHistoryMixin, TimeStampedModel):
 
     def update_product_data_modified_timestamp(self):
         if self.has_changed:
+            logger.info(
+                f"Changes detected in DegreeCost {self.pk}, updating data modified "
+                f"timestamps for related degree {self.degree_id}."
+            )
             Degree.objects.filter(id__in=[self.degree_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
@@ -4432,6 +4456,10 @@ class Curriculum(ManageHistoryMixin, TimeStampedModel):
     def update_product_data_modified_timestamp(self, bypass_has_changed=False):
         if self.has_changed or bypass_has_changed:
             if self.program:
+                logger.info(
+                    f"Changes detected in Curriculum {self.pk}, updating data modified "
+                    f"timestamps for related program {self.program_id}."
+                )
                 Program.objects.filter(id=self.program_id).update(
                     data_modified_timestamp=datetime.datetime.now(pytz.UTC)
                 )
@@ -4458,6 +4486,10 @@ class CurriculumProgramMembership(ManageHistoryMixin, TimeStampedModel):
 
     def update_product_data_modified_timestamp(self, bypass_has_changed=False):
         if self.has_changed or bypass_has_changed:
+            logger.info(
+                f"Changes detected in CurriculumProgramMembership {self.pk}, updating data modified "
+                f"timestamps for related products."
+            )
             Program.objects.filter(id__in=[self.curriculum.program_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
@@ -4489,6 +4521,10 @@ class CurriculumCourseMembership(ManageHistoryMixin, TimeStampedModel):
 
     def update_product_data_modified_timestamp(self, bypass_has_changed=False):
         if self.has_changed or bypass_has_changed:
+            logger.info(
+                f"Changes detected in CurriculumCourseMembership {self.pk}, updating data modified "
+                f"timestamps for related products."
+            )
             Program.objects.filter(id__in=[self.curriculum.program_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )
@@ -4753,6 +4789,10 @@ class ProgramLocationRestriction(ManageHistoryMixin, AbstractLocationRestriction
 
     def update_product_data_modified_timestamp(self, bypass_has_changed=False):
         if self.has_changed or bypass_has_changed:
+            logger.info(
+                f"Changes detected in ProgramLocationRestriction {self.pk}, updating data modified "
+                f"timestamps for related program {self.program_id}."
+            )
             Program.objects.filter(id__in=[self.program_id]).update(
                 data_modified_timestamp=datetime.datetime.now(pytz.UTC)
             )

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -1667,7 +1667,7 @@ class Course(ManageHistoryMixin, DraftModelMixin, PkSearchableMixin, CachedMixin
         Course.everything.filter(key=self.key).update(
             data_modified_timestamp=datetime.datetime.now(pytz.UTC)
         )
-        Program.objects.filter(courses__in=[Course.everything.filter(key=self.key)]).update(
+        Program.objects.filter(courses__in=Course.everything.filter(key=self.key)).update(
             data_modified_timestamp=datetime.datetime.now(pytz.UTC)
         )
         self.refresh_from_db()
@@ -4078,7 +4078,7 @@ class Specialization(ManageHistoryMixin, AbstractValueModel):
 
     def update_product_data_modified_timestamp(self):
         if self.has_changed:
-            Degree.objects.filter(rankings=self).update(
+            Degree.objects.filter(specializations=self).update(
                 data_modified_timestamp=datetime.datetime.now()
             )
 

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -457,6 +457,7 @@ def program_labels_changed(sender, instance, action, **kwargs):
     """
     if action in ['pre_add', 'pre_remove'] and not kwargs['reverse'] \
             and kwargs['pk_set'] and instance._meta.label in ['course_metadata.Program', 'course_metadata.Degree']:
+        logger.info(f"{sender} has been updated for Program {instance.uuid}.")
         instance._meta.model.objects.filter(pk=instance.pk).update(
             data_modified_timestamp = datetime.now(pytz.UTC)
         )
@@ -538,10 +539,7 @@ def program_sorted_m2m_changed(sender, instance, action, **kwargs):  # pylint: d
         # corresponds to the frame of the set method. the objs param of that method contains
         # the values being set()
         objs = inspect.stack()[4][0].f_locals['objs']
-        if (len(objs) and isinstance(objs[0], int)):
-            to_set = objs.copy()
-        else:
-            to_set = [obj.id for obj in objs]
+        to_set = [obj if isinstance(obj, int) else obj.id for obj in objs]
         already_set = list(getattr(instance, field_name).all().values_list('id', flat=True))
 
         if to_set != already_set:

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -3,7 +3,6 @@ import inspect
 import logging
 import time
 from datetime import datetime, timezone
-import datetime
 import waffle  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from celery import shared_task
 from django.apps import apps
@@ -458,7 +457,7 @@ def program_labels_changed(sender, instance, action, **kwargs):
     if action in ['pre_add', 'pre_remove'] and not kwargs['reverse'] \
             and kwargs['pk_set'] and instance._meta.label in ['course_metadata.Program', 'course_metadata.Degree']:
         instance._meta.model.objects.filter(pk=instance.pk).update(
-            data_modified_timestamp = datetime.datetime.now()
+            data_modified_timestamp = datetime.now()
         )
 
 
@@ -543,7 +542,7 @@ def program_sorted_m2m_changed(sender, instance, action, **kwargs):  # pylint: d
 
         if to_set != already_set:
             instance._meta.model.objects.filter(pk=instance.pk).update(
-                data_modified_timestamp = datetime.datetime.now()
+                data_modified_timestamp = datetime.now()
             )
 
 
@@ -552,7 +551,7 @@ def program_excluded_runs(sender, instance, action, **kwargs):  # pylint: disabl
 
     if action in ['pre_add', 'pre_remove']:
         instance._meta.model.objects.filter(pk=instance.pk).update(
-            data_modified_timestamp = datetime.datetime.now()
+            data_modified_timestamp = datetime.now()
         )
 
 

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -561,8 +561,8 @@ def program_excluded_runs(sender, instance, action, **kwargs):  # pylint: disabl
 
 def connect_course_data_modified_timestamp_related_models():
     """
-    This wrapper is used to connect Course model's related models (ForeignKey)
-    whose data change should update data_modified_timestamp in Course model.
+    This wrapper is used to connect Course/Program model's related models (ForeignKey)
+    whose data change should update data_modified_timestamp in Course/Program model.
     """
     for model in [
         AdditionalMetadata,
@@ -600,8 +600,8 @@ def connect_course_data_modified_timestamp_related_models():
 
 def disconnect_course_data_modified_timestamp_related_models():
     """
-    This wrapper is used to disconnect Course model's related models (ForeignKey)
-    whose data change should update data_modified_timestamp in Course model. This
+    This wrapper is used to disconnect Course/Program model's related models (ForeignKey)
+    whose data change should update data_modified_timestamp in Course/Program model. This
     is to be used in unit tests to disconnect these signals.
     """
     for model in [
@@ -641,7 +641,7 @@ def disconnect_course_data_modified_timestamp_related_models():
 def disconnect_course_data_modified_timestamp_signal_handlers():
     """
     Util method to disconnect all signal handlers that update data_modified_timestamp on
-    Course model.
+    Course/Program models.
     """
     disconnect_course_data_modified_timestamp_related_models()
     m2m_changed.disconnect(product_meta_taggable_changed, sender=ProductMeta.keywords.through)
@@ -651,12 +651,29 @@ def disconnect_course_data_modified_timestamp_signal_handlers():
     m2m_changed.disconnect(course_collaborators_changed, Course.collaborators.through)
     m2m_changed.disconnect(course_subjects_changed, Course.subjects.through)
     m2m_changed.disconnect(course_run_staff_changed, CourseRun.staff.through)
+    m2m_changed.disconnect(program_labels_changed, sender=Program.labels.through)
+    m2m_changed.disconnect(program_excluded_runs, sender=Program.excluded_course_runs.through)
+
+    for m2m_field in [
+        Program.authoring_organizations.through,
+        Program.expected_learning_items.through,
+        Program.faq.through,
+        Program.instructor_ordering.through,
+        Program.credit_backing_organizations.through,
+        Program.corporate_endorsements.through,
+        Program.job_outlook_items.through,
+        Program.individual_endorsements.through,
+        Program.courses.through,
+        Degree.specializations.through,
+        Degree.rankings.through,
+    ]:
+        m2m_changed.disconnect(program_sorted_m2m_changed, sender=m2m_field)
 
 
 def connect_course_data_modified_timestamp_signal_handlers():
     """
     Util method to connect all signal handlers that update data_modified_timestamp on
-    Course model.
+    Course/Program models.
     """
     connect_course_data_modified_timestamp_related_models()
     m2m_changed.connect(product_meta_taggable_changed, sender=ProductMeta.keywords.through)
@@ -666,7 +683,23 @@ def connect_course_data_modified_timestamp_signal_handlers():
     m2m_changed.connect(course_collaborators_changed, Course.collaborators.through)
     m2m_changed.connect(course_subjects_changed, Course.subjects.through)
     m2m_changed.connect(course_run_staff_changed, CourseRun.staff.through)
+    m2m_changed.connect(program_labels_changed, sender=Program.labels.through)
+    m2m_changed.connect(program_excluded_runs, sender=Program.excluded_course_runs.through)
 
+    for m2m_field in [
+        Program.authoring_organizations.through,
+        Program.expected_learning_items.through,
+        Program.faq.through,
+        Program.instructor_ordering.through,
+        Program.credit_backing_organizations.through,
+        Program.corporate_endorsements.through,
+        Program.job_outlook_items.through,
+        Program.individual_endorsements.through,
+        Program.courses.through,
+        Degree.specializations.through,
+        Degree.rankings.through,
+    ]:
+        m2m_changed.connect(program_sorted_m2m_changed, sender=m2m_field)
 
 @receiver(m2m_changed, sender=User.groups.through)
 def handle_organization_group_removal(sender, instance, action, pk_set, reverse, **kwargs):  # pylint: disable=unused-argument

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -534,7 +534,11 @@ def program_sorted_m2m_changed(sender, instance, action, **kwargs):  # pylint: d
     field_name = sender._meta.model_name.split("_", 1)[1]
 
     if action == 'pre_clear' and not kwargs['reverse']:
-        to_set = [obj.id for obj in inspect.stack()[4][0].f_locals['objs']]
+        objs = inspect.stack()[4][0].f_locals['objs']
+        if (len(objs) and isinstance(objs[0], int)):
+            to_set = objs.copy()
+        else:
+            to_set = [obj.id for obj in objs]
         already_set = list(getattr(instance, field_name).all().values_list('id', flat=True))
 
         if to_set != already_set:

--- a/course_discovery/apps/course_metadata/signals.py
+++ b/course_discovery/apps/course_metadata/signals.py
@@ -559,7 +559,7 @@ def program_excluded_runs(sender, instance, action, **kwargs):  # pylint: disabl
         )
 
 
-def connect_course_data_modified_timestamp_related_models():
+def connect_product_data_modified_timestamp_related_models():
     """
     This wrapper is used to connect Course/Program model's related models (ForeignKey)
     whose data change should update data_modified_timestamp in Course/Program model.
@@ -598,7 +598,7 @@ def connect_course_data_modified_timestamp_related_models():
         pre_delete.connect(data_modified_timestamp_update__deletion, sender=model)
 
 
-def disconnect_course_data_modified_timestamp_related_models():
+def disconnect_product_data_modified_timestamp_related_models():
     """
     This wrapper is used to disconnect Course/Program model's related models (ForeignKey)
     whose data change should update data_modified_timestamp in Course/Program model. This
@@ -638,12 +638,12 @@ def disconnect_course_data_modified_timestamp_related_models():
         pre_delete.disconnect(data_modified_timestamp_update__deletion, sender=model)
 
 
-def disconnect_course_data_modified_timestamp_signal_handlers():
+def disconnect_product_data_modified_timestamp_signal_handlers():
     """
     Util method to disconnect all signal handlers that update data_modified_timestamp on
     Course/Program models.
     """
-    disconnect_course_data_modified_timestamp_related_models()
+    disconnect_product_data_modified_timestamp_related_models()
     m2m_changed.disconnect(product_meta_taggable_changed, sender=ProductMeta.keywords.through)
     m2m_changed.disconnect(course_topics_taggable_changed, sender=Course.topics.through)
     m2m_changed.disconnect(additional_metadata_facts_changed, sender=AdditionalMetadata.facts.through)
@@ -670,12 +670,12 @@ def disconnect_course_data_modified_timestamp_signal_handlers():
         m2m_changed.disconnect(program_sorted_m2m_changed, sender=m2m_field)
 
 
-def connect_course_data_modified_timestamp_signal_handlers():
+def connect_product_data_modified_timestamp_signal_handlers():
     """
     Util method to connect all signal handlers that update data_modified_timestamp on
     Course/Program models.
     """
-    connect_course_data_modified_timestamp_related_models()
+    connect_product_data_modified_timestamp_related_models()
     m2m_changed.connect(product_meta_taggable_changed, sender=ProductMeta.keywords.through)
     m2m_changed.connect(course_topics_taggable_changed, sender=Course.topics.through)
     m2m_changed.connect(additional_metadata_facts_changed, sender=AdditionalMetadata.facts.through)
@@ -737,4 +737,4 @@ def handle_organization_group_removal(sender, instance, action, pk_set, reverse,
             )
 
 
-connect_course_data_modified_timestamp_related_models()
+connect_product_data_modified_timestamp_related_models()

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -758,7 +758,7 @@ class ProgramBaseFactory(factory.django.DjangoModelFactory):
     ## while running the other postgen hooks (e.g in signal handlers)
     @factory.post_generation
     def refresh(self, create, extracted, **kwargs):
-        if create:  # pragma: no cover
+        if create and extracted:  # pragma: no cover
             self.refresh_from_db()
 
 

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -753,9 +753,9 @@ class ProgramBaseFactory(factory.django.DjangoModelFactory):
         if create:  # pragma: no cover
             add_m2m_data(self.curricula, extracted)
 
-    ## This hook must be the last one as it is responsible for refreshing the
-    ## object to pick up any changes that may have been made in the database
-    ## while running the other postgen hooks (e.g in signal handlers)
+    # This hook must be the last one as it is responsible for refreshing the
+    # object to pick up any changes that may have been made in the database
+    # while running the other postgen hooks (e.g in signal handlers)
     @factory.post_generation
     def refresh(self, create, extracted, **kwargs):
         if create and extracted:  # pragma: no cover

--- a/course_discovery/apps/course_metadata/tests/factories.py
+++ b/course_discovery/apps/course_metadata/tests/factories.py
@@ -753,6 +753,14 @@ class ProgramBaseFactory(factory.django.DjangoModelFactory):
         if create:  # pragma: no cover
             add_m2m_data(self.curricula, extracted)
 
+    ## This hook must be the last one as it is responsible for refreshing the
+    ## object to pick up any changes that may have been made in the database
+    ## while running the other postgen hooks (e.g in signal handlers)
+    @factory.post_generation
+    def refresh(self, create, extracted, **kwargs):
+        if create:  # pragma: no cover
+            self.refresh_from_db()
+
 
 class ProgramFactory(ProgramBaseFactory):
     status = ProgramStatus.Active

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -339,7 +339,6 @@ class TestCourse(TestCase):
         """
         course = factories.CourseFactory(draft=False)
         program = factories.ProgramFactory(courses=[course])
-        program.refresh_from_db()
 
         data_modified_timestamp = course.data_modified_timestamp
         prog_modified_timestamp = program.data_modified_timestamp
@@ -359,7 +358,6 @@ class TestCourse(TestCase):
             additional_metadata=AdditionalMetadataFactory(external_identifier='identifier_1')
         )
         prog = factories.ProgramFactory(courses=[course])
-        prog.refresh_from_db()
         data_modified_timestamp = course.data_modified_timestamp
         prog_timestamp = prog.data_modified_timestamp
         course.additional_metadata = AdditionalMetadataFactory(external_identifier='identifier_2')
@@ -602,7 +600,6 @@ class TestCourse(TestCase):
         draft_course = CourseFactory(draft=True, title="Test course")
         non_draft_course = CourseFactory(draft_version=draft_course, title=draft_course.title, key=draft_course.key)
         program = ProgramFactory(courses=[non_draft_course])
-        program.refresh_from_db()
         draft_course.url_slug_history.all().delete()
         non_draft_course.url_slug_history.all().delete()
         # Need to clear cache explicitly as marketing_url creation, that uses active_url_slug, sets the
@@ -676,7 +673,6 @@ class TestCourse(TestCase):
         draft_course = CourseFactory(draft=True, title="Test course")
         non_draft_course = CourseFactory(draft_version=draft_course, title=draft_course.title, key=draft_course.key)
         program = ProgramFactory(courses=[non_draft_course])
-        program.refresh_from_db()
         draft_course.url_slug_history.all().delete()
         non_draft_course.url_slug_history.all().delete()
 
@@ -1666,7 +1662,6 @@ class CourseRunTests(OAuth2Mixin, TestCase):
         """
         course_run = CourseRunFactory(draft=True, max_effort=9)
         program = ProgramFactory(courses=[course_run.course])
-        program.refresh_from_db()
         course_timestamp = course_run.course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         course_run.max_effort = 10
@@ -2283,7 +2278,6 @@ class CertificateInfoTests(TestCase):
             )
         )
         program = factories.ProgramFactory(courses=[course])
-        program.refresh_from_db()
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         cert_info.heading = 'updated heading'
@@ -2333,7 +2327,6 @@ class ProductMetaTests(TestCase):
         course.refresh_from_db()
         assert course_timestamp == course.data_modified_timestamp
         program = factories.ProgramFactory(courses=[official_course])
-        program.refresh_from_db()
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         product_meta.title = 'updated heading'
@@ -2377,7 +2370,6 @@ class ProductMetaTests(TestCase):
         )
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
         program = factories.ProgramFactory(courses=[official_course])
-        program.refresh_from_db()
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         with LogCapture(LOGGER_PATH) as log:
@@ -2420,7 +2412,6 @@ class ProductValueTests(TestCase):
             in_year_value=product_value
         )
         program = factories.ProgramFactory(courses=[course])
-        program.refresh_from_db()
 
         program_timestamp = program.data_modified_timestamp
         course_timestamp = course.data_modified_timestamp
@@ -2468,7 +2459,6 @@ class GeoLocationTests(TestCase):
             geolocation=geoloc
         )
         program = factories.ProgramFactory(courses=[course])
-        program.refresh_from_db()
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         geoloc.location_name = 'location 2'
@@ -2512,7 +2502,6 @@ class CourseLocationRestrictionTests(TestCase):
             location_restriction=location_restriction
         )
         program = factories.ProgramFactory(courses=[course])
-        program.refresh_from_db()
         program_timestamp = program.data_modified_timestamp
         course_timestamp = course.data_modified_timestamp
         location_restriction.restriction_type = 'blacklist'
@@ -2564,7 +2553,6 @@ class AdditionalMetadataTests(TestCase):
             additional_metadata=additional_metadata
         )
         program = factories.ProgramFactory(courses=[course])
-        program.refresh_from_db()
 
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
@@ -2606,7 +2594,6 @@ class AdditionalMetadataTests(TestCase):
 
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
         program = factories.ProgramFactory(courses=[official_course])
-        program.refresh_from_db()
 
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
@@ -2703,7 +2690,6 @@ class TaxiFormTests(TestCase):
         course2 = CourseFactory(additional_metadata=additional_metadata)
 
         program = ProgramFactory(courses = [course1])
-        program.refresh_from_db()
 
         program_timestamp = program.data_modified_timestamp
         course1_timestamp = course1.data_modified_timestamp
@@ -2727,7 +2713,6 @@ class TaxiFormTests(TestCase):
         additional_metadata = AdditionalMetadataFactory(taxi_form=taxi_form)
         course = CourseFactory(additional_metadata=additional_metadata)
         program = ProgramFactory(courses = [course])
-        program.refresh_from_db()
 
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
@@ -3896,7 +3881,6 @@ class CourseEntitlementTests(TestCase):
         course = factories.CourseFactory(draft=True)
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
         program = factories.ProgramFactory(courses=[official_course])
-        program.refresh_from_db()
         entitlement = factories.CourseEntitlementFactory(course=course, mode=self.mode, draft=True, price=50)
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -59,8 +59,9 @@ from course_discovery.apps.course_metadata.tests.mixins import MarketingSitePubl
 from course_discovery.apps.course_metadata.toggles import (
     IS_SUBDIRECTORY_SLUG_FORMAT_ENABLED, IS_SUBDIRECTORY_SLUG_FORMAT_FOR_BOOTCAMP_ENABLED
 )
-from course_discovery.apps.course_metadata.utils import ensure_draft_world, set_official_state
+from course_discovery.apps.course_metadata.utils import ensure_draft_world
 from course_discovery.apps.course_metadata.utils import logger as utils_logger
+from course_discovery.apps.course_metadata.utils import set_official_state
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.tests.factories import OrganizationExtensionFactory
 
@@ -964,13 +965,13 @@ class CourseRunTests(OAuth2Mixin, TestCase):
                                                   upgrade_deadline=None)
         honor_seat = factories.SeatFactory(course_run=course_run, type=honor_seat_type, upgrade_deadline=None)
         assert course_run.enrollable_seats([verified_seat_type, professional_seat_type]) == \
-               [verified_seat, professional_seat]
+            [verified_seat, professional_seat]
 
         # The method should not care about the course run's start date.
         course_run.start = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=1)
         course_run.save()
         assert course_run.enrollable_seats([verified_seat_type, professional_seat_type]) ==\
-               [verified_seat, professional_seat]
+            [verified_seat, professional_seat]
 
         # Enrollable seats of any type should be returned when no type parameter is specified.
         assert course_run.enrollable_seats() == [verified_seat, professional_seat, honor_seat]
@@ -2430,6 +2431,7 @@ class ProductValueTests(TestCase):
         program.refresh_from_db()
         assert course_timestamp == course.data_modified_timestamp
         assert program_timestamp == program.data_modified_timestamp
+
     def test_defaults(self):
         product_value = factories.ProductValue()
         assert product_value.per_click_international == product_value.per_click_usa == 5
@@ -2467,7 +2469,6 @@ class GeoLocationTests(TestCase):
         program.refresh_from_db()
         assert course_timestamp < course.data_modified_timestamp
         assert program_timestamp < program.data_modified_timestamp
-
 
         geoloc.save()
         course_timestamp = course.data_modified_timestamp
@@ -2520,6 +2521,7 @@ class CourseLocationRestrictionTests(TestCase):
         program.refresh_from_db()
         assert course_timestamp == course.data_modified_timestamp
         assert program_timestamp == program.data_modified_timestamp
+
 
 class AdditionalMetadataTests(TestCase):
     """ Tests for AdditionalMetadata. """
@@ -2689,7 +2691,7 @@ class TaxiFormTests(TestCase):
         course1 = CourseFactory(additional_metadata=additional_metadata)
         course2 = CourseFactory(additional_metadata=additional_metadata)
 
-        program = ProgramFactory(courses = [course1], refresh=True)
+        program = ProgramFactory(courses=[course1], refresh=True)
 
         program_timestamp = program.data_modified_timestamp
         course1_timestamp = course1.data_modified_timestamp
@@ -2712,7 +2714,7 @@ class TaxiFormTests(TestCase):
         taxi_form = factories.TaxiFormFactory()
         additional_metadata = AdditionalMetadataFactory(taxi_form=taxi_form)
         course = CourseFactory(additional_metadata=additional_metadata)
-        program = ProgramFactory(courses = [course], refresh=True)
+        program = ProgramFactory(courses=[course], refresh=True)
 
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
@@ -3135,7 +3137,7 @@ class ProgramTests(TestCase):
         """ Verify the property returns marketing url as it is if marketing_slug contains a slash"""
         self.program.marketing_slug = 'type/subject/org-title'
         assert self.program.marketing_url == f"{self.program.partner.marketing_site_url_root}" \
-                                             f"{self.program.marketing_slug}"
+            f"{self.program.marketing_slug}"
 
     def test_course_runs(self):
         """
@@ -3951,6 +3953,7 @@ class RankingTests(TestCase):
 @ddt.ddt
 class CurriculumTests(TestCase):
     """ Tests of the Curriculum model. """
+
     def setUp(self):
         super().setUp()
         self.course_run = factories.CourseRunFactory()
@@ -3979,6 +3982,7 @@ class CurriculumTests(TestCase):
 
 class CurriculumProgramMembershipTests(TestCase):
     """ Tests of the CurriculumProgramMembership model. """
+
     def setUp(self):
         super().setUp()
         self.course_run = factories.CourseRunFactory()
@@ -4014,6 +4018,7 @@ class CurriculumProgramMembershipTests(TestCase):
 
 class CurriculumCourseMembershipTests(TestCase):
     """ Tests of the CurriculumCourseMembership model. """
+
     def setUp(self):
         super().setUp()
         self.course_run = factories.CourseRunFactory()
@@ -4069,6 +4074,7 @@ class CurriculumCourseMembershipTests(TestCase):
 @ddt.ddt
 class DegreeDeadlineTests(TestCase):
     """ Tests the DegreeDeadline model."""
+
     def setUp(self):
         super().setUp()
         self.course_run = factories.CourseRunFactory()
@@ -4099,6 +4105,7 @@ class DegreeDeadlineTests(TestCase):
 
 class DegreeCostTests(TestCase):
     """ Tests the DegreeCost model."""
+
     def setUp(self):
         super().setUp()
         self.course_run = factories.CourseRunFactory()
@@ -4221,6 +4228,7 @@ class DegreeTests(TestCase):
         self.degree.save()
         assert self.degree.data_modified_timestamp == last_data_modified
 
+
 class CourseUrlSlugHistoryTest(TestCase):
 
     def test_slug_with_partner_mismatch(self):
@@ -4231,10 +4239,10 @@ class CourseUrlSlugHistoryTest(TestCase):
         with pytest.raises(ValidationError) as validation_error:
             slug_object.save()
         assert validation_error.value.message_dict['partner'] == \
-               ['Partner {partner_key} and course partner {course_partner_key} do not match when attempting to save'
-                ' url slug {url_slug}'
-                   .format(partner_key=mismatch_partner.name, course_partner_key=slug_object.course.partner.name,
-                           url_slug=slug_object.url_slug)]
+            ['Partner {partner_key} and course partner {course_partner_key} do not match when attempting to save'
+             ' url slug {url_slug}'
+             .format(partner_key=mismatch_partner.name, course_partner_key=slug_object.course.partner.name,
+                     url_slug=slug_object.url_slug)]
 
 
 class TestCourseRecommendations(TestCase):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -2350,7 +2350,7 @@ class ProductMetaTests(TestCase):
                 LOGGER_PATH,
                 'INFO',
                 f"ProductMeta update_product_data_modified_timestamp triggered for {product_meta.pk}."
-                f"Updating timestamp for related courses."
+                f"Updating timestamp for related products."
             )
         )
 
@@ -2391,7 +2391,7 @@ class ProductMetaTests(TestCase):
                 LOGGER_PATH,
                 'INFO',
                 f"ProductMeta update_product_data_modified_timestamp triggered for {product_meta.pk}."
-                f"Updating timestamp for related courses."
+                f"Updating timestamp for related products."
             )
         )
 
@@ -2580,7 +2580,7 @@ class AdditionalMetadataTests(TestCase):
                 LOGGER_PATH,
                 'INFO',
                 f"AdditionalMetadata update_product_data_modified_timestamp triggered "
-                f"for {additional_metadata.external_identifier}.Updating data modified timestamp for related courses."
+                f"for {additional_metadata.external_identifier}.Updating data modified timestamp for related products."
             )
         )
 
@@ -2622,7 +2622,7 @@ class AdditionalMetadataTests(TestCase):
                 LOGGER_PATH,
                 'INFO',
                 f"AdditionalMetadata update_product_data_modified_timestamp triggered "
-                f"for {additional_metadata.external_identifier}.Updating data modified timestamp for related courses."
+                f"for {additional_metadata.external_identifier}.Updating data modified timestamp for related products."
             )
         )
 

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -338,7 +338,7 @@ class TestCourse(TestCase):
         Verify data modified timestamp does not change for non-draft course change.
         """
         course = factories.CourseFactory(draft=False)
-        program = factories.ProgramFactory(courses=[course])
+        program = factories.ProgramFactory(courses=[course], refresh=True)
 
         data_modified_timestamp = course.data_modified_timestamp
         prog_modified_timestamp = program.data_modified_timestamp
@@ -357,14 +357,14 @@ class TestCourse(TestCase):
             draft=True,
             additional_metadata=AdditionalMetadataFactory(external_identifier='identifier_1')
         )
-        prog = factories.ProgramFactory(courses=[course])
+        program = factories.ProgramFactory(courses=[course], refresh=True)
         data_modified_timestamp = course.data_modified_timestamp
-        prog_timestamp = prog.data_modified_timestamp
+        program_timestamp = program.data_modified_timestamp
         course.additional_metadata = AdditionalMetadataFactory(external_identifier='identifier_2')
         course.save()
-        prog.refresh_from_db()
+        program.refresh_from_db()
         assert data_modified_timestamp < course.data_modified_timestamp
-        assert prog_timestamp < prog.data_modified_timestamp
+        assert program_timestamp < program.data_modified_timestamp
 
     def test_data_modified_timestamp_no_change(self):
         """
@@ -599,7 +599,7 @@ class TestCourse(TestCase):
         """
         draft_course = CourseFactory(draft=True, title="Test course")
         non_draft_course = CourseFactory(draft_version=draft_course, title=draft_course.title, key=draft_course.key)
-        program = ProgramFactory(courses=[non_draft_course])
+        program = ProgramFactory(courses=[non_draft_course], refresh=True)
         draft_course.url_slug_history.all().delete()
         non_draft_course.url_slug_history.all().delete()
         # Need to clear cache explicitly as marketing_url creation, that uses active_url_slug, sets the
@@ -672,7 +672,7 @@ class TestCourse(TestCase):
         """
         draft_course = CourseFactory(draft=True, title="Test course")
         non_draft_course = CourseFactory(draft_version=draft_course, title=draft_course.title, key=draft_course.key)
-        program = ProgramFactory(courses=[non_draft_course])
+        program = ProgramFactory(courses=[non_draft_course], refresh=True)
         draft_course.url_slug_history.all().delete()
         non_draft_course.url_slug_history.all().delete()
 
@@ -1661,7 +1661,7 @@ class CourseRunTests(OAuth2Mixin, TestCase):
         for Course.
         """
         course_run = CourseRunFactory(draft=True, max_effort=9)
-        program = ProgramFactory(courses=[course_run.course])
+        program = ProgramFactory(courses=[course_run.course], refresh=True)
         course_timestamp = course_run.course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         course_run.max_effort = 10
@@ -2277,7 +2277,7 @@ class CertificateInfoTests(TestCase):
                 certificate_info=cert_info
             )
         )
-        program = factories.ProgramFactory(courses=[course])
+        program = factories.ProgramFactory(courses=[course], refresh=True)
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         cert_info.heading = 'updated heading'
@@ -2326,7 +2326,7 @@ class ProductMetaTests(TestCase):
         course_timestamp = course.data_modified_timestamp
         course.refresh_from_db()
         assert course_timestamp == course.data_modified_timestamp
-        program = factories.ProgramFactory(courses=[official_course])
+        program = factories.ProgramFactory(courses=[official_course], refresh=True)
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         product_meta.title = 'updated heading'
@@ -2369,7 +2369,7 @@ class ProductMetaTests(TestCase):
             )
         )
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
-        program = factories.ProgramFactory(courses=[official_course])
+        program = factories.ProgramFactory(courses=[official_course], refresh=True)
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         with LogCapture(LOGGER_PATH) as log:
@@ -2411,7 +2411,7 @@ class ProductValueTests(TestCase):
             draft=True,
             in_year_value=product_value
         )
-        program = factories.ProgramFactory(courses=[course])
+        program = factories.ProgramFactory(courses=[course], refresh=True)
 
         program_timestamp = program.data_modified_timestamp
         course_timestamp = course.data_modified_timestamp
@@ -2458,7 +2458,7 @@ class GeoLocationTests(TestCase):
             draft=True,
             geolocation=geoloc
         )
-        program = factories.ProgramFactory(courses=[course])
+        program = factories.ProgramFactory(courses=[course], refresh=True)
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
         geoloc.location_name = 'location 2'
@@ -2501,7 +2501,7 @@ class CourseLocationRestrictionTests(TestCase):
             draft=True,
             location_restriction=location_restriction
         )
-        program = factories.ProgramFactory(courses=[course])
+        program = factories.ProgramFactory(courses=[course], refresh=True)
         program_timestamp = program.data_modified_timestamp
         course_timestamp = course.data_modified_timestamp
         location_restriction.restriction_type = 'blacklist'
@@ -2552,7 +2552,7 @@ class AdditionalMetadataTests(TestCase):
             draft=True,
             additional_metadata=additional_metadata
         )
-        program = factories.ProgramFactory(courses=[course])
+        program = factories.ProgramFactory(courses=[course], refresh=True)
 
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
@@ -2593,7 +2593,7 @@ class AdditionalMetadataTests(TestCase):
         )
 
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
-        program = factories.ProgramFactory(courses=[official_course])
+        program = factories.ProgramFactory(courses=[official_course], refresh=True)
 
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
@@ -2689,7 +2689,7 @@ class TaxiFormTests(TestCase):
         course1 = CourseFactory(additional_metadata=additional_metadata)
         course2 = CourseFactory(additional_metadata=additional_metadata)
 
-        program = ProgramFactory(courses = [course1])
+        program = ProgramFactory(courses = [course1], refresh=True)
 
         program_timestamp = program.data_modified_timestamp
         course1_timestamp = course1.data_modified_timestamp
@@ -2712,7 +2712,7 @@ class TaxiFormTests(TestCase):
         taxi_form = factories.TaxiFormFactory()
         additional_metadata = AdditionalMetadataFactory(taxi_form=taxi_form)
         course = CourseFactory(additional_metadata=additional_metadata)
-        program = ProgramFactory(courses = [course])
+        program = ProgramFactory(courses = [course], refresh=True)
 
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
@@ -3880,7 +3880,7 @@ class CourseEntitlementTests(TestCase):
         """
         course = factories.CourseFactory(draft=True)
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
-        program = factories.ProgramFactory(courses=[official_course])
+        program = factories.ProgramFactory(courses=[official_course], refresh=True)
         entitlement = factories.CourseEntitlementFactory(course=course, mode=self.mode, draft=True, price=50)
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -47,7 +47,7 @@ from course_discovery.apps.course_metadata.publishers import (
     CourseRunMarketingSitePublisher, ProgramMarketingSitePublisher
 )
 from course_discovery.apps.course_metadata.signals import (
-    connect_course_data_modified_timestamp_related_models, disconnect_course_data_modified_timestamp_related_models
+    connect_product_data_modified_timestamp_related_models, disconnect_product_data_modified_timestamp_related_models
 )
 from course_discovery.apps.course_metadata.tests import factories
 from course_discovery.apps.course_metadata.tests.factories import (
@@ -75,11 +75,11 @@ class TestCourse(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def test_str(self):
@@ -938,11 +938,11 @@ class CourseRunTests(OAuth2Mixin, TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def setUp(self):
@@ -2248,11 +2248,11 @@ class CertificateInfoTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def test_str(self):
@@ -2303,11 +2303,11 @@ class ProductMetaTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def test_update_product_data_modified_timestamp(self):
@@ -2394,11 +2394,11 @@ class ProductValueTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def test_update_product_data_modified_timestamp(self):
@@ -2441,11 +2441,11 @@ class GeoLocationTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def test_update_product_data_modified_timestamp(self):
@@ -2484,11 +2484,11 @@ class CourseLocationRestrictionTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def test_update_product_data_modified_timestamp(self):
@@ -2527,11 +2527,11 @@ class AdditionalMetadataTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def test_taxi_form(self):
@@ -2655,11 +2655,11 @@ class TaxiFormTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def setUp(self):
@@ -3853,11 +3853,11 @@ class CourseEntitlementTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_related_models()
+        disconnect_product_data_modified_timestamp_related_models()
 
     @classmethod
     def tearDownClass(cls):
-        connect_course_data_modified_timestamp_related_models()
+        connect_product_data_modified_timestamp_related_models()
         super().tearDownClass()
 
     def setUp(self):

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -4215,6 +4215,7 @@ class DegreeTests(TestCase):
         self.assertEqual(degree.specializations.first().value, specialization.value)
 
     def test_degree_timestamp_update_simple_changes(self):
+        """Verify that changes on the Degree model update the data_modified_timestamp"""
         self.degree.refresh_from_db()
 
         last_data_modified = self.degree.data_modified_timestamp

--- a/course_discovery/apps/course_metadata/tests/test_models.py
+++ b/course_discovery/apps/course_metadata/tests/test_models.py
@@ -3168,6 +3168,8 @@ class ProgramTests(TestCase):
         data_modified_timestamp = program.data_modified_timestamp
         program.geolocation.location_name = 'New Location name'
         program.save()
+        program.geolocation.save()
+        program.refresh_from_db()
         assert data_modified_timestamp < program.data_modified_timestamp
 
     def test_data_modified_timestamp_no_change(self):
@@ -3242,7 +3244,7 @@ class ProgramTests(TestCase):
         assert self.program.start == expected_start
 
         # Verify start is None for programs with no courses.
-        self.program.courses.clear()
+        self.program.courses.set([])
         assert self.program.start is None
 
         # Verify start is None if no course runs have a start date.

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -8,7 +8,7 @@ import pytest
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db.models.signals import m2m_changed, pre_save, pre_delete
+from django.db.models.signals import m2m_changed, pre_delete, pre_save
 from django.test import TestCase, override_settings
 from factory.django import DjangoModelFactory
 from opaque_keys.edx.keys import CourseKey
@@ -25,23 +25,25 @@ from course_discovery.apps.course_metadata.algolia_models import (
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.models import (
     AdditionalMetadata, BackfillCourseRunSlugsConfig, BackpopulateCourseTypeConfig, BulkModifyProgramHookConfig,
-    BulkOperationTask, BulkUpdateImagesConfig, BulkUploadTagsConfig, Course, CourseEditor, CourseRun, CSVDataLoaderConfiguration,
-    Curriculum, CurriculumCourseMembership, CurriculumProgramMembership, DataLoaderConfig, DeduplicateHistoryConfig, Degree, DeletePersonDupsConfig,
-    DrupalPublishUuidConfig, LevelTypeTranslation, MigrateCourseSlugConfiguration,
-    MigratePublisherToCourseMetadataConfig, ProductMeta, ProfileImageDownloadConfig, Program, ProgramTypeTranslation,
-    RemoveRedirectsConfig, SubjectTranslation, TagCourseUuidsConfig, TaxiForm, TopicTranslation
+    BulkOperationTask, BulkUpdateImagesConfig, BulkUploadTagsConfig, Course, CourseEditor, CourseRun,
+    CSVDataLoaderConfiguration, Curriculum, CurriculumCourseMembership, CurriculumProgramMembership, DataLoaderConfig,
+    DeduplicateHistoryConfig, Degree, DeletePersonDupsConfig, DrupalPublishUuidConfig, LevelTypeTranslation,
+    MigrateCourseSlugConfiguration, MigratePublisherToCourseMetadataConfig, ProductMeta, ProfileImageDownloadConfig,
+    Program, ProgramTypeTranslation, RemoveRedirectsConfig, SubjectTranslation, TagCourseUuidsConfig, TaxiForm,
+    TopicTranslation
 )
 from course_discovery.apps.course_metadata.signals import (
     _duplicate_external_key_message, additional_metadata_facts_changed,
     connect_product_data_modified_timestamp_signal_handlers, course_collaborators_changed, course_run_staff_changed,
     course_run_transcript_languages_changed, course_subjects_changed, course_topics_taggable_changed,
-    disconnect_product_data_modified_timestamp_signal_handlers, product_meta_taggable_changed,
-    update_course_data_from_event, program_labels_changed, program_sorted_m2m_changed,
-    program_excluded_runs, 
+    disconnect_product_data_modified_timestamp_signal_handlers, product_meta_taggable_changed, program_excluded_runs,
+    program_labels_changed, program_sorted_m2m_changed, update_course_data_from_event
 )
 from course_discovery.apps.course_metadata.tests import factories
 from course_discovery.apps.course_metadata.tests.factories import CourseEditorFactory, CourseFactory
-from course_discovery.apps.course_metadata.utils import set_official_state, data_modified_timestamp_update, data_modified_timestamp_update__deletion
+from course_discovery.apps.course_metadata.utils import (
+    data_modified_timestamp_update, data_modified_timestamp_update__deletion, set_official_state
+)
 from course_discovery.apps.ietf_language_tags.models import LanguageTag
 from course_discovery.apps.publisher.tests.factories import GroupFactory, OrganizationExtensionFactory
 
@@ -893,7 +895,7 @@ class TestCourseDataUpdateSignal(TestCase):
                     metadata=metadata
                 )
                 assert f"COURSE_CATALOG_INFO_CHANGED event received within the " \
-                       f"delay applicable window for course run {self.course_key}." in logger.output[0]
+                    f"delay applicable window for course run {self.course_key}." in logger.output[0]
 
         sleep_patch.assert_called_once_with(settings.EVENT_BUS_PROCESSING_DELAY_SECONDS)
 
@@ -902,6 +904,7 @@ class OrganizationGroupRemovalTests(TestCase):
     """
     Tests for the handle_organization_group_removal signal handler
     """
+
     def setUp(self):
         self.user_1 = UserFactory(username="user1")
         self.user_2 = UserFactory(username="user2")
@@ -1316,7 +1319,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         )
         program = factories.ProgramFactory(courses=[non_draft_course], refresh=True)
 
-
         staff1 = factories.PersonFactory()
         staff2 = factories.PersonFactory()
         staff3 = factories.PersonFactory()
@@ -1372,9 +1374,9 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         m2m_changed.connect(program_labels_changed, sender=Program.labels.through)
 
         program = factories.ProgramFactory(refresh=True)
-        
+
         last_change_time = program.data_modified_timestamp
-        
+
         program.labels.set(['my_label', 'your_label'])
 
         program.refresh_from_db()
@@ -1391,10 +1393,10 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
 
         run1, run2 = factories.CourseRunFactory.create_batch(2)
 
-        program = factories.ProgramFactory(courses = [run1.course, run2.course], refresh=True)
-        
+        program = factories.ProgramFactory(courses=[run1.course, run2.course], refresh=True)
+
         last_change_time = program.data_modified_timestamp
-        
+
         program.excluded_course_runs.set([run1])
 
         program.refresh_from_db()
@@ -1429,9 +1431,9 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         program = factories.ProgramFactory()
         obj1, obj2 = factory.create_batch(2)
         program.refresh_from_db()
-        
+
         last_change_time = program.data_modified_timestamp
-        
+
         getattr(program, field).set([obj1.pk, obj2.pk])
 
         program.refresh_from_db()
@@ -1450,7 +1452,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         assert last_change_time < program.data_modified_timestamp
         m2m_changed.disconnect(program_sorted_m2m_changed, sender=getattr(Program, field).through)
 
-
     @ddt.data(
         ['specializations', factories.SpecializationFactory],
         ['rankings', factories.RankingFactory],
@@ -1463,9 +1464,9 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         degree = factories.DegreeFactory()
         obj1, obj2 = factory.create_batch(2)
         degree.refresh_from_db()
-        
+
         last_change_time = degree.data_modified_timestamp
-        
+
         getattr(degree, field).set([obj1.pk, obj2.pk])
 
         degree.refresh_from_db()
@@ -1503,7 +1504,7 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         degree.save()
         degree.refresh_from_db()
 
-        last_timestamp  = degree.data_modified_timestamp
+        last_timestamp = degree.data_modified_timestamp
         taxi.post_submit_url = 'https://post-submit-url.com'
         taxi.save()
 
@@ -1535,7 +1536,7 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         assert last_modified < degree.data_modified_timestamp
 
         last_modified = degree.data_modified_timestamp
-        curr_course_member = factories.CurriculumCourseMembershipFactory(curriculum = curriculum)
+        curr_course_member = factories.CurriculumCourseMembershipFactory(curriculum=curriculum)
         degree.refresh_from_db()
         assert last_modified < degree.data_modified_timestamp
 
@@ -1544,9 +1545,8 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         degree.refresh_from_db()
         assert last_modified < degree.data_modified_timestamp
 
-
         last_modified = degree.data_modified_timestamp
-        curr_program_member = factories.CurriculumProgramMembershipFactory(curriculum = curriculum)
+        curr_program_member = factories.CurriculumProgramMembershipFactory(curriculum=curriculum)
         degree.refresh_from_db()
         assert last_modified < degree.data_modified_timestamp
 
@@ -1564,7 +1564,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
             pre_save.disconnect(data_modified_timestamp_update, sender=model)
             pre_delete.disconnect(data_modified_timestamp_update__deletion, sender=model)
 
-
     @ddt.data(
         (factories.DegreeAdditionalMetadataFactory, 'external_url', "https://www.external-url.com/"),
         (factories.IconTextPairingFactory, 'text', 'I am 45 feet tall'),
@@ -1572,7 +1571,9 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         (factories.DegreeDeadlineFactory, 'date', 'September 12, 1520')
     )
     @ddt.unpack
-    def test_degree_reverse_foreign_key_field_update_timestamp(self, related_factory, related_obj_field_name, related_obj_field_val):
+    def test_degree_reverse_foreign_key_field_update_timestamp(
+        self, related_factory, related_obj_field_name, related_obj_field_val
+    ):
         pre_save.connect(data_modified_timestamp_update, sender=related_factory._meta.model)
 
         degree = factories.DegreeFactory()
@@ -1599,19 +1600,21 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         ('geolocation', factories.GeoLocationFactory, 'location_name', 'Lahore, PK'),
     )
     @ddt.unpack
-    def test_program_foreign_key_field_update_timestamp(self, field_name, related_factory, related_obj_field_name, related_obj_field_val):
+    def test_program_foreign_key_field_update_timestamp(
+        self, field_name, related_factory, related_obj_field_name, related_obj_field_val
+    ):
         pre_save.connect(data_modified_timestamp_update, sender=related_factory._meta.model)
 
         program = factories.ProgramFactory()
         related_obj = related_factory()
-        setattr(program, field_name, related_obj) 
+        setattr(program, field_name, related_obj)
 
         last_modified = program.data_modified_timestamp
         program.save()
         program.refresh_from_db()
         assert last_modified < program.data_modified_timestamp
 
-        last_modified  = program.data_modified_timestamp
+        last_modified = program.data_modified_timestamp
         related_obj.save()
         program.refresh_from_db()
         assert last_modified == program.data_modified_timestamp

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -1055,7 +1055,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         )
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
         program = factories.ProgramFactory(courses=[official_course])
-        program.refresh_from_db()
 
         course_timestamp = course.data_modified_timestamp
         program_timestamp = program.data_modified_timestamp
@@ -1126,7 +1125,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         )
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
         program = factories.ProgramFactory(courses=[official_course])
-        program.refresh_from_db()
         fact_1 = factories.FactFactory()
         fact_2 = factories.FactFactory()
         course_timestamp = course.data_modified_timestamp
@@ -1157,7 +1155,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         draft_course = CourseFactory(draft=True)
         non_draft_course = CourseFactory(draft_version=draft_course, key=draft_course.key)
         program = factories.ProgramFactory(courses=[non_draft_course])
-        program.refresh_from_db()
 
         program_timestamp = program.data_modified_timestamp
         course_timestamp = draft_course.data_modified_timestamp
@@ -1219,7 +1216,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         draft_course = CourseFactory(draft=True)
         non_draft_course = CourseFactory(draft_version=draft_course, key=draft_course.key)
         program = factories.ProgramFactory(courses=[non_draft_course])
-        program.refresh_from_db()
 
         program_timestamp = program.data_modified_timestamp
         course_timestamp = draft_course.data_modified_timestamp
@@ -1278,7 +1274,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         course = CourseFactory(draft=True)
         official_course = set_official_state(Course.everything.get(pk=course.pk), Course)
         program = factories.ProgramFactory(courses=[official_course])
-        program.refresh_from_db()
         course_run = factories.CourseRunFactory(course=course, draft=True)
         language_tags = LanguageTag.objects.all()[:2]
         course_timestamp = course.data_modified_timestamp
@@ -1319,7 +1314,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
             course=non_draft_course, draft_version=draft_course_run, key=draft_course_run.key
         )
         program = factories.ProgramFactory(courses=[non_draft_course])
-        program.refresh_from_db()
 
 
         staff1 = factories.PersonFactory()
@@ -1375,7 +1369,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
 
     def test_program_labels_taggable_change(self):
         program = factories.ProgramFactory()
-        program.refresh_from_db()
         
         last_change_time = program.data_modified_timestamp
         
@@ -1393,7 +1386,6 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         run1, run2 = factories.CourseRunFactory.create_batch(2)
 
         program = factories.ProgramFactory(courses = [run1.course, run2.course])
-        program.refresh_from_db()
         
         last_change_time = program.data_modified_timestamp
         

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -33,9 +33,9 @@ from course_discovery.apps.course_metadata.models import (
 )
 from course_discovery.apps.course_metadata.signals import (
     _duplicate_external_key_message, additional_metadata_facts_changed,
-    connect_course_data_modified_timestamp_signal_handlers, course_collaborators_changed, course_run_staff_changed,
+    connect_product_data_modified_timestamp_signal_handlers, course_collaborators_changed, course_run_staff_changed,
     course_run_transcript_languages_changed, course_subjects_changed, course_topics_taggable_changed,
-    disconnect_course_data_modified_timestamp_signal_handlers, product_meta_taggable_changed,
+    disconnect_product_data_modified_timestamp_signal_handlers, product_meta_taggable_changed,
     update_course_data_from_event, program_labels_changed, program_sorted_m2m_changed,
     program_excluded_runs, 
 )
@@ -1034,11 +1034,11 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        disconnect_course_data_modified_timestamp_signal_handlers()
+        disconnect_product_data_modified_timestamp_signal_handlers()
 
     @classmethod
     def tearDownClass(cls) -> None:
-        connect_course_data_modified_timestamp_signal_handlers()
+        connect_product_data_modified_timestamp_signal_handlers()
         super().tearDownClass()
 
     def test_product_meta_keywords_change(self):

--- a/course_discovery/apps/course_metadata/tests/test_signals.py
+++ b/course_discovery/apps/course_metadata/tests/test_signals.py
@@ -1590,10 +1590,10 @@ class DataModifiedTimestampUpdateSignalsTests(TestCase):
         last_modified  = program.data_modified_timestamp
         related_obj.save()
         program.refresh_from_db()
-        assert last_modified == prog.data_modified_timestamp
+        assert last_modified == program.data_modified_timestamp
 
         setattr(related_obj, related_obj_field_name, related_obj_field_val)
         related_obj.save()
         program.refresh_from_db()
 
-        assert last_modified < prog.data_modified_timestamp
+        assert last_modified < program.data_modified_timestamp

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -1022,16 +1022,17 @@ def data_modified_timestamp_update(sender, instance, **kwargs):  # pylint: disab
      * A method called update_product_data_modified_stamp which will be implemented by each model
      depending upon its relation with Course/Program.
     """
-    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'): 
+    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):
         instance.update_product_data_modified_timestamp()
 
-def data_modified_timestamp_update__deletion(sender, instance, **kwargs):
+
+def data_modified_timestamp_update__deletion(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """
     Receiver function to trigger update data modified timestamp on Course or Program
     when one of their related models is being deleted. Note that deletion of only a select few
     models will trigger this (see `signals.py`)
     """
-    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):            
+    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):
         instance.update_product_data_modified_timestamp(bypass_has_changed=True)
 
 

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -1022,8 +1022,12 @@ def data_modified_timestamp_update(sender, instance, **kwargs):  # pylint: disab
      * A method called update_product_data_modified_stamp which will be implemented by each model
      depending upon its relation with Course/Program.
     """
-    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):
+    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):            
         instance.update_product_data_modified_timestamp()
+
+def data_modified_timestamp_update__deletion(sender, instance, **kwargs):
+    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):            
+        instance.update_product_data_modified_timestamp(bypass_has_changed=True)
 
 
 def is_valid_slug_format(val):

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -1026,6 +1026,11 @@ def data_modified_timestamp_update(sender, instance, **kwargs):  # pylint: disab
         instance.update_product_data_modified_timestamp()
 
 def data_modified_timestamp_update__deletion(sender, instance, **kwargs):
+    """
+    Receiver function to trigger update data modified timestamp on Course or Program
+    when one of their related models is being deleted. Note that deletion of only a select few
+    models will trigger this (see `signals.py`)
+    """
     if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):            
         instance.update_product_data_modified_timestamp(bypass_has_changed=True)
 

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -1022,7 +1022,7 @@ def data_modified_timestamp_update(sender, instance, **kwargs):  # pylint: disab
      * A method called update_product_data_modified_stamp which will be implemented by each model
      depending upon its relation with Course/Program.
     """
-    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'):            
+    if hasattr(instance, 'field_tracker') and hasattr(instance, 'update_product_data_modified_timestamp'): 
         instance.update_product_data_modified_timestamp()
 
 def data_modified_timestamp_update__deletion(sender, instance, **kwargs):

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -180,7 +180,7 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
+USE_L10N = False
 
 USE_TZ = True
 
@@ -567,6 +567,11 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         'debug_toolbar.panels.redirects.RedirectsPanel',
         'elastic_panel.panel.ElasticDebugPanel'
     ]
+
+DATETIME_FORMAT = 'N j, Y, H:i:s' 
+
+
+
 
 AWS_SES_REGION_ENDPOINT = "email.us-east-1.amazonaws.com"
 AWS_SES_REGION_NAME = "us-east-1"

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -180,7 +180,7 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = False
+USE_L10N = True
 
 USE_TZ = True
 
@@ -567,11 +567,6 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         'debug_toolbar.panels.redirects.RedirectsPanel',
         'elastic_panel.panel.ElasticDebugPanel'
     ]
-
-DATETIME_FORMAT = 'N j, Y, H:i:s' 
-
-
-
 
 AWS_SES_REGION_ENDPOINT = "email.us-east-1.amazonaws.com"
 AWS_SES_REGION_NAME = "us-east-1"


### PR DESCRIPTION
### [PROD-3295](https://2u-internal.atlassian.net/browse/PROD-3295)

This PR adds the relevant code changes for updating the `data_modified_timestamp` field for Programs and Degrees when related fields change.

#### Testing instructions 
1. Check out this branch
2. Open a program or degree page in django admin. Make any edits. Verify that the `data_modified_timestamp` field is updated appropriately.
3. From publisher, make edits to a course. Verify that the `data_modified_timestamp` field on the course's associated programs is updated appropriately.