### PR TITLE
test: add debug step to inspect runner Python packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install edx repo tools
+        run: pip install "edx-repo-tools[find_dependencies]>=3.1.0"
+
+      - name: Debug runner packages
+        run: |
+          echo "Python location:"
+          which python
+          python -V
+          echo "Installed packages:"
+          pip freeze | grep setuptools || true
+          pip freeze | grep requirements-parser || true
+          pip freeze | grep djchoices || true
+          echo "Testing pkg_resources:"
+          python -c "import pkg_resources; print('pkg_resources OK')" || echo "pkg_resources missing"  
+
       - name: Format Python Version
         id: format_python_version
         shell: bash
@@ -33,6 +49,7 @@ jobs:
           echo "Using Python Version: $FORMATTED_VERSION"
 
       - run: make ci_up
+
       - name: run tests
         env:
           DB_HOST: ${{ matrix.db-version }}
@@ -42,8 +59,8 @@ jobs:
         # that would note the failure, but not fail the entire workflow and not email the author about it.
         # See https://github.com/actions/toolkit/issues/399
         continue-on-error: ${{ matrix.status == 'ignored' }}
+
       - name: Upload coverage
-        # Upload coverage only from the django52 job to avoid duplicate artifacts across the Django test matrix.
         if: matrix.db-version == 'mysql80' && matrix.django-version == 'django52'
         uses: actions/upload-artifact@v4
         with:
@@ -57,14 +74,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install edx repo tools
+        run: pip install "edx-repo-tools[find_dependencies]>=3.1.0"
+
       - run: make ci_up
         env:
           PYTHON_VERSION: 3.12
+
       - name: Download all artifacts
         # Downloads coverage1, coverage2, etc.
         uses: actions/download-artifact@v4
+
       - name: Run coverage
         run: make ci_coverage
+
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -74,9 +98,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install edx repo tools
+        run: pip install "edx-repo-tools[find_dependencies]>=3.1.0"
+
       - run: make ci_up
         env:
           PYTHON_VERSION: 3.12
+
       - run: make ci_quality
 
   semgrep:
@@ -86,8 +115,13 @@ jobs:
         python-version: ['3.12']
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install edx repo tools
+        run: pip install "edx-repo-tools[find_dependencies]>=3.1.0"
+
       - run: make ci_up
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
+
       - name: Run semgrep Django rules
         run: make ci_semgrep


### PR DESCRIPTION
This is a temporary PR to inspect the Python environment on the GitHub Actions runner 
for course-discovery CI. 

The debug step prints:
- Python version
- setuptools version
- requirements-parser version
- djchoices version
- pkg_resources availability

This will help identify why CI is failing with pkg_resources / requirements-parser 
errors in the pytest job. 

