### PR TITLE
refactor: move common utils in DataLoaderMixin

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/__init__.py
+++ b/course_discovery/apps/course_metadata/data_loaders/__init__.py
@@ -18,7 +18,7 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
     LOADER_MAX_RETRY = 3
     PAGE_SIZE = 50
 
-    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, enable_api=True):
+    def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, enable_api=True, **kwargs):
         """
         Arguments:
             partner (Partner): Partner which owns the APIs and data being loaded
@@ -28,6 +28,7 @@ class AbstractDataLoader(metaclass=abc.ABCMeta):
             enable_api (bool): True if we want to use the api functionalities and clients with the dataloader.
                 This will most likely only be turned off for event bus use cases.
         """
+
         self.partner = partner
         self.enable_api = enable_api
         if self.enable_api:

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -47,7 +47,13 @@ class CoursesApiDataLoader(AbstractDataLoader):
     PAGE_SIZE = 50
 
     def __init__(self, partner, api_url=None, max_workers=None, is_threadsafe=False, enable_api=True):
-        super().__init__(partner, api_url, max_workers, is_threadsafe, enable_api)
+        super().__init__(
+            partner=partner,
+            api_url=api_url,
+            max_workers=max_workers,
+            is_threadsafe=is_threadsafe,
+            enable_api=enable_api
+        )
         self.default_product_source, __ = Source.objects.get_or_create(
             name=settings.DEFAULT_PRODUCT_SOURCE_NAME,
             slug=settings.DEFAULT_PRODUCT_SOURCE_SLUG
@@ -330,7 +336,13 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     LOADER_MAX_RETRY = 2
 
     def __init__(self, partner, api_url, max_workers=None, is_threadsafe=False, **kwargs):
-        super().__init__(partner, api_url, max_workers, is_threadsafe, **kwargs)
+        super().__init__(
+            partner=partner,
+            api_url=api_url,
+            max_workers=max_workers,
+            is_threadsafe=is_threadsafe,
+            **kwargs
+        )
         self.initial_page = 1
         self.enrollment_skus = []
         self.entitlement_skus = []
@@ -850,7 +862,12 @@ class ProgramsApiDataLoader(AbstractDataLoader):
     XSERIES = None
 
     def __init__(self, partner, api_url, max_workers=None, is_threadsafe=False):
-        super().__init__(partner, api_url, max_workers, is_threadsafe)
+        super().__init__(
+            partner=partner,
+            api_url=api_url,
+            max_workers=max_workers,
+            is_threadsafe=is_threadsafe
+        )
         self.XSERIES = ProgramType.objects.get(translations__name_t='XSeries')
 
     def ingest(self):

--- a/course_discovery/apps/course_metadata/data_loaders/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/mixins.py
@@ -1,0 +1,252 @@
+"""Mixins related to Data Loaders"""
+import logging
+from abc import ABC, abstractmethod
+from functools import cache
+
+from dateutil.parser import parse
+from django.conf import settings
+from django.urls import reverse
+
+from course_discovery.apps.core.utils import serialize_datetime
+from course_discovery.apps.course_metadata.choices import CourseRunStatus
+from course_discovery.apps.course_metadata.models import CourseRun, CourseRunPacing, CourseRunType
+
+logger = logging.getLogger(__name__)
+
+
+class DataLoaderMixin(ABC):
+    """
+    Mixin having all the commonly used utility functions for data loaders.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        if not hasattr(self, 'api_client') or self.api_client is None:
+            raise ValueError("api_client must be set before using DataLoaderMixin.")
+
+    @staticmethod
+    def transform_dict_keys(data):
+        """
+        Given a data dictionary, return a new dict that has its keys transformed to
+        snake case. For example, Enrollment Track becomes enrollment_track.
+
+        Each key is stripped of whitespaces around the edges, converted to lower case,
+        and has internal spaces converted to _. This convention removes the dependency on CSV
+        headers format(Enrollment Track vs Enrollment track) and makes code flexible to ignore
+        any case sensitivity, among other things.
+        """
+        transformed_dict = {}
+        for key, value in data.items():
+            updated_key = key.strip().lower().replace(' ', '_')
+            transformed_dict[updated_key] = value
+        return transformed_dict
+
+    @staticmethod
+    def get_formatted_datetime_string(date_string):
+        """
+        Return the datetime string into the desired format %Y-%m-%dT%H:%M:%SZ
+        """
+        return serialize_datetime(parse(date_string)) if date_string else None
+
+    @staticmethod
+    def extract_seat_prices(course_run):
+        """
+        Return a dictionary with seat types as keys and their prices as string values.
+        Example:
+            {
+                "audit": "0.00",
+                "verified": "100.00"
+            }
+        """
+        prices = {}
+
+        for seat in course_run.seats.all():
+            prices[seat.type.slug] = f"{seat.price:.2f}"
+        return prices
+
+    def create_course_run(self, data, course, course_type, course_run_type_uuid, rerun=None):
+        """
+        Make a course run entry through course run api.
+        """
+        url = f"{settings.DISCOVERY_BASE_URL}{reverse('api:v1:course_run-list')}"
+        request_data = self.create_course_run_api_request_data(data, course, course_type, course_run_type_uuid, rerun)
+        response = self.call_course_api('POST', url, request_data)
+        if response.status_code not in (200, 201):
+            logger.info(f"Course run creation response: {response.content}")
+        return response.json()
+
+    def create_course_run_api_request_data(self, data, course, course_type, course_run_type_uuid, rerun=None):
+        """
+        Given a data dictionary, return a reduced data representation in dict
+        which will be used as input for course run creation via course run api.
+        """
+        pricing = self.get_pricing_representation(data['verified_price'], course_type)
+        course_run_creation_fields = {
+            'pacing_type': self.get_pacing_type(data['course_pacing']),
+            'start': self.get_formatted_datetime_string(f"{data['start_date']} {data['start_time']}"),
+            'end': self.get_formatted_datetime_string(f"{data['end_date']} {data['end_time']}"),
+            'run_type': str(course_run_type_uuid),
+            'prices': pricing,
+            'course': course.key,
+        }
+
+        if rerun:
+            course_run_creation_fields['rerun'] = rerun
+        return course_run_creation_fields
+
+    def call_course_api(self, method, url, data):
+        """
+        Helper method to make course and course run api calls.
+        """
+        response = self.api_client.request(
+            method,
+            url,
+            json=data,
+            headers={'content-type': 'application/json'}
+        )
+        if not response.ok:
+            logger.info("API request failed for url %s with response: %s", url, response.content.decode('utf-8'))
+        response.raise_for_status()
+        return response
+
+    @staticmethod
+    def get_pacing_type(pacing):
+        """
+        Return appropriate pacing selection against a provided pacing string.
+        """
+        if pacing:
+            pacing = pacing.lower()
+
+        if pacing == 'instructor-paced':
+            return CourseRunPacing.Instructor.value
+        elif pacing == 'self-paced':
+            return CourseRunPacing.Self.value
+        else:
+            return None
+
+    @staticmethod
+    @cache
+    def get_course_run_type(course_run_type_name):
+        """
+        Retrieve a CourseRunType object, using a cache to avoid redundant queries.
+
+        Args:
+            course_run_type_name (str): Course run type name
+        """
+        try:
+            return CourseRunType.objects.get(name=course_run_type_name)
+        except CourseRunType.DoesNotExist:
+            return None
+
+    @staticmethod
+    def get_pricing_representation(price, course_type):
+        """
+        Return dict representation of prices for a given course type.
+        """
+        prices = {}
+        entitlement_types = course_type.entitlement_types.all()
+        for entitlement_type in entitlement_types:
+            prices.update({entitlement_type.slug: price})
+        return prices
+
+    @staticmethod
+    def get_course_key(organization_key, number):
+        """
+        Given organization key and course number, return course key.
+        """
+        return '{org}+{number}'.format(org=organization_key, number=number)
+
+    def create_course(self, data, course_type, course_run_type_uuid, product_source=None):
+        """
+        Make a course entry through course api.
+        """
+        course_api_url = reverse('api:v1:course-list')
+        url = f"{settings.DISCOVERY_BASE_URL}{course_api_url}"
+
+        request_data = self.create_course_api_request_data(data, course_type, course_run_type_uuid, product_source)
+        response = self.call_course_api('POST', url, request_data)
+        if response.status_code not in (200, 201):
+            logger.info(f"Course creation response: {response.content}")
+        return response.json()
+
+    def create_course_api_request_data(self, data, course_type, course_run_type_uuid, product_source=None):
+        """
+        Given a data dictionary, return a reduced data representation in dict
+        which will be used as input for course creation via course api.
+        """
+        pricing = self.get_pricing_representation(data['verified_price'], course_type)
+        product_source_slug = product_source.slug if product_source else None
+
+        course_run_creation_fields = {
+            'pacing_type': self.get_pacing_type(data['course_pacing']),
+            'start': self.get_formatted_datetime_string(f"{data['start_date']} {data['start_time']}"),
+            'end': self.get_formatted_datetime_string(f"{data['end_date']} {data['end_time']}"),
+            'run_type': str(course_run_type_uuid),
+            'prices': pricing,
+        }
+
+        return {
+            'org': data['organization'],
+            'title': data['title'],
+            'number': data['number'],
+            'product_source': product_source_slug,
+            'type': str(course_type.uuid),
+            'prices': pricing,
+            'course_run': course_run_creation_fields
+        }
+
+    def update_course(self, course_data, course, is_draft):
+        """
+        Update the course data.
+        """
+        course_api_url = reverse('api:v1:course-detail', kwargs={'key': course.uuid})
+        url = f"{settings.DISCOVERY_BASE_URL}{course_api_url}?exclude_utm=1"
+        request_data = self.update_course_api_request_data(course_data, course, is_draft)
+        response = self.call_course_api('PATCH', url, request_data)
+
+        if response.status_code not in (200, 201):
+            logger.info(f"Course update response: {response.content}")
+        return response.json()
+
+    def update_course_run(self, course_run_data, course_run, course_type, is_draft):
+        """
+        Update the course run data.
+        """
+        course_run_api_url = reverse('api:v1:course_run-detail', kwargs={'key': course_run.key})
+        url = f"{settings.DISCOVERY_BASE_URL}{course_run_api_url}?exclude_utm=1"
+        request_data = self.update_course_run_api_request_data(course_run_data, course_run, course_type, is_draft)
+        response = self.call_course_api('PATCH', url, request_data)
+        if response.status_code not in (200, 201):
+            logger.info(f"Course run update response: {response.content}")
+        return response.json()
+
+    @abstractmethod
+    def update_course_api_request_data(self, course_data, course, is_draft):
+        """Update the course API request data based on the course and draft state."""
+
+    @abstractmethod
+    def update_course_run_api_request_data(self, course_run_data, course_run, course_type, is_draft):
+        """Update the course run API request data based on the run, type, and draft state."""
+
+    @staticmethod
+    def get_draft_flag(course):
+        """
+        To keep behavior consistent with publisher, draft flag is false only when:
+            1. Course run is moved from Unpublished -> Review State
+            2. Any of the Course run is in published state
+        No 1 is not applicable at the moment as we are changing status via data loaders, so we are sending false
+        draft flag to the course_run api directly for now.
+        """
+        return not CourseRun.objects.filter_drafts(course=course, status=CourseRunStatus.Published).exists()
+
+    @staticmethod
+    def add_product_source(course, product_source):
+        """
+        Associate product source object with provided course object.
+        """
+        course.product_source = product_source
+        if course.official_version:
+            course.official_version.product_source = product_source
+            course.official_version.save(update_fields=['product_source'])
+        course.save(update_fields=['product_source'])

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_csv_loader.py
@@ -180,7 +180,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)
@@ -236,7 +236,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(
@@ -348,7 +348,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(
@@ -438,7 +438,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)
@@ -531,7 +531,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                 with LogCapture(LOGGER_PATH) as log_capture:
                     with mock.patch.object(
                             CSVDataLoader,
-                            '_call_course_api',
+                            'call_course_api',
                             self.mock_call_course_api
                     ):
                         loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)
@@ -659,7 +659,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                 with LogCapture(LOGGER_PATH):
                     with mock.patch.object(
                             CSVDataLoader,
-                            '_call_course_api',
+                            'call_course_api',
                             self.mock_call_course_api
                     ):
                         loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)
@@ -691,17 +691,16 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             csv = self._write_csv(csv, [mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT])
 
             with mock.patch.object(
-                CSVDataLoader, "_call_course_api", self.mock_call_course_api
+                CSVDataLoader, "call_course_api", self.mock_call_course_api
             ):
                 loader = CSVDataLoader(
                     self.partner, csv_path=csv.name, product_source=self.source.slug
                 )
                 # pylint: disable=protected-access
                 loader._register_ingestion_error = mock.MagicMock()
-                loader._update_course = mock.MagicMock()
+                loader.update_course = mock.MagicMock()
 
-                # pylint: disable=protected-access
-                loader._update_course.side_effect = MockExceptionWithResponse(b"Update course error")
+                loader.update_course.side_effect = MockExceptionWithResponse(b"Update course error")
 
                 with LogCapture(LOGGER_PATH):
                     loader.ingest()
@@ -766,7 +765,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             csv = self._write_csv(csv, [mock_data.VALID_COURSE_AND_COURSE_RUN_CSV_DICT, mocked_data])
             with override_waffle_switch(IS_COURSE_RUN_VARIANT_ID_EDITABLE, active=True):
                 with mock.patch.object(
-                    CSVDataLoader, "_call_course_api", self.mock_call_course_api
+                    CSVDataLoader, "call_course_api", self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(
                         self.partner, csv_path=csv.name, product_source=self.source.slug
@@ -884,7 +883,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
 
             with mock.patch.object(
                 CSVDataLoader,
-                '_call_course_api',
+                'call_course_api',
                 self.mock_call_course_api
             ):
                 with mock.patch.object(CSVDataLoader, '_register_ingestion_error') as mock_register_error:
@@ -914,7 +913,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)
@@ -986,7 +985,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
 
@@ -1055,7 +1054,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
 
@@ -1106,7 +1105,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)
@@ -1166,7 +1165,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)
@@ -1241,7 +1240,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)
@@ -1272,7 +1271,7 @@ class TestCSVDataLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             with LogCapture(LOGGER_PATH) as log_capture:
                 with mock.patch.object(
                         CSVDataLoader,
-                        '_call_course_api',
+                        'call_course_api',
                         self.mock_call_course_api
                 ):
                     loader = CSVDataLoader(self.partner, csv_path=csv.name, product_source=self.source.slug)

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_mixins.py
@@ -1,0 +1,277 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+from ddt import data, ddt, unpack
+from django.test import TestCase
+
+from course_discovery.apps.course_metadata.data_loaders.mixins import DataLoaderMixin
+from course_discovery.apps.course_metadata.models import CourseRunPacing, CourseRunStatus
+from course_discovery.apps.course_metadata.tests.factories import (
+    CourseFactory, CourseRunFactory, CourseRunTypeFactory, CourseTypeFactory, SeatFactory, SeatTypeFactory,
+    SourceFactory
+)
+
+LOGGER_PATH = 'course_discovery.apps.course_metadata.data_loaders.mixins'
+
+
+class DummyBaseLoader:
+    """
+    Dummy base class for testing, mimicking AbstractDataLoader behavior.
+    """
+
+    def __init__(self, api_client=None, **kwargs):
+        self.api_client = api_client
+        super().__init__(**kwargs)
+
+
+class DataLoaderTestMixin(DummyBaseLoader, DataLoaderMixin):
+    """
+    Test class combining DummyBaseLoader and DataLoaderMixin for safe testing.
+    """
+
+    def update_course_api_request_data(self, course_data, course, is_draft):
+        pass  # pragma: no cover
+
+    def update_course_run_api_request_data(self, course_run_data, course_run, course_type, is_draft):
+        pass  # pragma: no cover
+
+
+@ddt
+class TestDataLoaderMixin(TestCase):
+    """
+    Test suite for the DataLoaderMixin class.
+    """
+
+    def setUp(self):
+        self.mock_api_client = MagicMock()
+        self.mixin = DataLoaderTestMixin(api_client=self.mock_api_client)
+
+    def test_init_with_api_client(self):
+        """Test that initializing DataLoaderMixin with api_client sets the attribute correctly."""
+        client = MagicMock()
+        mixin_instance = DataLoaderTestMixin(api_client=client)
+        assert mixin_instance.api_client == client
+
+    def test_init_without_api_client(self):
+        """Test that initializing DataLoaderMixin without api_client raises a ValueError."""
+        with self.assertRaises(ValueError) as context:
+            DataLoaderTestMixin()
+
+        self.assertIn("api_client must be set", str(context.exception))
+
+    def test_transform_dict_keys(self):
+        """Test transformation of dictionary keys to snake_case."""
+        input_data = {
+            'Enrollment Track': 'verified',
+            '  Course Pacing ': 'self-paced',
+            'Title': 'Test Course'
+        }
+        expected = {
+            'enrollment_track': 'verified',
+            'course_pacing': 'self-paced',
+            'title': 'Test Course'
+        }
+        assert self.mixin.transform_dict_keys(input_data) == expected
+
+    def test_get_formatted_datetime_string(self):
+        """Test that date strings are formatted to ISO 8601 UTC format."""
+        date_string = "2025-04-22 15:30:00"
+        expected = '2025-04-22T15:30:00Z'
+        assert self.mixin.get_formatted_datetime_string(date_string) == expected
+
+    def test_get_formatted_datetime_string_with_none(self):
+        """Test that None as input returns None for datetime string formatting."""
+        assert self.mixin.get_formatted_datetime_string(None) is None
+
+    def test_extract_seat_prices(self):
+        """Test extraction of seat prices using real SeatFactory objects."""
+        course_run = CourseRunFactory()
+
+        SeatFactory(course_run=course_run, type=SeatTypeFactory.audit(), price=0.0)
+        SeatFactory(course_run=course_run, type=SeatTypeFactory.verified(), price=100.0)
+
+        expected = {'audit': '0.00', 'verified': '100.00'}
+        result = self.mixin.extract_seat_prices(course_run)
+
+        assert result == expected, f"Expected {expected}, but got {result}"
+
+    @data(
+        ('Instructor-Paced', CourseRunPacing.Instructor.value),
+        ('self-paced', CourseRunPacing.Self.value),
+        ('other', None),
+        (None, None),
+    )
+    @unpack
+    def test_get_pacing_type(self, input_value, expected_output):
+        """Test correct pacing type is returned based on input string."""
+        self.assertEqual(self.mixin.get_pacing_type(input_value), expected_output)
+
+    def test_get_course_run_type_returns_correct_instance(self):
+        """Test get_course_run_type returns the correct CourseRunType object."""
+        course_run_type = CourseRunTypeFactory(name="SampleType")
+        result = self.mixin.get_course_run_type("SampleType")
+        assert result == course_run_type
+
+    def test_get_course_run_type_returns_none_for_invalid_name(self):
+        """Test get_course_run_type returns None when no matching CourseRunType exists."""
+        result = self.mixin.get_course_run_type("NonExistentType")
+        assert result is None
+
+    def test_get_pricing_representation(self):
+        """Test pricing representation returns correct entitlement-based dictionary."""
+        verified = SeatTypeFactory.verified()
+        audit = SeatTypeFactory.audit()
+        course_type = CourseTypeFactory(entitlement_types=[verified, audit])
+
+        expected = {'verified': '100.00', 'audit': '100.00'}
+        result = DataLoaderTestMixin.get_pricing_representation('100.00', course_type)
+        self.assertEqual(result, expected)
+
+    def test_get_course_key(self):
+        """Test course key generation from organization and number."""
+        assert self.mixin.get_course_key('ORG', '101') == 'ORG+101'
+
+    def test_call_course_api_success(self):
+        """Test successful API call returns correct response."""
+        mock_response = MagicMock(ok=True, status_code=200, json=lambda: {'result': 'success'})
+        self.mock_api_client.request.return_value = mock_response
+
+        result = self.mixin.call_course_api('POST', 'http://testserver/api', {'key': 'value'})
+        assert result == mock_response
+
+    @responses.activate
+    def test_call_course_api_failure_logs_and_raises(self):
+        """Test failed API call logs error and raises exception."""
+        url = 'http://testserver/api'
+        responses.add(
+            responses.POST,
+            url,
+            json={'error': 'bad request'},
+            status=400
+        )
+
+        self.mock_api_client.request.side_effect = lambda method, url, json, headers=None: responses.calls[0].response
+
+        with pytest.raises(Exception):
+            self.mixin.call_course_api('POST', url, {'key': 'value'})
+
+    def test_get_draft_flag_false_when_published_exists(self):
+        """Test draft flag returns False when a published course run exists."""
+        course_run = CourseRunFactory(status=CourseRunStatus.Published)
+        course = course_run.course
+        assert self.mixin.get_draft_flag(course) is False
+
+    def test_get_draft_flag_true_when_no_published(self):
+        """Test draft flag returns True when no published course runs exist."""
+        course_run = CourseRunFactory(status=CourseRunStatus.Unpublished)
+        course = course_run.course
+        assert self.mixin.get_draft_flag(course) is True
+
+    def test_add_product_source(self):
+        """Test product source is added to course and its official version."""
+        draft_course = CourseFactory(draft=True)
+        official_course = CourseFactory(draft=False)
+        official_course.draft_version = draft_course
+
+        source = SourceFactory(name='product_source_mock')
+        self.mixin.add_product_source(draft_course, source)
+
+        assert draft_course.product_source == source
+        assert draft_course.official_version.product_source == source
+
+    @patch(f'{LOGGER_PATH}.logger')
+    def test_create_course_failure_logs(self, mock_logger):
+        """
+        Test that the logger correctly logs failure details when course creation fails.
+        """
+        course_type = CourseTypeFactory()
+        course_run_type = CourseRunTypeFactory()
+        request_data = {
+            'organization': 'ORG',
+            'title': 'Test Course',
+            'number': '101',
+            'verified_price': '100.00',
+            'course_pacing': 'self-paced',
+            'start_date': '2025-04-25',
+            'start_time': '09:00:00',
+            'end_date': '2025-04-30',
+            'end_time': '17:00:00'
+        }
+
+        mock_response = MagicMock(status_code=400, ok=False, json=lambda: {'error': 'bad request'},
+                                  content=b'{"error":"bad request"}')
+        mock_response.raise_for_status.side_effect = Exception("Request failed")
+        self.mock_api_client.request.return_value = mock_response
+
+        with self.assertRaises(Exception):
+            self.mixin.create_course(request_data, course_type, course_run_type.uuid)
+
+        # Adjusted to match the actual log message with dynamically generated URL
+        mock_logger.info.assert_called_with(
+            'API request failed for url %s with response: %s',
+            'http://localhost:18381/api/v1/courses/',
+            '{"error":"bad request"}'
+        )
+
+    @patch(f'{LOGGER_PATH}.logger')
+    def test_update_course_failure_logs(self, mock_logger):
+        """
+        Test that the logger correctly logs failure details when course update fails.
+        """
+        course = CourseFactory()
+        self.mixin.update_course_api_request_data = MagicMock(return_value={'title': 'Updated Title'})
+
+        mock_response = MagicMock(status_code=400, ok=False, json=lambda: {'error': 'bad update'},
+                                  content=b'{"error":"bad update"}')
+        mock_response.raise_for_status.side_effect = Exception("Request failed")
+        self.mock_api_client.request.return_value = mock_response
+
+        with self.assertRaises(Exception):
+            self.mixin.update_course({'title': 'Updated Title'}, course, is_draft=False)
+
+        # Adjusted to match the actual log message with dynamically generated URL
+        mock_logger.info.assert_called_with(
+            'API request failed for url %s with response: %s',
+            f'http://localhost:18381/api/v1/courses/{course.uuid}/?exclude_utm=1',
+            '{"error":"bad update"}'
+        )
+
+    def test_create_course_success(self):
+        """
+        Test the successful creation of a course.
+        """
+        course_type = CourseTypeFactory()
+        course_run_type = CourseRunTypeFactory()
+        request_data = {
+            'organization': 'ORG',
+            'title': 'Test Course',
+            'number': '101',
+            'verified_price': '100.00',
+            'course_pacing': 'self-paced',
+            'start_date': '2025-04-25',
+            'start_time': '09:00:00',
+            'end_date': '2025-04-30',
+            'end_time': '17:00:00'
+        }
+
+        mock_response = MagicMock(status_code=201, ok=True, json=lambda: {'result': 'created'})
+        self.mock_api_client.request.return_value = mock_response
+
+        result = self.mixin.create_course(request_data, course_type, course_run_type.uuid)
+        self.assertEqual(result, {'result': 'created'})
+        self.mock_api_client.request.assert_called_once()
+
+    def test_update_course_success(self):
+        """
+        Test the successful update of a course.
+        """
+        course = CourseFactory()
+        self.mixin.update_course_api_request_data = MagicMock(return_value={'title': 'Updated Title'})
+
+        mock_response = MagicMock(status_code=200, ok=True, json=lambda: {'result': 'updated'})
+        self.mock_api_client.request.return_value = mock_response
+
+        result = self.mixin.update_course({'title': 'Updated Title'}, course, is_draft=False)
+        self.assertEqual(result, {'result': 'updated'})
+        self.mock_api_client.request.assert_called_once()

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_import_course_metadata.py
@@ -138,7 +138,7 @@ class TestImportCourseMetadata(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                 with LogCapture(LOGGER_PATH) as log_capture:
                     with mock.patch.object(
                             CSVDataLoader,
-                            '_call_course_api',
+                            'call_course_api',
                             self.mock_call_course_api
                     ):
                         call_command(
@@ -189,7 +189,7 @@ class TestImportCourseMetadata(CSVLoaderMixin, OAuth2Mixin, APITestCase):
                 with LogCapture(LOGGER_PATH) as log_capture:
                     with mock.patch.object(
                             CSVDataLoader,
-                            '_call_course_api',
+                            'call_course_api',
                             self.mock_call_course_api
                     ):
                         call_command(


### PR DESCRIPTION
[PROD-4353](https://2u-internal.atlassian.net/browse/PROD-4353)
Moves most of the commonly used utils to a mixin so it is easier to use among other data loaders. 