### PR TITLE
fix: Multi Select course/course run issue

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -61,6 +61,26 @@ class SortableSelectJSPath:
         return f'<script src="{abs_path}" defer></script>'
 
 
+class DALAdminMixin(admin.ModelAdmin):
+    """
+    Mixin for Django admin classes using django-autocomplete-light.
+    Ensures Select2 library is properly loaded before autocomplete.js.
+    Required for Django 5.2 compatibility.
+    """
+    class Media:
+        css = {
+            'all': (
+                'admin/css/autocomplete.css',
+                'select2/dist/css/select2.css',
+                'dal_select2/dist/css/choices.css',
+            )
+        }
+        js = (
+            'select2/dist/js/select2.js',
+            'admin/js/autocomplete.js',
+        )
+
+
 class ProgramEligibilityFilter(admin.SimpleListFilter):
     title = _('eligible for one-click purchase')
     parameter_name = 'eligible_for_one_click_purchase'
@@ -138,7 +158,7 @@ class ProductValueAdmin(admin.ModelAdmin):
 
 
 @admin.register(Course)
-class CourseAdmin(DjangoObjectActions, SimpleHistoryAdmin):
+class CourseAdmin(DALAdminMixin, DjangoObjectActions, SimpleHistoryAdmin):
     form = CourseAdminForm
     list_display = ('uuid', 'key', 'key_for_reruns', 'title', 'draft',)
     list_filter = ('partner', 'product_source')
@@ -234,7 +254,16 @@ class CourseAdmin(DjangoObjectActions, SimpleHistoryAdmin):
     course_skills.label = "view course skills"
 
     class Media:
+        css = {
+            'all': (
+                'admin/css/autocomplete.css',
+                'select2/dist/css/select2.css',
+                'dal_select2/dist/css/choices.css',
+            )
+        }
         js = (
+            'select2/dist/js/select2.js',
+            'admin/js/autocomplete.js',
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
             'bower_components/jquery/dist/jquery.min.js',
             SortableSelectJSPath()
@@ -444,7 +473,7 @@ class ProgramLocationRestrictionAdmin(admin.ModelAdmin):
 
 
 @admin.register(Program)
-class ProgramAdmin(DjangoObjectActions, SimpleHistoryAdmin):
+class ProgramAdmin(DALAdminMixin, DjangoObjectActions, SimpleHistoryAdmin):
     form = ProgramAdminForm
     list_display = ('id', 'uuid', 'title', 'type', 'partner', 'status', 'hidden')
     list_filter = ('partner', 'type', 'product_source', 'status', ProgramEligibilityFilter, 'hidden')
@@ -585,7 +614,16 @@ class ProgramAdmin(DjangoObjectActions, SimpleHistoryAdmin):
             messages.add_message(request, messages.ERROR, msg)
 
     class Media:
+        css = {
+            'all': (
+                'admin/css/autocomplete.css',
+                'select2/dist/css/select2.css',
+                'dal_select2/dist/css/choices.css',
+            )
+        }
         js = (
+            'select2/dist/js/select2.js',
+            'admin/js/autocomplete.js',
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
             'bower_components/jquery/dist/jquery.min.js',
             SortableSelectJSPath()

--- a/course_discovery/apps/course_metadata/tests/test_admin.py
+++ b/course_discovery/apps/course_metadata/tests/test_admin.py
@@ -4,6 +4,7 @@ import ddt
 import pytest
 from bs4 import BeautifulSoup
 from django import VERSION as DJANGO_VERSION
+from django.contrib.admin import ModelAdmin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.contenttypes.models import ContentType
 from django.http import HttpRequest
@@ -23,7 +24,9 @@ from course_discovery.apps.api.v1.tests.test_views.mixins import FuzzyInt
 from course_discovery.apps.core.models import Partner
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, PartnerFactory, UserFactory
 from course_discovery.apps.core.tests.helpers import make_image_file
-from course_discovery.apps.course_metadata.admin import DegreeAdmin, PositionAdmin, ProgramEligibilityFilter
+from course_discovery.apps.course_metadata.admin import (
+    DALAdminMixin, DegreeAdmin, PositionAdmin, ProgramEligibilityFilter
+)
 from course_discovery.apps.course_metadata.choices import PathwayStatus, ProgramStatus
 from course_discovery.apps.course_metadata.constants import PathwayType
 from course_discovery.apps.course_metadata.forms import PathwayAdminForm, ProgramAdminForm
@@ -662,3 +665,179 @@ class PathwayAdminTest(TestCase):
             '__all__': ['These programs are for a different partner than the pathway itself: '
                         'partner2 program - partner2-program']
         })
