### PR TITLE
feat: Not to avoid Update flow in case course shell is already present

### DIFF
--- a/course_discovery/apps/api/tests/test_utils.py
+++ b/course_discovery/apps/api/tests/test_utils.py
@@ -150,7 +150,7 @@ class StudioAPITests(OAuth2Mixin, APITestCase):
     def test_update_run(self):
         run = CourseRunFactory()
 
-        expected_data = self.make_studio_data(run, add_pacing=False, add_schedule=False)
+        expected_data = self.make_studio_data(run, add_pacing=False, add_schedule=False, add_enrollment_dates=True)
         responses.add(responses.PATCH, f'{self.studio_url}api/v1/course_runs/{run.key}/',
                       match=[responses.matchers.json_params_matcher(expected_data)])
 

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -294,12 +294,12 @@ class StudioAPI:
                 'end': serialize_datetime(end),
             }
 
-        if not creating and course_run.course.is_external_course and (enrollment_start or enrollment_end):
+        if not creating and (enrollment_start or enrollment_end):
             # The dates are intentionally not allowed when creating the course run.
             # It is possible to send enrollment dates in API when the course run is being created.
             # But when the course run is created, in Studio or Discovery, the enrollment dates are not taken as input.
             # It is better to keep the flow consistent across places.
-            # Allow sending enrollment start and end dates for external courses as part of Update only.
+            # Allow sending enrollment start and end dates as part of Update only.
             data['schedule'] = {
                 'enrollment_start': serialize_datetime(course_run.enrollment_start),
                 'enrollment_end': serialize_datetime(course_run.enrollment_end),


### PR DESCRIPTION
This PR adds changes in CourseLoader, not to prevent updates when a course shell already exists. Also, it adds handling of date/schedule fields for the following fields:

- start
- end
- enrollment_start
- enrollment_end