### PR TITLE
feat: add handling for some legal review fields in course run loader

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/course_run_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/course_run_loader.py
@@ -9,7 +9,7 @@ import logging
 from course_discovery.apps.course_metadata.choices import CourseRunStatus
 from course_discovery.apps.course_metadata.data_loaders import AbstractDataLoader
 from course_discovery.apps.course_metadata.data_loaders.constants import (
-    CSV_LOADER_ERROR_LOG_SEQUENCE, CSVIngestionErrors, CSVIngestionErrorMessages
+    CSV_LOADER_ERROR_LOG_SEQUENCE, CSVIngestionErrorMessages, CSVIngestionErrors
 )
 from course_discovery.apps.course_metadata.data_loaders.mixins import DataLoaderMixin
 from course_discovery.apps.course_metadata.data_loaders.utils import prune_empty_values
@@ -136,9 +136,9 @@ class CourseRunDataLoader(AbstractDataLoader, DataLoaderMixin):
 
                     new_course_run.status = CourseRunStatus.LegalReview
                     new_course_run.save(update_fields=['status'], send_emails=True)
-                
+
                 self.ingestion_summary['success_count'] += 1
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-exception-caught
                 self.log_ingestion_error(
                     CSVIngestionErrors.COURSE_RUN_CREATE_ERROR,
                     f"[Row {index}] Error creating rerun for course '{course.title}': {str(e)}"

--- a/course_discovery/apps/course_metadata/data_loaders/mixins.py
+++ b/course_discovery/apps/course_metadata/data_loaders/mixins.py
@@ -57,7 +57,7 @@ class DataLoaderMixin:
         "maximum_effort": "max_effort",
         "length": "weeks_to_complete",
     }
-    
+
     LEGAL_REVIEW_REQUIRED_FIELDS = [
         *LEGAL_REVIEW_REQUIRED_FIELDS__COURSE.keys(),
         *LEGAL_REVIEW_REQUIRED_FIELDS__COURSE_RUN.keys()

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
@@ -246,7 +246,7 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         csv_data.pop("Maximum Effort")
         csv_data.pop("Primary Subject")
 
-        loader, _ = self.perform_partial_updates(csv_data)
+        self.perform_partial_updates(csv_data)
 
         course = Course.everything.get()
         course_run = CourseRun.everything.get()

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_loader.py
@@ -242,18 +242,19 @@ class TestCourseLoader(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             **mock_data.COURSE_LOADER_COURSE_AND_COURSE_RUN_PARTIAL_UPDATES_SIMPLE,
             **mock_data.COURSE_LOADER_COURSE_AND_COURSE_RUN_PARTIAL_UPDATES_FOR_REVIEW
         }
-
         csv_data.pop("Image")
         csv_data.pop("Maximum Effort")
+        csv_data.pop("Primary Subject")
+
+        loader, _ = self.perform_partial_updates(csv_data)
 
         course = Course.everything.get()
         course_run = CourseRun.everything.get()
 
-        row = CourseLoader.transform_dict_keys(csv_data)
-        missing_fields = CourseLoader.missing_fields_for_legal_review(CourseLoader, course, course_run, row)
-        assert set(missing_fields) == {'image', 'maximum_effort'}
-        course_run.maximum_effort = 8
-        assert CourseLoader.missing_fields_for_legal_review(CourseLoader, course, course_run, row) == ['image']
+        missing_fields = CourseLoader.missing_fields_for_legal_review(course, course_run)
+        assert set(missing_fields) == {'image', 'maximum_effort', 'primary_subject'}
+        course_run.max_effort = 8
+        assert CourseLoader.missing_fields_for_legal_review(course, course_run) == ['image', 'primary_subject']
 
     @data(True, False)
     def test_course_loader_partial_updates__track_change(self, is_price_in_csv, mock_jwt_decode_handler):  # pylint: disable=unused-argument

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_course_run_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_course_run_loader.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import responses
 from testfixtures import LogCapture
+from ddt import data, ddt
 
 from course_discovery.apps.api.v1.tests.test_views.mixins import APITestCase, OAuth2Mixin
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
@@ -16,18 +17,24 @@ from course_discovery.apps.course_metadata.data_loaders.tests.mixins import CSVL
 from course_discovery.apps.course_metadata.data_loaders.tests.mock_data import VALID_COURSE_RERUN_DATA
 from course_discovery.apps.course_metadata.models import CourseRun, CourseType
 from course_discovery.apps.course_metadata.tests.factories import (
-    CourseFactory, CourseRunFactory, SeatFactory, SeatTypeFactory
+    CourseFactory, CourseRunFactory, SeatFactory, SeatTypeFactory, SubjectFactory
 )
 
 LOGGER_PATH = 'course_discovery.apps.course_metadata.data_loaders.course_run_loader'
 
 
+@ddt
 @mock.patch(
     'course_discovery.apps.course_metadata.data_loaders.configured_jwt_decode_handler',
     return_value={'preferred_username': 'test_username'}
 )
 class CourseRunDataLoaderTests(CSVLoaderMixin, OAuth2Mixin, APITestCase):
     """Tests for CourseRunDataLoader ingestion scenarios."""
+
+    rerun_fields = [
+        'last_active_run_key', 'start_date', 'start_time',
+        'end_date', 'end_time', 'run_type', 'pacing_type', 'move_to_legal_review',
+    ]
 
     def setUp(self):
         """Set up a test user, partner course, course run, and seat."""
@@ -41,26 +48,30 @@ class CourseRunDataLoaderTests(CSVLoaderMixin, OAuth2Mixin, APITestCase):
             partner=self.partner,
             type=CourseType.objects.get(slug=CourseType.VERIFIED_AUDIT),
             draft=True,
-            key_for_reruns=''
+            key_for_reruns='',
+            subjects=[SubjectFactory()]  
         )
         self.existing_run = CourseRunFactory(
             course=self.course,
             key=self.COURSE_RUN_KEY,
             status='published',
             draft=True,
+            weeks_to_complete=5,
         )
         SeatFactory(course_run=self.existing_run, type=SeatTypeFactory.verified(), price=200.0)
 
     def mock_call_course_api(self, method, url, payload):
