### PR TITLE
fix: Removed depricate storage path

### DIFF
--- a/course_discovery/apps/core/tests/test_prod_config.py
+++ b/course_discovery/apps/core/tests/test_prod_config.py
@@ -16,7 +16,6 @@ def test_production_media_storage(monkeypatch, tmp_path):
           AWS_QUERYSTRING_EXPIRE: false
           AWS_S3_CUSTOM_DOMAIN: cdn.org
           AWS_STORAGE_BUCKET_NAME: tests
-          DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage
           MEDIA_ROOT: media
           MEDIA_URL: https://cdn.org/media/
     """)

--- a/course_discovery/apps/core/tests/test_prod_config.py
+++ b/course_discovery/apps/core/tests/test_prod_config.py
@@ -18,6 +18,9 @@ def test_production_media_storage(monkeypatch, tmp_path):
           AWS_STORAGE_BUCKET_NAME: tests
           MEDIA_ROOT: media
           MEDIA_URL: https://cdn.org/media/
+        STORAGES:
+          default:
+            BACKEND: storages.backends.s3boto3.S3Boto3Storage
     """)
     fake_config.write_text(fake_yaml_content)
 

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -42,14 +42,6 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
     vars().update(config_from_yaml)
 
     MEDIA_STORAGE_BACKEND = config_from_yaml.get("MEDIA_STORAGE_BACKEND", {})
-    default_backend = MEDIA_STORAGE_BACKEND.pop("DEFAULT_FILE_STORAGE", None)
-    static_backend = MEDIA_STORAGE_BACKEND.pop("STATICFILES_STORAGE", None)
-
-    if default_backend:
-        STORAGES["default"]["BACKEND"] = default_backend
-
-    if static_backend:
-        STORAGES["staticfiles"]["BACKEND"] = static_backend
 
     # Unpack media storage settings.
     # It's important we unpack here because of https://github.com/openedx/configuration/pull/3307

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -42,7 +42,6 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
     vars().update(config_from_yaml)
 
     MEDIA_STORAGE_BACKEND = config_from_yaml.get("MEDIA_STORAGE_BACKEND", {})
-
     # Unpack media storage settings.
     # It's important we unpack here because of https://github.com/openedx/configuration/pull/3307
     vars().update(MEDIA_STORAGE_BACKEND)


### PR DESCRIPTION
Remove DEFAULT_FILE_STORAGE and STATICFILES_STORAGES. This addresses [issue](https://github.com/openedx/course-discovery/issues/4668).

Tested with this yml.

```
LANGUAGE_CODE: en
MEDIA_STORAGE_BACKEND:
    STORAGES:
        default:
            BACKEND: storages.backends.s3boto3.S3Boto3Storage   
        staticfiles:
            BACKEND: storages.backends.s3boto3.S3Boto3Storage             
    MEDIA_ROOT: /edx/var/discovery/media
    MEDIA_URL: /media/
OPENEXCHANGERATES_API_KEY: ''
PARLER_DEFAULT_LANGUAGE_CODE: en
PARLER_LANGUAGES:

```


