### PR TITLE
feat: add the functionallity in bulk_operation tasks endpoint to include result  attr as well

### DIFF
--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -2782,6 +2782,7 @@ class BulkOperationTaskSerializer(serializers.ModelSerializer):
     Serializer for BulkOperationTask model.
     """
     uploaded_by = serializers.SerializerMethodField(read_only=True)
+    result = serializers.SerializerMethodField()
 
     class Meta:
         model = BulkOperationTask
@@ -2793,3 +2794,15 @@ class BulkOperationTaskSerializer(serializers.ModelSerializer):
         Return the username of the user who uploaded the task.
         """
         return obj.uploaded_by.username if obj.uploaded_by else None
+
+    def get_result(self, obj):
+        """
+        Return the result of the task if `include_result` is set to True in the context.
+        If no result is available, return None.
+        """
+        include_result = self.context.get('include_result', False)
+        if not include_result:
+            return None
+
+        task_result = obj.task_result
+        return task_result.result if task_result else None

--- a/course_discovery/apps/api/v1/views/bulk_operation_tasks.py
+++ b/course_discovery/apps/api/v1/views/bulk_operation_tasks.py
@@ -12,9 +12,6 @@ from course_discovery.apps.course_metadata.models import BulkOperationTask
 
 class BulkOperationTaskViewSet(CompressedCacheResponseMixin, mixins.CreateModelMixin, mixins.RetrieveModelMixin,
                                mixins.ListModelMixin, viewsets.GenericViewSet):
-    """
-    ViewSet for BulkOperationTask model.
-    """
     queryset = BulkOperationTask.objects.all()
     serializer_class = BulkOperationTaskSerializer
     permission_classes = [IsStaffOrSuperuser]
@@ -25,7 +22,13 @@ class BulkOperationTaskViewSet(CompressedCacheResponseMixin, mixins.CreateModelM
     search_fields = ('task_type', 'uploaded_by__username')
 
     def perform_create(self, serializer):
+        serializer.save(uploaded_by=self.request.user)
+
+    def get_serializer_context(self):
         """
         Overriding perform_create to set the uploaded_by field to the current user.
         """
-        serializer.save(uploaded_by=self.request.user)
+        context = super().get_serializer_context()
+        include_result = self.request.query_params.get('include_result', 'false').lower() == 'true'
+        context['include_result'] = include_result
+        return context


### PR DESCRIPTION
This PR adds the functionality to add `result` attr from TaskResult model in `bulk-operations-tasks` api response.