### PR TITLE
[PROD-4408] Include start/end dates for external course runs in Studio API payload

### DIFF
--- a/course_discovery/apps/api/tests/test_utils.py
+++ b/course_discovery/apps/api/tests/test_utils.py
@@ -116,16 +116,19 @@ class StudioAPITests(OAuth2Mixin, APITestCase):
         }
         if add_pacing:
             data['pacing_type'] = run.pacing_type
-        if add_schedule:
-            data['schedule'] = {
-                'start': serialize_datetime(run.start),
-                'end': serialize_datetime(run.end),
-            }
-        if add_enrollment_dates:
-            data['schedule'] = {
-                'enrollment_start': serialize_datetime(run.enrollment_start),
-                'enrollment_end': serialize_datetime(run.enrollment_end),
-            }
+        
+        if add_schedule or add_enrollment_dates:
+            data['schedule'] = {}
+            if add_schedule:
+                data['schedule'].update({
+                    'start': serialize_datetime(run.start),
+                    'end': serialize_datetime(run.end),
+                })
+            if add_enrollment_dates:
+                data['schedule'].update({
+                    'enrollment_start': serialize_datetime(run.enrollment_start),
+                    'enrollment_end': serialize_datetime(run.enrollment_end),
+                })
         return data
 
     def test_create_rerun(self):
@@ -217,6 +220,32 @@ class StudioAPITests(OAuth2Mixin, APITestCase):
                 f'Enrollment information added to data {output_data} for course run {run.key}'
             )
 
+    def test_generate_data_for_studio_api__non_external_course_no_start_end_on_update(self):
+        """Test that start/end are NOT included when updating a non-external course."""
+        run = CourseRunFactory()  # Default: non-external
+        expected_data = self.make_studio_data(run, add_pacing=False, add_schedule=False, add_enrollment_dates=True)
+        with mock.patch('course_discovery.apps.api.utils.logger') as mock_logger:
+            output_data = StudioAPI.generate_data_for_studio_api(run, creating=False)
+            self.assertEqual(output_data, expected_data)
+        mock_logger.info.assert_called_with(
+            f'Enrollment information added to data {output_data} for course run {run.key}'
+        )
+
+    def test_generate_data_for_studio_api__external_course_start_end_on_update(self):
+        """Test that start/end are included for external course on update."""
+        exec_ed_type = CourseTypeFactory(slug=CourseType.EXECUTIVE_EDUCATION_2U)
+        run = CourseRunFactory(course=CourseFactory(type=exec_ed_type))
+        
+        expected_data = self.make_studio_data(run, add_pacing=False, add_schedule=True, add_enrollment_dates=True)
+        
+        with mock.patch('course_discovery.apps.api.utils.logger') as mock_logger:
+            output_data = StudioAPI.generate_data_for_studio_api(run, creating=False)
+            self.assertEqual(output_data, expected_data)
+        
+        mock_logger.info.assert_called_with(
+            f'Enrollment information added to data {output_data} for course run {run.key}'
+        )
+        
     def test_calculate_course_run_key_run_value_with_multiple_runs_per_trimester(self):
         start = datetime.datetime(2017, 2, 1)
 

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -255,8 +255,8 @@ class StudioAPI:
         key = CourseKey.from_string(course_run.key)
 
         is_external = course_run.course.is_external_course
-
-        # start, end, and pacing are not sent on updates - Studio is where users edit them
+        #Include start and end only if creating or if it's an external course during update
+        
         start = course_run.start if creating or is_external  else None
         end = course_run.end if creating or is_external  else None
         pacing = course_run.pacing_type if creating else None

--- a/course_discovery/apps/api/utils.py
+++ b/course_discovery/apps/api/utils.py
@@ -254,9 +254,11 @@ class StudioAPI:
         editors = [editor.user for editor in course_run.course.editors.all()]
         key = CourseKey.from_string(course_run.key)
 
+        is_external = course_run.course.is_external_course
+
         # start, end, and pacing are not sent on updates - Studio is where users edit them
-        start = course_run.start if creating else None
-        end = course_run.end if creating else None
+        start = course_run.start if creating or is_external  else None
+        end = course_run.end if creating or is_external  else None
         pacing = course_run.pacing_type if creating else None
         enrollment_start = course_run.enrollment_start
         enrollment_end = course_run.enrollment_end
@@ -300,10 +302,11 @@ class StudioAPI:
             # But when the course run is created, in Studio or Discovery, the enrollment dates are not taken as input.
             # It is better to keep the flow consistent across places.
             # Allow sending enrollment start and end dates as part of Update only.
-            data['schedule'] = {
+            data.setdefault('schedule', {})
+            data['schedule'].update({
                 'enrollment_start': serialize_datetime(course_run.enrollment_start),
                 'enrollment_end': serialize_datetime(course_run.enrollment_end),
-            }
+            })
             logger.info(f"Enrollment information added to data {data} for course run {course_run.key}")
 
         return data

--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -481,6 +481,8 @@ class CSVDataLoader(AbstractDataLoader, DataLoaderMixin):
             'prices': self.get_pricing_representation(course_run_data['verified_price'], course_type),
             'staff': staff_uuids,
             'draft': is_draft,
+            'start': self.get_formatted_datetime_string(f"{course_run_data['start_date']} {course_run_data['start_time']}"),
+            'end': self.get_formatted_datetime_string(f"{course_run_data['end_date']} {course_run_data['end_time']}"),
 
             'weeks_to_complete': course_run_data['length'],
             'min_effort': course_run_data['minimum_effort'],


### PR DESCRIPTION
This PR addresses the need to ensure that external course runs include their start and end dates when updating via the Studio API.

Ticket - https://2u-internal.atlassian.net/browse/PROD-4408

Key Changes:

1. Introduced is_external_course property on the Course model to determine external product types.
2. Updated generate_data_for_studio_api:
3. start and end dates are now included when either creating the course run or when the course is external.
4. Enrollment start/end dates remain update-only, consistent with current API behavior.
5. Refactored make_studio_data in test suite to merge schedule fields when both start/end and enrollment_start/end are present.
6. Added unit tests to verify:
- Inclusion of start/end for external vs. non-external courses.
-  Correct behavior on create vs. update operations.

This ensures Studio receives the appropriate scheduling metadata for external products, avoiding downstream issues related to incomplete data.