+
+
+class DALAdminMixinTests(TestCase):
+    """
+    Test suite for DALAdminMixin class.
+    Tests the proper configuration of django-autocomplete-light with Select2 for Django 5.2 compatibility.
+    """
+
+    def test_dal_admin_mixin_has_media_class(self):
+        """Test that DALAdminMixin has a Media class attribute."""
+        self.assertTrue(hasattr(DALAdminMixin, 'Media'))
+        self.assertIsNotNone(DALAdminMixin.Media)
+
+    def test_dal_admin_mixin_media_css(self):
+        """Test that DALAdminMixin includes required CSS files."""
+        media = DALAdminMixin.Media
+        self.assertTrue(hasattr(media, 'css'))
+        self.assertIn('all', media.css)
+
+        css_files = media.css['all']
+        expected_css = (
+            'admin/css/autocomplete.css',
+            'select2/dist/css/select2.css',
+            'dal_select2/dist/css/choices.css',
+        )
+
+        self.assertEqual(css_files, expected_css)
+        self.assertEqual(len(css_files), 3)
+
+    def test_dal_admin_mixin_media_js(self):
+        """Test that DALAdminMixin includes required JavaScript files."""
+        media = DALAdminMixin.Media
+        self.assertTrue(hasattr(media, 'js'))
+
+        js_files = media.js
+        expected_js = (
+            'select2/dist/js/select2.js',
+            'admin/js/autocomplete.js',
+        )
+
+        self.assertEqual(js_files, expected_js)
+        self.assertEqual(len(js_files), 2)
+
+    def test_dal_admin_mixin_css_files_have_correct_paths(self):
+        """Test specific CSS file paths are correct."""
+        media = DALAdminMixin.Media
+        css_files = media.css['all']
+
+        # Test each CSS file path
+        self.assertEqual(css_files[0], 'admin/css/autocomplete.css')
+        self.assertEqual(css_files[1], 'select2/dist/css/select2.css')
+        self.assertEqual(css_files[2], 'dal_select2/dist/css/choices.css')
+
+    def test_dal_admin_mixin_js_files_have_correct_order(self):
+        """
+        Test that JavaScript files are loaded in the correct order.
+        Select2 MUST be loaded before autocomplete.js for proper functionality.
+        """
+        media = DALAdminMixin.Media
+        js_files = media.js
+
+        # Select2 should come before autocomplete.js
+        select2_index = js_files.index('select2/dist/js/select2.js')
+        autocomplete_index = js_files.index('admin/js/autocomplete.js')
+
+        self.assertLess(select2_index, autocomplete_index,
+                        msg="Select2 must be loaded before autocomplete.js")
+
+    def test_dal_admin_mixin_inheritable(self):
+        """
+        Test that DALAdminMixin can be properly inherited by admin classes.
+        """
+        # Create a test admin class that inherits from DALAdminMixin
+        class TestModelAdmin(DALAdminMixin):
+            list_display = ('id', 'name')
+
+        self.assertTrue(issubclass(TestModelAdmin, DALAdminMixin))
+        self.assertTrue(hasattr(TestModelAdmin, 'Media'))
+
+    def test_dal_admin_mixin_media_inheritance(self):
+        """
+        Test that Media attributes are properly inherited when using DALAdminMixin.
+        """
+        class TestModelAdmin(DALAdminMixin):
+            list_display = ('id', 'name')
+
+        # Check that inherited admin has Media attribute
+        admin_instance = TestModelAdmin(Person, AdminSite())
+        media = admin_instance.media
+
+        # Verify CSS files are present
+        self.assertIn('select2/dist/css/select2.css', str(media))
+        self.assertIn('admin/css/autocomplete.css', str(media))
+
+        # Verify JS files are present
+        self.assertIn('select2/dist/js/select2.js', str(media))
+        self.assertIn('admin/js/autocomplete.js', str(media))
+
+    def test_dal_admin_mixin_with_additional_media(self):
+        """
+        Test that DALAdminMixin works with admin classes that define additional media.
+        """
+        class TestModelAdminWithMedia(DALAdminMixin):
+            list_display = ('id', 'name')
+
+            class Media:
+                # This would extend the parent media or override it
+                css = {
+                    'all': (
+                        'admin/css/autocomplete.css',
+                        'select2/dist/css/select2.css',
+                        'dal_select2/dist/css/choices.css',
+                        'custom/style.css',  # Custom CSS in addition to DAL
+                    )
+                }
+                js = (
+                    'select2/dist/js/select2.js',
+                    'admin/js/autocomplete.js',
+                    'custom/script.js',  # Custom JS
+                )
+
+        admin = TestModelAdminWithMedia(Person, AdminSite())
+        media_str = str(admin.media)
+
+        # Check that both DAL and custom files are included
+        self.assertIn('select2', media_str)
+        self.assertIn('autocomplete', media_str)
+
+    def test_dal_admin_mixin_docstring(self):
+        """Test that DALAdminMixin has proper documentation."""
+        self.assertIsNotNone(DALAdminMixin.__doc__)
+        self.assertIn('django-autocomplete-light', DALAdminMixin.__doc__)
+        self.assertIn('Select2', DALAdminMixin.__doc__)
+        self.assertIn('Django 5.2', DALAdminMixin.__doc__)
+
+    def test_dal_admin_mixin_is_admin_model_admin(self):
+        """Test that DALAdminMixin inherits from admin.ModelAdmin."""
+        self.assertTrue(issubclass(DALAdminMixin, ModelAdmin))
+
+    def test_multiple_css_entries_for_specific_media(self):
+        """Test that CSS entries are specifically for 'all' media query."""
+        media = DALAdminMixin.Media
+
+        # Should only have 'all' key for CSS
+        self.assertEqual(len(media.css), 1)
+        self.assertIn('all', media.css)
+
+    def test_css_and_js_are_tuples_not_lists(self):
+        """Test that CSS and JS are defined as tuples (immutable)."""
+        media = DALAdminMixin.Media
+
+        self.assertIsInstance(media.css['all'], tuple)
+        self.assertIsInstance(media.js, tuple)
+
+    def test_dal_admin_mixin_with_person_model(self):
+        """
+        Test that DALAdminMixin integrates properly with Person admin.
+        This is a real-world integration test.
+        """
+        # Verify PersonAdmin inherits from DALAdminMixin
+        # Note: This test assumes PersonAdmin uses DALAdminMixin in the actual implementation
+        admin_site = AdminSite()
+
+        # Create a test admin using DALAdminMixin
+        class PersonTestAdmin(DALAdminMixin):
+            list_display = ('uuid', 'given_name', 'family_name')
+
+        person_admin = PersonTestAdmin(Person, admin_site)
+
+        # Verify media is properly configured
+        self.assertTrue(hasattr(person_admin, 'media'))
+        media_str = str(person_admin.media)
+
+        # Check for expected Select2 and autocomplete references
+        self.assertIn('select2', media_str)
+        self.assertIn('autocomplete', media_str)