-        """Mock POST requests to the course API using Django test client."""
-        return self.client.post(url, data=payload, format='json') if method == 'POST' else None
+        """Mock requests to the course API using Django test client."""
+        if method == 'POST':
+            return self.client.post(url, data=payload, format='json')
+        elif method == 'PATCH':
+            return self.client.patch(url, data=payload, format='json')
+        else:
+            return None
 
     def _write_csv(self, csv, lines_dict_list, headers=None):
         """Write course rerun data to CSV."""
-        rerun_fields = [
-            'last_active_run_key', 'start_date', 'start_time',
-            'end_date', 'end_time', 'run_type', 'pacing_type', 'move_to_legal_review',
-        ]
+        rerun_fields = self.rerun_fields
         headers = headers or rerun_fields
         header_line = ','.join(key.replace('_', ' ').title() for key in headers) + '\n'
         csv.write(header_line.encode())
@@ -167,10 +178,11 @@ class CourseRunDataLoaderTests(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         self.assertEqual(summary['failure_count'], 1)
 
     @responses.activate
-    def test_ingest_legal_review_flag_applied(self, jwt_decode_patch):  # pylint: disable=unused-argument
-        """Verify course run is marked for legal review when flag is true."""
+    @data(True, False)
+    def test_ingest_legal_review_flag_applied(self, has_publish_date, jwt_decode_patch):  # pylint: disable=unused-argument
+        """Verify course run is marked for legal review when flag is true and required data is present."""
         self._setup_prerequisites(self.partner)
-        self.mock_studio_calls(self.partner)
+        self.mock_studio_calls(self.partner, run_key='course-v1:edx+csv_123+1T2025')
 
         studio_url = f'{self.partner.studio_url.strip("/")}/api/v1/course_runs/'
         responses.add(responses.POST, f'{studio_url}{self.existing_run.key}/rerun/', status=200)
@@ -178,12 +190,58 @@ class CourseRunDataLoaderTests(CSVLoaderMixin, OAuth2Mixin, APITestCase):
         data = VALID_COURSE_RERUN_DATA.copy()
         data['move_to_legal_review'] = 'true'
 
+        if has_publish_date:
+            data['publish_date'] = '03/01/2025'
+
         with NamedTemporaryFile() as csv:
-            csv = self._write_csv(csv, [data])
+            csv = self._write_csv(csv, [data], headers=[*self.rerun_fields, 'publish_date'])
             with mock.patch.object(CourseRunDataLoader, 'call_course_api', self.mock_call_course_api):
                 loader = CourseRunDataLoader(self.partner, csv_path=csv.name)
                 summary = loader.ingest()['summary']
 
-        self.assertEqual(summary['success_count'], 1)
         run = CourseRun.everything.get(key=summary['new_runs'][0])
-        self.assertEqual(run.status, CourseRunStatus.LegalReview)
+        if has_publish_date:
+            self.assertEqual(summary['success_count'], 1)
+            self.assertEqual(run.status, CourseRunStatus.LegalReview)
+            self.assertTrue(run.go_live_date)
+        else:
+            self.assertEqual(summary['failure_count'], 1)
+            self.assertEqual(run.status, CourseRunStatus.Unpublished)
+            self.assertIn('The missing data elements are "[\'publish_date\']"', loader.error_logs['MISSING_REQUIRED_DATA'][0])
+            self.assertFalse(run.go_live_date)
+
+    @responses.activate
+    @data(True, False)
+    def test_ingest_change_fields(self, move_to_legal_review, jwt_decode_patch):  # pylint: disable=unused-argument
+        """Verify that course run effort and length fields can be changed"""
+        self._setup_prerequisites(self.partner)
+        self.mock_studio_calls(self.partner, run_key='course-v1:edx+csv_123+1T2025')
+
+        studio_url = f'{self.partner.studio_url.strip("/")}/api/v1/course_runs/'
+        responses.add(responses.POST, f'{studio_url}{self.existing_run.key}/rerun/', status=200)
+
+        data = VALID_COURSE_RERUN_DATA.copy()
+        if move_to_legal_review:
+            data['move_to_legal_review'] = 'true'
+            data['publish_date'] = '03/01/2025'
+
+        data['minimum_effort'] = 3
+        data['maximum_effort'] = 11
+        data['length'] = 7
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_csv(csv, [data], headers=[*self.rerun_fields, 'publish_date', 'minimum_effort', 'maximum_effort', 'length'])
+            with mock.patch.object(CourseRunDataLoader, 'call_course_api', self.mock_call_course_api):
+                loader = CourseRunDataLoader(self.partner, csv_path=csv.name)
+                summary = loader.ingest()['summary']
+
+        run = CourseRun.everything.get(key=summary['new_runs'][0])
+        self.assertEqual(run.min_effort, 3)
+        self.assertEqual(run.max_effort, 11)
+        self.assertEqual(run.weeks_to_complete, 7)
+        self.assertNotEqual(run.weeks_to_complete, self.existing_run.weeks_to_complete)
+
+        if move_to_legal_review:
+            self.assertEqual(run.status, CourseRunStatus.LegalReview)
+        else:
+            self.assertEqual(run.status, CourseRunStatus.Unpublished)


### PR DESCRIPTION
## [PROD-4392](https://2u-internal.atlassian.net/browse/PROD-4392)
This PR ensures that runs can not be pushed to legal review without publish_date (and other required fields). Furthermore, it adds the ability to update max_effort, min_effort, and weeks_to_complete.

## Testing

1. Create a csv for the course run loader including the effort and length fields. 
2. Ensure that the effort and length fields are appropriately updated

1. Create a csv for the course run loader and do not add the publish date
2. Set Move to Legal Review to True
3. Verify that the loader errors and the run is not pushed to legal review
4. Add the publish date to the csv
5. Rerun loader and verify that run is pushed to legal review