### PR TITLE
fix: check type validity before updating course in Publisher

### DIFF
--- a/course_discovery/apps/api/v1/views/course_runs.py
+++ b/course_discovery/apps/api/v1/views/course_runs.py
@@ -355,6 +355,18 @@ class CourseRunViewSet(CompressedCacheResponseMixin, ValidElasticSearchQueryRequ
         serializer = self.get_serializer(course_run, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
 
+        course_type = course_run.course.type
+        course_run_type = serializer.validated_data.get('type')
+
+        if course_type and course_run_type and course_run_type not in course_type.course_run_types.all():
+            return Response(
+                _("The course run type '{course_run_type}' is not valid for this course type '{course_type}'.").format(
+                    course_run_type=course_run_type,
+                    course_type=course_type
+                ),
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
         # Handle staff update on course run in review with valid status transition
         if (request.user.is_staff and course_run.in_review and 'status' in request.data and
                 request.data['status'] in CourseRunStatus.INTERNAL_STATUS_TRANSITIONS()):


### PR DESCRIPTION
[PROD-4342](https://2u-internal.atlassian.net/browse/PROD-4342)
Before saving the course run changes from Publisher, it also verifies if the assigned course run type matches with the course type of that run. 

<img width="933" alt="Screenshot 2025-05-07 at 2 20 25 PM" src="https://github.com/user-attachments/assets/c1f8bd4b-603c-492a-8c73-85457fbe8328" />
