### PR TITLE
feat: send course deadline email

### DIFF
--- a/course_discovery/apps/course_metadata/emails.py
+++ b/course_discovery/apps/course_metadata/emails.py
@@ -453,9 +453,10 @@ def send_course_deadline_email(course, course_run, recipients, deadline_email_va
     html_template = 'course_metadata/email/course_deadline.html'
     template = get_template(html_template)
     subject_lookup = {
-        "course_ended": f"Reminder: {course.title} has ended",
-        "two_days_reminder": f"Reminder: {course.title} ends in 2 days",
+        "three_months_reminder": f"Reminder: {course.title} ends in 3 months",
+        "one_month_reminder": f"Reminder: {course.title} ends in 1 month",
         "seven_days_reminder": f"Reminder: {course.title} ends in 7 days",
+        "course_ended": f"Reminder: {course.title} has ended",
     }
 
     subject = subject_lookup.get(deadline_email_variant, f"Reminder: {course.title} deadline is approaching")
@@ -465,7 +466,12 @@ def send_course_deadline_email(course, course_run, recipients, deadline_email_va
         "course_name": course.title,
         "course_key": course.key,
         "course_end_date": (course_run.end.strftime("%m/%d/%Y") if course_run.end else None),
-        "days_to_expire": '2 days' if deadline_email_variant == "two_days_reminder" else '7 days' if deadline_email_variant == "seven_days_reminder" else 'course ended',  # pylint: disable=line-too-long
+        "days_to_expire": (
+            "90 days" if deadline_email_variant == "three_months_reminder"
+            else "30 days" if deadline_email_variant == "one_month_reminder"
+            else "7 days" if deadline_email_variant == "seven_days_reminder"
+            else "course_ended"
+        ),
         "publisher_url": course.partner.publisher_url,
         "course_schedule_settings_url": f"{course.partner.studio_url}/settings/details/{course_run.key}#schedule",
         "partner_marketing_site_url": course.partner.marketing_site_url_root,

--- a/course_discovery/apps/course_metadata/management/commands/send_course_deadline_emails.py
+++ b/course_discovery/apps/course_metadata/management/commands/send_course_deadline_emails.py
@@ -19,7 +19,7 @@ from course_discovery.apps.course_metadata.tasks import process_send_course_dead
 from course_discovery.apps.publisher.choices import InternalUserRole
 from course_discovery.apps.publisher.models import OrganizationUserRole
 
-EMAIL_DELTA_DAYS = [2, 7, -1]
+EMAIL_DELTA_DAYS = [90, 30, 7, -1]
 LAST_RUN_END_DELTA = -1
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,8 @@ class Command(BaseCommand):
     help = 'Send course deadline emails to Project Coordinators and Course Editors.'
 
     DEADLINE_VARIANTS = {
-        2: "two_days_reminder",
+        90: "three_months_reminder",
+        30: "one_month_reminder",
         7: "seven_days_reminder",
         -1: "course_ended",
     }
@@ -41,8 +42,9 @@ class Command(BaseCommand):
         logger.info("Initializing course deadline email management command.")
         now = datetime.now(timezone.utc)
         courses_with_deadlines = []
-        courses_with_self_paced_runs = Course.objects.filter(
-            course_runs__pacing_type=CourseRunPacing.Self,
+        # Include both Self-paced and Instructor-paced
+        courses_with_runs = Course.objects.filter(
+            course_runs__pacing_type__in=[CourseRunPacing.Self, CourseRunPacing.Instructor],
             course_runs__end__isnull=False,
             product_source__slug=settings.DEFAULT_PRODUCT_SOURCE_SLUG,
         ).annotate(
@@ -55,10 +57,10 @@ class Command(BaseCommand):
             'course_runs',
             'editors',
         ).distinct()
-        logger.info(f'Found {courses_with_self_paced_runs.count()} courses with self-paced runs.')
-        courses_with_self_paced_runs = courses_with_self_paced_runs.iterator()
+        logger.info(f'Found {courses_with_runs.count()} courses with matching runs.')
+        courses_with_runs = courses_with_runs.iterator()
 
-        for course in courses_with_self_paced_runs:
+        for course in courses_with_runs:
             advertised_run = course.advertised_course_run
 
             if advertised_run:

--- a/course_discovery/apps/course_metadata/management/commands/send_course_deadline_emails.py
+++ b/course_discovery/apps/course_metadata/management/commands/send_course_deadline_emails.py
@@ -57,9 +57,8 @@ class Command(BaseCommand):
             'course_runs',
             'editors',
         ).distinct()
-        logger.info(f'Found {courses_with_self_paced_runs.count()} courses with self-paced runs.')
-        courses_with_self_paced_runs = courses_with_self_paced_runs.iterator(
-            chunk_size=settings.ITERATOR_CHUNK_SIZE)
+        logger.info(f'Found {courses_with_runs.count()} courses with matching runs.')
+        courses_with_runs = courses_with_runs.iterator(chunk_size=settings.ITERATOR_CHUNK_SIZE)
 
         for course in courses_with_runs:
             advertised_run = course.advertised_course_run

--- a/course_discovery/apps/course_metadata/management/commands/tests/test_send_course_deadline_emails.py
+++ b/course_discovery/apps/course_metadata/management/commands/tests/test_send_course_deadline_emails.py
@@ -100,7 +100,7 @@ class SendCourseDeadlineEmailsTests(TestCase):
                 (
                     LOGGER_PATH,
                     'INFO',
-                    'Found 0 courses with self-paced runs.'
+                    'Found 0 courses with matching runs.'
                 ),
                 (
                     LOGGER_PATH,
@@ -110,7 +110,10 @@ class SendCourseDeadlineEmailsTests(TestCase):
             )
 
     @ddt.data(
-        (2, "two_days_reminder"), (7, "seven_days_reminder"), (-1, "course_ended")
+        (90, "three_months_reminder"),
+        (30, "one_month_reminder"),
+        (7, "seven_days_reminder"),
+        (-1, "course_ended"),
     )
     @ddt.unpack
     @mock.patch('course_discovery.apps.course_metadata.tasks.process_send_course_deadline_email.apply_async')
@@ -119,7 +122,7 @@ class SendCourseDeadlineEmailsTests(TestCase):
     ):
         """
         Test that the command sends emails when there are advertised course runs with end dates within
-        the specified range.
+        the specified range (90, 30, 7, -1 days).
         """
         self.non_draft_course_run.end = timezone.now() + timedelta(days=days_until_end)
         self.non_draft_course_run.save()
@@ -130,7 +133,7 @@ class SendCourseDeadlineEmailsTests(TestCase):
         # pylint: disable=line-too-long
             log_capture.check(
                 (LOGGER_PATH, 'INFO', "Initializing course deadline email management command."),
-                (LOGGER_PATH, 'INFO', 'Found 1 courses with self-paced runs.'),
+                (LOGGER_PATH, 'INFO', 'Found 1 courses with matching runs.'),
                 (LOGGER_PATH, 'INFO', f'Scheduling deadline email for course {self.non_draft_course.title} ({self.non_draft_course.key}).'),
                 (LOGGER_PATH, 'INFO', f'Deadline email has been scheduled for course {self.non_draft_course.title} ({self.non_draft_course.key}).'),
                 (LOGGER_PATH, 'INFO', 'Scheduled course deadline emails for:\n' f"- {self.non_draft_course.title} ({self.non_draft_course.uuid})"),
@@ -174,7 +177,7 @@ class SendCourseDeadlineEmailsTests(TestCase):
 
             log_capture.check(
                 (LOGGER_PATH, 'INFO', "Initializing course deadline email management command."),
-                (LOGGER_PATH, 'INFO', 'Found 1 courses with self-paced runs.'),
+                (LOGGER_PATH, 'INFO', 'Found 1 courses with matching runs.'),
                 (
                     LOGGER_PATH,
                     'INFO',
@@ -197,7 +200,7 @@ class SendCourseDeadlineEmailsTests(TestCase):
 
             log_capture.check(
                 (LOGGER_PATH, 'INFO', "Initializing course deadline email management command."),
-                (LOGGER_PATH, 'INFO', 'Found 1 courses with self-paced runs.'),
+                (LOGGER_PATH, 'INFO', 'Found 1 courses with matching runs.'),
                 (
                     LOGGER_PATH,
                     'INFO',

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/course_deadline.html
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/course_deadline.html
@@ -8,14 +8,14 @@
 </p>
 
 <p>
-    {% if days_to_expire == '2 days' or days_to_expire == '7 days' %}
+    {% if days_to_expire == '90 days' or days_to_expire == '30 days' or days_to_expire == '7 days' %}
         {% blocktrans with course_name=course_name course_key=course_key course_end_date=course_end_date days=days_to_expire %}
         This is an automated reminder that the course "{{ course_name }}" (Course Key: {{ course_key }}) is scheduled to end in {{ days }} on {{ course_end_date }}.
         {% endblocktrans %}
         <p>
             {% trans "To ensure uninterrupted learner access and enrollment, please take one of the following actions:" %}
         </p>
-    {% elif days_to_expire == 'ended' %}
+    {% elif days_to_expire == 'course_ended' %}
         {% blocktrans with course_name=course_name course_key=course_key course_end_date=course_end_date %}
         This is an automated reminder that the course "{{ course_name }}" (Course Key: {{ course_key }}) has officially ended as of {{ course_end_date }}.
         {% endblocktrans %}
@@ -37,7 +37,7 @@
     {% trans "You can review and modify the course end settings here:" %} 
     <a href="{{ course_schedule_settings_url }}">{{ course_schedule_settings_url }}</a>
     <br/>
-    {% if days_to_expire == 'ended' %}
+    {% if days_to_expire == 'course_ended' %}
         {% blocktrans with partner_marketing_site_url=partner_marketing_site_url %}
         If no action is taken, the course will no longer be available for enrollment or access by learners on 
         <a href="{{ partner_marketing_site_url }}">{{ partner_marketing_site_url }}</a> after the end date.

--- a/course_discovery/apps/course_metadata/templates/course_metadata/email/course_deadline.txt
+++ b/course_discovery/apps/course_metadata/templates/course_metadata/email/course_deadline.txt
@@ -2,19 +2,19 @@
 
 {% trans "Hi Course Team," %}
 
-{% if days_to_expire == '2 days' or days_to_expire == '7 days' %}
+{% if days_to_expire == '90 days' or days_to_expire == '30 days' or days_to_expire == '7 days' %}
 {% blocktrans with course_name=course_name course_key=course_key course_end_date=course_end_date days=days_to_expire %}
 This is an automated reminder that the course "{{ course_name }}" (Course Key: {{ course_key }}) is scheduled to end in {{ days }} on {{ course_end_date }}.
 {% endblocktrans %}
-{% elif days_to_expire == 'ended' %}
+{% elif days_to_expire == 'course_ended' %}
 {% blocktrans with course_name=course_name course_key=course_key course_end_date=course_end_date %}
 This is an automated reminder that the course "{{ course_name }}" (Course Key: {{ course_key }}) has officially ended as of {{ course_end_date }}.
 {% endblocktrans %}
 {% endif %}
 
-{% if days_to_expire == '2 days' or days_to_expire == '7 days' %}
+{% if days_to_expire == '90 days' or days_to_expire == '30 days' or days_to_expire == '7 days' %}
 {% trans "To ensure uninterrupted learner access and enrollment, please take one of the following actions:" %}
-{% elif days_to_expire == 'ended' %}
+{% elif days_to_expire == 'course_ended' %}
 {% trans "If this was intentional, no action is needed. However, if this course was meant to remain available, you have two options to restore access:" %}
 {% endif %}
 
@@ -25,7 +25,7 @@ This is an automated reminder that the course "{{ course_name }}" (Course Key: {
 {% trans "You can review and modify the course end settings here:" %}
 {{ course_schedule_settings_url }}
 
-{% if days_to_expire == 'ended' %}
+{% if days_to_expire == 'course_ended' %}
 {% blocktrans with partner_marketing_site_url=partner_marketing_site_url %}
 If no action is taken, the course will no longer be available for enrollment or access by learners on {{ partner_marketing_site_url }} after the end date.
 {% endblocktrans %}

--- a/course_discovery/apps/course_metadata/tests/test_emails.py
+++ b/course_discovery/apps/course_metadata/tests/test_emails.py
@@ -722,7 +722,7 @@ class TestCourseDeadlineEmail(TestCase):
         self.course = CourseFactory(draft_version=self.draft_course, draft=False)
         self.course_run = CourseRunFactory(
             course=self.course, title_override='Test Course Run',
-            start=datetime.datetime.now(UTC), end=datetime.datetime.now(UTC) + datetime.timedelta(days=2),
+            start=datetime.datetime.now(UTC), end=datetime.datetime.now(UTC) + datetime.timedelta(days=7),
             status=CourseRunStatus.Published
         )
         self.partner = self.course.partner
@@ -739,18 +739,18 @@ class TestCourseDeadlineEmail(TestCase):
         """
         with LogCapture(emails.logger.name) as log_capture:
             emails.send_course_deadline_email(
-                self.course, self.course_run, [self.editor.email], deadline_email_variant='two_days_reminder'
+                self.course, self.course_run, [self.editor.email], deadline_email_variant='seven_days_reminder'
             )
 
             assert len(mail.outbox) == 1
             email = mail.outbox[0]
-            assert str(email.subject) == f'Reminder: {self.course.title} ends in 2 days'
+            assert str(email.subject) == f'Reminder: {self.course.title} ends in 7 days'
             assert email.to == [self.editor.email]
             assert email.from_email == settings.PUBLISHER_FROM_EMAIL
             assert 'Hi Course Team' in email.body
             assert (
                 f'This is an automated reminder that the course "{self.course.title}" (Course Key: {self.course.key})'
-                f' is scheduled to end in 2 days on {self.course_run.end.strftime("%m/%d/%Y")}.'
+                f' is scheduled to end in 7 days on {self.course_run.end.strftime("%m/%d/%Y")}.'
                 in email.body
             )
             log_capture.check(


### PR DESCRIPTION
This PR adds the functionality of sending Course Deadline Reminder Emails for self-paced and instructor-paced courses. Course editors and assigned PCs will now receive reminder emails 90, 30, and 7 days before a course ends, and once after it has ended. Emails won’t be sent if a subsequent run with Scheduled or Published status exists.

Ticket - https://2u-internal.atlassian.net/browse/PROD-4409