### PR TITLE
refactor: clean_html() to improve HTML sanitization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal as app
+FROM ubuntu:jammy as app
 
 ARG PYTHON_VERSION=3.12
 

--- a/course_discovery/apps/course_metadata/tests/test_utils.py
+++ b/course_discovery/apps/course_metadata/tests/test_utils.py
@@ -880,10 +880,21 @@ class UtilsTests(TestCase):
             '<p>Some text</p>\n<p>· Item 1</p>\n<ul>\n<li>Item 2</li>\n</ul>\n<p>Regular paragraph</p>\n<p>· Item 3</p>'
         )
     )
+    @ddt.data(
+        (
+            '<p><em>The content of this course also forms part of the six-month online<a href="https://example.com">Example Link</a></em></p>',  # pylint: disable=line-too-long
+            '<p><em>The content of this course also forms part of the six-month online <a href="https://example.com">Example Link</a></em></p>'  # pylint: disable=line-too-long
+        ),
+        (
+            '<div><p>online course.</p><p><strong>Module 1:</strong></p></div>',
+            '<p>online course. <strong>Module 1:</strong></p>'
+        )
+    )
     @ddt.unpack
     def test_clean_html(self, content, expected):
         """ Verify the method removes unnecessary HTML attributes. """
-        assert clean_html(content) == expected
+        result = clean_html(content)
+        assert result == expected, f"\nExpected:\n{expected}\nGot:\n{result}"
 
     def test_skill_data_transformation(self):
         category_data = {

--- a/course_discovery/apps/course_metadata/utils.py
+++ b/course_discovery/apps/course_metadata/utils.py
@@ -774,6 +774,8 @@ def clean_html(content):
     (indicating right-to-left direction), this method will ensure that the 'dir' attribute is preserved
     or added to maintain consistency with the original content.
     """
+    if not content:
+        return ''
     LIST_TAGS = ['ul', 'ol']
     is_list_with_dir_attr_present = False
 
@@ -790,12 +792,13 @@ def clean_html(content):
     cleaned = cleaned.replace('<p><b></b></p>', '')
     html_converter = HTML2TextWithLangSpans(bodywidth=None)
     html_converter.wrap_links = False
-    cleaned = html_converter.handle(cleaned).strip()
-    cleaned = markdown.markdown(cleaned)
-    for tag in LIST_TAGS:
-        cleaned = cleaned.replace(f'<{tag}>', f'<{tag} dir="rtl">') if is_list_with_dir_attr_present else cleaned
-
-    return cleaned
+    markdown_text = html_converter.handle(cleaned).strip()
+    cleaned = markdown.markdown(markdown_text)
+    cleaned = re.sub(r'([^\s>])\s*(<a\b)', r'\1 \2', cleaned)
+    if is_list_with_dir_attr_present:
+        for tag in LIST_TAGS:
+            cleaned = cleaned.replace(f'<{tag}>', f'<{tag} dir="rtl">')
+    return cleaned.strip()
 
 
 def get_file_from_drive_link(image_url):


### PR DESCRIPTION
This PR refactors the clean_html() utility to enhance HTML cleaning while ensuring consistent formatting with generated content.

ticket for this : https://2u-internal.atlassian.net/browse/PROD-4415

Key changes:

- Removed non-breaking spaces (&nbsp;) to prevent unwanted spacing in output.
- Preserved ul  and ol tags dir="rtl" attributes by temporarily removing and restoring them after processing.

Improved HTML normalization:

- Converted HTML → Markdown → HTML to remove unsupported attributes, inline styles, and normalize tag structure.
- Ensured no line wrapping in converted Markdown (bodywidth=None).
- Fixed <a> tag spacing issue where anchor tags were stuck to preceding words/tags.
- Removed unnecessary hr / tags.
- Collapsed multiple blank lines into a single line for cleaner output.
- Returned final HTML with trimmed whitespace for consistent output formatting.
- 
IN TEST CASAES
Before Code Update Test SS
<img width="925" height="620" alt="image (1)" src="https://github.com/user-attachments/assets/0a011d7a-f18a-4b14-8582-64dd211dc874" />

After Code Update Test SS
<img width="1204" height="618" alt="Clean_html() after" src="https://github.com/user-attachments/assets/4daca307-c1cb-4c6f-b6c2-5f4545d3c5b7" />
