### PR TITLE
fix: handling of duplicate slug issue

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/mixins.py
@@ -454,6 +454,11 @@ class CSVLoaderMixin:
         beginner.name_t = 'beginner'
         beginner.save()
 
+        intermediate = LevelTypeFactory(name='Intermediate')
+        intermediate.set_current_language('en')
+        intermediate.name_t = 'Intermediate'
+        intermediate.save()
+
         SubjectFactory(name='Computer Science')
         SubjectFactory(name='Social Sciences')
 

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -1342,7 +1342,7 @@ class CourseSlugMethodsTests(TestCase):
         subject = SubjectFactory(name='business')
         organization = OrganizationFactory(name='test-organization')
         for course_count in range(3):
-            course = CourseFactory(title='test-title')
+            course = CourseFactory(title='Test Title')
             course.subjects.add(subject)
             course.authoring_organizations.add(organization)
             course.partner = partner
@@ -1353,7 +1353,7 @@ class CourseSlugMethodsTests(TestCase):
 
             assert error is None
             slug_end_prefix = f"-{course_count + 1}" if course_count else ""
-            assert slug == f"learn/{subject.slug}/{organization.name}-{course.title}{slug_end_prefix}"
+            assert slug == f"learn/{subject.slug}/{organization.name}-{slugify(course.title)}{slug_end_prefix}"
             course.set_active_url_slug(slug)
 
     def test_get_slug_for_exec_ed_course__with_existing_url_slug(self):

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -1149,7 +1149,7 @@ def get_slug_for_course(course):
             slug = f"learn/{primary_subject_slug}/{organization_slug}-{course_slug}"
             if is_existing_slug(slug, course):
                 logger.info(f"Slug '{slug}' already exists in DB, recreating slug by adding a number in course_title")
-                course_slug = f"{course.title}-{get_existing_slug_count(slug) + 1}"
+                course_slug = f"{course_slug}-{get_existing_slug_count(slug) + 1}"
         slug = f"learn/{primary_subject_slug}/{organization_slug}-{course_slug}"
         return slug, None
 


### PR DESCRIPTION
[PROD-4391](https://2u-internal.atlassian.net/browse/PROD-4391)
---------
This PR fixes handling of slug duplicate issue using exception catch/block block and save it in error logs.

Currently, the issue is that if a slug is already present, it doesn't check for duplication and simply updates the slug to a subdirectory format without validation. Which leads to error raised by set_active_url

https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/course_metadata/utils.py#L1147