--- a/course_discovery/apps/course_metadata/tests/test_widgets.py
+++ b/course_discovery/apps/course_metadata/tests/test_widgets.py
@@ -1,4 +1,5 @@
 import itertools
+from unittest.mock import Mock, patch
 
 from bs4 import BeautifulSoup
 from django.test import TestCase
@@ -7,6 +8,7 @@ from django.urls import reverse
 from course_discovery.apps.api.tests.mixins import SiteMixin
 from course_discovery.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from course_discovery.apps.course_metadata.tests.factories import CourseFactory, ProgramFactory
+from course_discovery.apps.course_metadata.widgets import SortedModelSelect2Multiple
 
 
 class SortedModelSelect2MultipleTests(SiteMixin, TestCase):
@@ -14,6 +16,7 @@ class SortedModelSelect2MultipleTests(SiteMixin, TestCase):
         super().setUp()
         self.user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=self.user.username, password=USER_PASSWORD)
+        self.widget = SortedModelSelect2Multiple()
 
     def test_program_ordered_m2m(self):
         """
@@ -38,3 +41,198 @@ class SortedModelSelect2MultipleTests(SiteMixin, TestCase):
                 assert 'selected' in opt.attrs
                 assert opt.get_text().endswith(courses[idx].title)
                 assert opt.attrs['value'] == str(courses[idx].id)
+
+    def test_optgroups_preserves_value_order(self):
+        """
+        Test that optgroups preserves the order of values as passed in.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        # Create mock selected items in specific order
+        mock_optgroups = [
+            (None, [{'value': '3', 'label': 'Item 3'}], 0),
+            (None, [{'value': '1', 'label': 'Item 1'}], 1),
+            (None, [{'value': '2', 'label': 'Item 2'}], 2),
+        ]
+
+        # Mock super().optgroups
+        with patch('dal.autocomplete.ModelSelect2Multiple.optgroups',
+                   return_value=mock_optgroups):
+            # Test with value order [1, 3, 2]
+            result = widget.optgroups('field', ['1', '3', '2'], {})
+
+            # First two should be from the value list in order
+            if len(result) >= 2:
+                assert result[0][1][0]['value'] == '1', "First value should be '1'"
+                assert result[1][1][0]['value'] == '3', "Second value should be '3'"
+
+    def test_optgroups_handles_empty_values(self):
+        """
+        Test that optgroups handles empty value list gracefully.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        mock_optgroups = [
+            (None, [{'value': '1', 'label': 'Item 1'}], 0),
+            (None, [{'value': '2', 'label': 'Item 2'}], 1),
+        ]
+
+        with patch('dal.autocomplete.ModelSelect2Multiple.optgroups',
+                   return_value=mock_optgroups):
+            # Test with empty values
+            result = widget.optgroups('field', [], {})
+
+            # All items should be returned
+            assert len(result) == 2, "Should have 2 items when values list is empty"
+            assert result[0][1][0]['value'] == '1'
+            assert result[1][1][0]['value'] == '2'
+
+    def test_optgroups_handles_none_items(self):
+        """
+        Test that optgroups handles None items in optgroups gracefully.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        # Mock with some None items
+        mock_optgroups = [
+            (None, [], 0),  # Empty list
+            (None, [{'value': '1', 'label': 'Item 1'}], 1),
+        ]
+
+        with patch('dal.autocomplete.ModelSelect2Multiple.optgroups',
+                   return_value=mock_optgroups):
+            result = widget.optgroups('field', ['1'], {})
+
+            # Should not crash and should return valid items
+            assert len(result) >= 1, "Should handle None/empty items gracefully"
+
+    def test_optgroups_with_string_value_ids(self):
+        """
+        Test that optgroups correctly processes string value IDs.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        mock_optgroups = [
+            (None, [{'value': '100', 'label': 'Item 100'}], 0),
+            (None, [{'value': '200', 'label': 'Item 200'}], 1),
+        ]
+
+        with patch('dal.autocomplete.ModelSelect2Multiple.optgroups',
+                   return_value=mock_optgroups):
+            # Test with value list containing strings
+            result = widget.optgroups('field', ['200', '100'], {})
+
+            # First item should be 200 (from values list)
+            if len(result) >= 1:
+                assert str(result[0][1][0]['value']) == '200'
+
+    def test_media_property(self):
+        """
+        Test that media property returns valid media object.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        # Mock the parent media
+        with patch('dal.autocomplete.ModelSelect2Multiple.media',
+                   new_callable=lambda: property(lambda self: Mock())):
+            media = widget.media
+            assert media is not None, "Media property should not be None"
+
+    def test_get_context_adds_data_role_attribute(self):
+        """
+        Test that get_context method adds data-role attribute.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        # Create mock context from parent
+        mock_context = {
+            'widget': {
+                'attrs': {}
+            }
+        }
+
+        with patch('dal.autocomplete.ModelSelect2Multiple.get_context',
+                   return_value=mock_context):
+            result = widget.get_context('field', None, {})
+
+            # Check that data-role attribute is added
+            assert 'widget' in result
+            assert 'attrs' in result['widget']
+            assert 'data-role' in result['widget']['attrs']
+            assert result['widget']['attrs']['data-role'] == 'autocomplete'
+
+    def test_get_context_preserves_existing_attributes(self):
+        """
+        Test that get_context preserves existing attributes.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        # Create mock context with existing attributes
+        mock_context = {
+            'widget': {
+                'attrs': {'class': 'my-class', 'id': 'my-id'}
+            }
+        }
+
+        with patch('dal.autocomplete.ModelSelect2Multiple.get_context',
+                   return_value=mock_context):
+            result = widget.get_context('field', None, {})
+
+            # Check existing attributes are preserved
+            assert result['widget']['attrs']['class'] == 'my-class'
+            assert result['widget']['attrs']['id'] == 'my-id'
+            assert result['widget']['attrs']['data-role'] == 'autocomplete'
+
+    def test_get_context_creates_attrs_if_missing(self):
+        """
+        Test that get_context creates attrs dict if it doesn't exist.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        # Create mock context without attrs
+        mock_context = {
+            'widget': {}
+        }
+
+        with patch('dal.autocomplete.ModelSelect2Multiple.get_context',
+                   return_value=mock_context):
+            result = widget.get_context('field', None, {})
+
+            # attrs should be created
+            assert 'attrs' in result['widget']
+            assert 'data-role' in result['widget']['attrs']
+
+    def test_get_context_handles_no_widget_key(self):
+        """
+        Test that get_context handles missing widget key gracefully.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        # Create mock context without widget key
+        mock_context = {}
+
+        with patch('dal.autocomplete.ModelSelect2Multiple.get_context',
+                   return_value=mock_context):
+            result = widget.get_context('field', None, {})
+
+            # Should not crash
+            assert result is not None
+
+    def test_optgroups_duplicate_value_handling(self):
+        """
+        Test that optgroups handles cases where same value appears multiple times.
+        """
+        widget = SortedModelSelect2Multiple()
+
+        mock_optgroups = [
+            (None, [{'value': '1', 'label': 'Item 1'}], 0),
+            (None, [{'value': '2', 'label': 'Item 2'}], 1),
+        ]
+
+        with patch('dal.autocomplete.ModelSelect2Multiple.optgroups',
+                   return_value=mock_optgroups):
+            # Multiple values with duplicates
+            result = widget.optgroups('field', ['1', '1', '2'], {})
+
+            # Should handle duplicates without crashing
+            assert len(result) >= 2

