### PR TITLE
fix: Include start/end dates for external course run

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
+++ b/course_discovery/apps/course_metadata/data_loaders/csv_loader.py
@@ -481,6 +481,8 @@ class CSVDataLoader(AbstractDataLoader, DataLoaderMixin):
             'prices': self.get_pricing_representation(course_run_data['verified_price'], course_type),
             'staff': staff_uuids,
             'draft': is_draft,
+            'start': self.get_formatted_datetime_string(f"{course_run_data['start_date']} {course_run_data['start_time']}"),  # pylint: disable=line-too-long
+            'end': self.get_formatted_datetime_string(f"{course_run_data['end_date']} {course_run_data['end_time']}"),
 
             'weeks_to_complete': course_run_data['length'],
             'min_effort': course_run_data['minimum_effort'],


### PR DESCRIPTION
This PR addresses the need to ensure that external course runs include their start and end dates when updating via the Studio API.

Ticket - https://2u-internal.atlassian.net/browse/PROD-4408

Key Changes:

Introduced is_external_course property on the Course model to determine external product types.
Updated generate_data_for_studio_api:
start and end dates are now included when either creating the course run or when the course is external.
Enrollment start/end dates remain update-only, consistent with current API behavior.
Refactored make_studio_data in test suite to merge schedule fields when both start/end and enrollment_start/end are present.
Added unit tests to verify:
Inclusion of start/end for external vs. non-external courses.
Correct behavior on create vs. update operations.
This ensures Studio receives the appropriate scheduling metadata for external products, avoiding downstream issues related to incomplete data.