### PR TITLE
feat: support nested course run ordering in courses API

### DIFF
--- a/course_discovery/apps/api/filters.py
+++ b/course_discovery/apps/api/filters.py
@@ -9,6 +9,7 @@ from django_filters import rest_framework as filters
 from dry_rest_permissions.generics import DRYPermissionFiltersBase
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.filters import OrderingFilter
 
 from course_discovery.apps.api.utils import cast2int
 from course_discovery.apps.course_metadata.choices import BulkOperationStatus, CourseRunStatus, ProgramStatus
@@ -153,6 +154,40 @@ class CourseRunFilter(FilterSetMixin, filters.FilterSet):
     class Meta:
         model = CourseRun
         fields = ('keys', 'hidden', 'license',)
+
+
+class NestedCourseRunOrderingFilter(OrderingFilter):
+    """
+    Applies ordering to CourseRun querysets used as nested data in course responses.
+
+    This uses a dedicated query parameter to avoid conflicting with the top-level
+    course ordering behavior.
+    """
+
+    ordering_param = 'course_runs_ordering'
+    allowed_ordering_fields = ('key', 'start')
+
+    def get_ordering(self, request, queryset, view):
+        params = request.query_params.get(self.ordering_param)
+
+        if not params:
+            return None
+
+        fields = [param.strip() for param in params.split(',')]
+        ordering = [
+            field for field in fields
+            if field.lstrip('-') in self.allowed_ordering_fields
+        ]
+
+        return ordering or None
+
+    def filter_queryset(self, request, queryset, view):
+        ordering = self.get_ordering(request, queryset, view)
+
+        if ordering:
+            return queryset.order_by(*ordering)
+
+        return queryset
 
 
 class ProgramFilter(FilterSetMixin, filters.FilterSet):