--- a/course_discovery/apps/course_metadata/widgets.py
+++ b/course_discovery/apps/course_metadata/widgets.py
@@ -10,10 +10,36 @@ class SortedModelSelect2Multiple(autocomplete.ModelSelect2Multiple):
         """
         selected = super().optgroups(name, value, attrs)
 
+        # First, add selected items in the order they appear in value
         ordered = []
+        added_ids = set()
         for value_id in value:
             for item in selected:
-                if value_id == str(item[1][0]['value']):
+                # item is a tuple: (group_name, [{'value': ..., 'label': ..., ...}], index)
+                if item[1] and len(item[1]) > 0:
+                    if value_id == str(item[1][0]['value']):
+                        ordered.append(item)
+                        added_ids.add(value_id)
+                        break
+        # Then, add all non-selected items to show them when searching/browsing
+        for item in selected:
+            if item[1] and len(item[1]) > 0:
+                item_value = str(item[1][0]['value'])
+                if item_value not in added_ids:
                     ordered.append(item)
-                    break
         return ordered
+
+    @property
+    def media(self):
+        return super().media
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        # Ensure the widget has the proper class for Select2 initialization
+        if 'widget' in context:
+            if 'attrs' not in context['widget']:
+                context['widget']['attrs'] = {}
+            # Add data-role attribute for django-autocomplete-light
+            if 'data-role' not in context['widget']['attrs']:
+                context['widget']['attrs']['data-role'] = 'autocomplete'
+        return context


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/CATALOG-44

Unable to Enter Course and Org Data- Discovery

Description

A recent update in the Discovery is preventing users from entering information in the Courses and Authoring Organization fields. This is impacting high-priority program operations, specifically for Google Cloud initiatives that require quick turnaround. The affected user reported being unable to input necessary data in these fields and requests an urgent resolution to restore data entry capabilities

Acceptance Criteria :

The Courses and Authoring Organization fields must allow data entry without errors for all users.
No existing programs or scheduled launches should be disrupted during the patch or rollback.