### PR TITLE
fix: resolve jQuery conflict breaking admin autocomplete fields in Django 5

### DIFF
--- a/course_discovery/apps/course_metadata/admin.py
+++ b/course_discovery/apps/course_metadata/admin.py
@@ -235,8 +235,8 @@ class CourseAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Media:
         js = (
+            'js/jquery_shim.js',
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
-            'bower_components/jquery/dist/jquery.min.js',
             SortableSelectJSPath()
         )
 
@@ -586,8 +586,8 @@ class ProgramAdmin(DjangoObjectActions, SimpleHistoryAdmin):
 
     class Media:
         js = (
+            'js/jquery_shim.js',
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
-            'bower_components/jquery/dist/jquery.min.js',
             SortableSelectJSPath()
         )
 
@@ -1080,8 +1080,8 @@ class SearchDefaultResultsConfigurationAdmin(admin.ModelAdmin):
 
     class Media:
         js = (
+            'js/jquery_shim.js',
             'bower_components/jquery-ui/ui/minified/jquery-ui.min.js',
-            'bower_components/jquery/dist/jquery.min.js',
             'js/sortable_select.js'
         )
 

--- a/course_discovery/static/js/jquery_shim.js
+++ b/course_discovery/static/js/jquery_shim.js
@@ -1,0 +1,5 @@
+// Expose django.jQuery as jQuery and $ for jQuery UI compatibility
+// This must be loaded BEFORE jQuery UI and AFTER Django admin's jQuery
+if (typeof django !== 'undefined' && django.jQuery) {
+    window.jQuery = window.$ = django.jQuery;
+}

--- a/course_discovery/static/js/sortable_select.js
+++ b/course_discovery/static/js/sortable_select.js
@@ -1,49 +1,51 @@
-function updateSelect2Data(el){
-    var i, j,
-        visibleTitlesLength,
-        selectOptionsLength,
-        visibleTitles = [],
-        selectOptions = [],
-        items = [],
-        selectOptionsElement = $(el).find('.select2-hidden-accessible'),
-        selectChoicesElement = $(el).find('.select2-selection__choice'),
-        selectOptionElement = $(selectOptionsElement).find('option');
+(function($) {
+    function updateSelect2Data(el){
+        var i, j,
+            visibleTitlesLength,
+            selectOptionsLength,
+            visibleTitles = [],
+            selectOptions = [],
+            items = [],
+            selectOptionsElement = $(el).find('.select2-hidden-accessible'),
+            selectChoicesElement = $(el).find('.select2-selection__choice'),
+            selectOptionElement = $(selectOptionsElement).find('option');
 
-    selectChoicesElement.each(function(index, value){
-        if (value.title){
-            visibleTitles.push(value.title);
-        }
-    });
+        selectChoicesElement.each(function(index, value){
+            if (value.title){
+                visibleTitles.push(value.title);
+            }
+        });
 
-    selectOptionElement.each(function(index, value){
-        selectOptions.push({id: value.value, text: value.text});
-    });
+        selectOptionElement.each(function(index, value){
+            selectOptions.push({id: value.value, text: value.text});
+        });
 
-    // Update select2 options with new data
-    visibleTitlesLength = visibleTitles.length;
-    selectOptionsLength = selectOptions.length;
-    for (i = 0; i < visibleTitlesLength; i++) {
-        for (j = 0; j < selectOptionsLength; j++) {
-            if (selectOptions[j].text === visibleTitles[i]){
-                items.push('<option selected="selected" value="' + selectOptions[j].id + '">' +
-                           selectOptions[j].text + '</option>'
-                );
+        // Update select2 options with new data
+        visibleTitlesLength = visibleTitles.length;
+        selectOptionsLength = selectOptions.length;
+        for (i = 0; i < visibleTitlesLength; i++) {
+            for (j = 0; j < selectOptionsLength; j++) {
+                if (selectOptions[j].text === visibleTitles[i]){
+                    items.push('<option selected="selected" value="' + selectOptions[j].id + '">' +
+                               selectOptions[j].text + '</option>'
+                    );
+                }
             }
         }
+
+        if (items){
+            selectOptionsElement.html(items.join('\n'));
+        }
     }
 
-    if (items){
-        selectOptionsElement.html(items.join('\n'));
-    }
-}
-
-window.addEventListener('load', function(){
-    $(function() {
-        $('.sortable-select').parents('.form-row').each(function(index, el){
-            $(el).find('ul.select2-selection__rendered').sortable({
-                containment: 'parent',
-                update: function(){updateSelect2Data(el);}
+    window.addEventListener('load', function(){
+        $(function() {
+            $('.sortable-select').parents('.form-row').each(function(index, el){
+                $(el).find('ul.select2-selection__rendered').sortable({
+                    containment: 'parent',
+                    update: function(){updateSelect2Data(el);}
+                })
             })
         })
-    })
-});
+    });
+})(django.jQuery);


### PR DESCRIPTION
The admin's SortedModelSelect2Multiple widgets were broken because:
1. Django admin namespaces jQuery as django.jQuery and removes $ from global scope
2. The Media class was loading bower's jQuery which overwrote $ with a new instance
3. Select2 was attached to django.jQuery but code was calling $().select2()

This fix:
- Adds jquery_shim.js to expose django.jQuery as global $ and jQuery
- Wraps sortable_select.js in IIFE using django.jQuery
- Removes conflicting bower jQuery from Media classes

ENT-11757

🤖 Generated with [Claude Code](https://claude.com/claude-code)