### PR TITLE
fix: editors fetching query for self paced courses in send_course_deadline_emails command

### DIFF
--- a/course_discovery/apps/course_metadata/management/commands/send_course_deadline_emails.py
+++ b/course_discovery/apps/course_metadata/management/commands/send_course_deadline_emails.py
@@ -97,7 +97,7 @@ class Command(BaseCommand):
         This method retrieves the email addresses of course editors and project coordinators associated with the course
         and schedules the email to be sent using the `process_send_course_deadline_email` task.
         """
-        course_editors = list(course.editors.values_list('user__email', flat=True).distinct())
+        course_editors = list(course.draft_version.editors.values_list('user__email', flat=True).distinct())
         project_coordinators = list(OrganizationUserRole.objects.filter(
             organization__in=course.authoring_organizations.all(),
             role=InternalUserRole.ProjectCoordinator

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_send_course_deadline_emails.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_send_course_deadline_emails.py
@@ -72,7 +72,7 @@ class SendCourseDeadlineEmailsTests(TestCase):
 
         self.user = UserFactory()
         self.course_editor = CourseEditorFactory(
-            course=self.non_draft_course,
+            course=self.draft_course,
             user=self.user
         )
         OrganizationUserRoleFactory(

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -722,7 +722,7 @@ class TestCourseDeadlineEmail(TestCase):
     def setUp(self):
         super().setUp()
         self.draft_course = CourseFactory(title='Draft Course', key='edX+draft_course', draft=True)
-        self.course = CourseFactory(course=self.draft_course, draft=False)
+        self.course = CourseFactory(draft_version=self.draft_course, draft=False)
         self.course_run = CourseRunFactory(
             course=self.course, title_override='Test Course Run',
             start=datetime.datetime.now(UTC), end=datetime.datetime.now(UTC) + datetime.timedelta(days=2),

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -721,7 +721,8 @@ class TestCourseDeadlineEmail(TestCase):
     """
     def setUp(self):
         super().setUp()
-        self.course = CourseFactory(title='Test Course', key='edX+test_course', draft=False)
+        self.draft_course = CourseFactory(title='Draft Course', key='edX+draft_course', draft=True)
+        self.course = CourseFactory(course=self.draft_course, draft=False)
         self.course_run = CourseRunFactory(
             course=self.course, title_override='Test Course Run',
             start=datetime.datetime.now(UTC), end=datetime.datetime.now(UTC) + datetime.timedelta(days=2),
@@ -733,7 +734,7 @@ class TestCourseDeadlineEmail(TestCase):
             first_name='Test',
             last_name='Editor',
         )
-        CourseEditorFactory(user=self.editor, course=self.course)
+        CourseEditorFactory(user=self.editor, course=self.draft_course)
 
     def test_send_course_deadline_email(self):
         """


### PR DESCRIPTION
This PR fixes the editors query to fetch them from the draft version of the course instead of the official version. While testing the send_course_deadline_emails command, I found that course editors are linked to the draft entry of the course, not the non-draft version.

I've verified email sending functionality by assigning manually course_editor to draft entry of course.