### PR TITLE
fix: Multi Select course/course run issue

### DIFF
--- a/course_discovery/apps/course_metadata/templates/admin/course_metadata/course_run.html
+++ b/course_discovery/apps/course_metadata/templates/admin/course_metadata/course_run.html
@@ -5,6 +5,19 @@
   change-program-excluded-course-runs-form
 {% endblock %}
 
+{% block extrastyle %}
+<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" rel="stylesheet">
+{% endblock %}
+
+{% block extrahead %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        $('.select2').select2();
+    });
+</script>
+{% endblock %}
+
 {% block content %}
 <form class="form" method="post" action="">
     {% csrf_token %}


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/CATALOG-44

Unable to Enter Course and Org Data- Discovery

Description

A recent update in the Discovery  is preventing users from entering information in the Courses and Authoring Organization fields. This is impacting high-priority program operations, specifically for Google Cloud initiatives that require quick turnaround. The affected user reported being unable to input necessary data in these fields and requests an urgent resolution to restore data entry capabilities

Acceptance Criteria :

The Courses and Authoring Organization fields must allow data entry without errors for all users.
No existing programs or scheduled launches should be disrupted during the patch or rollback.
 