### PR TITLE
chore: update email content upon publish

### DIFF
--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/go_live.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/go_live.html
@@ -7,7 +7,7 @@
 <p>
     {% filter force_escape %}
         {% blocktrans trimmed %}
-            Dear {{ recipient_name }},
+            Hi Course Team,
         {% endblocktrans %}
     {% endfilter %}
 </p>
@@ -15,20 +15,13 @@
 <p>
     {% filter force_escape %}
         {% blocktrans trimmed %}
-            The About page for the {{ course_run_number }} course run of {{ course_name }} has been published. No further action is necessary.
+            The About page for the {{ course_run_number }} course run of {{ course_name }} has been submitted for publishing. The new session will appear on the edX website following the next couple of deployments—typically within 24 to 48 business hours.
         {% endblocktrans %}
     {% endfilter %}
 </p>
 
 <p>
-    {% blocktrans trimmed asvar tmsg %}
-        {link_start}{preview_url}{link_middle}View this About page.{link_end}
-    {% endblocktrans %}
-    {% interpolate_html tmsg link_start='<a href="'|safe link_middle='">'|safe link_end='</a>'|safe preview_url=preview_url|safe %}
-</p>
-
-<p>
-    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator(s):
+    Note: This is a no-reply email. For any questions or comments, please contact your Project Coordinator at 
     {% for contact_us_email in contact_us_emails %}
         {% blocktrans trimmed asvar tmsg %}
         {link_start}{contact_us_email}{link_middle}{contact_us_email}{link_end}
@@ -36,7 +29,7 @@
         {% if forloop.last %}
         {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>'|safe contact_us_email=contact_us_email|safe %}
         {% else %}
-        {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>, '|safe contact_us_email=contact_us_email|safe %}
+        {% interpolate_html tmsg link_start='<a href="mailto:'|safe link_middle='">'|safe link_end='</a>'|safe contact_us_email=contact_us_email|safe %}
         {% endif %}
     {% endfor %}
 </p>

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/go_live.txt
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/go_live.txt
@@ -1,17 +1,13 @@
 {% load i18n %}
 
 {% blocktrans trimmed %}
-    Dear {{ recipient_name }},
+    Hi Course Team,
 {% endblocktrans %}
 
 {% blocktrans trimmed %}
-    The About page for the {{ course_run_number }} course run of {{ course_name }} has been published. No further action is necessary.
+    The About page for the {{ course_run_number }} course run of {{ course_name }} has been submitted for publishing. The new session will appear on the edX website following the next couple of deployments—typically within 24 to 48 business hours.
 {% endblocktrans %}
 
 {% blocktrans trimmed %}
-    View this About page. {{ preview_url }}
-{% endblocktrans %}
-
-{% blocktrans trimmed %}
-    Note: This email address is unable to receive replies. For questions or comments, please contact your Project Coordinator(s):
-{% endblocktrans %}{% for contact_us_email in contact_us_emails %}{% if forloop.last %}{{ contact_us_email }}{% else %}{{ contact_us_email }},{% endif %}{% endfor %}
+    Note: This is a no-reply email. For any questions or comments, please contact your Project Coordinator at 
+{% endblocktrans %}{% for contact_us_email in contact_us_emails %}{% if forloop.last %} {{ contact_us_email }} {% else %} {{ contact_us_email }} ,{% endif %}{% endfor %}

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -244,23 +244,20 @@ class EmailTests(TestCase):
         """
         Verify that send_email_for_go_live's happy path works as expected
         """
+        # pylint: disable=line-too-long
         kwargs = {
             'both_regexes': [
-                'The About page for the %s course run of %s has been published.' %
+                'The About page for the %s course run of %s has been submitted for publishing. The new session will appear on the edX website following the next couple of deployments—typically within 24 to 48 business hours' %
                 (self.run_num, self.course_run.title),
-                'No further action is necessary.',
             ],
             'html_regexes': [
-                '<a href="%s">View this About page.</a>' % self.course_run.marketing_url,
-                r'For questions or comments, please contact your Project Coordinator\(s\):',
+                r'Note: This is a no-reply email. For any questions or comments, please contact your Project Coordinator at ',
                 '<a href="mailto:pc@example.com">pc@example.com</a>',
             ],
             'text_regexes': [
-                '\n\nView this About page. %s\n' % self.course_run.marketing_url,
-                r'For questions or comments, please contact your Project Coordinator\(s\):pc@example.com'
+                r'Note: This is a no-reply email. For any questions or comments, please contact your Project Coordinator at pc@example.com'
             ],
         }
-
         self.assertEmailSent(
             emails.send_email_for_go_live,
             f'^Published: {self.course_run.title}$',


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/PROD-4410
This PR ensures that upon publishing a course run, an updated email notification is automatically sent to course editors and project coordinators.

New Email Format:
Hi Course Team,

The About Page for the [Term] course run of [Course Name] has been submitted for publishing. The new session will appear on the edX website following the next couple of deployments—typically within 24 to 48 business hours.

Note: This is a no-reply email. For any questions or comments, please contact your Project Coordinator at [PC email]

Testing:-

Create a course run
Set the course status to “Published”
Automatically receive an email from project coordinators and course editors