### PR TITLE
perf: attempt at improving memory usage for update_course_ai_languages

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/update_course_ai_languages.py
+++ b/course_discovery/apps/course_metadata/management/commands/update_course_ai_languages.py
@@ -68,6 +68,9 @@ class Command(BaseCommand):
         elif options['marketable']:
             course_runs = course_runs.marketable()
 
+        # Reduce the memory usage
+        course_runs = course_runs.iterator()
+
         for course_run in course_runs:
             try:
                 ai_languages_data = lms_api_client.get_course_run_translations_and_transcriptions(course_run.key)


### PR DESCRIPTION
### [PROD-4343](https://2u-internal.atlassian.net/browse/PROD-4343)

This PR is an attempt at improving memory usage for the `update_course_run_ai_languages` command by using [queryset.iterator](https://docs.djangoproject.com/en/5.1/ref/models/querysets/#iterator)

Profiling using memray with 5000 randomly generated course runs, this change brought the memory usage down from ~245 Mbs to ~205 Mbs