### PR TITLE
fix: Use correct elasticsearch field name for .raw field facet filtering

### DIFF
--- a/course_discovery/apps/edx_elasticsearch_dsl_extensions/backends.py
+++ b/course_discovery/apps/edx_elasticsearch_dsl_extensions/backends.py
@@ -121,7 +121,9 @@ class FacetedFieldSearchFilterBackend(FacetedSearchFilterBackend):
             if not field_facets.get(field):
                 raise ParseError('The selected query facet [{facet}] is not valid.'.format(facet=field))
 
-            _filters.append(ESDSLQ('term', **{field: value}))
+            # Use the actual elasticsearch field name from configuration, not the facet key
+            elasticsearch_field = field_facets[field]['field']
+            _filters.append(ESDSLQ('term', **{elasticsearch_field: value}))
 
         queryset = queryset.query('bool', **{'filter': _filters})
         return queryset


### PR DESCRIPTION
## Problem
- Facet configuration: 'language': {'field': 'language.raw', 'enabled': True}
- URL parameter: selected_facets=language_exact:English
- Backend extracted: field='language', value='English'
- Filter applied: ESDSLQ('term', language='English') 
- Expected filter: ESDSLQ('term', **{'language.raw': 'English'}) 

The incorrect field name caused `elasticsearch` to query the analyzed
'language' field instead of the case-sensitive 'language.raw' keyword
field, resulting in no matches for capitalized values.

## Solution
Modified FacetedFieldSearchFilterBackend.filter_by_facets() to use
the configured elasticsearch field name from field_facets[field]['field']
instead of the facet key when building elasticsearch term queries.

## Testing
This fix ensures that URLs like:
`/api/v1/search/course_runs/facets/?selected_facets=language_exact:English`
now correctly filter results using the language.raw field instead of
failing due to case sensitivity mismatches.