--- a/course_discovery/apps/api/v1/tests/test_views/test_courses.py
+++ b/course_discovery/apps/api/v1/tests/test_views/test_courses.py
@@ -295,6 +295,98 @@ class CourseViewSetTests(SerializationMixin, ElasticsearchTestMixin, OAuth2Mixin
         self.assertListEqual(response.data['course_run_keys'], expected_keys)
         self.assertListEqual([run['key'] for run in response.data['course_runs']], expected_keys)
 
+    @ddt.data(
+        (
+            'start',
+            [
+                'course-v1:edX+Fake101+2000',
+                'course-v1:edX+Fake101+2003',
+                'course-v1:edX+Fake101+2007',
+            ],
+        ),
+        (
+            '-start',
+            [
+                'course-v1:edX+Fake101+2007',
+                'course-v1:edX+Fake101+2003',
+                'course-v1:edX+Fake101+2000',
+            ],
+        ),
+        (
+            'key',
+            [
+                'course-v1:edX+Fake101+2000',
+                'course-v1:edX+Fake101+2003',
+                'course-v1:edX+Fake101+2007',
+            ],
+        ),
+        (
+            '-key',
+            [
+                'course-v1:edX+Fake101+2007',
+                'course-v1:edX+Fake101+2003',
+                'course-v1:edX+Fake101+2000',
+            ],
+        ),
+    )
+    @ddt.unpack
+    def test_list_course_runs_ordering(self, course_runs_ordering, expected_keys):
+        """Verify that course runs inside course list responses can be ordered."""
+        CourseRunFactory(
+            course=self.course,
+            key='course-v1:edX+Fake101+2003',
+            start=datetime.datetime(2003, 1, 1, tzinfo=pytz.UTC),
+        )
+        CourseRunFactory(
+            course=self.course,
+            key='course-v1:edX+Fake101+2000',
+            start=datetime.datetime(2000, 1, 1, tzinfo=pytz.UTC),
+        )
+        CourseRunFactory(
+            course=self.course,
+            key='course-v1:edX+Fake101+2007',
+            start=datetime.datetime(2007, 1, 1, tzinfo=pytz.UTC),
+        )
+
+        url = reverse('api:v1:course-list')
+        url = f'{url}?course_runs_ordering={course_runs_ordering}'
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+        assert len(response.data['results']) == 1
+        assert [run['key'] for run in response.data['results'][0]['course_runs']] == expected_keys
+        assert response.data['results'][0]['course_run_keys'] == expected_keys
+
+    def test_list_course_runs_ordering_ignores_invalid_fields(self):
+        """Verify that invalid nested course run ordering fields are ignored."""
+        run1 = CourseRunFactory(
+            course=self.course,
+            key='course-v1:edX+Fake101+2003',
+            start=datetime.datetime(2003, 1, 1, tzinfo=pytz.UTC),
+        )
+        run2 = CourseRunFactory(
+            course=self.course,
+            key='course-v1:edX+Fake101+2000',
+            start=datetime.datetime(2000, 1, 1, tzinfo=pytz.UTC),
+        )
+        run3 = CourseRunFactory(
+            course=self.course,
+            key='course-v1:edX+Fake101+2007',
+            start=datetime.datetime(2007, 1, 1, tzinfo=pytz.UTC),
+        )
+
+        url = reverse('api:v1:course-list')
+        url = f'{url}?course_runs_ordering=invalid_field'
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200
+
+        expected_keys = [run2.key, run1.key, run3.key]
+        assert [run['key'] for run in response.data['results'][0]['course_runs']] == expected_keys
+        assert response.data['results'][0]['course_run_keys'] == expected_keys
+
     @ddt.data(True, False)
     def test_course_runs_restriction(self, include_restriction_param):
         run_restricted = CourseRunFactory(

--- a/course_discovery/apps/api/v1/views/courses.py
+++ b/course_discovery/apps/api/v1/views/courses.py
@@ -129,6 +129,11 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
         if q:
             queryset = Course.search(q, queryset=queryset)
             course_runs = CourseRun.objects.exclude(restricted_run__restriction_type__in=excluded_restriction_types)
+            course_runs = filters.NestedCourseRunOrderingFilter().filter_queryset(
+                self.request,
+                course_runs,
+                CourseRunViewSet,
+            )
             queryset = self.get_serializer_class().prefetch_queryset(
                 queryset=queryset, partner=partner, course_runs=course_runs
             )
@@ -156,6 +161,11 @@ class CourseViewSet(CompressedCacheResponseMixin, viewsets.ModelViewSet):
                 programs = Program.objects.exclude(status=ProgramStatus.Deleted)
 
             course_runs = course_runs.exclude(restricted_run__restriction_type__in=excluded_restriction_types)
+            course_runs = filters.NestedCourseRunOrderingFilter().filter_queryset(
+                self.request,
+                course_runs,
+                CourseRunViewSet,
+            )
             queryset = self.get_serializer_class().prefetch_queryset(
                 queryset=queryset,
                 course_runs=course_runs,


### PR DESCRIPTION
## Description

This PR adds support for ordering course runs nested in `/api/v1/courses/` responses using a dedicated query parameter:

```http
/api/v1/courses/?course_runs_ordering=start
/api/v1/courses/?course_runs_ordering=-start
/api/v1/courses/?course_runs_ordering=key
/api/v1/courses/?course_runs_ordering=-key
```

The existing `/api/v1/course_runs/` endpoint already supports ordering course runs directly, but there is currently no equivalent way to order the course_runs nested in course responses from `/api/v1/courses/`.

This change applies ordering to the CourseRun queryset before it is passed to the course serializer prefetch logic.

## Motivation

Consumers of the courses API may need deterministic ordering of nested course runs, for example to present course runs from oldest to newest, newest to oldest, or by key.

Without this support, clients need to sort the nested course runs after receiving the API response. Adding server-side ordering keeps the behavior consistent and avoids duplicating ordering logic across API consumers.

### Backwards compatibility

This change is opt-in.

If course_runs_ordering is not provided, the existing behavior is preserved.

Invalid ordering fields are ignored and the existing default behavior is preserved.

Supported ordering fields are:

- start
- -start
- key
- -key

## Testing

Added tests covering:

- course_runs_ordering=start
- course_runs_ordering=-start
- course_runs_ordering=key
- course_runs_ordering=-key
- invalid ordering fields

## How to test

```http
/api/v1/courses/?course_runs_ordering=start
/api/v1/courses/?course_runs_ordering=-start
```

## Notes

The parameter is intentionally named course_runs_ordering instead of reusing DRF's top-level ordering parameter, because this ordering applies to nested course runs rather than to the top-level course queryset.

I kept this separate from the existing top-level ordering behavior to avoid ambiguity between ordering courses and ordering nested course runs.