### PR TITLE
fix: update e-comm loader to be backwards compatible with edx ecommerce

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -585,7 +585,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     def update_seat(self, course_run, product_body):
         stock_record = product_body['stockrecords'][0]
         currency_code = stock_record['price_currency']
-        price = Decimal(stock_record.get('price_excl_tax', stock_record['price']))
+        price = Decimal(stock_record.get('price_excl_tax') or stock_record.get('price'))
         sku = stock_record['partner_sku']
 
         # For more context see ADR docs/decisions/0025-dont-sync-mobile-skus-on-discovery.rst
@@ -656,7 +656,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     def validate_stockrecord(self, stockrecords, title, product_class):
         """
         Argument:
-            sockrecords (list): a list of stock records to validate from ecommerce
+            stockrecords (list): a list of stock records to validate from ecommerce
             title (str): product title
             product_class (str): either entitlement or enrollment code
         Returns:
@@ -695,7 +695,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
 
         try:
             currency_code = stock_record['price_currency']
-            Decimal(stock_record.get('price_excl_tax', stock_record['price']))
+            Decimal(stock_record.get('price_excl_tax') or stock_record.get('price'))
             sku = stock_record['partner_sku']
         except (KeyError, ValueError):
             msg = 'A necessary stockrecord field is missing or incorrectly set for {product} {title}'.format(
@@ -734,7 +734,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
 
         stock_record = stockrecords[0]
         currency_code = stock_record['price_currency']
-        price = Decimal(stock_record.get('price_excl_tax', stock_record['price']))
+        price = Decimal(stock_record.get('price_excl_tax') or stock_record.get('price'))
         sku = stock_record['partner_sku']
 
         try:

--- a/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mock_data.py
@@ -192,10 +192,11 @@ ECOMMERCE_API_BODIES = [
                 "structure": "child",
                 "expires": None,
                 "attribute_values": [],
+                "price": "0.00",
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price": "0.00",
+                        "price_excl_tax": "0.00",
                         "partner_sku": "sku001",
                     }
                 ]
@@ -242,7 +243,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price": "25.00",
+                        "price_excl_tax": "25.00",
                         "partner_sku": "sku003",
                     }
                 ]
@@ -260,7 +261,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "EUR",
-                        "price": "250.00",
+                        "price_excl_tax": "250.00",
                         "partner_sku": "mobile.android.sku003",
                     }
                 ]
@@ -304,7 +305,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price": "0.00",
+                        "price_excl_tax": "0.00",
                         "partner_sku": "sku005",
                     }
                 ]
@@ -321,7 +322,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price": "25.00",
+                        "price_excl_tax": "25.00",
                         "partner_sku": "sku006",
                     }
                 ]
@@ -350,7 +351,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price": "250.00",
+                        "price_excl_tax": "250.00",
                         "partner_sku": "sku007",
                     }
                 ]
@@ -404,7 +405,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "123",
-                        "price": "0.00",
+                        "price_excl_tax": "0.00",
                         "partner_sku": "sku009",
                     }
                 ]
@@ -429,7 +430,7 @@ ECOMMERCE_API_BODIES = [
                 "stockrecords": [
                     {
                         "price_currency": "USD",
-                        "price": "0.00",
+                        "price_excl_tax": "0.00",
                         "partner_sku": "sku010",
                     }
                 ]

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -856,7 +856,7 @@ class EcommerceApiDataLoaderTests(DataLoaderTestMixin, TestCase):
         for product in products:
             stock_record = product['stockrecords'][0]
             price_currency = stock_record['price_currency']
-            price = Decimal(stock_record['price'])
+            price = Decimal(stock_record.get('price') or stock_record.get('price_excl_tax'))
             sku = stock_record['partner_sku']
             certificate_type = Seat.AUDIT
             credit_provider = None


### PR DESCRIPTION
### [PROD-4386](https://2u-internal.atlassian.net/browse/PROD-4386)


### Description

ecomm data loader was updated in https://github.com/openedx/course-discovery/pull/4459/files to work with django-oscar upgrade. However, in edx/ecommerce, django-oscar upgrade was reverted in https://github.com/edx/ecommerce/commit/dfd8916a1d37897725bdb12ab0a591107bcf50f2 (See context on https://github.com/openedx/course-discovery/pull/4291). This resulted in ecomm loader breaking unexpectedly. In the loader, code flow was `stock_record.get('price_excl_tax', stock_record['price'])`. Since .get is a function call, the params are evaluated beforehand. price is not found in dict, which results in KeyError. 

This PR updates the logic to handle both the old and new formats of stock_records pricing without causing KeyError. In mock_data, the data has been updated to have a combination of old and new formats.